### PR TITLE
make: don't install during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 vendor
 .idea
 .Gopkg.updated
+
+/gpupgrade
+/gpupgrade_hub
+/gpupgrade_agent

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ On macos, one way to install this is via `brew install protobuf`
 make depend  # run this before the first build; it installs required Go utilities
 
 make
-make install # requires a running GPDB instance, for now
 make check   # runs tests
+make install # requires a running GPDB instance, for now
 ```
 
 ### Dependency vendoring


### PR DESCRIPTION
Previously we were putting binaries into the GOPATH during build. But the user should really be able to run `make check` before installing, so that we don't accidentally install a build that doesn't pass the tests.

Instead, put the binaries into the current directory, and make use of them during the end-to-end tests that are run as part of `make check`. They will still be installed under the GPDB bin/ directory during
installation. (Note that the integration tests build their own versions of the utilities already and don't need to be modified here.)

Now you can actually run `make && make check && make install`, and as an additional bonus we won't forget to install before the end-to-end tests anymore.