### PR TITLE
Implement --daemonize for Agent and Hub

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -63,6 +63,10 @@
 
 [[constraint]]
   branch = "master"
+  name = "golang.org/x/crypto"
+
+[[constraint]]
+  branch = "master"
   name = "golang.org/x/net"
 
 [[constraint]]

--- a/agent/gpupgrade_agent_main.go
+++ b/agent/gpupgrade_agent_main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"syscall"
 	"time"
+
+	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpupgrade/agent/services"
@@ -30,6 +33,11 @@ func main() {
 		Long:  `Start the Command Listener (blocks)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gplog.InitializeLogging("gpupgrade_agent", logdir)
+
+			if daemon && terminal.IsTerminal(int(os.Stdout.Fd())) {
+				// Shouldn't be calling this from the command line.
+				return fmt.Errorf("--daemon is an internal option (did you mean --daemonize?)")
+			}
 
 			// TODO: this is all copy-pasted from the hub code. Consolidate!
 			if daemonize {

--- a/agent/gpupgrade_agent_main.go
+++ b/agent/gpupgrade_agent_main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"os"
 	"os/exec"
+	"syscall"
+	"time"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpupgrade/agent/services"
@@ -20,12 +22,50 @@ func main() {
 	//	os.Exit(utils.GetExitCodeForError(err))
 	//}
 	var logdir, statedir string
+	var daemonize bool
+	var daemon bool
 	var RootCmd = &cobra.Command{
 		Use:   "gpupgrade_agent ",
 		Short: "Start the Command Listener (blocks)",
 		Long:  `Start the Command Listener (blocks)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gplog.InitializeLogging("gpupgrade_agent", logdir)
+
+			// TODO: this is all copy-pasted from the hub code. Consolidate!
+			if daemonize {
+				// Strip out the --daemonize option and add --daemon.
+				daemonArgs := make([]string, 0)
+				for _, arg := range os.Args[1:] {
+					if arg == "--daemonize" {
+						arg = "--daemon"
+					}
+					daemonArgs = append(daemonArgs, arg)
+				}
+
+				command := exec.Command(os.Args[0], daemonArgs...)
+				// TODO: what's a good timeout?
+				err := utils.Daemonize(command, os.Stdout, os.Stderr, 2*time.Second)
+
+				if err != nil {
+					exitError, ok := err.(*exec.ExitError)
+					if ok {
+						// Exit with the same code as the child, if we can
+						// figure it out.
+						code := 1
+
+						status, ok := exitError.Sys().(syscall.WaitStatus)
+						if ok {
+							code = status.ExitStatus()
+						}
+
+						os.Exit(code)
+					}
+
+					// Otherwise, deal with the error normally.
+				}
+
+				return err
+			}
 
 			conf := services.AgentConfig{
 				Port:     6416,
@@ -35,7 +75,12 @@ func main() {
 			commandExecer := func(command string, vars ...string) helpers.Command {
 				return exec.Command(command, vars...)
 			}
+
 			agentServer := services.NewAgentServer(commandExecer, conf)
+			if daemon {
+				agentServer.MakeDaemon()
+			}
+
 			agentServer.Start()
 
 			agentServer.Stop()
@@ -46,6 +91,10 @@ func main() {
 
 	RootCmd.Flags().StringVar(&logdir, "log-directory", "", "command_listener log directory")
 	RootCmd.Flags().StringVar(&statedir, "state-directory", utils.GetStateDir(), "Agent state directory")
+
+	RootCmd.Flags().BoolVar(&daemonize, "daemonize", false, "start hub in the background")
+	RootCmd.Flags().BoolVar(&daemon, "daemon", false, "disconnect standard streams (internal option; use --daemonize instead)")
+	RootCmd.Flags().MarkHidden("daemon")
 
 	if err := RootCmd.Execute(); err != nil {
 		gplog.Error(err.Error())

--- a/agent/gpupgrade_agent_main.go
+++ b/agent/gpupgrade_agent_main.go
@@ -97,6 +97,14 @@ func main() {
 	RootCmd.Flags().MarkHidden("daemon")
 
 	if err := RootCmd.Execute(); err != nil {
+		if gplog.GetLogger() == nil {
+			// In case we didn't get through RootCmd.Execute(), set up logging
+			// here. Otherwise we crash.
+			// XXX it'd be really nice to have a "ReinitializeLogging" building
+			// block somewhere.
+			gplog.InitializeLogging("gpupgrade_agent", "")
+		}
+
 		gplog.Error(err.Error())
 		os.Exit(1)
 	}

--- a/agent/services/agent_server.go
+++ b/agent/services/agent_server.go
@@ -48,7 +48,6 @@ func (a *AgentServer) MakeDaemon() {
 }
 
 func (a *AgentServer) Start() {
-	gplog.Error("something")
 	createIfNotExists(a.conf.StateDir)
 	lis, err := net.Listen("tcp", ":"+strconv.Itoa(a.conf.Port))
 	if err != nil {

--- a/cli/commanders/preparer.go
+++ b/cli/commanders/preparer.go
@@ -49,13 +49,17 @@ func (p Preparer) StartHub() error {
 	}
 
 	//assume that gpupgrade_hub is on the PATH
-	cmd := exec.Command("gpupgrade_hub")
-	cmdErr := cmd.Start()
+	cmd := exec.Command("gpupgrade_hub", "--daemonize")
+	stdout, cmdErr := cmd.Output()
 	if cmdErr != nil {
-		gplog.Error("gpupgrade_hub kickoff failed")
-		return cmdErr
+		err := fmt.Errorf("failed to start hub (%s)", cmdErr)
+		if exitErr, ok := cmdErr.(*exec.ExitError); ok {
+			// Annotate with the Stderr capture, if we have it.
+			err = fmt.Errorf("%s: %s", err, exitErr.Stderr)
+		}
+		return err
 	}
-	gplog.Debug("gpupgrade_hub started")
+	gplog.Debug("gpupgrade_hub started successfully: %s", stdout)
 	return nil
 }
 

--- a/hub/cluster_ssher/cluster_ssher.go
+++ b/hub/cluster_ssher/cluster_ssher.go
@@ -48,9 +48,10 @@ func (c *ClusterSsher) Start(hostnames []string) {
 	gphome := os.Getenv("GPHOME")
 	agentPath := filepath.Join(gphome, "bin", "gpupgrade_agent")
 	greenplumPath := filepath.Join(gphome, "greenplum_path.sh")
-	////ssh -n -f user@host "sh -c 'cd /whereever; nohup ./whatever > /dev/null 2>&1 &'"
-	completeCommandString := fmt.Sprintf(`sh -c '. %s ; nohup %s > /dev/null 2>&1 & '`, greenplumPath, agentPath)
-	c.remoteExec(hostnames, statedir, []string{completeCommandString})
+	completeCommandString := fmt.Sprintf(`sh -c '. %s ; %s --daemonize'`, greenplumPath, agentPath)
+
+	// FIXME: don't ignore errors here, bubble them up!
+	_ = c.remoteExec(hostnames, statedir, []string{completeCommandString})
 
 	//check that all the agents are running
 	var err error

--- a/hub/cluster_ssher/cluster_ssher_test.go
+++ b/hub/cluster_ssher/cluster_ssher_test.go
@@ -92,7 +92,7 @@ var _ = Describe("ClusterSsher", func() {
 				"-o",
 				"StrictHostKeyChecking=no",
 				"doesnt matter",
-				"sh -c '. " + pathToGreenplumPathScript + " ; nohup " + pathToAgent + " > /dev/null 2>&1 & '",
+				"sh -c '. " + pathToGreenplumPathScript + " ; " + pathToAgent + " --daemonize'",
 			}))
 
 			Expect(cw.WasReset("start-agents")).To(BeTrue())

--- a/hub/gpupgrade_hub_main.go
+++ b/hub/gpupgrade_hub_main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"runtime/debug"
 	"syscall"
 	"time"
+
+	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpupgrade/helpers"
@@ -31,6 +34,11 @@ func main() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gplog.InitializeLogging("gpupgrade_hub", logdir)
 			debug.SetTraceback("all")
+
+			if daemon && terminal.IsTerminal(int(os.Stdout.Fd())) {
+				// Shouldn't be calling this from the command line.
+				return fmt.Errorf("--daemon is an internal option (did you mean --daemonize?)")
+			}
 
 			if daemonize {
 				// Strip out the --daemonize option and add --daemon.

--- a/integrations/hub_test.go
+++ b/integrations/hub_test.go
@@ -1,0 +1,76 @@
+package integrations_test
+
+import (
+	"os/exec"
+	"regexp"
+	"strconv"
+	"syscall"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+func killHub() {
+	killCommand := exec.Command("pkill", "-9", "gpupgrade_hub")
+	session, err := Start(killCommand, GinkgoWriter, GinkgoWriter)
+
+	Expect(err).ToNot(HaveOccurred())
+	session.Wait()
+
+	Expect(checkPortIsAvailable(port)).To(BeTrue())
+}
+
+var _ = Describe("gpupgrade_hub", func() {
+
+	// XXX We should be testing the locally built artifacts, and killing only
+	// hubs that are started as part of this test. The current logic will break
+	// functional installed systems.
+	BeforeEach(func() {
+		killHub()
+	})
+
+	AfterEach(func() {
+		killHub()
+	})
+
+	It("does not daemonize unless explicitly told to", func() {
+		// XXX for now, assume we're running the utility from PATH
+		cmd := exec.Command("gpupgrade_hub")
+		err := make(chan error, 1)
+
+		go func() {
+			// We expect this to never return.
+			err <- cmd.Run()
+		}()
+
+		Consistently(err).ShouldNot(Receive())
+	})
+
+	It("daemonizes and prints the PID when passed the --daemonize option", func() {
+		// XXX for now, assume we're running the utility from PATH
+		stdout := gbytes.NewBuffer()
+		cmd := exec.Command("gpupgrade_hub", "--daemonize")
+		session, err := Start(cmd, stdout, GinkgoWriter)
+
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(session).Should(Exit(0))
+
+		// Get the returned PID.
+		output := string(stdout.Contents())
+		pidmatcher := regexp.MustCompile(`pid (\d+)`)
+		matches := pidmatcher.FindStringSubmatch(output)
+		Expect(len(matches)).To(Equal(2), `hub output does not contain a PID: "%s"`, output)
+
+		pid, err := strconv.Atoi(pidmatcher.FindStringSubmatch(output)[1])
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pid).To(BeNumerically(">", 0))
+
+		// Make a best-effort check for process existence...
+		// XXX Note that we don't actually verify that this is the hub. Is there
+		// a way to do that with standard Go?
+		err = syscall.Kill(pid, syscall.Signal(0))
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/integrations/prepare_start_agents_test.go
+++ b/integrations/prepare_start_agents_test.go
@@ -74,7 +74,7 @@ var _ = Describe("prepare", func() {
 			Eventually(prepareStartAgentsSession).Should(Exit(0))
 
 			Expect(commandExecer.Command()).To(Equal("ssh"))
-			Expect(strings.Join(commandExecer.Args(), "")).To(ContainSubstring("nohup"))
+			Expect(strings.Join(commandExecer.Args(), "")).To(ContainSubstring("--daemonize"))
 			Expect(cm.IsComplete(upgradestatus.START_AGENTS)).To(BeTrue())
 		})
 	})

--- a/integrations/prepare_start_hub_test.go
+++ b/integrations/prepare_start_hub_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Start Hub", func() {
 		gpUpgradeSession := runCommand("prepare", "start-hub")
 		Eventually(gpUpgradeSession).Should(Exit(0))
 
-		verificationCmd := exec.Command("bash", "-c", `ps -ef | grep -Gq "[g]pupgrade_hub$"`)
+		verificationCmd := exec.Command("bash", "-c", `ps -ef | grep -Gq "[g]pupgrade_hub --daemon$"`)
 		verificationSession, err := Start(verificationCmd, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(verificationSession).Should(Exit(0))

--- a/utils/daemon.go
+++ b/utils/daemon.go
@@ -1,0 +1,85 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
+)
+
+type DaemonizableCommand interface {
+	StdoutPipe() (io.ReadCloser, error)
+	StderrPipe() (io.ReadCloser, error)
+	Start() error
+	Wait() error
+}
+
+func Daemonize(command DaemonizableCommand, output io.Writer, errput io.Writer, timeout time.Duration) error {
+	// Open up pipes from the child process and start it.
+	stderr, err := command.StderrPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := command.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	err = command.Start()
+	if err != nil {
+		return err
+	}
+
+	// Spin up two goroutines to copy the entire contents of both pipes to our
+	// output Writers.
+	done := make(chan error)
+	connectPipe := func(out io.Writer, in io.Reader, written *bool) {
+		num, err := io.Copy(out, in)
+		if written != nil {
+			*written = (num > 0)
+		}
+		done <- err
+	}
+
+	var hadStderr bool
+	go connectPipe(output, stdout, nil)
+	go connectPipe(errput, stderr, &hadStderr)
+
+	// Wait for both pipes to fully drain.
+	for waiting := 2; waiting > 0; {
+		select {
+		case err := <-done:
+			if err != nil {
+				// TODO: anything?
+				gplog.Error("Could not copy from child pipe: %v", err)
+			}
+			waiting--
+		}
+	}
+
+	// If we got stderr, wait for the process to exit.
+	if hadStderr {
+		var timer <-chan time.Time
+		if timeout > 0 {
+			timer = time.After(timeout)
+		}
+
+		result := make(chan error, 1)
+		go func() {
+			result <- command.Wait()
+		}()
+
+		select {
+		case err := <-result:
+			return err
+		case <-timer:
+			// XXX We leave the Wait()ing goroutine to die. Is that okay? We
+			// don't want to kill the process; it might be functional, and
+			// that's for the user to decide...
+			return fmt.Errorf("The daemon process reported an error but did not immediately exit. Review the logs before continuing.")
+		}
+	}
+
+	return nil
+}

--- a/utils/daemon_test.go
+++ b/utils/daemon_test.go
@@ -1,0 +1,167 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// basicReadCloser is a helper struct for the implementation of NewReadCloser.
+type basicReadCloser struct {
+	io.Reader
+}
+
+func (_ basicReadCloser) Close() error {
+	return nil
+}
+
+// NewReadCloser is a very simple wrapper around bytes.NewReader which returns
+// an io.ReadCloser instead of an io.Reader. The Close() method on this struct
+// does absolutely nothing.
+func NewReadCloser(buf []byte) io.ReadCloser {
+	return basicReadCloser{
+		Reader: bytes.NewReader(buf),
+	}
+}
+
+// MockDaemonizableCommand is an implementation of main.DaemonizableCommand that
+// provides some test helpers.
+type MockDaemonizableCommand struct {
+	Started    bool
+	StartError error
+	Waited     bool
+	WaitError  error
+
+	StdoutBuf   []byte
+	StdoutError error
+	StderrBuf   []byte
+	StderrError error
+
+	Hang bool
+}
+
+func (m *MockDaemonizableCommand) Start() error {
+	m.Started = true
+	return m.StartError
+}
+
+func (m *MockDaemonizableCommand) Wait() (err error) {
+	m.Waited = true
+
+	if m.Hang {
+		select {}
+	}
+
+	return m.WaitError
+}
+
+func (m *MockDaemonizableCommand) StdoutPipe() (io.ReadCloser, error) {
+	if m.StdoutError != nil {
+		return nil, m.StdoutError
+	}
+	return NewReadCloser(m.StdoutBuf), nil
+}
+
+func (m *MockDaemonizableCommand) StderrPipe() (io.ReadCloser, error) {
+	if m.StderrError != nil {
+		return nil, m.StderrError
+	}
+	return NewReadCloser(m.StderrBuf), nil
+}
+
+var _ = Describe("Daemonize", func() {
+	outbuf := new(bytes.Buffer)
+	errbuf := new(bytes.Buffer)
+
+	BeforeEach(func() {
+		outbuf.Reset()
+		errbuf.Reset()
+	})
+
+	It("starts the passed command", func() {
+		cmd := MockDaemonizableCommand{}
+		err := Daemonize(&cmd, outbuf, errbuf, 0)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cmd.Started).To(BeTrue())
+	})
+
+	It("does not wait for the command to complete if there is no stderr", func() {
+		cmd := MockDaemonizableCommand{}
+		err := Daemonize(&cmd, outbuf, errbuf, 0)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cmd.Waited).To(BeFalse())
+	})
+
+	It("waits for the command to complete if stderr contents are found", func() {
+		errput := []byte("this is an error\n")
+		exitErr := fmt.Errorf("process exited with code 1")
+		cmd := MockDaemonizableCommand{StderrBuf: errput, WaitError: exitErr}
+
+		err := Daemonize(&cmd, outbuf, errbuf, 0)
+		Expect(err).To(Equal(exitErr))
+		Expect(cmd.Waited).To(BeTrue())
+	})
+
+	It("does not start the command if standard pipes cannot be created", func() {
+		pipeErr := fmt.Errorf("generic failure")
+		cmds := [...]MockDaemonizableCommand{
+			{StdoutError: pipeErr},
+			{StderrError: pipeErr},
+		}
+
+		for i, cmd := range cmds {
+			err := Daemonize(&cmd, outbuf, errbuf, 0)
+			Expect(err).To(Equal(pipeErr), "in iteration %d:", i)
+			Expect(cmd.Started).To(BeFalse(), "in iteration %d:", i)
+		}
+	})
+
+	It("returns an error if the command cannot be started", func() {
+		startErr := fmt.Errorf("start failure")
+		cmd := MockDaemonizableCommand{StartError: startErr}
+
+		err := Daemonize(&cmd, outbuf, errbuf, 0)
+		Expect(err).To(Equal(startErr))
+	})
+
+	It("passes through pipe content from the child", func() {
+		output := []byte("this is output\n")
+		errput := []byte("this is an error\n")
+
+		cmd := MockDaemonizableCommand{StdoutBuf: output, StderrBuf: errput}
+		Daemonize(&cmd, outbuf, errbuf, 0)
+
+		Expect(outbuf.Bytes()).To(Equal(output))
+		Expect(errbuf.Bytes()).To(Equal(errput))
+	})
+
+	It("times out if an error is reported but the command does not exit", func() {
+		errput := []byte("this is an error\n")
+		cmd := MockDaemonizableCommand{StderrBuf: errput, Hang: true}
+		err := Daemonize(&cmd, outbuf, errbuf, 1*time.Millisecond)
+
+		Expect(cmd.Waited).To(BeTrue())
+		Expect(errbuf.Bytes()).To(Equal(errput))
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("does not time out if the timeout is set to zero", func() {
+		errput := []byte("this is an error\n")
+		cmd := MockDaemonizableCommand{StderrBuf: errput, Hang: true}
+
+		c := make(chan error, 1)
+		go func() {
+			// Daemonize() should NOT return to write to the channel.
+			c <- Daemonize(&cmd, outbuf, errbuf, 0)
+		}()
+
+		Consistently(c).ShouldNot(Receive())
+		Expect(cmd.Waited).To(BeTrue())
+	})
+})


### PR DESCRIPTION
This patchset implements a `fork()`-less fork of a process. The system works as follows:
- The parent process is called with the `--daemonize` option, which signals it to fork a child.
- The child process is started with the `--daemon` option, which signals it to close its stdout/err streams before performing its main server loop.
- The parent, via `utils.Daemonize()`, echoes all stdout/err from the child, and waits for the streams to be disconnected before exiting and allowing the child to continue independently.
- If the child would rather exit with an error, it writes bytes to the stderr stream, and the parent's `Daemonize()` will wait on the child to obtain the exit code. (This won't wait forever; there's a timeout to prevent a stray write to stderr from hanging the call.) 

`--daemonize` has been implemented for both the hub and the agent.

The final two patches in the set are fixes to agent bugs encountered during this work.