### PR TITLE
fixup: hub_prepare_init_cluster test

### DIFF
--- a/hub/services/hub_prepare_init_cluster_test.go
+++ b/hub/services/hub_prepare_init_cluster_test.go
@@ -159,7 +159,7 @@ var _ = Describe("Hub prepare init-cluster", func() {
 				return nil
 			}
 			badConnection, _ := grpc.DialContext(context.Background(), "localhost:6416", grpc.WithInsecure())
-			fakeConns := []*services.Connection{{badConnection, "localhost", func() {}}}
+			fakeConns := []*services.Connection{{badConnection, nil, "localhost", func() {}}}
 			err := hub.CreateAllDataDirectories(gpinitsystemConfig, fakeConns, segDataDirMap)
 			Expect(err).To(HaveOccurred())
 		})


### PR DESCRIPTION
Broken test is using a struct that was missing a field,
This test does not use the missing value so we passed in nil.

Authored-by: Kevin Yeap <kyeap@pivotal.io>