### PR TITLE
Refactor validate-start-cluster

### DIFF
--- a/cli/commanders/upgrader.go
+++ b/cli/commanders/upgrader.go
@@ -60,11 +60,8 @@ func (u *Upgrader) ShareOids() error {
 	return nil
 }
 
-func (u *Upgrader) ValidateStartCluster(newDataDir string, newBinDir string) error {
-	_, err := u.client.UpgradeValidateStartCluster(context.Background(), &pb.UpgradeValidateStartClusterRequest{
-		NewDataDir: newDataDir,
-		NewBinDir:  newBinDir,
-	})
+func (u *Upgrader) ValidateStartCluster() error {
+	_, err := u.client.UpgradeValidateStartCluster(context.Background(), &pb.UpgradeValidateStartClusterRequest{})
 	if err != nil {
 		gplog.Error(err.Error())
 		return err

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -352,7 +352,7 @@ var subValidateStartCluster = &cobra.Command{
 		}
 
 		client := pb.NewCliToHubClient(conn)
-		err := commanders.NewUpgrader(client).ValidateStartCluster(newDataDir, newBinDir)
+		err := commanders.NewUpgrader(client).ValidateStartCluster()
 		if err != nil {
 			gplog.Error(err.Error())
 			os.Exit(1)

--- a/cli/gpupgrade_main.go
+++ b/cli/gpupgrade_main.go
@@ -108,10 +108,6 @@ func addFlagOptionsToShutdownClusters() {
 }
 
 func addFlagOptionsToValidateStartCluster() {
-	subValidateStartCluster.Flags().StringVar(&newDataDir, "new-datadir", "", "data directory for new gpdb version")
-	subValidateStartCluster.MarkFlagRequired("new-datadir")
-	subValidateStartCluster.Flags().StringVar(&newBinDir, "new-bindir", "", "install directory for new gpdb version")
-	subValidateStartCluster.MarkFlagRequired("new-bindir")
 }
 
 func addFlagOptionsToInit() {

--- a/hub/services/hub_prepare_start_agents_test.go
+++ b/hub/services/hub_prepare_start_agents_test.go
@@ -39,7 +39,7 @@ var _ = Describe("PrepareStartAgents", func() {
 			Err: errChan,
 			Out: outChan,
 		})
-		cm := testutils.NewMockChecklistManager()
+		cm = testutils.NewMockChecklistManager()
 		clusterPair := testutils.CreateSampleClusterPair()
 		hub = services.NewHub(clusterPair, grpc.DialContext, commandExecer.Exec, conf, stubRemoteExecutor, cm)
 	})

--- a/hub/services/hub_status_conversion_test.go
+++ b/hub/services/hub_status_conversion_test.go
@@ -43,7 +43,7 @@ var _ = Describe("hub", func() {
 		}
 		stubRemoteExecutor = testutils.NewStubRemoteExecutor()
 
-		cm := testutils.NewMockChecklistManager()
+		cm = testutils.NewMockChecklistManager()
 		hub = services.NewHub(clusterPair, grpc.DialContext, nil, conf, stubRemoteExecutor, cm)
 	})
 

--- a/hub/services/hub_upgrade_validate_start_cluster.go
+++ b/hub/services/hub_upgrade_validate_start_cluster.go
@@ -21,7 +21,7 @@ func (h *Hub) UpgradeValidateStartCluster(ctx context.Context, in *pb.UpgradeVal
 
 func (h *Hub) startNewCluster() {
 	gplog.Debug(h.conf.StateDir)
-	c := upgradestatus.NewChecklistManager(h.conf.StateDir)
+	c := h.checklistWriter
 	err := c.ResetStateDir(upgradestatus.VALIDATE_START_CLUSTER)
 	if err != nil {
 		gplog.Error("failed to reset the state dir for validate-start-cluster")

--- a/hub/services/hub_upgrade_validate_start_cluster.go
+++ b/hub/services/hub_upgrade_validate_start_cluster.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	pb "github.com/greenplum-db/gpupgrade/idl"
@@ -38,7 +37,7 @@ func (h *Hub) startNewCluster() {
 
 	newBinDir := h.clusterPair.NewBinDir
 	newDataDir := h.clusterPair.NewCluster.GetDirForContent(-1)
-	_, err = h.clusterPair.NewCluster.ExecuteLocalCommand(fmt.Sprintf("PYTHONPATH=%s && %s/gpstart -a -d %s", os.Getenv("PYTHONPATH"), newBinDir, newDataDir))
+	_, err = h.clusterPair.NewCluster.ExecuteLocalCommand(fmt.Sprintf("source %s/../greenplum_path.sh; %s/gpstart -a -d %s", newBinDir, newBinDir, newDataDir))
 	if err != nil {
 		gplog.Error(err.Error())
 		cmErr := c.MarkFailed(upgradestatus.VALIDATE_START_CLUSTER)

--- a/hub/services/hub_upgrade_validate_start_cluster_test.go
+++ b/hub/services/hub_upgrade_validate_start_cluster_test.go
@@ -69,8 +69,8 @@ var _ = Describe("upgrade validate start cluster", func() {
 
 		Eventually(func() bool { return cm.IsComplete("validate-start-cluster") }).Should(BeTrue())
 		Expect(testExecutor.NumExecutions).To(Equal(1))
-		Expect(testExecutor.LocalCommands[0]).To(ContainSubstring("PYTHONPATH="))
-		-Expect(testExecutor.LocalCommands[0]).To(ContainSubstring("&& bin/gpstart -a -d data"))
+		Expect(testExecutor.LocalCommands[0]).To(ContainSubstring("source /new/bindir/../greenplum_path.sh"))
+		Expect(testExecutor.LocalCommands[0]).To(ContainSubstring("/new/bindir/gpstart -a -d /new/datadir"))
 	})
 
 	It("sets status to FAILED when the validate start cluster request returns an error", func() {

--- a/hub/services/hub_upgrade_validate_start_cluster_test.go
+++ b/hub/services/hub_upgrade_validate_start_cluster_test.go
@@ -112,10 +112,7 @@ var _ = Describe("upgrade validate start cluster", func() {
 	It("sets status to FAILED when the validate start cluster request returns an error", func() {
 		testExecutor.LocalError = errors.New("some error")
 
-		_, err := hub.UpgradeValidateStartCluster(nil, &pb.UpgradeValidateStartClusterRequest{
-			NewBinDir:  "bin",
-			NewDataDir: "data",
-		})
+		_, err := hub.UpgradeValidateStartCluster(nil, &pb.UpgradeValidateStartClusterRequest{})
 		Expect(err).ToNot(HaveOccurred())
 
 		stateChecker := upgradestatus.NewStateCheck(

--- a/idl/cli_to_hub.proto
+++ b/idl/cli_to_hub.proto
@@ -33,10 +33,7 @@ message UpgradeConvertPrimariesReply {}
 message UpgradeShareOidsRequest {}
 message UpgradeShareOidsReply {}
 
-message UpgradeValidateStartClusterRequest {
-    string NewBinDir = 1;
-    string NewDataDir = 2;
-}
+message UpgradeValidateStartClusterRequest {}
 message UpgradeValidateStartClusterReply {}
 
 message PingRequest {}

--- a/integrations/check_config_test.go
+++ b/integrations/check_config_test.go
@@ -46,7 +46,7 @@ var _ = Describe("check config", func() {
 	})
 
 	It("happy: the database configuration is saved to a specified location", func() {
-		session := runCommand("check", "config", "--master-host", "localhost", "--old-bindir", "/non/existent/path")
+		session := runCommand("check", "config", "--master-host", "localhost", "--old-bindir", "/old/bin/dir")
 		if session.ExitCode() != 0 {
 			fmt.Println("make sure greenplum is running")
 		}

--- a/integrations/prepare_init_cluster_test.go
+++ b/integrations/prepare_init_cluster_test.go
@@ -62,8 +62,7 @@ var _ = Describe("prepare", func() {
 		Expect(port).ToNot(BeEmpty())
 
 		Expect(cm.IsPending(upgradestatus.INIT_CLUSTER)).To(BeTrue())
-
-		session := runCommand("prepare", "init-cluster", "--port", port, "--new-bindir", "/non/existent/path")
+		session := runCommand("prepare", "init-cluster", "--port", port, "--new-bindir", "/new/bin/dir")
 		Eventually(session).Should(Exit(0))
 
 		Expect(cm.IsComplete(upgradestatus.INIT_CLUSTER)).To(BeTrue())

--- a/integrations/upgrade_convert_primaries_test.go
+++ b/integrations/upgrade_convert_primaries_test.go
@@ -2,7 +2,6 @@ package integrations_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -64,7 +63,7 @@ var _ = Describe("upgrade convert primaries", func() {
 		})
 
 		clusterSsher := cluster_ssher.NewClusterSsher(
-			upgradestatus.NewChecklistManager(conf.StateDir),
+			cm,
 			services.NewPingerManager(conf.StateDir, 500*time.Millisecond),
 			hubCommandExecer.Exec,
 		)

--- a/integrations/upgrade_convert_primaries_test.go
+++ b/integrations/upgrade_convert_primaries_test.go
@@ -10,7 +10,6 @@ import (
 	agentServices "github.com/greenplum-db/gpupgrade/agent/services"
 	"github.com/greenplum-db/gpupgrade/hub/cluster_ssher"
 	"github.com/greenplum-db/gpupgrade/hub/services"
-	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	"github.com/greenplum-db/gpupgrade/testutils"
 
 	. "github.com/onsi/ginkgo"
@@ -25,8 +24,6 @@ var _ = Describe("upgrade convert primaries", func() {
 		agent              *agentServices.AgentServer
 		hubCommandExecer   *testutils.FakeCommandExecer
 		agentCommandExecer *testutils.FakeCommandExecer
-		oldBinDir          string
-		newBinDir          string
 		oidFile            string
 		hubOutChan         chan []byte
 		agentCommandOutput chan []byte
@@ -102,8 +99,8 @@ var _ = Describe("upgrade convert primaries", func() {
 		upgradeConvertPrimaries := runCommand(
 			"upgrade",
 			"convert-primaries",
-			"--old-bindir", oldBinDir,
-			"--new-bindir", newBinDir,
+			"--old-bindir", "/old/bindir",
+			"--new-bindir", "/new/bindir",
 		)
 		Expect(upgradeConvertPrimaries).To(Exit(0))
 
@@ -137,8 +134,8 @@ var _ = Describe("upgrade convert primaries", func() {
 		upgradeConvertPrimaries := runCommand(
 			"upgrade",
 			"convert-primaries",
-			"--old-bindir", oldBinDir,
-			"--new-bindir", newBinDir,
+			"--old-bindir", "/old/bindir",
+			"--new-bindir", "/new/bindir",
 		)
 		Expect(upgradeConvertPrimaries).Should(Exit(0))
 

--- a/integrations/upgrade_convert_primaries_test.go
+++ b/integrations/upgrade_convert_primaries_test.go
@@ -37,11 +37,6 @@ var _ = Describe("upgrade convert primaries", func() {
 
 	BeforeEach(func() {
 		var err error
-		oldBinDir, err = ioutil.TempDir("", "")
-		Expect(err).ToNot(HaveOccurred())
-		newBinDir, err = ioutil.TempDir("", "")
-		Expect(err).ToNot(HaveOccurred())
-
 		segmentDataDir := os.Getenv("MASTER_DATA_DIRECTORY")
 		Expect(segmentDataDir).ToNot(Equal(""), "MASTER_DATA_DIRECTORY needs to be set!")
 

--- a/integrations/upgrade_validate_start_cluster_test.go
+++ b/integrations/upgrade_validate_start_cluster_test.go
@@ -1,7 +1,6 @@
 package integrations_test
 
 import (
-	"io/ioutil"
 	"time"
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
@@ -75,7 +74,7 @@ var _ = Describe("upgrade validate-start-cluster", func() {
 
 		Expect(testExecutor.NumExecutions).To(Equal(1))
 		Expect(testExecutor.LocalCommands[0]).To(ContainSubstring("gpstart"))
-		Expect(cm.IsPending(upgradestatus.VALIDATE_START_CLUSTER)).To(BeTrue())
+		Expect(cm.IsComplete(upgradestatus.VALIDATE_START_CLUSTER)).To(BeTrue())
 
 	})
 
@@ -89,6 +88,6 @@ var _ = Describe("upgrade validate-start-cluster", func() {
 
 		Expect(testExecutor.NumExecutions).To(Equal(1))
 		Expect(testExecutor.LocalCommands[0]).To(ContainSubstring("gpstart"))
-		Expect(cm.IsPending(upgradestatus.VALIDATE_START_CLUSTER)).To(BeTrue())
+		Expect(cm.IsFailed(upgradestatus.VALIDATE_START_CLUSTER)).To(BeTrue())
 	})
 })

--- a/testutils/test_utils.go
+++ b/testutils/test_utils.go
@@ -68,7 +68,8 @@ func CreateSampleClusterPair() *services.ClusterPair {
 	}
 	cp.OldCluster.Executor = &testhelper.TestExecutor{}
 	cp.NewCluster.Executor = &testhelper.TestExecutor{}
-
+	cp.OldBinDir = "/old/bindir"
+	cp.NewBinDir = "/new/bindir"
 	return cp
 }
 
@@ -79,9 +80,9 @@ func InitClusterPairFromDB() *services.ClusterPair {
 	cp := &services.ClusterPair{}
 	segConfig := cluster.MustGetSegmentConfiguration(conn)
 	cp.OldCluster = cluster.NewCluster(segConfig)
-	cp.OldBinDir = "/non/existent/old/path"
+	cp.OldBinDir = "/old/bindir"
 	cp.NewCluster = cluster.NewCluster(segConfig)
-	cp.NewBinDir = "/non/existent/new/path"
+	cp.NewBinDir = "/new/bindir"
 	return cp
 }
 


### PR DESCRIPTION
This series of commits refactors validate-start-cluster to source greenplum_path.sh when running gpstart instead of using the current PYTHONPATH, as PYTHONPATH will differ based on whether the old or new cluster's PYTHONPATH is currently exported.

The main commits for this refactor are the "Remove flags" and "Refactor" commits; the "Modify tests" commit fixes the formerly-broken validate-start-cluster test so that this refactor could be tested, and the "Change directory names" commit is minor test cleanup added on since I was touching the bin directories in the "Remove flags" commit.