### PR TITLE
Decouple GPDB from `make check`

### DIFF
--- a/hub/services/hub_check_seginstall.go
+++ b/hub/services/hub_check_seginstall.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
@@ -41,8 +40,8 @@ func VerifyAgentsInstalled(source *utils.Cluster, step upgradestatus.StateWriter
 	var err error
 
 	// TODO: if this finds nothing, should we err out? do a fallback check based on $GPHOME?
-	logStr := "check gpupgrade_agent is installed in GPHOME on master and hosts"
-	agentPath := filepath.Join(os.Getenv("GPHOME"), "bin", "gpupgrade_agent")
+	logStr := "check gpupgrade_agent is installed in cluster's binary directory on master and hosts"
+	agentPath := filepath.Join(source.BinDir, "gpupgrade_agent")
 	returnLsCommand := func(contentID int) string { return "ls " + agentPath }
 	remoteOutput := source.GenerateAndExecuteCommand(logStr, returnLsCommand, cluster.ON_HOSTS_AND_MASTER)
 

--- a/hub/services/hub_check_seginstall_test.go
+++ b/hub/services/hub_check_seginstall_test.go
@@ -2,7 +2,6 @@ package services_test
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
@@ -38,7 +37,7 @@ var _ = Describe("hub CheckSeginstall", func() {
 		Expect(testExecutor.NumExecutions).To(Equal(1))
 		Expect(cm.IsComplete(upgradestatus.SEGINSTALL)).To(BeTrue())
 
-		lsCmd := fmt.Sprintf("ls %s/bin/gpupgrade_agent", os.Getenv("GPHOME"))
+		lsCmd := fmt.Sprintf("ls %s/gpupgrade_agent", source.BinDir)
 		clusterCommands := testExecutor.ClusterCommands[0]
 		for _, command := range clusterCommands {
 			Expect(command).To(ContainElement(lsCmd))

--- a/hub/services/hub_prepare_start_agents.go
+++ b/hub/services/hub_prepare_start_agents.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
@@ -42,7 +41,7 @@ func StartAgents(source *utils.Cluster, step upgradestatus.StateWriter) {
 
 	// TODO: if this finds nothing, should we err out? do a fallback check based on $GPHOME?
 	logStr := "start agents on master and hosts"
-	agentPath := filepath.Join(os.Getenv("GPHOME"), "bin", "gpupgrade_agent")
+	agentPath := filepath.Join(source.BinDir, "gpupgrade_agent")
 	runAgentCmd := func(contentID int) string { return agentPath + " --daemonize" }
 	remoteOutput := source.GenerateAndExecuteCommand(logStr, runAgentCmd, cluster.ON_HOSTS_AND_MASTER)
 

--- a/hub/services/hub_prepare_start_agents_test.go
+++ b/hub/services/hub_prepare_start_agents_test.go
@@ -2,7 +2,6 @@ package services_test
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
@@ -38,7 +37,7 @@ var _ = Describe("hub PrepareStartAgents", func() {
 		Expect(testExecutor.NumExecutions).To(Equal(1))
 		Expect(cm.IsComplete(upgradestatus.START_AGENTS)).To(BeTrue())
 
-		startAgentsCmd := fmt.Sprintf("%s/bin/gpupgrade_agent --daemonize", os.Getenv("GPHOME"))
+		startAgentsCmd := fmt.Sprintf("%s/gpupgrade_agent --daemonize", source.BinDir)
 		clusterCommands := testExecutor.ClusterCommands[0]
 		for _, command := range clusterCommands {
 			Expect(command).To(ContainElement(startAgentsCmd))

--- a/integrations/check_seginstall_test.go
+++ b/integrations/check_seginstall_test.go
@@ -2,7 +2,6 @@ package integrations_test
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	. "github.com/onsi/ginkgo"
@@ -29,7 +28,7 @@ var _ = Describe("check seginstall", func() {
 		// These assertions are identical to the ones in the hub_check_seginstall unit tests but just to be safe we are leaving it in.
 		Expect(testExecutor.NumExecutions).To(Equal(1))
 
-		lsCmd := fmt.Sprintf("ls %s/bin/gpupgrade_agent", os.Getenv("GPHOME"))
+		lsCmd := fmt.Sprintf("ls %s/gpupgrade_agent", source.BinDir)
 		clusterCommands := testExecutor.ClusterCommands[0]
 		for _, command := range clusterCommands {
 			Expect(command).To(ContainElement(lsCmd))

--- a/integrations/prepare_init_cluster_test.go
+++ b/integrations/prepare_init_cluster_test.go
@@ -17,13 +17,6 @@ import (
 
 // the `prepare start-hub` tests are currently in master_only_integration_test
 var _ = Describe("prepare", func() {
-	/* This is demonstrating the limited implementation of init-cluster.
-	    Assuming the user has already set up their new cluster, they should `init-cluster`
-		with the port at which they stood it up, so the upgrade tool can create new_cluster_config
-
-		In the future, the upgrade tool might take responsibility for starting its own cluster,
-		in which case it won't need the port, but would still generate new_cluster_config
-	*/
 	BeforeEach(func() {
 		go agent.Start()
 	})
@@ -31,12 +24,9 @@ var _ = Describe("prepare", func() {
 		os.Remove(fmt.Sprintf("%s_upgrade", testWorkspaceDir))
 	})
 	It("can save the database configuration json under the name 'new cluster'", func() {
-		port := os.Getenv("PGPORT")
-		Expect(port).ToNot(BeEmpty())
-
 		mockdb, mock := testhelper.CreateMockDB()
 		testDriver := testhelper.TestDriver{DB: mockdb, DBName: "testdb", User: "testrole"}
-		db := dbconn.NewDBConnFromEnvironment("testdb")
+		db := dbconn.NewDBConn(testDriver.DBName, testDriver.User, "fakehost", -1 /* not used */)
 		db.Driver = testDriver
 
 		mock.ExpectQuery("SELECT version()").WillReturnRows(getFakeVersionRow())

--- a/integrations/prepare_start_agents_test.go
+++ b/integrations/prepare_start_agents_test.go
@@ -2,7 +2,6 @@ package integrations_test
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	. "github.com/onsi/ginkgo"
@@ -20,7 +19,7 @@ var _ = Describe("prepare start-agents", func() {
 		// These assertions are identical to the ones in the prepare_start_agent unit tests but just to be safe we are leaving it in.
 		Expect(testExecutor.NumExecutions).To(Equal(1))
 
-		startAgentsCmd := fmt.Sprintf("%s/bin/gpupgrade_agent --daemonize", os.Getenv("GPHOME"))
+		startAgentsCmd := fmt.Sprintf("%s/gpupgrade_agent --daemonize", source.BinDir)
 		clusterCommands := testExecutor.ClusterCommands[0]
 		for _, command := range clusterCommands {
 			Expect(command).To(ContainElement(startAgentsCmd))


### PR DESCRIPTION
With these three commits, I can get a green test run from `make check` with no `GPHOME` set (and no database running). The only test that truly needs these things (at the moment) is the `check config` test, and it is now skipped if we fail to establish a connection to the database.