### PR TITLE
pipeline: deploy to prod by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ clean:
 .PHONY: deploy-pipeline expose-pipeline
 
 # You can override these two from the command line.
-FLY_TARGET := gpdb-dev
+FLY_TARGET := gpdb-prod
 PIPELINE_NAME := gpupgrade
 
 deploy-pipeline:


### PR DESCRIPTION
This just sets the default `FLY_TARGET`; you can still override it to whatever you want. This pipeline is now deployed [here](https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade).