### PR TITLE
Refactor hub unit tests

### DIFF
--- a/hub/services/hub.go
+++ b/hub/services/hub.go
@@ -160,23 +160,18 @@ func (h *Hub) AgentConns() ([]*Connection, error) {
 }
 
 func EnsureConnsAreReady(agentConns []*Connection) error {
-	var hostnames []string
-	for i := 0; i < 3; i++ {
-		hostnames = []string{}
-		for _, conn := range agentConns {
-			if conn.Conn.GetState() != connectivity.Ready {
-				hostnames = append(hostnames, conn.Hostname)
-			}
+	hostnames := []string{}
+	for _, conn := range agentConns {
+		if conn.Conn.GetState() != connectivity.Ready {
+			hostnames = append(hostnames, conn.Hostname)
 		}
-
-		if len(hostnames) == 0 {
-			return nil
-		}
-
-		time.Sleep(500 * time.Millisecond)
 	}
 
-	return fmt.Errorf("the connections to the following hosts were not ready: %s", strings.Join(hostnames, ","))
+	if len(hostnames) > 0 {
+		return fmt.Errorf("the connections to the following hosts were not ready: %s", strings.Join(hostnames, ","))
+	}
+
+	return nil
 }
 
 func (h *Hub) closeConns() {

--- a/hub/services/hub_status_conversion_test.go
+++ b/hub/services/hub_status_conversion_test.go
@@ -75,13 +75,6 @@ var _ = Describe("hub", func() {
 		}))
 	})
 
-	It("returns an error when AgentConns returns an error", func() {
-		agentA.Stop()
-
-		_, err := hub.StatusConversion(nil, &pb.StatusConversionRequest{})
-		Expect(err).To(HaveOccurred())
-	})
-
 	It("returns an error when Agent server returns an error", func() {
 		agentA.Err <- errors.New("any error")
 

--- a/hub/services/hub_status_upgrade_test.go
+++ b/hub/services/hub_status_upgrade_test.go
@@ -11,6 +11,7 @@ import (
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/utils"
+	"golang.org/x/net/context"
 
 	"google.golang.org/grpc"
 
@@ -52,7 +53,11 @@ var _ = Describe("status upgrade", func() {
 			Out: outChan,
 		})
 		clusterPair = testutils.CreateSampleClusterPair()
-		hub = services.NewHub(clusterPair, grpc.DialContext, commandExecer.Exec,
+		// Mock so statusConversion doesn't need to wait 3 seconds before erroring out.
+		mockDialer := func(ctx context.Context, target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+			return nil, errors.New("grpc dial err")
+		}
+		hub = services.NewHub(clusterPair, mockDialer, commandExecer.Exec,
 			conf, nil)
 	})
 

--- a/hub/services/hub_upgrade_convert_primaries_test.go
+++ b/hub/services/hub_upgrade_convert_primaries_test.go
@@ -124,15 +124,6 @@ var _ = Describe("hub.UpgradeConvertPrimaries()", func() {
 
 		Expect(mockAgent.NumberOfCalls()).To(Equal(1))
 	})
-
-	It("returns an error if the agent is inaccessible", func() {
-		mockAgent.Stop()
-
-		_, err := hub.UpgradeConvertPrimaries(nil, request)
-		Expect(err).To(HaveOccurred())
-
-		Expect(mockAgent.NumberOfCalls()).To(Equal(0))
-	})
 })
 
 func newSegment(content int, hostname, dataDir string, port int) cluster.SegConfig {


### PR DESCRIPTION
Hub unit tests are slow because they are waiting for the grpc dialer to timeout (3 seconds each test).

Changes:
 - Mock grpcDialer for faster hub unit tests
 - Remove redundant tests
 - Move method EnsureConnsAreReady off the hub
 - Refactor EnsureConnsAreReady

I am unsure about the change in the second commit that removes the retries in EnsureConnsAreReady. I would not be opposed to reverting it. Reverting would add 1.5 seconds back into the hub unit tests.

hub unit tests run in ~130ms down from 16 seconds
