### PR TITLE
Some more Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,18 @@ protobuf :
 		mockgen -source idl/cli_to_hub.pb.go  > mock_idl/cli_to_hub_mock.pb.go
 		mockgen -source idl/hub_to_agent.pb.go  > mock_idl/hub_to_agent_mock.pb.go
 
-build :
-		go build $(GOFLAGS) -o $(BIN_DIR)/$(AGENT) -ldflags $(UPGRADE_VERSION_STR) $(AGENT_PACKAGE)
-		go build $(GOFLAGS) -o $(BIN_DIR)/$(CLI) -ldflags $(UPGRADE_VERSION_STR) $(CLI_PACKAGE)
-		go build $(GOFLAGS) -o $(BIN_DIR)/$(HUB) -ldflags $(UPGRADE_VERSION_STR) $(HUB_PACKAGE)
+PACKAGES := $(addsuffix -package,agent cli hub)
+
+.PHONY: build $(PACKAGES)
+
+build: $(PACKAGES)
+
+agent-package: EXE_NAME := $(AGENT)
+cli-package: EXE_NAME := $(CLI)
+hub-package: EXE_NAME := $(HUB)
+
+$(PACKAGES): %-package:
+	go build $(GOFLAGS) -o $(BIN_DIR)/$(EXE_NAME) -ldflags $(UPGRADE_VERSION_STR) github.com/greenplum-db/gpupgrade/$*
 
 build_linux :
 		$(LINUX_PREFIX) go build $(GOFLAGS) -o $(BIN_DIR)/$(AGENT)$(LINUX_POSTFIX) -ldflags $(UPGRADE_VERSION_STR) $(AGENT_PACKAGE)

--- a/Makefile
+++ b/Makefile
@@ -66,27 +66,23 @@ protobuf :
 		mockgen -source idl/hub_to_agent.pb.go  > mock_idl/hub_to_agent_mock.pb.go
 
 PACKAGES := $(addsuffix -package,agent cli hub)
+PREFIX = $($(OS)_PREFIX)
+POSTFIX = $($(OS)_POSTFIX)
 
-.PHONY: build $(PACKAGES)
+.PHONY: build build_linux build_mac $(PACKAGES)
 
 build: $(PACKAGES)
+
+build_linux: OS := LINUX
+build_mac: OS := MAC
+build_linux build_mac: build
 
 agent-package: EXE_NAME := $(AGENT)
 cli-package: EXE_NAME := $(CLI)
 hub-package: EXE_NAME := $(HUB)
 
 $(PACKAGES): %-package:
-	go build $(GOFLAGS) -o $(BIN_DIR)/$(EXE_NAME) -ldflags $(UPGRADE_VERSION_STR) github.com/greenplum-db/gpupgrade/$*
-
-build_linux :
-		$(LINUX_PREFIX) go build $(GOFLAGS) -o $(BIN_DIR)/$(AGENT)$(LINUX_POSTFIX) -ldflags $(UPGRADE_VERSION_STR) $(AGENT_PACKAGE)
-		$(LINUX_PREFIX) go build $(GOFLAGS) -o $(BIN_DIR)/$(CLI)$(LINUX_POSTFIX) -ldflags $(UPGRADE_VERSION_STR) $(CLI_PACKAGE)
-		$(LINUX_PREFIX) go build $(GOFLAGS) -o $(BIN_DIR)/$(HUB)$(LINUX_POSTFIX) -ldflags $(UPGRADE_VERSION_STR) $(HUB_PACKAGE)
-
-build_mac:
-		$(MAC_PREFIX) go build $(GOFLAGS) -o $(BIN_DIR)/$(AGENT)$(MAC_POSTFIX) -ldflags $(UPGRADE_VERSION_STR) $(AGENT_PACKAGE)
-		$(MAC_PREFIX) go build $(GOFLAGS) -o $(BIN_DIR)/$(CLI)$(MAC_POSTFIX) -ldflags $(UPGRADE_VERSION_STR) $(CLI_PACKAGE)
-		$(MAC_PREFIX) go build $(GOFLAGS) -o $(BIN_DIR)/$(HUB)$(MAC_POSTFIX) -ldflags $(UPGRADE_VERSION_STR) $(HUB_PACKAGE)
+	$(PREFIX) go build $(GOFLAGS) -o $(BIN_DIR)/$(EXE_NAME)$(POSTFIX) -ldflags $(UPGRADE_VERSION_STR) github.com/greenplum-db/gpupgrade/$*
 
 install_agent :
 		@psql -t -d template1 -c 'SELECT DISTINCT hostname FROM gp_segment_configuration WHERE content != -1' > /tmp/seg_hosts 2>/dev/null; \

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ hub-package: EXE_NAME := $(HUB)
 $(PACKAGES): %-package:
 	$(PREFIX) go build $(GOFLAGS) -o $(BIN_DIR)/$(EXE_NAME)$(POSTFIX) -ldflags $(UPGRADE_VERSION_STR) github.com/greenplum-db/gpupgrade/$*
 
-install_agent :
+install_agent: agent-package
 		@psql -t -d template1 -c 'SELECT DISTINCT hostname FROM gp_segment_configuration WHERE content != -1' > /tmp/seg_hosts 2>/dev/null; \
 		if [ $$? -eq 0 ]; then \
 			gpscp -f /tmp/seg_hosts $(BIN_DIR)/$(AGENT) =:$(GPHOME)/bin/$(AGENT); \
@@ -98,7 +98,7 @@ install_agent :
 		fi; \
 		rm /tmp/seg_hosts
 
-install : build install_agent
+install: cli-package hub-package install_agent
 		cp -p $(BIN_DIR)/$(CLI) $(GPHOME)/bin/$(CLI)
 		cp -p $(BIN_DIR)/$(HUB) $(GPHOME)/bin/$(HUB)
 


### PR DESCRIPTION
Get rid of most of the copy-paste for build targets, and add correct deps for the installation recipes.

Ideas for future work:
1. Continue reducing duplication, this time for the install step.
2. Decide why we're using a branch name for the Mac/Linux builds (in fact, why do those targets exist in the first place?).
3. Move some configure-type information (where do we install? what hosts are we talking to? which platform are we building?) out of the Makefile into an actual configure script.
4. Don't use `$GOBIN` as a build staging area; that's in my `PATH` and it shouldn't be touched unless I explicitly install. 😄 