### PR TITLE
Some simple fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,11 @@ install_agent :
 				echo 'Successfully copied gpupgrade_agent to $(GPHOME) on all segments'; \
 			else \
 				echo 'Failed to copy gpupgrade_agent to $(GPHOME)'; \
+				exit 1; \
 			fi; \
 		else \
 			echo 'Database is not running, please start the database and run this make target again'; \
+			exit 1; \
 		fi; \
 		rm /tmp/seg_hosts
 

--- a/integrations/prepare_start_agents_test.go
+++ b/integrations/prepare_start_agents_test.go
@@ -59,6 +59,7 @@ var _ = Describe("prepare", func() {
 		hub = services.NewHub(&cluster.Pair{}, &reader, grpc.DialContext, commandExecer.Exec, conf, clusterSsher)
 
 		pgPort := os.Getenv("PGPORT")
+		Expect(pgPort).ToNot(Equal(""), "Please set PGPORT to a useful value and rerun the tests.")
 
 		clusterConfig := fmt.Sprintf(`{"SegConfig":[{
               "content": -1,


### PR DESCRIPTION
We've been carrying these for a little bit and they should probably be posted for master.

First, error out nicely in the tests if `PGPORT` is unset (because otherwise JSON fails to serialize, which is a surprising result).

Second, don't let `make install` succeed if `gpupgrade_agent` hasn't actually been installed.