### PR TITLE
Some more small fixes

### DIFF
--- a/cli/commanders/reporter.go
+++ b/cli/commanders/reporter.go
@@ -46,7 +46,7 @@ func (r *Reporter) OverallUpgradeStatus() error {
 	status, err := r.client.StatusUpgrade(context.Background(), &pb.StatusUpgradeRequest{})
 	if err != nil {
 		// find some way to expound on the error message? Integration test failing because we no longer log here
-		return errors.New("Unable to connect to hub: " + err.Error())
+		return errors.New("Failed to retrieve status from hub: " + err.Error())
 	}
 
 	if len(status.GetListOfUpgradeStepStatuses()) == 0 {

--- a/hub/gpupgrade_hub_main.go
+++ b/hub/gpupgrade_hub_main.go
@@ -62,6 +62,14 @@ func main() {
 	RootCmd.PersistentFlags().StringVar(&logdir, "log-directory", "", "gpupgrade_hub log directory")
 
 	if err := RootCmd.Execute(); err != nil {
+		if gplog.GetLogger() == nil {
+			// In case we didn't get through RootCmd.Execute(), set up logging
+			// here. Otherwise we crash.
+			// XXX it'd be really nice to have a "ReinitializeLogging" building
+			// block somewhere.
+			gplog.InitializeLogging("gpupgrade_hub", "")
+		}
+
 		gplog.Error(err.Error())
 		os.Exit(1)
 	}


### PR DESCRIPTION
1. If the `RootCmd` of `gpupgrade_hub_main` errors out before we initialize `gplog`, we can't actually log an error or we'll crash. Fix this by doing a basic initialization if there is no logger set up.

2. Correct the error message if `StatusUpgrade` fails. We were getting errors that basically said `Unable to connect to hub: hub handed us an error over the connection we just claimed we couldn't make`.