### PR TITLE
make format: use goimports exclusively and do a run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ depend : dependencies
 
 format :
 		goimports -w .
-		gofmt -s -w .
 
 lint :
 		! gofmt -l agent/ cli/ db/ helpers/ hub/ install/ integrations/ shellparsers/ testutils/ utils/ | read

--- a/agent/services/agent_server.go
+++ b/agent/services/agent_server.go
@@ -3,6 +3,7 @@ package services
 import (
 	"fmt"
 	"net"
+	"os"
 	"strconv"
 	"sync"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
-	"os"
 )
 
 type AgentServer struct {

--- a/agent/services/agent_server_test.go
+++ b/agent/services/agent_server_test.go
@@ -1,15 +1,17 @@
 package services_test
 
 import (
-	"github.com/greenplum-db/gpupgrade/utils"
-
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/greenplum-db/gpupgrade/agent/services"
-	"github.com/greenplum-db/gpupgrade/testutils"
 	"io/ioutil"
 	"os"
+
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+
+	"github.com/greenplum-db/gpupgrade/agent/services"
+	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/utils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("AgentServer", func() {

--- a/agent/services/conversion_status.go
+++ b/agent/services/conversion_status.go
@@ -2,12 +2,12 @@ package services
 
 import (
 	"context"
-
 	"errors"
 	"fmt"
+	"path/filepath"
+
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	pb "github.com/greenplum-db/gpupgrade/idl"
-	"path/filepath"
 )
 
 func (s *AgentServer) CheckConversionStatus(ctx context.Context, in *pb.CheckConversionStatusRequest) (*pb.CheckConversionStatusReply, error) {

--- a/agent/services/conversion_status_test.go
+++ b/agent/services/conversion_status_test.go
@@ -1,6 +1,10 @@
 package services_test
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/utils"
@@ -11,9 +15,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 )
 
 var _ = Describe("CommandListener", func() {

--- a/cli/commanders/check_config.go
+++ b/cli/commanders/check_config.go
@@ -2,6 +2,7 @@ package commanders
 
 import (
 	"context"
+
 	pb "github.com/greenplum-db/gpupgrade/idl"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"

--- a/cli/commanders/check_disk_usage.go
+++ b/cli/commanders/check_disk_usage.go
@@ -2,6 +2,7 @@ package commanders
 
 import (
 	"context"
+
 	pb "github.com/greenplum-db/gpupgrade/idl"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"

--- a/cli/commanders/check_disk_usage_test.go
+++ b/cli/commanders/check_disk_usage_test.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	"github.com/greenplum-db/gpupgrade/utils"
+	"github.com/pkg/errors"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
-	"github.com/greenplum-db/gpupgrade/utils"
 )
 
 var _ = Describe("object count tests", func() {

--- a/cli/commanders/check_object_count.go
+++ b/cli/commanders/check_object_count.go
@@ -2,6 +2,7 @@ package commanders
 
 import (
 	"context"
+
 	pb "github.com/greenplum-db/gpupgrade/idl"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"

--- a/cli/commanders/check_object_count_test.go
+++ b/cli/commanders/check_object_count_test.go
@@ -2,16 +2,18 @@ package commanders_test
 
 import (
 	"errors"
+
 	"github.com/greenplum-db/gpupgrade/cli/commanders"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	mockpb "github.com/greenplum-db/gpupgrade/mock_idl"
 
 	"github.com/golang/mock/gomock"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	"github.com/greenplum-db/gpupgrade/utils"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"github.com/greenplum-db/gpupgrade/utils"
 )
 
 var _ = Describe("object count tests", func() {

--- a/cli/commanders/check_version.go
+++ b/cli/commanders/check_version.go
@@ -2,6 +2,7 @@ package commanders
 
 import (
 	"context"
+
 	pb "github.com/greenplum-db/gpupgrade/idl"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"

--- a/cli/commanders/check_version_test.go
+++ b/cli/commanders/check_version_test.go
@@ -1,17 +1,18 @@
 package commanders_test
 
 import (
+	"errors"
+
 	"github.com/greenplum-db/gpupgrade/cli/commanders"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	mockpb "github.com/greenplum-db/gpupgrade/mock_idl"
 
-	"errors"
-
 	"github.com/golang/mock/gomock"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	"github.com/greenplum-db/gpupgrade/utils"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/greenplum-db/gpupgrade/utils"
 )
 
 var _ bool = Describe("object count tests", func() {

--- a/cli/commanders/reporter.go
+++ b/cli/commanders/reporter.go
@@ -3,6 +3,7 @@ package commanders
 import (
 	"context"
 	"fmt"
+
 	pb "github.com/greenplum-db/gpupgrade/idl"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"

--- a/cli/commanders/reporter_test.go
+++ b/cli/commanders/reporter_test.go
@@ -2,16 +2,18 @@ package commanders_test
 
 import (
 	"errors"
+
 	"github.com/greenplum-db/gpupgrade/cli/commanders"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 
 	"github.com/golang/mock/gomock"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	"github.com/greenplum-db/gpupgrade/utils"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"github.com/greenplum-db/gpupgrade/utils"
 )
 
 var _ = Describe("Reporter", func() {

--- a/cli/commanders/upgrader_test.go
+++ b/cli/commanders/upgrader_test.go
@@ -10,10 +10,11 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	"github.com/greenplum-db/gpupgrade/utils"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"github.com/greenplum-db/gpupgrade/utils"
 )
 
 var _ = Describe("reporter", func() {

--- a/hub/services/hub_check_object_count_test.go
+++ b/hub/services/hub_check_object_count_test.go
@@ -2,14 +2,16 @@ package services_test
 
 import (
 	"database/sql/driver"
+
 	"github.com/greenplum-db/gpupgrade/hub/services"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	"github.com/greenplum-db/gpupgrade/utils"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
-	"github.com/greenplum-db/gpupgrade/utils"
 )
 
 var _ = Describe("hub", func() {

--- a/hub/upgradestatus/checklist_manager_test.go
+++ b/hub/upgradestatus/checklist_manager_test.go
@@ -1,15 +1,16 @@
 package upgradestatus_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
 	"errors"
-	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
-	"github.com/greenplum-db/gpupgrade/utils"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
+	"github.com/greenplum-db/gpupgrade/utils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("upgradestatus/ChecklistManager", func() {

--- a/utils/sys_utils_test.go
+++ b/utils/sys_utils_test.go
@@ -1,8 +1,9 @@
 package utils
 
 import (
-	"github.com/pkg/errors"
 	"os/user"
+
+	"github.com/pkg/errors"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
Just use goimports when performing a `make format`.

Imports have been reformatted across the project, with some slight manual tweaks to grouping.