### PR TITLE
Make StatusConversion more unit testable

### DIFF
--- a/hub/services/hub.go
+++ b/hub/services/hub.go
@@ -45,6 +45,7 @@ type Hub struct {
 
 type Connection struct {
 	Conn          *grpc.ClientConn
+	AgentClient   pb.AgentClient
 	Hostname      string
 	CancelContext func()
 }
@@ -136,6 +137,7 @@ func (h *Hub) AgentConns() ([]*Connection, error) {
 		}
 		h.agentConns = append(h.agentConns, &Connection{
 			Conn:          conn,
+			AgentClient:   pb.NewAgentClient(conn),
 			Hostname:      host,
 			CancelContext: cancelFunc,
 		})

--- a/hub/services/hub_status_conversion.go
+++ b/hub/services/hub_status_conversion.go
@@ -6,20 +6,36 @@ import (
 
 	pb "github.com/greenplum-db/gpupgrade/idl"
 
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"golang.org/x/net/context"
 )
 
 func (h *Hub) StatusConversion(ctx context.Context, in *pb.StatusConversionRequest) (*pb.StatusConversionReply, error) {
-	conns, err := h.AgentConns()
+	agentConnections, err := h.AgentConns()
 	if err != nil {
 		return &pb.StatusConversionReply{}, err
 	}
-
 	segments := h.segmentsByHost()
 
+	statuses, err := GetConversionStatusFromPrimaries(agentConnections, segments)
+	if err != nil {
+		err := fmt.Errorf("Could not get conversion status from primaries. Err: \"%v\"", err)
+		gplog.Error(err.Error())
+		return &pb.StatusConversionReply{}, err
+	}
+
+	return &pb.StatusConversionReply{
+		ConversionStatuses: statuses,
+	}, nil
+}
+
+// Helper function to make grpc calls to all agents on primaries for their status
+// TODO: Check conversion statuses in parallel
+func GetConversionStatusFromPrimaries(conns []*Connection, segments map[string][]cluster.SegConfig) ([]string, error) {
 	var statuses []string
 	for _, conn := range conns {
+		// Build a list of segments on the host in which the agent resides on.
 		var agentSegments []*pb.SegmentInfo
 		for _, segment := range segments[conn.Hostname] {
 			agentSegments = append(agentSegments, &pb.SegmentInfo{
@@ -29,23 +45,22 @@ func (h *Hub) StatusConversion(ctx context.Context, in *pb.StatusConversionReque
 			})
 		}
 
-		// TODO: allow the client to be mocked out.
-		status, err := pb.NewAgentClient(conn.Conn).CheckConversionStatus(context.Background(), &pb.CheckConversionStatusRequest{
+		status, err := conn.AgentClient.CheckConversionStatus(context.Background(), &pb.CheckConversionStatusRequest{
 			Segments: agentSegments,
 			Hostname: conn.Hostname,
 		})
 		if err != nil {
-			return &pb.StatusConversionReply{}, fmt.Errorf("agent on host %s returned an error when checking conversion status: %s", conn.Hostname, err)
+			return nil, fmt.Errorf("agent on host %s returned an error when checking conversion status: %s", conn.Hostname, err)
 		}
 
 		statuses = append(statuses, status.GetStatuses()...)
 	}
 
-	return &pb.StatusConversionReply{
-		ConversionStatuses: statuses,
-	}, nil
+	return statuses, nil
 }
 
+// PrimaryConversionStatus a function that matches the interface of Step.Status_
+// It is used by the state manager to get status for the CONVERT_PRIMARY step.
 func PrimaryConversionStatus(hub *Hub) pb.StepStatus {
 	// We can't determine the actual status if there's an error, so we log it and return PENDING
 	conversionStatus, err := hub.StatusConversion(nil, &pb.StatusConversionRequest{})


### PR DESCRIPTION
Tried to break status conversion into a more unit testable piece. 
Made StatusConversion more unit testable. (it a looks a little more complicated though?)
I managed to break the dependency of `agent.Start()` for the two `StatusConversion` tests

Not sure if this should be merged, but would love to get your thoughts.