### PR TITLE
Introduce centralized state management with Checklist

### DIFF
--- a/agent/services/conversion_status.go
+++ b/agent/services/conversion_status.go
@@ -28,10 +28,11 @@ func (s *AgentServer) CheckConversionStatus(ctx context.Context, in *pb.CheckCon
 
 		status := conversionStatus.GetStatus()
 
+		// FIXME: we have status codes; why convert to strings?
 		if segment.GetDbid() == 1 && segment.GetContent() == -1 {
-			master = fmt.Sprintf(format, status.Status.String(), segment.GetDbid(), segment.GetContent(), "MASTER", in.GetHostname())
+			master = fmt.Sprintf(format, status.String(), segment.GetDbid(), segment.GetContent(), "MASTER", in.GetHostname())
 		} else {
-			replies = append(replies, fmt.Sprintf(format, status.Status.String(), segment.GetDbid(), segment.GetContent(), "PRIMARY", in.GetHostname()))
+			replies = append(replies, fmt.Sprintf(format, status.String(), segment.GetDbid(), segment.GetContent(), "PRIMARY", in.GetHostname()))
 		}
 	}
 

--- a/agent/services/conversion_status.go
+++ b/agent/services/conversion_status.go
@@ -19,14 +19,11 @@ func (s *AgentServer) CheckConversionStatus(ctx context.Context, in *pb.CheckCon
 	var replies []string
 	var master string
 	for _, segment := range in.GetSegments() {
-		conversionStatus := upgradestatus.NewPGUpgradeStatusChecker(
-			upgradestatus.PRIMARY,
+		status := upgradestatus.SegmentConversionStatus(
 			filepath.Join(s.conf.StateDir, "pg_upgrade", fmt.Sprintf("seg-%d", segment.GetContent())),
 			segment.GetDataDir(),
 			s.executor,
 		)
-
-		status := conversionStatus.GetStatus()
 
 		// FIXME: we have status codes; why convert to strings?
 		if segment.GetDbid() == 1 && segment.GetContent() == -1 {

--- a/hub/gpupgrade_hub_main.go
+++ b/hub/gpupgrade_hub_main.go
@@ -103,20 +103,14 @@ func main() {
 			}
 
 			shutDownStatus := func(step upgradestatus.StateReader) pb.StepStatus {
-				// TODO: get rid of the "helper struct" layer here; it's not
-				// getting us much.
-				shutDownClusterPath := filepath.Join(conf.StateDir, step.Name())
-				checker := upgradestatus.NewShutDownClusters(shutDownClusterPath, cp.OldCluster.Executor)
-				return checker.GetStatus()
+				stepdir := filepath.Join(conf.StateDir, step.Name())
+				return upgradestatus.ClusterShutdownStatus(stepdir, cp.OldCluster.Executor)
 			}
 
 			convertMasterStatus := func(step upgradestatus.StateReader) pb.StepStatus {
-				// TODO: get rid of the "helper struct" layer here; it's not
-				// getting us much.
 				convertMasterPath := filepath.Join(conf.StateDir, step.Name())
 				oldDataDir := cp.OldCluster.GetDirForContent(-1)
-				checker := upgradestatus.NewPGUpgradeStatusChecker(upgradestatus.MASTER, convertMasterPath, oldDataDir, cp.OldCluster.Executor)
-				return checker.GetStatus()
+				return upgradestatus.SegmentConversionStatus(convertMasterPath, oldDataDir, cp.OldCluster.Executor)
 			}
 
 			convertPrimariesStatus := func(step upgradestatus.StateReader) pb.StepStatus {

--- a/hub/services/hub.go
+++ b/hub/services/hub.go
@@ -35,11 +35,11 @@ type RemoteExecutor interface {
 type Hub struct {
 	conf *HubConfig
 
-	agentConns      []*Connection
-	clusterPair     *utils.ClusterPair
-	grpcDialer      Dialer
-	remoteExecutor  RemoteExecutor
-	checklistWriter ChecklistWriter
+	agentConns     []*Connection
+	clusterPair    *utils.ClusterPair
+	grpcDialer     Dialer
+	remoteExecutor RemoteExecutor
+	checklist      Checklist
 
 	mu      sync.Mutex
 	server  *grpc.Server
@@ -61,18 +61,18 @@ type HubConfig struct {
 	LogDir         string
 }
 
-// TODO: remove in favor of upgradestatus.StateWriter
-type ChecklistWriter interface {
+type Checklist interface {
+	StepReader(step string) upgradestatus.StateReader
 	StepWriter(step string) upgradestatus.StateWriter
 }
 
-func NewHub(pair *utils.ClusterPair, grpcDialer Dialer, conf *HubConfig, checklistWriter ChecklistWriter) *Hub {
+func NewHub(pair *utils.ClusterPair, grpcDialer Dialer, conf *HubConfig, checklist Checklist) *Hub {
 	h := &Hub{
-		stopped:         make(chan struct{}, 1),
-		conf:            conf,
-		clusterPair:     pair,
-		grpcDialer:      grpcDialer,
-		checklistWriter: checklistWriter,
+		stopped:     make(chan struct{}, 1),
+		conf:        conf,
+		clusterPair: pair,
+		grpcDialer:  grpcDialer,
+		checklist:   checklist,
 	}
 
 	return h

--- a/hub/services/hub.go
+++ b/hub/services/hub.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
 
@@ -60,11 +61,9 @@ type HubConfig struct {
 	LogDir         string
 }
 
+// TODO: remove in favor of upgradestatus.StateWriter
 type ChecklistWriter interface {
-	MarkInProgress(string) error
-	ResetStateDir(string) error
-	MarkFailed(string) error
-	MarkComplete(string) error
+	StepWriter(step string) upgradestatus.StateWriter
 }
 
 func NewHub(pair *utils.ClusterPair, grpcDialer Dialer, conf *HubConfig, checklistWriter ChecklistWriter) *Hub {

--- a/hub/services/hub.go
+++ b/hub/services/hub.go
@@ -39,7 +39,7 @@ type Hub struct {
 	clusterPair    *utils.ClusterPair
 	grpcDialer     Dialer
 	remoteExecutor RemoteExecutor
-	checklist      Checklist
+	checklist      upgradestatus.Checklist
 
 	mu      sync.Mutex
 	server  *grpc.Server
@@ -61,12 +61,7 @@ type HubConfig struct {
 	LogDir         string
 }
 
-type Checklist interface {
-	StepReader(step string) upgradestatus.StateReader
-	StepWriter(step string) upgradestatus.StateWriter
-}
-
-func NewHub(pair *utils.ClusterPair, grpcDialer Dialer, conf *HubConfig, checklist Checklist) *Hub {
+func NewHub(pair *utils.ClusterPair, grpcDialer Dialer, conf *HubConfig, checklist upgradestatus.Checklist) *Hub {
 	h := &Hub{
 		stopped:     make(chan struct{}, 1),
 		conf:        conf,
@@ -155,6 +150,11 @@ func (h *Hub) AgentConns() ([]*Connection, error) {
 	}
 
 	return h.agentConns, nil
+}
+
+// GetConfig returns a copy of the hub's current configuration.
+func (h *Hub) GetConfig() HubConfig {
+	return *h.conf
 }
 
 func EnsureConnsAreReady(agentConns []*Connection) error {

--- a/hub/services/hub_check_config.go
+++ b/hub/services/hub_check_config.go
@@ -18,7 +18,7 @@ func (h *Hub) CheckConfig(ctx context.Context, in *pb.CheckConfigRequest) (*pb.C
 	gplog.Info("starting CheckConfig()")
 
 	c := upgradestatus.NewChecklistManager(h.conf.StateDir)
-	step := c.StepWriter(upgradestatus.CONFIG)
+	step := c.GetStepWriter(upgradestatus.CONFIG)
 
 	err := step.ResetStateDir()
 	if err != nil {

--- a/hub/services/hub_check_seginstall.go
+++ b/hub/services/hub_check_seginstall.go
@@ -18,7 +18,7 @@ import (
 func (h *Hub) CheckSeginstall(ctx context.Context, in *idl.CheckSeginstallRequest) (*idl.CheckSeginstallReply, error) {
 	gplog.Info("Running CheckSeginstall()")
 
-	step := h.checklistWriter.StepWriter(upgradestatus.SEGINSTALL)
+	step := h.checklist.StepWriter(upgradestatus.SEGINSTALL)
 
 	err := step.ResetStateDir()
 	if err != nil {

--- a/hub/services/hub_check_seginstall.go
+++ b/hub/services/hub_check_seginstall.go
@@ -18,7 +18,7 @@ import (
 func (h *Hub) CheckSeginstall(ctx context.Context, in *idl.CheckSeginstallRequest) (*idl.CheckSeginstallReply, error) {
 	gplog.Info("Running CheckSeginstall()")
 
-	step := h.checklist.StepWriter(upgradestatus.SEGINSTALL)
+	step := h.checklist.GetStepWriter(upgradestatus.SEGINSTALL)
 
 	err := step.ResetStateDir()
 	if err != nil {

--- a/hub/services/hub_check_seginstall_test.go
+++ b/hub/services/hub_check_seginstall_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	_ "github.com/greenplum-db/gpupgrade/hub/services"
-	"github.com/greenplum-db/gpupgrade/utils"
 
 	"github.com/greenplum-db/gpupgrade/hub/services"
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
+	"github.com/greenplum-db/gpupgrade/utils"
 
 	"github.com/greenplum-db/gpupgrade/testutils"
 	. "github.com/onsi/ginkgo"
@@ -34,9 +34,12 @@ var _ = Describe("hub CheckSeginstall", func() {
 		testExecutor.ClusterOutput = &cluster.RemoteOutput{}
 		cp.OldCluster.Executor = testExecutor
 
-		services.VerifyAgentsInstalled(cp, cm)
+		step := cm.StepWriter(upgradestatus.SEGINSTALL)
+		step.MarkInProgress()
+		services.VerifyAgentsInstalled(cp, step)
 
 		Expect(testExecutor.NumExecutions).To(Equal(1))
+		Expect(cm.IsComplete(upgradestatus.SEGINSTALL)).To(BeTrue())
 
 		lsCmd := fmt.Sprintf("ls %s/bin/gpupgrade_agent", os.Getenv("GPHOME"))
 		clusterCommands := testExecutor.ClusterCommands[0]

--- a/hub/services/hub_check_seginstall_test.go
+++ b/hub/services/hub_check_seginstall_test.go
@@ -34,7 +34,7 @@ var _ = Describe("hub CheckSeginstall", func() {
 		testExecutor.ClusterOutput = &cluster.RemoteOutput{}
 		cp.OldCluster.Executor = testExecutor
 
-		step := cm.StepWriter(upgradestatus.SEGINSTALL)
+		step := cm.GetStepWriter(upgradestatus.SEGINSTALL)
 		step.MarkInProgress()
 		services.VerifyAgentsInstalled(cp, step)
 

--- a/hub/services/hub_prepare_init_cluster.go
+++ b/hub/services/hub_prepare_init_cluster.go
@@ -37,7 +37,7 @@ func SaveTargetClusterConfig(clusterPair *utils.ClusterPair, dbConnector *dbconn
 func (h *Hub) PrepareInitCluster(ctx context.Context, in *pb.PrepareInitClusterRequest) (*pb.PrepareInitClusterReply, error) {
 	gplog.Info("starting PrepareInitCluster()")
 
-	step := h.checklist.StepWriter(upgradestatus.INIT_CLUSTER)
+	step := h.checklist.GetStepWriter(upgradestatus.INIT_CLUSTER)
 	step.MarkInProgress()
 
 	dbConnector := db.NewDBConn("localhost", int(in.DbPort), "template1")

--- a/hub/services/hub_prepare_init_cluster.go
+++ b/hub/services/hub_prepare_init_cluster.go
@@ -37,7 +37,7 @@ func SaveTargetClusterConfig(clusterPair *utils.ClusterPair, dbConnector *dbconn
 func (h *Hub) PrepareInitCluster(ctx context.Context, in *pb.PrepareInitClusterRequest) (*pb.PrepareInitClusterReply, error) {
 	gplog.Info("starting PrepareInitCluster()")
 
-	step := h.checklistWriter.StepWriter(upgradestatus.INIT_CLUSTER)
+	step := h.checklist.StepWriter(upgradestatus.INIT_CLUSTER)
 	step.MarkInProgress()
 
 	dbConnector := db.NewDBConn("localhost", int(in.DbPort), "template1")

--- a/hub/services/hub_prepare_shutdown_clusters.go
+++ b/hub/services/hub_prepare_shutdown_clusters.go
@@ -21,7 +21,7 @@ func (h *Hub) PrepareShutdownClusters(ctx context.Context, in *pb.PrepareShutdow
 }
 
 func (h *Hub) ShutdownClusters() {
-	step := h.checklist.StepWriter(upgradestatus.SHUTDOWN_CLUSTERS)
+	step := h.checklist.GetStepWriter(upgradestatus.SHUTDOWN_CLUSTERS)
 
 	step.ResetStateDir()
 	step.MarkInProgress()

--- a/hub/services/hub_prepare_shutdown_clusters.go
+++ b/hub/services/hub_prepare_shutdown_clusters.go
@@ -21,7 +21,7 @@ func (h *Hub) PrepareShutdownClusters(ctx context.Context, in *pb.PrepareShutdow
 }
 
 func (h *Hub) ShutdownClusters() {
-	step := h.checklistWriter.StepWriter(upgradestatus.SHUTDOWN_CLUSTERS)
+	step := h.checklist.StepWriter(upgradestatus.SHUTDOWN_CLUSTERS)
 
 	step.ResetStateDir()
 	step.MarkInProgress()

--- a/hub/services/hub_prepare_shutdown_clusters.go
+++ b/hub/services/hub_prepare_shutdown_clusters.go
@@ -21,10 +21,10 @@ func (h *Hub) PrepareShutdownClusters(ctx context.Context, in *pb.PrepareShutdow
 }
 
 func (h *Hub) ShutdownClusters() {
-	step := upgradestatus.SHUTDOWN_CLUSTERS
+	step := h.checklistWriter.StepWriter(upgradestatus.SHUTDOWN_CLUSTERS)
 
-	h.checklistWriter.ResetStateDir(step)
-	h.checklistWriter.MarkInProgress(step)
+	step.ResetStateDir()
+	step.MarkInProgress()
 
 	var errOld error
 	errOld = StopCluster(h.clusterPair.OldCluster, h.clusterPair.OldBinDir)
@@ -39,11 +39,11 @@ func (h *Hub) ShutdownClusters() {
 	}
 
 	if errOld != nil || errNew != nil {
-		h.checklistWriter.MarkFailed(step)
+		step.MarkFailed()
 		return
 	}
 
-	h.checklistWriter.MarkComplete(step)
+	step.MarkComplete()
 }
 
 func StopCluster(c *cluster.Cluster, binDir string) error {

--- a/hub/services/hub_prepare_start_agents.go
+++ b/hub/services/hub_prepare_start_agents.go
@@ -18,7 +18,7 @@ import (
 func (h *Hub) PrepareStartAgents(ctx context.Context, in *idl.PrepareStartAgentsRequest) (*idl.PrepareStartAgentsReply, error) {
 	gplog.Info("Running PrepareStartAgents()")
 
-	step := h.checklist.StepWriter(upgradestatus.START_AGENTS)
+	step := h.checklist.GetStepWriter(upgradestatus.START_AGENTS)
 
 	err := step.ResetStateDir()
 	if err != nil {

--- a/hub/services/hub_prepare_start_agents.go
+++ b/hub/services/hub_prepare_start_agents.go
@@ -18,7 +18,7 @@ import (
 func (h *Hub) PrepareStartAgents(ctx context.Context, in *idl.PrepareStartAgentsRequest) (*idl.PrepareStartAgentsReply, error) {
 	gplog.Info("Running PrepareStartAgents()")
 
-	step := h.checklistWriter.StepWriter(upgradestatus.START_AGENTS)
+	step := h.checklist.StepWriter(upgradestatus.START_AGENTS)
 
 	err := step.ResetStateDir()
 	if err != nil {

--- a/hub/services/hub_prepare_start_agents_test.go
+++ b/hub/services/hub_prepare_start_agents_test.go
@@ -34,7 +34,7 @@ var _ = Describe("hub PrepareStartAgents", func() {
 		testExecutor.ClusterOutput = &cluster.RemoteOutput{}
 		cp.OldCluster.Executor = testExecutor
 
-		step := cm.StepWriter(upgradestatus.START_AGENTS)
+		step := cm.GetStepWriter(upgradestatus.START_AGENTS)
 		step.MarkInProgress()
 		services.StartAgents(cp, step)
 

--- a/hub/services/hub_prepare_start_agents_test.go
+++ b/hub/services/hub_prepare_start_agents_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	_ "github.com/greenplum-db/gpupgrade/hub/services"
-	"github.com/greenplum-db/gpupgrade/utils"
 
 	"github.com/greenplum-db/gpupgrade/hub/services"
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
+	"github.com/greenplum-db/gpupgrade/utils"
 
 	"github.com/greenplum-db/gpupgrade/testutils"
 	. "github.com/onsi/ginkgo"
@@ -34,9 +34,12 @@ var _ = Describe("hub PrepareStartAgents", func() {
 		testExecutor.ClusterOutput = &cluster.RemoteOutput{}
 		cp.OldCluster.Executor = testExecutor
 
-		services.StartAgents(cp, cm)
+		step := cm.StepWriter(upgradestatus.START_AGENTS)
+		step.MarkInProgress()
+		services.StartAgents(cp, step)
 
 		Expect(testExecutor.NumExecutions).To(Equal(1))
+		Expect(cm.IsComplete(upgradestatus.START_AGENTS)).To(BeTrue())
 
 		startAgentsCmd := fmt.Sprintf("%s/bin/gpupgrade_agent --daemonize", os.Getenv("GPHOME"))
 		clusterCommands := testExecutor.ClusterCommands[0]

--- a/hub/services/hub_status_upgrade.go
+++ b/hub/services/hub_status_upgrade.go
@@ -49,8 +49,8 @@ func (s Step) StatePath(h *Hub) string {
 // stateCheckStatus uses a NewStateCheck object to retrieve status; it's the
 // most general getStatus() implementation.
 func stateCheckStatus(s Step, h *Hub) *pb.UpgradeStepStatus {
-	state := upgradestatus.NewStateCheck(s.StatePath(h), s.StepCode)
-	return state.GetStatus()
+	state := h.checklist.StepReader(s.Name)
+	return &pb.UpgradeStepStatus{Step: s.StepCode, Status: state.GetStatus()}
 }
 
 // initStatus gets its status by checking for the existence of a new cluster
@@ -118,7 +118,7 @@ func (h *Hub) StatusUpgrade(ctx context.Context, in *pb.StatusUpgradeRequest) (*
 
 	steps := [...]Step{
 		{"check-config", pb.UpgradeSteps_CHECK_CONFIG, stateCheckStatus},
-		{"seginstall", pb.UpgradeSteps_SEGINSTALL, stateCheckStatus},
+		{"check-seginstall", pb.UpgradeSteps_SEGINSTALL, stateCheckStatus},
 		{"init-cluster", pb.UpgradeSteps_PREPARE_INIT_CLUSTER, initStatus},
 		{"gpstop", pb.UpgradeSteps_STOPPED_CLUSTER, shutdownStatus},
 		{"pg_upgrade", pb.UpgradeSteps_MASTERUPGRADE, pgUpgradeStatus},

--- a/hub/services/hub_status_upgrade.go
+++ b/hub/services/hub_status_upgrade.go
@@ -1,10 +1,6 @@
 package services
 
 import (
-	"path/filepath"
-	"strings"
-
-	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
 
@@ -12,128 +8,15 @@ import (
 	"golang.org/x/net/context"
 )
 
-// Step represents a single step during upgrade status (e.g. primary conversion,
-// check config, etc.).
-type Step struct {
-	// Name is a human-readable description of the Step, usually following the
-	// invocation on the command line. It must additionally be a valid directory
-	// name for all supported filesystems.
-	Name string
-
-	// StepCode is the gRPC code corresponding to this particular Step.
-	StepCode pb.UpgradeSteps
-
-	// getStatus is the private implementation of the Status method.
-	getStatus func(s Step, h *Hub) *pb.UpgradeStepStatus
-}
-
-// Status retrieves the UpgradeStepStatus (failed, completed, etc.) for this
-// Step on a given Hub.
-func (s Step) Status(h *Hub) *pb.UpgradeStepStatus {
-	return s.getStatus(s, h)
-}
-
-// StatePath returns the directory where the state for this Step is kept (if
-// applicable; not all Steps use a state directory in their implementation). It
-// is currently computed using the Hub's state directory and the Step name.
-func (s Step) StatePath(h *Hub) string {
-	path := filepath.Join(h.conf.StateDir, s.Name)
-	gplog.Debug("looking for %s state at %s", s.Name, path)
-	return path
-}
-
-/*
- * getStatus() Implementations
- */
-
-// stateCheckStatus uses a NewStateCheck object to retrieve status; it's the
-// most general getStatus() implementation.
-func stateCheckStatus(s Step, h *Hub) *pb.UpgradeStepStatus {
-	state := h.checklist.StepReader(s.Name)
-	return &pb.UpgradeStepStatus{Step: s.StepCode, Status: state.GetStatus()}
-}
-
-// initStatus gets its status by checking for the existence of a new cluster
-// config.
-func initStatus(s Step, h *Hub) *pb.UpgradeStepStatus {
-	status := h.GetPrepareNewClusterConfigStatus()
-	return status
-}
-
-// shutdownStatus checks whether all clusters have been stopped.
-func shutdownStatus(s Step, h *Hub) *pb.UpgradeStepStatus {
-	state := upgradestatus.NewShutDownClusters(s.StatePath(h), h.clusterPair.OldCluster.Executor)
-	return state.GetStatus()
-}
-
-// pgUpgradeStatus checks the pg_upgrade progress files for its status.
-func pgUpgradeStatus(s Step, h *Hub) *pb.UpgradeStepStatus {
-	status := &pb.UpgradeStepStatus{
-		Step: s.StepCode,
-	}
-	// We don't need to check the pg_upgrade status if there's no configuration yet
-	checkConfigStep := Step{upgradestatus.CONFIG, pb.UpgradeSteps_CHECK_CONFIG, stateCheckStatus}
-	if checkConfigStep.getStatus(checkConfigStep, h).Status != pb.StepStatus_COMPLETE {
-		status.Status = pb.StepStatus_PENDING
-		return status
-	}
-	state := upgradestatus.NewPGUpgradeStatusChecker(upgradestatus.MASTER, s.StatePath(h), h.clusterPair.OldCluster.GetDirForContent(-1), h.clusterPair.OldCluster.Executor)
-	return state.GetStatus()
-}
-
-// conversionStatus queries all segments for their upgrade status and
-// consolidates them into a single pass/fail.
-func conversionStatus(s Step, h *Hub) *pb.UpgradeStepStatus {
-	status := &pb.UpgradeStepStatus{
-		Step: s.StepCode,
-	}
-	// We can't check the status of agent processes if the agents haven't been started yet
-	startAgentsStep := Step{upgradestatus.START_AGENTS, pb.UpgradeSteps_PREPARE_START_AGENTS, stateCheckStatus}
-	if startAgentsStep.getStatus(startAgentsStep, h).Status != pb.StepStatus_COMPLETE {
-		status.Status = pb.StepStatus_PENDING
-		return status
-	}
-	// We can't determine the actual status if there's an error, so we log it and return PENDING
-	conversionStatus, err := h.StatusConversion(nil, &pb.StatusConversionRequest{})
-	if err != nil {
-		gplog.Error("Could not get primary conversion status: %s", err)
-		status.Status = pb.StepStatus_PENDING
-		return status
-	}
-	statuses := strings.Join(conversionStatus.GetConversionStatuses(), "\n")
-	if strings.Contains(statuses, "FAILED") {
-		status.Status = pb.StepStatus_FAILED
-	} else if strings.Contains(statuses, "RUNNING") {
-		status.Status = pb.StepStatus_RUNNING
-	} else if strings.Contains(statuses, "COMPLETE") {
-		status.Status = pb.StepStatus_COMPLETE
-	} else {
-		status.Status = pb.StepStatus_PENDING
-	}
-	return status
-}
-
 func (h *Hub) StatusUpgrade(ctx context.Context, in *pb.StatusUpgradeRequest) (*pb.StatusUpgradeReply, error) {
 	gplog.Info("starting StatusUpgrade")
 
-	steps := [...]Step{
-		{"check-config", pb.UpgradeSteps_CHECK_CONFIG, stateCheckStatus},
-		{"check-seginstall", pb.UpgradeSteps_SEGINSTALL, stateCheckStatus},
-		{"init-cluster", pb.UpgradeSteps_PREPARE_INIT_CLUSTER, initStatus},
-		{"gpstop", pb.UpgradeSteps_STOPPED_CLUSTER, shutdownStatus},
-		{"pg_upgrade", pb.UpgradeSteps_MASTERUPGRADE, pgUpgradeStatus},
-		{"start-agents", pb.UpgradeSteps_PREPARE_START_AGENTS, stateCheckStatus},
-		{"share-oids", pb.UpgradeSteps_SHARE_OIDS, stateCheckStatus},
-		{"validate-start-cluster", pb.UpgradeSteps_VALIDATE_START_CLUSTER, stateCheckStatus},
-		{"convert-primaries", pb.UpgradeSteps_CONVERT_PRIMARIES, conversionStatus},
-		{"reconfigure-ports", pb.UpgradeSteps_RECONFIGURE_PORTS, stateCheckStatus},
-	}
-
+	steps := h.checklist.AllSteps()
 	statuses := make([]*pb.UpgradeStepStatus, len(steps))
 
-	for i, desc := range steps {
-		gplog.Info("Checking %s...", desc.Name)
-		statuses[i] = desc.Status(h)
+	for i, step := range steps {
+		gplog.Info("Checking %s...", step.Name())
+		statuses[i] = &pb.UpgradeStepStatus{Step: step.Code(), Status: step.Status()}
 	}
 
 	return &pb.StatusUpgradeReply{
@@ -141,20 +24,14 @@ func (h *Hub) StatusUpgrade(ctx context.Context, in *pb.StatusUpgradeRequest) (*
 	}, nil
 }
 
-func (h *Hub) GetPrepareNewClusterConfigStatus() *pb.UpgradeStepStatus {
+func GetPrepareNewClusterConfigStatus(statedir string) pb.StepStatus {
 	/* Treat all stat failures as cannot find file. Conceal worse failures atm.*/
-	_, err := utils.System.Stat(utils.GetNewConfigFilePath(h.conf.StateDir))
+	_, err := utils.System.Stat(utils.GetNewConfigFilePath(statedir))
 
 	if err != nil {
 		gplog.Debug("%v", err)
-		return &pb.UpgradeStepStatus{
-			Step:   pb.UpgradeSteps_PREPARE_INIT_CLUSTER,
-			Status: pb.StepStatus_PENDING,
-		}
+		return pb.StepStatus_PENDING
 	}
 
-	return &pb.UpgradeStepStatus{
-		Step:   pb.UpgradeSteps_PREPARE_INIT_CLUSTER,
-		Status: pb.StepStatus_COMPLETE,
-	}
+	return pb.StepStatus_COMPLETE
 }

--- a/hub/services/hub_status_upgrade_test.go
+++ b/hub/services/hub_status_upgrade_test.go
@@ -78,12 +78,12 @@ var _ = Describe("status upgrade", func() {
 
 	It("responds with the statuses of the steps based on checklist state", func() {
 		for _, name := range []string{upgradestatus.CONFIG, upgradestatus.SEGINSTALL, upgradestatus.START_AGENTS} {
-			step := cm.StepWriter(name)
+			step := cm.GetStepWriter(name)
 			step.MarkInProgress()
 			step.MarkComplete()
 		}
 
-		step := cm.StepWriter(upgradestatus.SHARE_OIDS)
+		step := cm.GetStepWriter(upgradestatus.SHARE_OIDS)
 		step.MarkInProgress()
 		step.MarkFailed()
 
@@ -175,7 +175,7 @@ var _ = Describe("status upgrade", func() {
 				return stepStatusSaved
 			}
 
-			step := cm.StepWriter("start-agents")
+			step := cm.GetStepWriter("start-agents")
 			step.MarkInProgress()
 
 			status := pollStatusUpgrade()

--- a/hub/services/hub_upgrade_reconfigure_ports.go
+++ b/hub/services/hub_upgrade_reconfigure_ports.go
@@ -19,7 +19,7 @@ const (
 func (h *Hub) UpgradeReconfigurePorts(ctx context.Context, in *pb.UpgradeReconfigurePortsRequest) (*pb.UpgradeReconfigurePortsReply, error) {
 	gplog.Info("Started processing reconfigure-ports request")
 
-	step := h.checklist.StepWriter(upgradestatus.RECONFIGURE_PORTS)
+	step := h.checklist.GetStepWriter(upgradestatus.RECONFIGURE_PORTS)
 
 	err := step.ResetStateDir()
 	if err != nil {

--- a/hub/services/hub_upgrade_reconfigure_ports.go
+++ b/hub/services/hub_upgrade_reconfigure_ports.go
@@ -19,11 +19,13 @@ const (
 func (h *Hub) UpgradeReconfigurePorts(ctx context.Context, in *pb.UpgradeReconfigurePortsRequest) (*pb.UpgradeReconfigurePortsReply, error) {
 	gplog.Info("Started processing reconfigure-ports request")
 
-	err := h.checklistWriter.ResetStateDir(upgradestatus.RECONFIGURE_PORTS)
+	step := h.checklistWriter.StepWriter(upgradestatus.RECONFIGURE_PORTS)
+
+	err := step.ResetStateDir()
 	if err != nil {
 		gplog.Error("error from ResetStateDir " + err.Error())
 	}
-	err = h.checklistWriter.MarkInProgress(upgradestatus.RECONFIGURE_PORTS)
+	err = step.MarkInProgress()
 	if err != nil {
 		gplog.Error("error from MarkInProgress " + err.Error())
 	}
@@ -36,12 +38,12 @@ func (h *Hub) UpgradeReconfigurePorts(ctx context.Context, in *pb.UpgradeReconfi
 	if err != nil {
 		gplog.Error("reconfigure-ports failed %s: %s", output, err)
 
-		h.checklistWriter.MarkFailed(upgradestatus.RECONFIGURE_PORTS)
+		step.MarkFailed()
 		return nil, err
 	}
 
 	gplog.Info("reconfigure-ports succeeded")
-	h.checklistWriter.MarkComplete(upgradestatus.RECONFIGURE_PORTS)
+	step.MarkComplete()
 
 	return &pb.UpgradeReconfigurePortsReply{}, nil
 }

--- a/hub/services/hub_upgrade_reconfigure_ports.go
+++ b/hub/services/hub_upgrade_reconfigure_ports.go
@@ -19,7 +19,7 @@ const (
 func (h *Hub) UpgradeReconfigurePorts(ctx context.Context, in *pb.UpgradeReconfigurePortsRequest) (*pb.UpgradeReconfigurePortsReply, error) {
 	gplog.Info("Started processing reconfigure-ports request")
 
-	step := h.checklistWriter.StepWriter(upgradestatus.RECONFIGURE_PORTS)
+	step := h.checklist.StepWriter(upgradestatus.RECONFIGURE_PORTS)
 
 	err := step.ResetStateDir()
 	if err != nil {

--- a/hub/services/hub_upgrade_share_oids.go
+++ b/hub/services/hub_upgrade_share_oids.go
@@ -21,13 +21,14 @@ func (h *Hub) UpgradeShareOids(ctx context.Context, in *pb.UpgradeShareOidsReque
 }
 
 func (h *Hub) shareOidFiles() {
+	step := h.checklistWriter.StepWriter(upgradestatus.SHARE_OIDS)
 
-	err := h.checklistWriter.ResetStateDir(upgradestatus.SHARE_OIDS)
+	err := step.ResetStateDir()
 	if err != nil {
 		gplog.Error("error from ResetStateDir " + err.Error())
 		return
 	}
-	err = h.checklistWriter.MarkInProgress(upgradestatus.SHARE_OIDS)
+	err = step.MarkInProgress()
 	if err != nil {
 		gplog.Error("error from MarkInProgress " + err.Error())
 		return
@@ -53,12 +54,12 @@ func (h *Hub) shareOidFiles() {
 		}
 	}
 	if anyFailed {
-		h.checklistWriter.MarkFailed(upgradestatus.SHARE_OIDS)
+		step.MarkFailed()
 		if err != nil {
 			gplog.Error("error from MarkFailed " + err.Error())
 		}
 	} else {
-		h.checklistWriter.MarkComplete(upgradestatus.SHARE_OIDS)
+		step.MarkComplete()
 		if err != nil {
 			gplog.Error("error from MarkComplete " + err.Error())
 		}

--- a/hub/services/hub_upgrade_share_oids.go
+++ b/hub/services/hub_upgrade_share_oids.go
@@ -21,7 +21,7 @@ func (h *Hub) UpgradeShareOids(ctx context.Context, in *pb.UpgradeShareOidsReque
 }
 
 func (h *Hub) shareOidFiles() {
-	step := h.checklistWriter.StepWriter(upgradestatus.SHARE_OIDS)
+	step := h.checklist.StepWriter(upgradestatus.SHARE_OIDS)
 
 	err := step.ResetStateDir()
 	if err != nil {

--- a/hub/services/hub_upgrade_share_oids.go
+++ b/hub/services/hub_upgrade_share_oids.go
@@ -21,7 +21,7 @@ func (h *Hub) UpgradeShareOids(ctx context.Context, in *pb.UpgradeShareOidsReque
 }
 
 func (h *Hub) shareOidFiles() {
-	step := h.checklist.StepWriter(upgradestatus.SHARE_OIDS)
+	step := h.checklist.GetStepWriter(upgradestatus.SHARE_OIDS)
 
 	err := step.ResetStateDir()
 	if err != nil {

--- a/hub/services/hub_upgrade_validate_start_cluster.go
+++ b/hub/services/hub_upgrade_validate_start_cluster.go
@@ -20,15 +20,15 @@ func (h *Hub) UpgradeValidateStartCluster(ctx context.Context, in *pb.UpgradeVal
 
 func (h *Hub) startNewCluster() {
 	gplog.Debug(h.conf.StateDir)
-	c := h.checklistWriter
-	err := c.ResetStateDir(upgradestatus.VALIDATE_START_CLUSTER)
+	step := h.checklistWriter.StepWriter(upgradestatus.VALIDATE_START_CLUSTER)
+	err := step.ResetStateDir()
 	if err != nil {
 		gplog.Error("failed to reset the state dir for validate-start-cluster")
 
 		return
 	}
 
-	err = c.MarkInProgress(upgradestatus.VALIDATE_START_CLUSTER)
+	err = step.MarkInProgress()
 	if err != nil {
 		gplog.Error("failed to record in-progress for validate-start-cluster")
 
@@ -40,7 +40,7 @@ func (h *Hub) startNewCluster() {
 	_, err = h.clusterPair.NewCluster.ExecuteLocalCommand(fmt.Sprintf("source %s/../greenplum_path.sh; %s/gpstart -a -d %s", newBinDir, newBinDir, newDataDir))
 	if err != nil {
 		gplog.Error(err.Error())
-		cmErr := c.MarkFailed(upgradestatus.VALIDATE_START_CLUSTER)
+		cmErr := step.MarkFailed()
 		if cmErr != nil {
 			gplog.Error("failed to record failed for validate-start-cluster")
 		}
@@ -48,7 +48,7 @@ func (h *Hub) startNewCluster() {
 		return
 	}
 
-	err = c.MarkComplete(upgradestatus.VALIDATE_START_CLUSTER)
+	err = step.MarkComplete()
 	if err != nil {
 		gplog.Error("failed to record completed for validate-start-cluster")
 		return

--- a/hub/services/hub_upgrade_validate_start_cluster.go
+++ b/hub/services/hub_upgrade_validate_start_cluster.go
@@ -20,7 +20,7 @@ func (h *Hub) UpgradeValidateStartCluster(ctx context.Context, in *pb.UpgradeVal
 
 func (h *Hub) startNewCluster() {
 	gplog.Debug(h.conf.StateDir)
-	step := h.checklistWriter.StepWriter(upgradestatus.VALIDATE_START_CLUSTER)
+	step := h.checklist.StepWriter(upgradestatus.VALIDATE_START_CLUSTER)
 	err := step.ResetStateDir()
 	if err != nil {
 		gplog.Error("failed to reset the state dir for validate-start-cluster")

--- a/hub/services/hub_upgrade_validate_start_cluster.go
+++ b/hub/services/hub_upgrade_validate_start_cluster.go
@@ -20,7 +20,7 @@ func (h *Hub) UpgradeValidateStartCluster(ctx context.Context, in *pb.UpgradeVal
 
 func (h *Hub) startNewCluster() {
 	gplog.Debug(h.conf.StateDir)
-	step := h.checklist.StepWriter(upgradestatus.VALIDATE_START_CLUSTER)
+	step := h.checklist.GetStepWriter(upgradestatus.VALIDATE_START_CLUSTER)
 	err := step.ResetStateDir()
 	if err != nil {
 		gplog.Error("failed to reset the state dir for validate-start-cluster")

--- a/hub/upgradestatus/checklist_manager.go
+++ b/hub/upgradestatus/checklist_manager.go
@@ -32,8 +32,8 @@ const (
 type Checklist interface {
 	LoadSteps(steps []Step) // XXX Feels like this is an implementation detail.
 	AllSteps() []StateReader
-	StepReader(step string) StateReader
-	StepWriter(step string) StateWriter
+	GetStepReader(step string) StateReader
+	GetStepWriter(step string) StateWriter
 }
 
 type StateReader interface {
@@ -89,7 +89,7 @@ func (c *ChecklistManager) LoadSteps(steps []Step) {
 	}
 }
 
-func (c *ChecklistManager) StepReader(step string) StateReader {
+func (c *ChecklistManager) GetStepReader(step string) StateReader {
 	return c.stepmap[step]
 }
 
@@ -97,7 +97,7 @@ func (c *ChecklistManager) AllSteps() []StateReader {
 	return c.steps
 }
 
-func (c *ChecklistManager) StepWriter(step string) StateWriter {
+func (c *ChecklistManager) GetStepWriter(step string) StateWriter {
 	stepdir := filepath.Join(c.pathToStateDir, step)
 	return StepWriter{stepdir: stepdir}
 }

--- a/hub/upgradestatus/checklist_manager_test.go
+++ b/hub/upgradestatus/checklist_manager_test.go
@@ -23,7 +23,7 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 			tempdir, _ := ioutil.TempDir("", "")
 
 			cm := upgradestatus.NewChecklistManager(filepath.Join(tempdir, ".gpupgrade"))
-			step := cm.StepWriter("fancy_step")
+			step := cm.GetStepWriter("fancy_step")
 			step.ResetStateDir()
 			err := step.MarkInProgress()
 			Expect(err).ToNot(HaveOccurred())
@@ -36,7 +36,7 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 			tempdir, _ := ioutil.TempDir("", "")
 
 			cm := upgradestatus.NewChecklistManager(filepath.Join(tempdir, ".gpupgrade"))
-			step := cm.StepWriter("fancy_step")
+			step := cm.GetStepWriter("fancy_step")
 			step.ResetStateDir()
 			step.MarkInProgress() // lay the file down once
 			err := step.MarkInProgress()
@@ -54,7 +54,7 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 			tempdir, _ := ioutil.TempDir("", "")
 
 			cm := upgradestatus.NewChecklistManager(filepath.Join(tempdir, ".gpupgrade"))
-			step := cm.StepWriter("fancy_step")
+			step := cm.GetStepWriter("fancy_step")
 			step.ResetStateDir()
 			err := step.MarkInProgress()
 			Expect(err).To(HaveOccurred())
@@ -67,7 +67,7 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return errors.New("cant remove all")
 			}
 			cm := upgradestatus.NewChecklistManager("/some/random/dir")
-			step := cm.StepWriter("fancy_step")
+			step := cm.GetStepWriter("fancy_step")
 			err := step.ResetStateDir()
 			Expect(err).To(HaveOccurred())
 		})
@@ -80,7 +80,7 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return errors.New("cant make dir")
 			}
 			cm := upgradestatus.NewChecklistManager("/some/random/dir")
-			step := cm.StepWriter("fancy_step")
+			step := cm.GetStepWriter("fancy_step")
 			err := step.ResetStateDir()
 			Expect(err).To(HaveOccurred())
 		})
@@ -92,7 +92,7 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return nil
 			}
 			cm := upgradestatus.NewChecklistManager("/some/random/dir")
-			step := cm.StepWriter("fancy_step")
+			step := cm.GetStepWriter("fancy_step")
 			err := step.ResetStateDir()
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -104,7 +104,7 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return errors.New("remove failed")
 			}
 			cm := upgradestatus.NewChecklistManager("/some/random/dir")
-			step := cm.StepWriter("step")
+			step := cm.GetStepWriter("step")
 			err := step.MarkFailed()
 			Expect(err.Error()).To(ContainSubstring("remove failed"))
 		})
@@ -116,7 +116,7 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return nil, errors.New("open file failed")
 			}
 			cm := upgradestatus.NewChecklistManager("/some/random/dir")
-			step := cm.StepWriter("step")
+			step := cm.GetStepWriter("step")
 			err := step.MarkFailed()
 			Expect(err.Error()).To(ContainSubstring("open file failed"))
 		})
@@ -128,7 +128,7 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return nil, nil
 			}
 			cm := upgradestatus.NewChecklistManager("/some/random/dir")
-			step := cm.StepWriter("step")
+			step := cm.GetStepWriter("step")
 			err := step.MarkFailed()
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -140,7 +140,7 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return errors.New("remove failed")
 			}
 			cm := upgradestatus.NewChecklistManager("/some/random/dir")
-			step := cm.StepWriter("step")
+			step := cm.GetStepWriter("step")
 			err := step.MarkFailed()
 			Expect(err.Error()).To(ContainSubstring("remove failed"))
 		})
@@ -152,7 +152,7 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return nil, errors.New("open file failed")
 			}
 			cm := upgradestatus.NewChecklistManager("/some/random/dir")
-			step := cm.StepWriter("step")
+			step := cm.GetStepWriter("step")
 			err := step.MarkComplete()
 			Expect(err.Error()).To(ContainSubstring("open file failed"))
 		})
@@ -164,7 +164,7 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return nil, nil
 			}
 			cm := upgradestatus.NewChecklistManager("/some/random/dir")
-			step := cm.StepWriter("step")
+			step := cm.GetStepWriter("step")
 			err := step.MarkComplete()
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/hub/upgradestatus/checklist_manager_test.go
+++ b/hub/upgradestatus/checklist_manager_test.go
@@ -23,8 +23,9 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 			tempdir, _ := ioutil.TempDir("", "")
 
 			cm := upgradestatus.NewChecklistManager(filepath.Join(tempdir, ".gpupgrade"))
-			cm.ResetStateDir("fancy_step")
-			err := cm.MarkInProgress("fancy_step")
+			step := cm.StepWriter("fancy_step")
+			step.ResetStateDir()
+			err := step.MarkInProgress()
 			Expect(err).ToNot(HaveOccurred())
 			expectedFile := filepath.Join(tempdir, ".gpupgrade", "fancy_step", "in.progress")
 			_, err = os.Stat(expectedFile)
@@ -35,9 +36,10 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 			tempdir, _ := ioutil.TempDir("", "")
 
 			cm := upgradestatus.NewChecklistManager(filepath.Join(tempdir, ".gpupgrade"))
-			cm.ResetStateDir("fancy_step")
-			cm.MarkInProgress("fancy_step") // lay the file down once
-			err := cm.MarkInProgress("fancy_step")
+			step := cm.StepWriter("fancy_step")
+			step.ResetStateDir()
+			step.MarkInProgress() // lay the file down once
+			err := step.MarkInProgress()
 			Expect(err).ToNot(HaveOccurred())
 			expectedFile := filepath.Join(tempdir, ".gpupgrade", "fancy_step", "in.progress")
 			_, err = os.Stat(expectedFile)
@@ -52,8 +54,9 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 			tempdir, _ := ioutil.TempDir("", "")
 
 			cm := upgradestatus.NewChecklistManager(filepath.Join(tempdir, ".gpupgrade"))
-			cm.ResetStateDir("fancy_step")
-			err := cm.MarkInProgress("fancy_step")
+			step := cm.StepWriter("fancy_step")
+			step.ResetStateDir()
+			err := step.MarkInProgress()
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -64,7 +67,8 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return errors.New("cant remove all")
 			}
 			cm := upgradestatus.NewChecklistManager("/some/random/dir")
-			err := cm.ResetStateDir("fancy_step")
+			step := cm.StepWriter("fancy_step")
+			err := step.ResetStateDir()
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -76,7 +80,8 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return errors.New("cant make dir")
 			}
 			cm := upgradestatus.NewChecklistManager("/some/random/dir")
-			err := cm.ResetStateDir("fancy_step")
+			step := cm.StepWriter("fancy_step")
+			err := step.ResetStateDir()
 			Expect(err).To(HaveOccurred())
 		})
 		It("succeeds as long as we assume the file system calls do their job", func() {
@@ -87,7 +92,8 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return nil
 			}
 			cm := upgradestatus.NewChecklistManager("/some/random/dir")
-			err := cm.ResetStateDir("fancy_step")
+			step := cm.StepWriter("fancy_step")
+			err := step.ResetStateDir()
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -98,7 +104,8 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return errors.New("remove failed")
 			}
 			cm := upgradestatus.NewChecklistManager("/some/random/dir")
-			err := cm.MarkFailed("step")
+			step := cm.StepWriter("step")
+			err := step.MarkFailed()
 			Expect(err.Error()).To(ContainSubstring("remove failed"))
 		})
 		It("errors if failed file can't be created", func() {
@@ -109,7 +116,8 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return nil, errors.New("open file failed")
 			}
 			cm := upgradestatus.NewChecklistManager("/some/random/dir")
-			err := cm.MarkFailed("step")
+			step := cm.StepWriter("step")
+			err := step.MarkFailed()
 			Expect(err.Error()).To(ContainSubstring("open file failed"))
 		})
 		It("returns nil if nothing fails", func() {
@@ -120,7 +128,8 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return nil, nil
 			}
 			cm := upgradestatus.NewChecklistManager("/some/random/dir")
-			err := cm.MarkFailed("step")
+			step := cm.StepWriter("step")
+			err := step.MarkFailed()
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -131,7 +140,8 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return errors.New("remove failed")
 			}
 			cm := upgradestatus.NewChecklistManager("/some/random/dir")
-			err := cm.MarkFailed("step")
+			step := cm.StepWriter("step")
+			err := step.MarkFailed()
 			Expect(err.Error()).To(ContainSubstring("remove failed"))
 		})
 		It("errors if completed file can't be created", func() {
@@ -142,7 +152,8 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return nil, errors.New("open file failed")
 			}
 			cm := upgradestatus.NewChecklistManager("/some/random/dir")
-			err := cm.MarkComplete("step")
+			step := cm.StepWriter("step")
+			err := step.MarkComplete()
 			Expect(err.Error()).To(ContainSubstring("open file failed"))
 		})
 		It("returns nil if nothing fails", func() {
@@ -153,7 +164,8 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return nil, nil
 			}
 			cm := upgradestatus.NewChecklistManager("/some/random/dir")
-			err := cm.MarkComplete("step")
+			step := cm.StepWriter("step")
+			err := step.MarkComplete()
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/hub/upgradestatus/pg_upgrade_status_checker.go
+++ b/hub/upgradestatus/pg_upgrade_status_checker.go
@@ -44,37 +44,18 @@ func NewPGUpgradeStatusChecker(segType SegmentType, pgUpgradePath, oldDataDir st
 	- pg_upgrade will not fail without error before writing an inprogress file
 	- when a new pg_upgrade is started it deletes all *.done and *.inprogress files
 */
-func (c *ConvertSegment) GetStatus() *pb.UpgradeStepStatus {
-	//make default reply object
-	upgradeStatus := &pb.UpgradeStepStatus{
-		Status: pb.StepStatus_FAILED,
+func (c *ConvertSegment) GetStatus() pb.StepStatus {
+	_, err := utils.System.Stat(c.pgUpgradePath)
+	switch {
+	case utils.System.IsNotExist(err):
+		return pb.StepStatus_PENDING
+	case c.pgUpgradeRunning():
+		return pb.StepStatus_RUNNING
+	case !inProgressFilesExist(c.pgUpgradePath) && c.IsUpgradeComplete(c.pgUpgradePath):
+		return pb.StepStatus_COMPLETE
+	default:
+		return pb.StepStatus_FAILED
 	}
-	//update Step in reply object to match the conversion
-	if c.segType == MASTER {
-		upgradeStatus.Step = pb.UpgradeSteps_MASTERUPGRADE
-	} else if c.segType == PRIMARY {
-		upgradeStatus.Step = pb.UpgradeSteps_CONVERT_PRIMARIES
-	}
-	pgUpgradePath := c.pgUpgradePath
-
-	//update Status in reply object
-	if _, err := utils.System.Stat(pgUpgradePath); utils.System.IsNotExist(err) {
-		upgradeStatus.Status = pb.StepStatus_PENDING
-		return upgradeStatus
-	}
-
-	if c.pgUpgradeRunning() {
-		upgradeStatus.Status = pb.StepStatus_RUNNING
-		return upgradeStatus
-	}
-
-	if !inProgressFilesExist(pgUpgradePath) && c.IsUpgradeComplete(pgUpgradePath) {
-		upgradeStatus.Status = pb.StepStatus_COMPLETE
-		return upgradeStatus
-	}
-
-	//return default
-	return upgradeStatus
 }
 
 func (c *ConvertSegment) pgUpgradeRunning() bool {

--- a/hub/upgradestatus/pg_upgrade_status_checker_test.go
+++ b/hub/upgradestatus/pg_upgrade_status_checker_test.go
@@ -41,7 +41,7 @@ var _ = Describe("pg_upgrade status checker", func() {
 		}
 		subject := upgradestatus.NewPGUpgradeStatusChecker(upgradestatus.MASTER, "/tmp", "", testExecutor)
 		status := subject.GetStatus()
-		Expect(status.Status).To(Equal(pb.StepStatus_PENDING))
+		Expect(status).To(Equal(pb.StepStatus_PENDING))
 
 	})
 
@@ -57,7 +57,7 @@ var _ = Describe("pg_upgrade status checker", func() {
 
 		subject := upgradestatus.NewPGUpgradeStatusChecker(upgradestatus.MASTER, "/tmp", "", testExecutor)
 		status := subject.GetStatus()
-		Expect(status.Status).To(Equal(pb.StepStatus_RUNNING))
+		Expect(status).To(Equal(pb.StepStatus_RUNNING))
 	})
 
 	It("If pg_upgrade is not running and .done files exist and contain the string "+
@@ -99,7 +99,7 @@ var _ = Describe("pg_upgrade status checker", func() {
 
 		subject := upgradestatus.NewPGUpgradeStatusChecker(upgradestatus.MASTER, "/tmp", "/data/dir", testExecutor)
 		status := subject.GetStatus()
-		Expect(status.Status).To(Equal(pb.StepStatus_COMPLETE))
+		Expect(status).To(Equal(pb.StepStatus_COMPLETE))
 
 		Expect(testExecutor.LocalCommands).To(Equal([]string{"pgrep pg_upgrade | grep --old-datadir=/data/dir"}))
 	})
@@ -119,6 +119,6 @@ var _ = Describe("pg_upgrade status checker", func() {
 
 		subject := upgradestatus.NewPGUpgradeStatusChecker(upgradestatus.MASTER, "/tmp", "", testExecutor)
 		status := subject.GetStatus()
-		Expect(status.Status).To(Equal(pb.StepStatus_FAILED))
+		Expect(status).To(Equal(pb.StepStatus_FAILED))
 	})
 })

--- a/hub/upgradestatus/pg_upgrade_status_checker_test.go
+++ b/hub/upgradestatus/pg_upgrade_status_checker_test.go
@@ -39,8 +39,7 @@ var _ = Describe("pg_upgrade status checker", func() {
 		utils.System.IsNotExist = func(error) bool {
 			return true
 		}
-		subject := upgradestatus.NewPGUpgradeStatusChecker(upgradestatus.MASTER, "/tmp", "", testExecutor)
-		status := subject.GetStatus()
+		status := upgradestatus.SegmentConversionStatus("/tmp", "", testExecutor)
 		Expect(status).To(Equal(pb.StepStatus_PENDING))
 
 	})
@@ -55,8 +54,7 @@ var _ = Describe("pg_upgrade status checker", func() {
 
 		testExecutor.LocalOutput = "I'm running"
 
-		subject := upgradestatus.NewPGUpgradeStatusChecker(upgradestatus.MASTER, "/tmp", "", testExecutor)
-		status := subject.GetStatus()
+		status := upgradestatus.SegmentConversionStatus("/tmp", "", testExecutor)
 		Expect(status).To(Equal(pb.StepStatus_RUNNING))
 	})
 
@@ -97,8 +95,7 @@ var _ = Describe("pg_upgrade status checker", func() {
 			return os.Open(filename)
 		}
 
-		subject := upgradestatus.NewPGUpgradeStatusChecker(upgradestatus.MASTER, "/tmp", "/data/dir", testExecutor)
-		status := subject.GetStatus()
+		status := upgradestatus.SegmentConversionStatus("/tmp", "/data/dir", testExecutor)
 		Expect(status).To(Equal(pb.StepStatus_COMPLETE))
 
 		Expect(testExecutor.LocalCommands).To(Equal([]string{"pgrep pg_upgrade | grep --old-datadir=/data/dir"}))
@@ -117,8 +114,7 @@ var _ = Describe("pg_upgrade status checker", func() {
 
 		testExecutor.LocalError = errors.New("pg_upgrade failed")
 
-		subject := upgradestatus.NewPGUpgradeStatusChecker(upgradestatus.MASTER, "/tmp", "", testExecutor)
-		status := subject.GetStatus()
+		status := upgradestatus.SegmentConversionStatus("/tmp", "", testExecutor)
 		Expect(status).To(Equal(pb.StepStatus_FAILED))
 	})
 })

--- a/hub/upgradestatus/shutdown_clusters.go
+++ b/hub/upgradestatus/shutdown_clusters.go
@@ -8,26 +8,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 )
 
-type ShutDownClusters struct {
-	gpstopStatePath string
-	executor        cluster.Executor
-}
-
-func NewShutDownClusters(gpstopStatePath string, executor cluster.Executor) ShutDownClusters {
-	return ShutDownClusters{
-		gpstopStatePath: gpstopStatePath,
-		executor:        executor,
-	}
-}
-
-/*
- assumptions here are:
-	- gpstop will not fail without error before writing an inprogress file
-	- when a new gpstop is started it deletes all *.done and *.inprogress files
-*/
-func (s *ShutDownClusters) GetStatus() pb.StepStatus {
-	gpstopStatePath := s.gpstopStatePath
-
+func ClusterShutdownStatus(gpstopStatePath string, execer cluster.Executor) pb.StepStatus {
 	_, err := utils.System.Stat(gpstopStatePath)
 	switch {
 	case utils.System.IsNotExist(err):
@@ -38,10 +19,10 @@ func (s *ShutDownClusters) GetStatus() pb.StepStatus {
 	 * We only care if the inprogress file exists. We are relying on the hub to never go down
 	 * for this state processing to work.
 	 */
-	case s.isGpstopRunning() && s.inProgressFilesExist(gpstopStatePath):
+	case isGpstopRunning(execer) && stopProgressFilesExist(gpstopStatePath):
 		return pb.StepStatus_RUNNING
 
-	case !s.inProgressFilesExist(gpstopStatePath) && s.IsStopComplete(gpstopStatePath):
+	case !stopProgressFilesExist(gpstopStatePath) && isStopComplete(gpstopStatePath):
 		return pb.StepStatus_COMPLETE
 
 	default:
@@ -49,16 +30,19 @@ func (s *ShutDownClusters) GetStatus() pb.StepStatus {
 	}
 }
 
-func (s *ShutDownClusters) isGpstopRunning() bool {
+// XXX This is all pretty much a copy-paste from PGUpgradeStatusChecker... is
+// there a way to consolidate?
+
+func isGpstopRunning(execer cluster.Executor) bool {
 	//if pgrep doesnt find target, ExecCmdOutput will return empty byte array and err.Error()="exit status 1"
-	pgUpgradePids, err := s.executor.ExecuteLocalCommand("pgrep -f gpstop")
+	pgUpgradePids, err := execer.ExecuteLocalCommand("pgrep -f gpstop")
 	if err == nil && len(pgUpgradePids) != 0 {
 		return true
 	}
 	return false
 }
 
-func (s *ShutDownClusters) inProgressFilesExist(gpstopStatePath string) bool {
+func stopProgressFilesExist(gpstopStatePath string) bool {
 	files, err := utils.System.FilePathGlob(gpstopStatePath + "/*/in.progress")
 	if files == nil {
 		return false
@@ -72,7 +56,7 @@ func (s *ShutDownClusters) inProgressFilesExist(gpstopStatePath string) bool {
 	return true
 }
 
-func (s *ShutDownClusters) IsStopComplete(gpstopStatePath string) bool {
+func isStopComplete(gpstopStatePath string) bool {
 	completeFiles, completeErr := utils.System.FilePathGlob(gpstopStatePath + "/*/completed")
 	if completeFiles == nil {
 		return false

--- a/hub/upgradestatus/shutdown_clusters_test.go
+++ b/hub/upgradestatus/shutdown_clusters_test.go
@@ -30,7 +30,7 @@ var _ = Describe("hub", func() {
 		utils.System = utils.InitializeSystemFunctions()
 	})
 
-	Describe("ShutDownClusters", func() {
+	Describe("ClusterShutdownStatus", func() {
 		It("If gpstop dir does not exist, return status of PENDING", func() {
 			utils.System.Stat = func(name string) (os.FileInfo, error) {
 				return nil, nil
@@ -38,8 +38,7 @@ var _ = Describe("hub", func() {
 			utils.System.IsNotExist = func(error) bool {
 				return true
 			}
-			subject := upgradestatus.NewShutDownClusters("/tmp", testExecutor)
-			status := subject.GetStatus()
+			status := upgradestatus.ClusterShutdownStatus("/tmp", testExecutor)
 			Expect(status).To(Equal(pb.StepStatus_PENDING))
 
 		})
@@ -59,8 +58,7 @@ var _ = Describe("hub", func() {
 				}
 				return nil, errors.New("Test not configured for this glob.")
 			}
-			subject := upgradestatus.NewShutDownClusters("/tmp", testExecutor)
-			status := subject.GetStatus()
+			status := upgradestatus.ClusterShutdownStatus("/tmp", testExecutor)
 			Expect(status).To(Equal(pb.StepStatus_RUNNING))
 		})
 		It("If gpstop is not running and .complete files exist and contain the string "+
@@ -89,8 +87,7 @@ var _ = Describe("hub", func() {
 				}
 				return nil, nil
 			}
-			subject := upgradestatus.NewShutDownClusters("/tmp", testExecutor)
-			status := subject.GetStatus()
+			status := upgradestatus.ClusterShutdownStatus("/tmp", testExecutor)
 			Expect(status).To(Equal(pb.StepStatus_COMPLETE))
 		})
 		// We are assuming that no inprogress actually exists in the path we're using,
@@ -106,8 +103,7 @@ var _ = Describe("hub", func() {
 
 			testExecutor.LocalError = errors.New("gpstop failed")
 
-			subject := upgradestatus.NewShutDownClusters("/tmp", testExecutor)
-			status := subject.GetStatus()
+			status := upgradestatus.ClusterShutdownStatus("/tmp", testExecutor)
 			Expect(status).To(Equal(pb.StepStatus_FAILED))
 		})
 	})

--- a/hub/upgradestatus/shutdown_clusters_test.go
+++ b/hub/upgradestatus/shutdown_clusters_test.go
@@ -40,7 +40,7 @@ var _ = Describe("hub", func() {
 			}
 			subject := upgradestatus.NewShutDownClusters("/tmp", testExecutor)
 			status := subject.GetStatus()
-			Expect(status.Status).To(Equal(pb.StepStatus_PENDING))
+			Expect(status).To(Equal(pb.StepStatus_PENDING))
 
 		})
 		It("If gpstop is running, return status of RUNNING", func() {
@@ -61,7 +61,7 @@ var _ = Describe("hub", func() {
 			}
 			subject := upgradestatus.NewShutDownClusters("/tmp", testExecutor)
 			status := subject.GetStatus()
-			Expect(status.Status).To(Equal(pb.StepStatus_RUNNING))
+			Expect(status).To(Equal(pb.StepStatus_RUNNING))
 		})
 		It("If gpstop is not running and .complete files exist and contain the string "+
 			"'Upgrade completed',return status of COMPLETED", func() {
@@ -91,7 +91,7 @@ var _ = Describe("hub", func() {
 			}
 			subject := upgradestatus.NewShutDownClusters("/tmp", testExecutor)
 			status := subject.GetStatus()
-			Expect(status.Status).To(Equal(pb.StepStatus_COMPLETE))
+			Expect(status).To(Equal(pb.StepStatus_COMPLETE))
 		})
 		// We are assuming that no inprogress actually exists in the path we're using,
 		// so we don't need to mock the checks out.
@@ -108,7 +108,7 @@ var _ = Describe("hub", func() {
 
 			subject := upgradestatus.NewShutDownClusters("/tmp", testExecutor)
 			status := subject.GetStatus()
-			Expect(status.Status).To(Equal(pb.StepStatus_FAILED))
+			Expect(status).To(Equal(pb.StepStatus_FAILED))
 		})
 	})
 })

--- a/hub/upgradestatus/state_checker_test.go
+++ b/hub/upgradestatus/state_checker_test.go
@@ -30,10 +30,9 @@ var _ = Describe("Upgradestatus/Seginstall", func() {
 	})
 
 	It("Reports PENDING if no directory exists", func() {
-		stateChecker := upgradestatus.NewStateCheck("/fake/path", pb.UpgradeSteps_SEGINSTALL)
+		stateChecker := upgradestatus.StateCheck{"/fake/path", pb.UpgradeSteps_SEGINSTALL}
 		upgradeStepStatus := stateChecker.GetStatus()
-		Expect(upgradeStepStatus.Step).To(Equal(pb.UpgradeSteps_SEGINSTALL))
-		Expect(upgradeStepStatus.Status).To(Equal(pb.StepStatus_PENDING))
+		Expect(upgradeStepStatus).To(Equal(pb.StepStatus_PENDING))
 	})
 	It("Reports RUNNING if statedir exists and contains inprogress file", func() {
 		fakePath := "/fake/path"
@@ -49,10 +48,9 @@ var _ = Describe("Upgradestatus/Seginstall", func() {
 			}
 			return nil, errors.New("didn't match expected glob pattern")
 		}
-		stateChecker := upgradestatus.NewStateCheck(fakePath, pb.UpgradeSteps_SEGINSTALL)
+		stateChecker := upgradestatus.StateCheck{fakePath, pb.UpgradeSteps_SEGINSTALL}
 		upgradeStepStatus := stateChecker.GetStatus()
-		Expect(upgradeStepStatus.Step).To(Equal(pb.UpgradeSteps_SEGINSTALL))
-		Expect(upgradeStepStatus.Status).To(Equal(pb.StepStatus_RUNNING))
+		Expect(upgradeStepStatus).To(Equal(pb.StepStatus_RUNNING))
 	})
 	It("Reports FAILED if statedir exists and contains failed file", func() {
 		fakePath := "/fake/path"
@@ -68,10 +66,9 @@ var _ = Describe("Upgradestatus/Seginstall", func() {
 			}
 			return nil, errors.New("didn't match expected glob pattern")
 		}
-		stateChecker := upgradestatus.NewStateCheck(fakePath, pb.UpgradeSteps_SEGINSTALL)
+		stateChecker := upgradestatus.StateCheck{fakePath, pb.UpgradeSteps_SEGINSTALL}
 		upgradeStepStatus := stateChecker.GetStatus()
-		Expect(upgradeStepStatus.Step).To(Equal(pb.UpgradeSteps_SEGINSTALL))
-		Expect(upgradeStepStatus.Status).To(Equal(pb.StepStatus_FAILED))
+		Expect(upgradeStepStatus).To(Equal(pb.StepStatus_FAILED))
 	})
 
 	It("logs an error if there is more than one file at the specified path", func() {
@@ -89,7 +86,7 @@ var _ = Describe("Upgradestatus/Seginstall", func() {
 			}
 			return nil, errors.New("didn't match expected glob pattern")
 		}
-		stateChecker := upgradestatus.NewStateCheck(overabundantDirectory, pb.UpgradeSteps_SEGINSTALL)
+		stateChecker := upgradestatus.StateCheck{overabundantDirectory, pb.UpgradeSteps_SEGINSTALL}
 		upgradeStepStatus := stateChecker.GetStatus()
 
 		// This is a little brittle, sorry...
@@ -97,7 +94,6 @@ var _ = Describe("Upgradestatus/Seginstall", func() {
 		Expect(testLog).To(gbytes.Say(expectederr))
 
 		// The installation should still be marked pending.
-		Expect(upgradeStepStatus.Step).To(Equal(pb.UpgradeSteps_SEGINSTALL))
-		Expect(upgradeStepStatus.Status).To(Equal(pb.StepStatus_PENDING))
+		Expect(upgradeStepStatus).To(Equal(pb.StepStatus_PENDING))
 	})
 })

--- a/integrations/status_command_test.go
+++ b/integrations/status_command_test.go
@@ -47,6 +47,7 @@ var _ = Describe("status", func() {
 			StateDir:       testStateDir,
 		}
 
+		cm = testutils.NewMockChecklistManager()
 		hub = hubServices.NewHub(testutils.InitClusterPairFromDB(), grpc.DialContext, conf, cm)
 		go hub.Start()
 	})

--- a/integrations/status_command_test.go
+++ b/integrations/status_command_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	agentServices "github.com/greenplum-db/gpupgrade/agent/services"
 	hubServices "github.com/greenplum-db/gpupgrade/hub/services"
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
+	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
 
 	"github.com/onsi/gomega/gbytes"
@@ -77,8 +79,16 @@ var _ = Describe("status", func() {
 		})
 	})
 
+	// FIXME: The LoadSteps() method is ugly. It kind of proves that this should
+	// be an end-to-end acceptance test, which ensures that `status upgrade`
+	// does something actually useful.
 	Describe("upgrade", func() {
-		It("Reports some demo status from the hub", func() {
+		It("Reports status from the hub Checklist", func() {
+			cm.LoadSteps([]upgradestatus.Step{
+				{upgradestatus.CONFIG, pb.UpgradeSteps_CHECK_CONFIG, nil},
+				{upgradestatus.SEGINSTALL, pb.UpgradeSteps_SEGINSTALL, nil},
+			})
+
 			statusSession := runCommand("status", "upgrade")
 			Eventually(statusSession).Should(Exit(0))
 

--- a/integrations/upgrade_convert_primaries_test.go
+++ b/integrations/upgrade_convert_primaries_test.go
@@ -89,7 +89,7 @@ var _ = Describe("upgrade convert primaries", func() {
 		Expect(runStatusUpgrade()).To(ContainSubstring("PENDING - Primary segment upgrade"))
 		testExecutor.LocalOutput = "TEST"
 
-		step := cm.StepWriter("start-agents")
+		step := cm.GetStepWriter("start-agents")
 		step.MarkInProgress()
 		step.MarkComplete()
 
@@ -136,7 +136,7 @@ var _ = Describe("upgrade convert primaries", func() {
 		Expect(runStatusUpgrade()).To(ContainSubstring("PENDING - Primary segment upgrade"))
 		setStateFile(testStateDir, "pg_upgrade/seg-0", "1.failed")
 
-		step := cm.StepWriter("start-agents")
+		step := cm.GetStepWriter("start-agents")
 		step.MarkInProgress()
 		step.MarkComplete()
 

--- a/integrations/upgrade_convert_primaries_test.go
+++ b/integrations/upgrade_convert_primaries_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	agentServices "github.com/greenplum-db/gpupgrade/agent/services"
 	"github.com/greenplum-db/gpupgrade/hub/services"
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
+	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/utils"
 
@@ -73,12 +75,17 @@ var _ = Describe("upgrade convert primaries", func() {
 		Expect(checkPortIsAvailable(port)).To(BeTrue())
 	})
 
-	// TODO: update to use MockChecklistManager.
-	It("updates status PENDING to RUNNING then to COMPLETE if successful", func() {
+	// Move this elsewhere; it's not testing what's useful anymore.
+	XIt("updates status PENDING to RUNNING then to COMPLETE if successful", func() {
 		utils.System.RunCommandAsync = func(cmdStr string, logFile string) error {
 			_, err := agentExecutor.ExecuteLocalCommand(cmdStr)
 			return err
 		}
+
+		cm.LoadSteps([]upgradestatus.Step{
+			{upgradestatus.CONVERT_PRIMARY, pb.UpgradeSteps_CONVERT_PRIMARIES, nil},
+		})
+
 		Expect(runStatusUpgrade()).To(ContainSubstring("PENDING - Primary segment upgrade"))
 		testExecutor.LocalOutput = "TEST"
 
@@ -120,7 +127,12 @@ var _ = Describe("upgrade convert primaries", func() {
 		Expect(runStatusUpgrade()).To(ContainSubstring("COMPLETE - Primary segment upgrade"))
 	})
 
-	It("updates status to FAILED if it fails to run", func() {
+	// Move this elsewhere; it's not testing what's useful anymore.
+	XIt("updates status to FAILED if convert primaries fails on at least 1 agent", func() {
+		cm.LoadSteps([]upgradestatus.Step{
+			{upgradestatus.CONVERT_PRIMARY, pb.UpgradeSteps_CONVERT_PRIMARIES, nil},
+		})
+
 		Expect(runStatusUpgrade()).To(ContainSubstring("PENDING - Primary segment upgrade"))
 		setStateFile(testStateDir, "pg_upgrade/seg-0", "1.failed")
 

--- a/testutils/mock_checklist_manager.go
+++ b/testutils/mock_checklist_manager.go
@@ -1,5 +1,7 @@
 package testutils
 
+import "github.com/greenplum-db/gpupgrade/hub/upgradestatus"
+
 type MockChecklistManager struct {
 	mapComplete   map[string]bool
 	mapFailed     map[string]bool
@@ -16,26 +18,35 @@ func NewMockChecklistManager() *MockChecklistManager {
 	}
 }
 
-func (cm *MockChecklistManager) MarkComplete(step string) error {
-	cm.mapComplete[step] = true
+func (cm *MockChecklistManager) StepWriter(step string) upgradestatus.StateWriter {
+	return MockStepWriter{step: step, manager: cm}
+}
+
+type MockStepWriter struct {
+	step    string
+	manager *MockChecklistManager
+}
+
+func (w MockStepWriter) MarkComplete() error {
+	w.manager.mapComplete[w.step] = true
 	return nil
 }
 
-func (cm *MockChecklistManager) MarkInProgress(step string) error {
-	cm.mapInProgress[step] = true
+func (w MockStepWriter) MarkInProgress() error {
+	w.manager.mapInProgress[w.step] = true
 	return nil
 }
 
-func (cm *MockChecklistManager) MarkFailed(step string) error {
-	cm.mapFailed[step] = true
+func (w MockStepWriter) MarkFailed() error {
+	w.manager.mapFailed[w.step] = true
 	return nil
 }
 
-func (cm *MockChecklistManager) ResetStateDir(step string) error {
-	cm.mapReset[step] = true
-	cm.mapComplete[step] = false
-	cm.mapFailed[step] = false
-	cm.mapInProgress[step] = false
+func (w MockStepWriter) ResetStateDir() error {
+	w.manager.mapReset[w.step] = true
+	w.manager.mapComplete[w.step] = false
+	w.manager.mapFailed[w.step] = false
+	w.manager.mapInProgress[w.step] = false
 	return nil
 }
 

--- a/testutils/mock_checklist_manager.go
+++ b/testutils/mock_checklist_manager.go
@@ -25,7 +25,7 @@ func NewMockChecklistManager() *MockChecklistManager {
 	}
 }
 
-func (cm *MockChecklistManager) StepReader(step string) upgradestatus.StateReader {
+func (cm *MockChecklistManager) GetStepReader(step string) upgradestatus.StateReader {
 	return MockStepReader{step: step, code: cm.loadedCodes[step], manager: cm}
 }
 
@@ -41,12 +41,12 @@ func (cm *MockChecklistManager) LoadSteps(steps []upgradestatus.Step) {
 func (cm *MockChecklistManager) AllSteps() []upgradestatus.StateReader {
 	steps := make([]upgradestatus.StateReader, len(cm.loadedNames))
 	for i, name := range cm.loadedNames {
-		steps[i] = cm.StepReader(name)
+		steps[i] = cm.GetStepReader(name)
 	}
 	return steps
 }
 
-func (cm *MockChecklistManager) StepWriter(step string) upgradestatus.StateWriter {
+func (cm *MockChecklistManager) GetStepWriter(step string) upgradestatus.StateWriter {
 	return MockStepWriter{step: step, manager: cm}
 }
 


### PR DESCRIPTION
Step state handling for `status upgrade` -- both reading and writing -- are now encapsulated in the top-level `Checklist`. Here are the key things that gives us:

- Since steps are now associated with their ProtoBuf code in the `Checklist`, we don't need to pass the codes around when fetching status. This lets us remove plenty of boilerplate code, as well as a couple of helper structs that didn't really serve any purpose except to remember which step we were on.
- State reading and writing are pulled into separate interfaces that encapsulate each operation. The API that writes state to the filesystem no longer requires callers to know the name or any other details of the step they're writing to; they just write to a step. Same for readers (see for instance the simplification of `StatusUpgrade`'s implementation).
- Centralization of state mocking during tests has flushed out coverage gaps and other deficiencies.

There's still plenty of work to do, but this should be a good step forward so we see what we like about the new interface and what we don't.