### PR TITLE
Testing: run every test suite and add a `make check` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ unit :
 integration:
 		ginkgo -r -keepGoing -randomizeAllSpecs integrations
 
+.PHONY: check
+check:
+		ginkgo -r -keepGoing -randomizeSuites -randomizeAllSpecs
+
 test : lint unit integration
 
 coverage :

--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,10 @@ lint :
 		gometalinter --config=gometalinter.config -s vendor ./...
 
 unit :
-		ginkgo -r -randomizeSuites -randomizeAllSpecs --skipPackage=integrations
+		ginkgo -r -keepGoing -randomizeSuites -randomizeAllSpecs --skipPackage=integrations
 
 integration:
-		ginkgo -r -randomizeAllSpecs integrations
+		ginkgo -r -keepGoing -randomizeAllSpecs integrations
 
 test : lint unit integration
 


### PR DESCRIPTION
- `-keepGoing` ensures that every test suite is run, even after the first failure.
- `make check` matches the "typical" Makefile test target (and it happens to save another couple seconds over `make unit integration`, since it doesn't have to initialize Ginkgo twice).

Maybe later we should bucket the `unit` and `integration` tests differently for the CI, but let's cross that bridge when we get to it.