### PR TITLE
Fix race conditions between hub start and stop functions.

### DIFF
--- a/hub/gpupgrade_hub_main.go
+++ b/hub/gpupgrade_hub_main.go
@@ -85,7 +85,10 @@ func main() {
 				hub.MakeDaemon()
 			}
 
-			hub.Start()
+			err := hub.Start()
+			if err != nil {
+				return err
+			}
 
 			hub.Stop()
 

--- a/hub/services/hub.go
+++ b/hub/services/hub.go
@@ -83,6 +83,11 @@ func (h *Hub) Start() {
 
 	server := grpc.NewServer()
 	h.mu.Lock()
+	if h.stopped == nil {
+		// Stop() has already been called; return without serving.
+		h.mu.Unlock()
+		return
+	}
 	h.server = server
 	h.lis = lis
 	h.mu.Unlock()
@@ -113,6 +118,10 @@ func (h *Hub) Stop() {
 		h.server.Stop()
 		<-h.stopped
 	}
+
+	// Mark this server stopped so that a concurrent Start() doesn't try to
+	// start things up again.
+	h.stopped = nil
 }
 
 func (h *Hub) AgentConns() ([]*Connection, error) {

--- a/hub/services/hub_test.go
+++ b/hub/services/hub_test.go
@@ -34,6 +34,22 @@ var _ = Describe("Hub", func() {
 		agentA.Stop()
 	})
 
+	It("will return from Start() if Stop is called concurrently", func() {
+		hubConfig := &services.HubConfig{
+			HubToAgentPort: port,
+		}
+		hub := services.NewHub(clusterPair, grpc.DialContext, hubConfig, nil)
+		done := make(chan bool, 1)
+
+		go func() {
+			hub.Start()
+			done <- true
+		}()
+		hub.Stop()
+
+		Eventually(done).Should(Receive())
+	})
+
 	It("closes open connections when shutting down", func() {
 		hubConfig := &services.HubConfig{
 			HubToAgentPort: port,


### PR DESCRIPTION
The gpupgrade pipeline https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade is failing on the CI, but not locally. The reason for this is because of a race condition between the calls to hub.Stop() and hub.Start() in the test. The reason is that hub.Stop() also closes agent connections. However, in the test, hub.Start() is called from a go routine which can sometimes start after the call to hub.Stop() has happened. Hence, the failure in hub.Stop() in the test.

We have fixed this by using a channel/flag to avoid the race condition.

Additional tests are also added.