### PR TITLE
Unify integration test initialization

### DIFF
--- a/integrations/check_config_test.go
+++ b/integrations/check_config_test.go
@@ -3,46 +3,16 @@ package integrations_test
 import (
 	"fmt"
 
-	"github.com/greenplum-db/gpupgrade/hub/services"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
-	"google.golang.org/grpc"
 )
 
 // needs the cli and the hub
 var _ = Describe("check config", func() {
-	var (
-		hub            *services.Hub
-		hubToAgentPort int
-	)
-
-	BeforeEach(func() {
-		hubToAgentPort = 6416
-
-		var err error
-
-		port, err = testutils.GetOpenPort()
-		Expect(err).ToNot(HaveOccurred())
-
-		conf := &services.HubConfig{
-			CliToHubPort:   port,
-			HubToAgentPort: hubToAgentPort,
-			StateDir:       testStateDir,
-		}
-
-		cm := testutils.NewMockChecklistManager()
-		hub = services.NewHub(testutils.InitClusterPairFromDB(), grpc.DialContext, conf, cm)
-		go hub.Start()
-	})
-
-	AfterEach(func() {
-		hub.Stop()
-	})
-
 	It("happy: the database configuration is saved to a specified location", func() {
 		session := runCommand("check", "config", "--master-host", "localhost", "--old-bindir", "/old/bin/dir")
 		if session.ExitCode() != 0 {

--- a/integrations/hub_test.go
+++ b/integrations/hub_test.go
@@ -12,16 +12,6 @@ import (
 	. "github.com/onsi/gomega/gexec"
 )
 
-func killHub() {
-	killCommand := exec.Command("pkill", "-9", "gpupgrade_hub")
-	session, err := Start(killCommand, GinkgoWriter, GinkgoWriter)
-
-	Expect(err).ToNot(HaveOccurred())
-	session.Wait()
-
-	Expect(checkPortIsAvailable(port)).To(BeTrue())
-}
-
 var _ = Describe("gpupgrade_hub", func() {
 
 	// XXX We should be testing the locally built artifacts, and killing only

--- a/integrations/prepare_init_cluster_test.go
+++ b/integrations/prepare_init_cluster_test.go
@@ -3,43 +3,15 @@ package integrations_test
 import (
 	"os"
 
-	"github.com/greenplum-db/gpupgrade/hub/services"
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
-	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
-	"google.golang.org/grpc"
 )
 
 // the `prepare start-hub` tests are currently in master_only_integration_test
 var _ = Describe("prepare", func() {
-	var (
-		hub *services.Hub
-		cm  *testutils.MockChecklistManager
-	)
-
-	BeforeEach(func() {
-		var err error
-		port, err = testutils.GetOpenPort()
-		Expect(err).ToNot(HaveOccurred())
-
-		conf := &services.HubConfig{
-			CliToHubPort:   port,
-			HubToAgentPort: 6416,
-			StateDir:       testStateDir,
-		}
-		cm = testutils.NewMockChecklistManager()
-		hub = services.NewHub(testutils.InitClusterPairFromDB(), grpc.DialContext, conf, cm)
-		go hub.Start()
-	})
-
-	AfterEach(func() {
-		hub.Stop()
-		Expect(checkPortIsAvailable(port)).To(BeTrue())
-	})
-
 	/* This is demonstrating the limited implementation of init-cluster.
 	    Assuming the user has already set up their new cluster, they should `init-cluster`
 		with the port at which they stood it up, so the upgrade tool can create new_cluster_config

--- a/integrations/prepare_shutdown_clusters_test.go
+++ b/integrations/prepare_shutdown_clusters_test.go
@@ -4,60 +4,31 @@ import (
 	"errors"
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"github.com/greenplum-db/gpupgrade/hub/services"
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
-	"github.com/greenplum-db/gpupgrade/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
-	"google.golang.org/grpc"
 )
 
 var _ = Describe("prepare shutdown-clusters", func() {
 	var (
-		hub             *services.Hub
 		mockAgent       *testutils.MockAgentServer
-		outChan         chan []byte
-		errChan         chan error
-		clusterPair     *utils.ClusterPair
 		testExecutorOld *testhelper.TestExecutor
 		testExecutorNew *testhelper.TestExecutor
-		cm              *testutils.MockChecklistManager
 	)
 
 	BeforeEach(func() {
+		mockAgent, hubToAgentPort = testutils.NewMockAgentServer()
 
-		var err error
-		port, err = testutils.GetOpenPort()
-		Expect(err).ToNot(HaveOccurred())
-
-		var agentPort int
-		mockAgent, agentPort = testutils.NewMockAgentServer()
-
-		conf := &services.HubConfig{
-			CliToHubPort:   port,
-			HubToAgentPort: agentPort,
-			StateDir:       testStateDir,
-		}
-		outChan = make(chan []byte, 5)
-		errChan = make(chan error, 5)
-
-		clusterPair = testutils.InitClusterPairFromDB()
 		testExecutorOld = &testhelper.TestExecutor{}
 		testExecutorNew = &testhelper.TestExecutor{}
-		clusterPair.OldCluster.Executor = testExecutorOld
-		clusterPair.NewCluster.Executor = testExecutorNew
-		clusterPair.OldBinDir = "/tmpOld"
-		clusterPair.NewBinDir = "/tmpNew"
-		cm = testutils.NewMockChecklistManager()
-		hub = services.NewHub(clusterPair, grpc.DialContext, conf, cm)
-		go hub.Start()
+		cp.OldCluster.Executor = testExecutorOld
+		cp.NewCluster.Executor = testExecutorNew
 	})
 
 	AfterEach(func() {
-		hub.Stop()
 		mockAgent.Stop()
 	})
 
@@ -68,16 +39,16 @@ var _ = Describe("prepare shutdown-clusters", func() {
 
 		Expect(cm.IsPending(upgradestatus.SHUTDOWN_CLUSTERS)).To(BeTrue())
 
-		prepareShutdownClustersSession := runCommand("prepare", "shutdown-clusters", "--old-bindir", clusterPair.OldBinDir, "--new-bindir", clusterPair.NewBinDir)
+		prepareShutdownClustersSession := runCommand("prepare", "shutdown-clusters", "--old-bindir", cp.OldBinDir, "--new-bindir", cp.NewBinDir)
 		Eventually(prepareShutdownClustersSession).Should(Exit(0))
 
 		Expect(testExecutorOld.NumExecutions).To(Equal(2))
 		Expect(testExecutorOld.LocalCommands[0]).To(ContainSubstring("pgrep"))
-		Expect(testExecutorOld.LocalCommands[1]).To(ContainSubstring(clusterPair.OldBinDir + "/gpstop -a"))
+		Expect(testExecutorOld.LocalCommands[1]).To(ContainSubstring(cp.OldBinDir + "/gpstop -a"))
 
 		Expect(testExecutorNew.NumExecutions).To(Equal(2))
 		Expect(testExecutorNew.LocalCommands[0]).To(ContainSubstring("pgrep"))
-		Expect(testExecutorNew.LocalCommands[1]).To(ContainSubstring(clusterPair.NewBinDir + "/gpstop -a"))
+		Expect(testExecutorNew.LocalCommands[1]).To(ContainSubstring(cp.NewBinDir + "/gpstop -a"))
 
 		Expect(cm.IsComplete(upgradestatus.SHUTDOWN_CLUSTERS)).To(BeTrue())
 	})
@@ -94,15 +65,15 @@ var _ = Describe("prepare shutdown-clusters", func() {
 		testExecutorOld.LocalError = errors.New("stop failed")
 		testExecutorNew.LocalError = errors.New("stop failed")
 
-		prepareShutdownClustersSession := runCommand("prepare", "shutdown-clusters", "--old-bindir", clusterPair.OldBinDir, "--new-bindir", clusterPair.NewBinDir)
+		prepareShutdownClustersSession := runCommand("prepare", "shutdown-clusters", "--old-bindir", cp.OldBinDir, "--new-bindir", cp.NewBinDir)
 		Eventually(prepareShutdownClustersSession).Should(Exit(0))
 
 		Expect(testExecutorOld.NumExecutions).To(Equal(2))
 		Expect(testExecutorOld.LocalCommands[0]).To(ContainSubstring("pgrep"))
-		Expect(testExecutorOld.LocalCommands[1]).To(ContainSubstring(clusterPair.OldBinDir + "/gpstop -a"))
+		Expect(testExecutorOld.LocalCommands[1]).To(ContainSubstring(cp.OldBinDir + "/gpstop -a"))
 		Expect(testExecutorOld.NumExecutions).To(Equal(2))
 		Expect(testExecutorNew.LocalCommands[0]).To(ContainSubstring("pgrep"))
-		Expect(testExecutorNew.LocalCommands[1]).To(ContainSubstring(clusterPair.NewBinDir + "/gpstop -a"))
+		Expect(testExecutorNew.LocalCommands[1]).To(ContainSubstring(cp.NewBinDir + "/gpstop -a"))
 		Expect(cm.IsFailed(upgradestatus.SHUTDOWN_CLUSTERS)).To(BeTrue())
 	})
 

--- a/integrations/prepare_start_agents_test.go
+++ b/integrations/prepare_start_agents_test.go
@@ -4,53 +4,14 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/greenplum-db/gp-common-go-libs/cluster"
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"github.com/greenplum-db/gpupgrade/hub/services"
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
-	"github.com/greenplum-db/gpupgrade/testutils"
-	"github.com/greenplum-db/gpupgrade/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
-	"google.golang.org/grpc"
 )
 
 var _ = Describe("prepare start-agents", func() {
-	var (
-		hub *services.Hub
-		cm  *testutils.MockChecklistManager
-		cp  *utils.ClusterPair
-		err error
-	)
-
-	BeforeEach(func() {
-		// The function runCommand depends on this port
-		port, err = testutils.GetOpenPort()
-		Expect(err).ToNot(HaveOccurred())
-
-		conf := &services.HubConfig{
-			CliToHubPort: port,
-			StateDir:     testStateDir,
-		}
-
-		cp = testutils.CreateSampleClusterPair()
-		cm = testutils.NewMockChecklistManager()
-
-		hub = services.NewHub(cp, grpc.DialContext, conf, cm)
-		go hub.Start()
-	})
-
-	AfterEach(func() {
-		hub.Stop()
-	})
-
 	It("updates status PENDING to RUNNING then to COMPLETE if successful", func() {
-		cp.OldCluster = testutils.CreateMultinodeSampleCluster()
-		testExecutor := &testhelper.TestExecutor{}
-		testExecutor.ClusterOutput = &cluster.RemoteOutput{}
-		cp.OldCluster.Executor = testExecutor
-
 		Expect(cm.IsPending(upgradestatus.START_AGENTS)).To(BeTrue())
 
 		prepareStartAgentsSession := runCommand("prepare", "start-agents")

--- a/integrations/prepare_start_hub_test.go
+++ b/integrations/prepare_start_hub_test.go
@@ -13,17 +13,11 @@ import (
 var _ = Describe("Start Hub", func() {
 
 	BeforeEach(func() {
-		killCommand := exec.Command("pkill", "-9", "gpupgrade_hub")
-		Start(killCommand, GinkgoWriter, GinkgoWriter)
-
-		Expect(checkPortIsAvailable(port)).To(BeTrue())
+		killHub()
 	})
 
 	AfterEach(func() {
-		killCommand := exec.Command("pkill", "-9", "gpupgrade_hub")
-		Start(killCommand, GinkgoWriter, GinkgoWriter)
-
-		Expect(checkPortIsAvailable(port)).To(BeTrue())
+		killHub()
 	})
 
 	It("finds the right hub binary and starts a daemonized process", func() {

--- a/integrations/status_command_test.go
+++ b/integrations/status_command_test.go
@@ -3,15 +3,10 @@ package integrations_test
 import (
 	"os"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	agentServices "github.com/greenplum-db/gpupgrade/agent/services"
-	hubServices "github.com/greenplum-db/gpupgrade/hub/services"
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	pb "github.com/greenplum-db/gpupgrade/idl"
-	"github.com/greenplum-db/gpupgrade/testutils"
 
 	"github.com/onsi/gomega/gbytes"
-	"google.golang.org/grpc"
 
 	"path/filepath"
 
@@ -21,45 +16,9 @@ import (
 )
 
 var _ = Describe("status", func() {
-	var (
-		hub   *hubServices.Hub
-		agent *agentServices.AgentServer
-		cm    *testutils.MockChecklistManager
-	)
-
 	BeforeEach(func() {
-		agentPort, err := testutils.GetOpenPort()
-		Expect(err).ToNot(HaveOccurred())
-
-		agentConf := agentServices.AgentConfig{
-			Port:     agentPort,
-			StateDir: testStateDir,
-		}
-
-		agentExecutor := &testhelper.TestExecutor{}
-		agent = agentServices.NewAgentServer(agentExecutor, agentConf)
 		go agent.Start()
-
-		port, err = testutils.GetOpenPort()
-		Expect(err).ToNot(HaveOccurred())
-
-		conf := &hubServices.HubConfig{
-			CliToHubPort:   port,
-			HubToAgentPort: agentPort,
-			StateDir:       testStateDir,
-		}
-
-		cm = testutils.NewMockChecklistManager()
-		hub = hubServices.NewHub(testutils.InitClusterPairFromDB(), grpc.DialContext, conf, cm)
-		go hub.Start()
 	})
-
-	AfterEach(func() {
-		hub.Stop()
-		agent.Stop()
-		Expect(checkPortIsAvailable(port)).To(BeTrue())
-	})
-
 	Describe("conversion", func() {
 		It("Displays status information for all segments", func() {
 			pathToSegUpgrade := filepath.Join(testStateDir, "pg_upgrade", "seg-0")

--- a/integrations/upgrade_convert_master_test.go
+++ b/integrations/upgrade_convert_master_test.go
@@ -1,42 +1,12 @@
 package integrations_test
 
 import (
-	"github.com/greenplum-db/gpupgrade/hub/services"
-	"github.com/greenplum-db/gpupgrade/testutils"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
-	"google.golang.org/grpc"
 )
 
 var _ = Describe("upgrade convert master", func() {
-	var (
-		hub *services.Hub
-		cm  *testutils.MockChecklistManager
-	)
-
-	BeforeEach(func() {
-		port, err := testutils.GetOpenPort()
-		Expect(err).ToNot(HaveOccurred())
-
-		conf := &services.HubConfig{
-			CliToHubPort:   port,
-			HubToAgentPort: 0,
-			StateDir:       testStateDir,
-		}
-
-		cm = testutils.NewMockChecklistManager()
-
-		hub = services.NewHub(testutils.InitClusterPairFromDB(), grpc.DialContext, conf, cm)
-		go hub.Start()
-	})
-
-	AfterEach(func() {
-		hub.Stop()
-		Expect(checkPortIsAvailable(port)).To(BeTrue())
-	})
-
 	/*
 	 * We don't have any integration tests testing the actual behavior of convert
 	 * master because that function just performs setup and then calls pg_upgrade,

--- a/integrations/upgrade_reconfigure_ports_test.go
+++ b/integrations/upgrade_reconfigure_ports_test.go
@@ -3,12 +3,7 @@ package integrations_test
 import (
 	"errors"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"github.com/greenplum-db/gpupgrade/hub/services"
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
-	"github.com/greenplum-db/gpupgrade/testutils"
-
-	"google.golang.org/grpc"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -16,45 +11,6 @@ import (
 )
 
 var _ = Describe("upgrade reconfigure ports", func() {
-
-	var (
-		hub       *services.Hub
-		agentPort int
-
-		testExecutor *testhelper.TestExecutor
-		cm           *testutils.MockChecklistManager
-	)
-
-	BeforeEach(func() {
-		var err error
-
-		agentPort, err = testutils.GetOpenPort()
-		Expect(err).ToNot(HaveOccurred())
-
-		port, err = testutils.GetOpenPort()
-		Expect(err).ToNot(HaveOccurred())
-
-		conf := &services.HubConfig{
-			CliToHubPort:   port,
-			HubToAgentPort: agentPort,
-			StateDir:       testStateDir,
-		}
-
-		cp := testutils.InitClusterPairFromDB()
-		testExecutor = &testhelper.TestExecutor{}
-		cp.OldCluster.Executor = testExecutor
-		cm = testutils.NewMockChecklistManager()
-		hub = services.NewHub(cp, grpc.DialContext, conf, cm)
-		go hub.Start()
-	})
-
-	AfterEach(func() {
-		hub.Stop()
-
-		Expect(checkPortIsAvailable(port)).To(BeTrue())
-		Expect(checkPortIsAvailable(agentPort)).To(BeTrue())
-	})
-
 	It("updates status PENDING to COMPLETE if successful", func() {
 		Expect(cm.IsPending(upgradestatus.RECONFIGURE_PORTS)).To(BeTrue())
 

--- a/integrations/upgrade_share_oids_test.go
+++ b/integrations/upgrade_share_oids_test.go
@@ -3,13 +3,7 @@ package integrations_test
 import (
 	"errors"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	agentServices "github.com/greenplum-db/gpupgrade/agent/services"
-	hubServices "github.com/greenplum-db/gpupgrade/hub/services"
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
-	"github.com/greenplum-db/gpupgrade/testutils"
-
-	"google.golang.org/grpc"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -17,56 +11,9 @@ import (
 )
 
 var _ = Describe("upgrade share oids", func() {
-	var (
-		hub       *hubServices.Hub
-		agent     *agentServices.AgentServer
-		agentPort int
-
-		testExecutor *testhelper.TestExecutor
-		cm           *testutils.MockChecklistManager
-	)
-
 	BeforeEach(func() {
-		var err error
-
-		agentPort, err = testutils.GetOpenPort()
-		Expect(err).ToNot(HaveOccurred())
-
-		agentConfig := agentServices.AgentConfig{
-			Port:     agentPort,
-			StateDir: testStateDir,
-		}
-
-		agentExecutor := &testhelper.TestExecutor{}
-
-		agent = agentServices.NewAgentServer(agentExecutor, agentConfig)
 		go agent.Start()
-
-		port, err = testutils.GetOpenPort()
-		Expect(err).ToNot(HaveOccurred())
-
-		conf := &hubServices.HubConfig{
-			CliToHubPort:   port,
-			HubToAgentPort: agentPort,
-			StateDir:       testStateDir,
-		}
-
-		cp := testutils.InitClusterPairFromDB()
-		testExecutor = &testhelper.TestExecutor{}
-		cp.OldCluster.Executor = testExecutor
-		cm = testutils.NewMockChecklistManager()
-		hub = hubServices.NewHub(cp, grpc.DialContext, conf, cm)
-		go hub.Start()
 	})
-
-	AfterEach(func() {
-		hub.Stop()
-		agent.Stop()
-
-		Expect(checkPortIsAvailable(port)).To(BeTrue())
-		Expect(checkPortIsAvailable(agentPort)).To(BeTrue())
-	})
-
 	It("updates status PENDING to RUNNING then to COMPLETE if successful", func() {
 
 		Expect(cm.IsPending(upgradestatus.SHARE_OIDS)).To(BeTrue())

--- a/integrations/upgrade_validate_start_cluster_test.go
+++ b/integrations/upgrade_validate_start_cluster_test.go
@@ -1,56 +1,15 @@
 package integrations_test
 
 import (
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"github.com/greenplum-db/gpupgrade/hub/services"
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
-	"github.com/greenplum-db/gpupgrade/testutils"
-	"github.com/greenplum-db/gpupgrade/utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
 	"github.com/pkg/errors"
-	"google.golang.org/grpc"
 )
 
 var _ = Describe("upgrade validate-start-cluster", func() {
-	var (
-		hub          *services.Hub
-		outChan      chan []byte
-		errChan      chan error
-		clusterPair  *utils.ClusterPair
-		testExecutor *testhelper.TestExecutor
-		cm           *testutils.MockChecklistManager
-	)
-
-	BeforeEach(func() {
-		var err error
-
-		port, err = testutils.GetOpenPort()
-		Expect(err).ToNot(HaveOccurred())
-
-		conf := &services.HubConfig{
-			CliToHubPort:   port,
-			HubToAgentPort: 6416,
-			StateDir:       testStateDir,
-		}
-		outChan = make(chan []byte, 2)
-		errChan = make(chan error, 2)
-
-		cm = testutils.NewMockChecklistManager()
-		clusterPair = testutils.InitClusterPairFromDB()
-		testExecutor = &testhelper.TestExecutor{}
-		clusterPair.NewCluster.Executor = testExecutor
-		hub = services.NewHub(clusterPair, grpc.DialContext, conf, cm)
-		go hub.Start()
-	})
-
-	AfterEach(func() {
-		hub.Stop()
-		Expect(checkPortIsAvailable(port)).To(BeTrue())
-	})
-
 	It("updates status PENDING to RUNNING then to COMPLETE if successful", func(done Done) {
 		defer close(done)
 		Expect(cm.IsPending(upgradestatus.VALIDATE_START_CLUSTER)).To(BeTrue())

--- a/integrations/version_command_test.go
+++ b/integrations/version_command_test.go
@@ -5,43 +5,13 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/greenplum-db/gpupgrade/hub/services"
-	"github.com/greenplum-db/gpupgrade/testutils"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
-	"google.golang.org/grpc"
 )
 
 var _ = Describe("version command", func() {
-	var (
-		hub *services.Hub
-		cm  *testutils.MockChecklistManager
-	)
-
-	BeforeEach(func() {
-		var err error
-
-		port, err = testutils.GetOpenPort()
-		Expect(err).ToNot(HaveOccurred())
-
-		conf := &services.HubConfig{
-			CliToHubPort:   port,
-			HubToAgentPort: 6416,
-			StateDir:       testStateDir,
-		}
-
-		hub = services.NewHub(testutils.InitClusterPairFromDB(), grpc.DialContext, conf, cm)
-		go hub.Start()
-	})
-
-	AfterEach(func() {
-		hub.Stop()
-		Expect(checkPortIsAvailable(port)).To(BeTrue())
-	})
-
 	It("reports the version that's injected at build-time", func() {
 		fake_version := fmt.Sprintf("v0.0.0-dev.%d", time.Now().Unix())
 		commandPathWithVersion, err := Build("github.com/greenplum-db/gpupgrade/cli", "-ldflags", "-X github.com/greenplum-db/gpupgrade/cli/commanders.UpgradeVersion="+fake_version)

--- a/testutils/test_utils.go
+++ b/testutils/test_utils.go
@@ -56,9 +56,9 @@ func CreateMultinodeSampleCluster() *cluster.Cluster {
 	return &cluster.Cluster{
 		ContentIDs: []int{-1, 0, 1},
 		Segments: map[int]cluster.SegConfig{
-			-1: cluster.SegConfig{ContentID: -1, Port: 15432, Hostname: "hostone", DataDir: "/data/master"},
-			0:  cluster.SegConfig{ContentID: 0, Port: 25432, Hostname: "hosttwo", DataDir: "/data/seg1"},
-			1:  cluster.SegConfig{ContentID: 1, Port: 25433, Hostname: "hostthree", DataDir: "/data/seg2"},
+			-1: cluster.SegConfig{ContentID: -1, DbID: 1, Port: 15432, Hostname: "localhost", DataDir: "/data/master"},
+			0:  cluster.SegConfig{ContentID: 0, DbID: 2, Port: 25432, Hostname: "localhost", DataDir: "/data/seg1"},
+			1:  cluster.SegConfig{ContentID: 1, DbID: 3, Port: 25433, Hostname: "localhost", DataDir: "/data/seg2"},
 		},
 	}
 }
@@ -70,6 +70,18 @@ func CreateSampleCluster(contentID int, port int, hostname string, datadir strin
 			contentID: cluster.SegConfig{ContentID: contentID, Port: port, Hostname: hostname, DataDir: datadir},
 		},
 	}
+}
+
+func CreateMultinodeSampleClusterPair() *utils.ClusterPair {
+	cp := &utils.ClusterPair{
+		OldCluster: CreateMultinodeSampleCluster(),
+		NewCluster: CreateMultinodeSampleCluster(),
+	}
+	cp.OldCluster.Executor = &testhelper.TestExecutor{}
+	cp.NewCluster.Executor = &testhelper.TestExecutor{}
+	cp.OldBinDir = "/old/bindir"
+	cp.NewBinDir = "/new/bindir"
+	return cp
 }
 
 func CreateSampleClusterPair() *utils.ClusterPair {


### PR DESCRIPTION
Previously, every integration test file performed its own setup and teardown in BeforeEach and AfterEach, most of which was just copy-pasted between test files, so any refactor touching the hub or agent would generally involve making the same change in lots of files.

This series of commits moves all of the duplicated logic to the BeforeEach and AfterEach in integration_suite_test.go, so that the initialization happens only once and refactors only need to make a given change once.

There are no observed test conflicts due to this change, and no test slowdowns due to performing unnecessary initialization for some tests.