### PR TITLE
Export filename constants (and use them)

### DIFF
--- a/hub/upgradestatus/checklist_manager.go
+++ b/hub/upgradestatus/checklist_manager.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus/file"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
 )
@@ -20,12 +21,6 @@ const (
 	CONVERT_PRIMARIES      = "convert-primaries"
 	VALIDATE_START_CLUSTER = "validate-start-cluster"
 	RECONFIGURE_PORTS      = "reconfigure-ports"
-)
-
-const (
-	fs_inprogress = "in.progress"
-	fs_failed     = "failed"
-	fs_completed  = "completed"
 )
 
 type Checklist interface {
@@ -108,12 +103,12 @@ type StepWriter struct {
 // FIXME: none of these operations are atomic on the FS; just move the progress
 // file from name to name instead
 func (sw StepWriter) MarkFailed() error {
-	err := utils.System.Remove(filepath.Join(sw.stepdir, fs_inprogress))
+	err := utils.System.Remove(filepath.Join(sw.stepdir, file.InProgress))
 	if err != nil {
 		return err
 	}
 
-	_, err = utils.System.OpenFile(path.Join(sw.stepdir, fs_failed), os.O_CREATE, 0700)
+	_, err = utils.System.OpenFile(path.Join(sw.stepdir, file.Failed), os.O_CREATE, 0700)
 	if err != nil {
 		return err
 	}
@@ -122,12 +117,12 @@ func (sw StepWriter) MarkFailed() error {
 }
 
 func (sw StepWriter) MarkComplete() error {
-	err := utils.System.Remove(filepath.Join(sw.stepdir, fs_inprogress))
+	err := utils.System.Remove(filepath.Join(sw.stepdir, file.InProgress))
 	if err != nil {
 		return err
 	}
 
-	_, err = utils.System.OpenFile(path.Join(sw.stepdir, fs_completed), os.O_CREATE, 0700)
+	_, err = utils.System.OpenFile(path.Join(sw.stepdir, file.Complete), os.O_CREATE, 0700)
 	if err != nil {
 		return err
 	}
@@ -136,7 +131,7 @@ func (sw StepWriter) MarkComplete() error {
 }
 
 func (sw StepWriter) MarkInProgress() error {
-	_, err := utils.System.OpenFile(path.Join(sw.stepdir, fs_inprogress), os.O_CREATE, 0700)
+	_, err := utils.System.OpenFile(path.Join(sw.stepdir, file.InProgress), os.O_CREATE, 0700)
 	if err != nil {
 		return err
 	}

--- a/hub/upgradestatus/checklist_manager_test.go
+++ b/hub/upgradestatus/checklist_manager_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus/file"
 	"github.com/greenplum-db/gpupgrade/utils"
 
 	. "github.com/onsi/ginkgo"
@@ -27,7 +28,7 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 			step.ResetStateDir()
 			err := step.MarkInProgress()
 			Expect(err).ToNot(HaveOccurred())
-			expectedFile := filepath.Join(tempdir, ".gpupgrade", "fancy_step", "in.progress")
+			expectedFile := filepath.Join(tempdir, ".gpupgrade", "fancy_step", file.InProgress)
 			_, err = os.Stat(expectedFile)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -41,7 +42,7 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 			step.MarkInProgress() // lay the file down once
 			err := step.MarkInProgress()
 			Expect(err).ToNot(HaveOccurred())
-			expectedFile := filepath.Join(tempdir, ".gpupgrade", "fancy_step", "in.progress")
+			expectedFile := filepath.Join(tempdir, ".gpupgrade", "fancy_step", file.InProgress)
 			_, err = os.Stat(expectedFile)
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/hub/upgradestatus/file/constants.go
+++ b/hub/upgradestatus/file/constants.go
@@ -1,0 +1,11 @@
+/*
+The file package simply exposes our filename constants for upgrade status
+monitoring.
+*/
+package file
+
+const (
+	InProgress = "in.progress" // started, but not yet completed or failed
+	Complete   = "completed"   // finished successfully
+	Failed     = "failed"      // stopped with an error
+)

--- a/hub/upgradestatus/shutdown_clusters.go
+++ b/hub/upgradestatus/shutdown_clusters.go
@@ -1,6 +1,7 @@
 package upgradestatus
 
 import (
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus/file"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
 
@@ -43,7 +44,7 @@ func isGpstopRunning(execer cluster.Executor) bool {
 }
 
 func stopProgressFilesExist(gpstopStatePath string) bool {
-	files, err := utils.System.FilePathGlob(gpstopStatePath + "/*/in.progress")
+	files, err := utils.System.FilePathGlob(gpstopStatePath + "/*/" + file.InProgress)
 	if files == nil {
 		return false
 	}
@@ -57,7 +58,7 @@ func stopProgressFilesExist(gpstopStatePath string) bool {
 }
 
 func isStopComplete(gpstopStatePath string) bool {
-	completeFiles, completeErr := utils.System.FilePathGlob(gpstopStatePath + "/*/completed")
+	completeFiles, completeErr := utils.System.FilePathGlob(gpstopStatePath + "/*/" + file.Complete)
 	if completeFiles == nil {
 		return false
 	}

--- a/hub/upgradestatus/shutdown_clusters_test.go
+++ b/hub/upgradestatus/shutdown_clusters_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus/file"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/utils"
@@ -53,7 +54,7 @@ var _ = Describe("hub", func() {
 			testExecutor.LocalOutput = "I'm running"
 
 			utils.System.FilePathGlob = func(glob string) ([]string, error) {
-				if strings.Contains(glob, "in.progress") {
+				if strings.Contains(glob, file.InProgress) {
 					return []string{"found something"}, nil
 				}
 				return nil, errors.New("Test not configured for this glob.")
@@ -73,9 +74,9 @@ var _ = Describe("hub", func() {
 			testExecutor.LocalError = errors.New("exit status 1")
 
 			utils.System.FilePathGlob = func(glob string) ([]string, error) {
-				if strings.Contains(glob, "in.progress") {
+				if strings.Contains(glob, file.InProgress) {
 					return nil, errors.New("fake error")
-				} else if strings.Contains(glob, "complete") {
+				} else if strings.Contains(glob, file.Complete) {
 					return []string{"old stop complete", "new stop complete"}, nil
 				}
 

--- a/hub/upgradestatus/state_checker.go
+++ b/hub/upgradestatus/state_checker.go
@@ -3,6 +3,7 @@ package upgradestatus
 import (
 	"path/filepath"
 
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus/file"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
 
@@ -43,11 +44,11 @@ func (c StateCheck) GetStatus() pb.StepStatus {
 		return pb.StepStatus_PENDING
 	} else if len(files) == 1 {
 		switch files[0] {
-		case filepath.Join(c.Path, "failed"):
+		case filepath.Join(c.Path, file.Failed):
 			return pb.StepStatus_FAILED
-		case filepath.Join(c.Path, "completed"):
+		case filepath.Join(c.Path, file.Complete):
 			return pb.StepStatus_COMPLETE
-		case filepath.Join(c.Path, "in.progress"):
+		case filepath.Join(c.Path, file.InProgress):
 			return pb.StepStatus_RUNNING
 		}
 	}

--- a/hub/upgradestatus/state_checker_test.go
+++ b/hub/upgradestatus/state_checker_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/onsi/gomega/gbytes"
 
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus/file"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
 
@@ -44,7 +45,7 @@ var _ = Describe("Upgradestatus/Seginstall", func() {
 		}
 		utils.System.FilePathGlob = func(glob string) ([]string, error) {
 			if glob == fakePath+"/*" {
-				return []string{filepath.Join(fakePath, "in.progress")}, nil
+				return []string{filepath.Join(fakePath, file.InProgress)}, nil
 			}
 			return nil, errors.New("didn't match expected glob pattern")
 		}
@@ -62,7 +63,7 @@ var _ = Describe("Upgradestatus/Seginstall", func() {
 		}
 		utils.System.FilePathGlob = func(glob string) ([]string, error) {
 			if glob == fakePath+"/*" {
-				return []string{filepath.Join(fakePath, "failed")}, nil
+				return []string{filepath.Join(fakePath, file.Failed)}, nil
 			}
 			return nil, errors.New("didn't match expected glob pattern")
 		}

--- a/integrations/upgrade_convert_primaries_test.go
+++ b/integrations/upgrade_convert_primaries_test.go
@@ -10,6 +10,7 @@ import (
 	agentServices "github.com/greenplum-db/gpupgrade/agent/services"
 	"github.com/greenplum-db/gpupgrade/hub/services"
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus/file"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/utils"
@@ -64,7 +65,7 @@ var _ = Describe("upgrade convert primaries", func() {
 			Port:     6416,
 			StateDir: testStateDir,
 		})
-		setStateFile(testStateDir, upgradestatus.START_AGENTS, "completed")
+		setStateFile(testStateDir, upgradestatus.START_AGENTS, file.Complete)
 		go agent.Start()
 	})
 


### PR DESCRIPTION
I pulled the constants into a subpackage purely for the readability of the code; `file.InProgress` felt better to me than `upgradestatus.InProgressFile` or whatever. Maybe we can rename `upgradestatus` to something more happy in the future, and lose the subpackage.