### PR TITLE
Run `dep ensure`, if necessary, during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 .idea
+.Gopkg.updated

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ agent-package: EXE_NAME := $(AGENT)
 cli-package: EXE_NAME := $(CLI)
 hub-package: EXE_NAME := $(HUB)
 
-$(PACKAGES): %-package:
+$(PACKAGES): %-package: .Gopkg.updated
 	$(PREFIX) go build $(GOFLAGS) -o $(BIN_DIR)/$(EXE_NAME)$(POSTFIX) -ldflags $(UPGRADE_VERSION_STR) github.com/greenplum-db/gpupgrade/$*
 
 install_agent: agent-package
@@ -115,3 +115,11 @@ clean:
 		# Code coverage files
 		rm -rf /tmp/cover*
 		rm -rf /tmp/unit*
+
+# This is a manual marker file to track the last time we ran `dep ensure`
+# locally, compared to the timestamps of the Gopkg.* metafiles. Define a
+# dependency on this marker to run a `dep ensure` (if necessary) before your
+# recipe is run.
+.Gopkg.updated: Gopkg.lock Gopkg.toml
+	dep ensure
+	touch $@


### PR DESCRIPTION
Track the last time we ran `dep ensure` with a hidden marker file. If the Gopkg files have changed since then, there's a good chance we need to grab new dependencies.

This isn't perfect -- you can still fool the system by touching files and modifying timestamps -- but the cost of failure here is low.