### PR TITLE
Refactor GetStatus patterns; add services.Step

### DIFF
--- a/agent/services/conversion_status.go
+++ b/agent/services/conversion_status.go
@@ -5,7 +5,6 @@ import (
 
 	"errors"
 	"fmt"
-	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"path/filepath"
@@ -26,11 +25,7 @@ func (s *AgentServer) CheckConversionStatus(ctx context.Context, in *pb.CheckCon
 			s.commandExecer,
 		)
 
-		status, err := conversionStatus.GetStatus()
-		if err != nil {
-			gplog.Error("Unable to get status for segment %d conversion: %s", segment.GetContent(), err)
-			return &pb.CheckConversionStatusReply{}, err
-		}
+		status := conversionStatus.GetStatus()
 
 		if segment.GetDbid() == 1 && segment.GetContent() == -1 {
 			master = fmt.Sprintf(format, status.Status.String(), segment.GetDbid(), segment.GetContent(), "MASTER", in.GetHostname())

--- a/hub/services/hub_status_upgrade.go
+++ b/hub/services/hub_status_upgrade.go
@@ -17,15 +17,14 @@ func (h *Hub) StatusUpgrade(ctx context.Context, in *pb.StatusUpgradeRequest) (*
 
 	checkconfigStatePath := filepath.Join(h.conf.StateDir, "check-config")
 	checkconfigState := upgradestatus.NewStateCheck(checkconfigStatePath, pb.UpgradeSteps_CHECK_CONFIG)
-	// XXX why do we ignore the error?
-	checkconfigStatus, _ := checkconfigState.GetStatus()
+	checkconfigStatus := checkconfigState.GetStatus()
 
 	prepareInitStatus, _ := h.GetPrepareNewClusterConfigStatus()
 
 	seginstallStatePath := filepath.Join(h.conf.StateDir, "seginstall")
 	gplog.Debug("looking for seginstall state at %s", seginstallStatePath)
 	seginstallState := upgradestatus.NewStateCheck(seginstallStatePath, pb.UpgradeSteps_SEGINSTALL)
-	seginstallStatus, _ := seginstallState.GetStatus()
+	seginstallStatus := seginstallState.GetStatus()
 
 	gpstopStatePath := filepath.Join(h.conf.StateDir, "gpstop")
 	gplog.Debug("looking for gpstop state at %s", gpstopStatePath)
@@ -40,15 +39,15 @@ func (h *Hub) StatusUpgrade(ctx context.Context, in *pb.StatusUpgradeRequest) (*
 	startAgentsStatePath := filepath.Join(h.conf.StateDir, "start-agents")
 	gplog.Debug("looking for start-agents state at %s", startAgentsStatePath)
 	prepareStartAgentsState := upgradestatus.NewStateCheck(startAgentsStatePath, pb.UpgradeSteps_PREPARE_START_AGENTS)
-	startAgentsStatus, _ := prepareStartAgentsState.GetStatus()
+	startAgentsStatus := prepareStartAgentsState.GetStatus()
 
 	shareOidsPath := filepath.Join(h.conf.StateDir, "share-oids")
 	shareOidsState := upgradestatus.NewStateCheck(shareOidsPath, pb.UpgradeSteps_SHARE_OIDS)
-	shareOidsStatus, _ := shareOidsState.GetStatus()
+	shareOidsStatus := shareOidsState.GetStatus()
 
 	validateStartClusterPath := filepath.Join(h.conf.StateDir, "validate-start-cluster")
 	validateStartClusterState := upgradestatus.NewStateCheck(validateStartClusterPath, pb.UpgradeSteps_VALIDATE_START_CLUSTER)
-	validateStartClusterStatus, _ := validateStartClusterState.GetStatus()
+	validateStartClusterStatus := validateStartClusterState.GetStatus()
 
 	conversionStatus, _ := h.StatusConversion(nil, &pb.StatusConversionRequest{})
 	upgradeConvertPrimariesStatus := &pb.UpgradeStepStatus{
@@ -57,7 +56,7 @@ func (h *Hub) StatusUpgrade(ctx context.Context, in *pb.StatusUpgradeRequest) (*
 
 	reconfigurePortsPath := filepath.Join(h.conf.StateDir, "reconfigure-ports")
 	reconfigurePortsState := upgradestatus.NewStateCheck(reconfigurePortsPath, pb.UpgradeSteps_RECONFIGURE_PORTS)
-	reconfigurePortsStatus, _ := reconfigurePortsState.GetStatus()
+	reconfigurePortsStatus := reconfigurePortsState.GetStatus()
 
 	statuses := strings.Join(conversionStatus.GetConversionStatuses(), " ")
 	if strings.Contains(statuses, "FAILED") {

--- a/hub/services/hub_status_upgrade_test.go
+++ b/hub/services/hub_status_upgrade_test.go
@@ -311,8 +311,7 @@ var _ = Describe("status upgrade", func() {
 			utils.System.Stat = func(filename string) (os.FileInfo, error) {
 				return nil, errors.New("cannot find file") /* This is normally a PathError */
 			}
-			stepStatus, err := hub.GetPrepareNewClusterConfigStatus()
-			Expect(err).To(BeNil()) // convert file-not-found errors into stepStatus
+			stepStatus := hub.GetPrepareNewClusterConfigStatus()
 			Expect(stepStatus.Step).To(Equal(pb.UpgradeSteps_PREPARE_INIT_CLUSTER))
 			Expect(stepStatus.Status).To(Equal(pb.StepStatus_PENDING))
 		})
@@ -322,8 +321,7 @@ var _ = Describe("status upgrade", func() {
 				return nil, nil
 			}
 
-			stepStatus, err := hub.GetPrepareNewClusterConfigStatus()
-			Expect(err).To(BeNil())
+			stepStatus := hub.GetPrepareNewClusterConfigStatus()
 			Expect(stepStatus.Step).To(Equal(pb.UpgradeSteps_PREPARE_INIT_CLUSTER))
 			Expect(stepStatus.Status).To(Equal(pb.StepStatus_COMPLETE))
 

--- a/hub/upgradestatus/pg_upgrade_status_checker.go
+++ b/hub/upgradestatus/pg_upgrade_status_checker.go
@@ -33,7 +33,7 @@ func NewPGUpgradeStatusChecker(pgUpgradePath, oldDataDir string, execer helpers.
 	- pg_upgrade will not fail without error before writing an inprogress file
 	- when a new pg_upgrade is started it deletes all *.done and *.inprogress files
 */
-func (c *ConvertMaster) GetStatus() (*pb.UpgradeStepStatus, error) {
+func (c *ConvertMaster) GetStatus() *pb.UpgradeStepStatus {
 	var masterUpgradeStatus *pb.UpgradeStepStatus
 	pgUpgradePath := c.pgUpgradePath
 
@@ -42,7 +42,7 @@ func (c *ConvertMaster) GetStatus() (*pb.UpgradeStepStatus, error) {
 			Step:   pb.UpgradeSteps_MASTERUPGRADE,
 			Status: pb.StepStatus_PENDING,
 		}
-		return masterUpgradeStatus, nil
+		return masterUpgradeStatus
 	}
 
 	if c.pgUpgradeRunning() {
@@ -50,7 +50,7 @@ func (c *ConvertMaster) GetStatus() (*pb.UpgradeStepStatus, error) {
 			Step:   pb.UpgradeSteps_MASTERUPGRADE,
 			Status: pb.StepStatus_RUNNING,
 		}
-		return masterUpgradeStatus, nil
+		return masterUpgradeStatus
 	}
 
 	if !inProgressFilesExist(pgUpgradePath) && c.IsUpgradeComplete(pgUpgradePath) {
@@ -58,7 +58,7 @@ func (c *ConvertMaster) GetStatus() (*pb.UpgradeStepStatus, error) {
 			Step:   pb.UpgradeSteps_MASTERUPGRADE,
 			Status: pb.StepStatus_COMPLETE,
 		}
-		return masterUpgradeStatus, nil
+		return masterUpgradeStatus
 	}
 
 	masterUpgradeStatus = &pb.UpgradeStepStatus{
@@ -66,7 +66,7 @@ func (c *ConvertMaster) GetStatus() (*pb.UpgradeStepStatus, error) {
 		Status: pb.StepStatus_FAILED,
 	}
 
-	return masterUpgradeStatus, nil
+	return masterUpgradeStatus
 }
 
 func (c *ConvertMaster) pgUpgradeRunning() bool {

--- a/hub/upgradestatus/pg_upgrade_status_checker_test.go
+++ b/hub/upgradestatus/pg_upgrade_status_checker_test.go
@@ -49,8 +49,7 @@ var _ = Describe("pg_upgrade status checker", func() {
 			return true
 		}
 		subject := upgradestatus.NewPGUpgradeStatusChecker("/tmp", "", commandExecer.Exec)
-		status, err := subject.GetStatus()
-		Expect(err).To(BeNil())
+		status := subject.GetStatus()
 		Expect(status.Status).To(Equal(pb.StepStatus_PENDING))
 
 	})
@@ -66,8 +65,7 @@ var _ = Describe("pg_upgrade status checker", func() {
 		outChan <- []byte("I'm running")
 
 		subject := upgradestatus.NewPGUpgradeStatusChecker("/tmp", "", commandExecer.Exec)
-		status, err := subject.GetStatus()
-		Expect(err).To(BeNil())
+		status := subject.GetStatus()
 		Expect(status.Status).To(Equal(pb.StepStatus_RUNNING))
 	})
 
@@ -109,8 +107,7 @@ var _ = Describe("pg_upgrade status checker", func() {
 		}
 
 		subject := upgradestatus.NewPGUpgradeStatusChecker("/tmp", "/data/dir", commandExecer.Exec)
-		status, err := subject.GetStatus()
-		Expect(err).To(BeNil())
+		status := subject.GetStatus()
 		Expect(status.Status).To(Equal(pb.StepStatus_COMPLETE))
 
 		Expect(commandExecer.Calls()).To(Equal([]string{"pgrep pg_upgrade | grep --old-datadir=/data/dir"}))
@@ -130,8 +127,7 @@ var _ = Describe("pg_upgrade status checker", func() {
 		errChan <- errors.New("pg_upgrade failed")
 
 		subject := upgradestatus.NewPGUpgradeStatusChecker("/tmp", "", commandExecer.Exec)
-		status, err := subject.GetStatus()
-		Expect(err).To(BeNil())
+		status := subject.GetStatus()
 		Expect(status.Status).To(Equal(pb.StepStatus_FAILED))
 	})
 })

--- a/hub/upgradestatus/shutdown_clusters.go
+++ b/hub/upgradestatus/shutdown_clusters.go
@@ -25,7 +25,7 @@ func NewShutDownClusters(gpstopStatePath string, execer helpers.CommandExecer) S
 	- gpstop will not fail without error before writing an inprogress file
 	- when a new gpstop is started it deletes all *.done and *.inprogress files
 */
-func (s *ShutDownClusters) GetStatus() (*pb.UpgradeStepStatus, error) {
+func (s *ShutDownClusters) GetStatus() *pb.UpgradeStepStatus {
 	var shutdownClustersStatus *pb.UpgradeStepStatus
 	gpstopStatePath := s.gpstopStatePath
 
@@ -34,7 +34,7 @@ func (s *ShutDownClusters) GetStatus() (*pb.UpgradeStepStatus, error) {
 			Step:   pb.UpgradeSteps_STOPPED_CLUSTER,
 			Status: pb.StepStatus_PENDING,
 		}
-		return shutdownClustersStatus, nil
+		return shutdownClustersStatus
 	}
 
 	/* There can be cases where gpstop is running but not as part of the pre-setup
@@ -47,7 +47,7 @@ func (s *ShutDownClusters) GetStatus() (*pb.UpgradeStepStatus, error) {
 			Step:   pb.UpgradeSteps_STOPPED_CLUSTER,
 			Status: pb.StepStatus_RUNNING,
 		}
-		return shutdownClustersStatus, nil
+		return shutdownClustersStatus
 	}
 
 	if !s.inProgressFilesExist(gpstopStatePath) && s.IsStopComplete(gpstopStatePath) {
@@ -55,7 +55,7 @@ func (s *ShutDownClusters) GetStatus() (*pb.UpgradeStepStatus, error) {
 			Step:   pb.UpgradeSteps_STOPPED_CLUSTER,
 			Status: pb.StepStatus_COMPLETE,
 		}
-		return shutdownClustersStatus, nil
+		return shutdownClustersStatus
 	}
 
 	shutdownClustersStatus = &pb.UpgradeStepStatus{
@@ -63,7 +63,7 @@ func (s *ShutDownClusters) GetStatus() (*pb.UpgradeStepStatus, error) {
 		Status: pb.StepStatus_FAILED,
 	}
 
-	return shutdownClustersStatus, nil
+	return shutdownClustersStatus
 }
 
 func (s *ShutDownClusters) isGpstopRunning() bool {

--- a/hub/upgradestatus/shutdown_clusters_test.go
+++ b/hub/upgradestatus/shutdown_clusters_test.go
@@ -49,8 +49,7 @@ var _ = Describe("hub", func() {
 				return true
 			}
 			subject := upgradestatus.NewShutDownClusters("/tmp", commandExecer.Exec)
-			status, err := subject.GetStatus()
-			Expect(err).To(BeNil())
+			status := subject.GetStatus()
 			Expect(status.Status).To(Equal(pb.StepStatus_PENDING))
 
 		})
@@ -71,8 +70,7 @@ var _ = Describe("hub", func() {
 				return nil, errors.New("Test not configured for this glob.")
 			}
 			subject := upgradestatus.NewShutDownClusters("/tmp", commandExecer.Exec)
-			status, err := subject.GetStatus()
-			Expect(err).To(BeNil())
+			status := subject.GetStatus()
 			Expect(status.Status).To(Equal(pb.StepStatus_RUNNING))
 		})
 		It("If gpstop is not running and .complete files exist and contain the string "+
@@ -102,8 +100,7 @@ var _ = Describe("hub", func() {
 				return nil, nil
 			}
 			subject := upgradestatus.NewShutDownClusters("/tmp", commandExecer.Exec)
-			status, err := subject.GetStatus()
-			Expect(err).To(BeNil())
+			status := subject.GetStatus()
 			Expect(status.Status).To(Equal(pb.StepStatus_COMPLETE))
 		})
 		// We are assuming that no inprogress actually exists in the path we're using,
@@ -120,8 +117,7 @@ var _ = Describe("hub", func() {
 			errChan <- errors.New("gpstop failed")
 
 			subject := upgradestatus.NewShutDownClusters("/tmp", commandExecer.Exec)
-			status, err := subject.GetStatus()
-			Expect(err).To(BeNil())
+			status := subject.GetStatus()
 			Expect(status.Status).To(Equal(pb.StepStatus_FAILED))
 		})
 	})

--- a/hub/upgradestatus/state_checker.go
+++ b/hub/upgradestatus/state_checker.go
@@ -5,7 +5,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/utils"
 	"path/filepath"
 
-	"github.com/pkg/errors"
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
 )
 
 type StateCheck struct {
@@ -20,24 +20,48 @@ func NewStateCheck(path string, step pb.UpgradeSteps) StateCheck {
 	}
 }
 
-func (c StateCheck) GetStatus() (*pb.UpgradeStepStatus, error) {
+// GetStatus returns the UpgradeStepStatus corresponding to the StateCheck's
+// step. Conceptually, this is one of (PENDING, RUNNING, COMPLETE, FAILED). This
+// method will never return an error; instead, it will log any internal failures
+// and return a PENDING status (because we currently expect that a re-run of the
+// affected step should clear the issue).
+//
+// XXX That last assumption is unlikely to hold for the more complicated steps.
+func (c StateCheck) GetStatus() *pb.UpgradeStepStatus {
 	_, err := utils.System.Stat(c.path)
 	if err != nil {
-		return &pb.UpgradeStepStatus{Step: c.step, Status: pb.StepStatus_PENDING}, nil
+		// It's okay if the state directory doesn't exist; that just means we
+		// haven't run the step yet.
+		return c.newStatus(pb.StepStatus_PENDING)
 	}
+
 	files, err := utils.System.FilePathGlob(filepath.Join(c.path, "*"))
+	if err != nil {
+		// Log the error and keep the status PENDING.
+		gplog.Error("Couldn't search status directory %s: %s", c.path, err.Error())
+	}
+
+	// FIXME: there's a race here: we delete the status file and then recreate
+	// it in the ChecklistManager, which means we can go from RUNNING to PENDING
+	// to COMPLETE/FAILED.
 	if len(files) > 1 {
-		return nil, errors.New("got more files than expected")
+		gplog.Error("Status directory %s has more than one file", c.path)
+		return c.newStatus(pb.StepStatus_PENDING)
 	} else if len(files) == 1 {
 		switch files[0] {
 		case filepath.Join(c.path, "failed"):
-			return &pb.UpgradeStepStatus{Step: c.step, Status: pb.StepStatus_FAILED}, nil
+			return c.newStatus(pb.StepStatus_FAILED)
 		case filepath.Join(c.path, "completed"):
-			return &pb.UpgradeStepStatus{Step: c.step, Status: pb.StepStatus_COMPLETE}, nil
+			return c.newStatus(pb.StepStatus_COMPLETE)
 		case filepath.Join(c.path, "in.progress"):
-			return &pb.UpgradeStepStatus{Step: c.step, Status: pb.StepStatus_RUNNING}, nil
+			return c.newStatus(pb.StepStatus_RUNNING)
 		}
 	}
 
-	return &pb.UpgradeStepStatus{Step: c.step, Status: pb.StepStatus_PENDING}, nil
+	return c.newStatus(pb.StepStatus_PENDING)
+}
+
+// newStatus builds a pb.UpgradeStepStatus using the current step.
+func (c StateCheck) newStatus(status pb.StepStatus) *pb.UpgradeStepStatus {
+	return &pb.UpgradeStepStatus{Step: c.step, Status: status}
 }


### PR DESCRIPTION
There are two conceptual changes here:

1. Don't claim to return an error from the `GetStatus` helpers, if we're just going to return `nil` all the time and ignore that error anyway in most/all of the callers. This isn't a long-term change -- we *do* want to handle errors here -- but we don't really have a good concept yet of how these errors should be correctly bubbled up. Since this "fake error" makes the next refactoring step messy, get rid of it for now.

2. Refactor away the duplication from the `Hub.StatusUpgrade()` function, by introducing a `Step` struct. This struct encapsulates a logical step in the status check -- its name, gRPC code, and implementation -- and provides a nice interface that makes it easy to loop through and check each status in order.