### PR TITLE
Unify unit test initialization

### DIFF
--- a/hub/services/hub_check_disk_space_test.go
+++ b/hub/services/hub_check_disk_space_test.go
@@ -2,34 +2,17 @@ package services_test
 
 import (
 	pb "github.com/greenplum-db/gpupgrade/idl"
-	mockpb "github.com/greenplum-db/gpupgrade/mock_idl"
 
 	"github.com/greenplum-db/gpupgrade/hub/services"
 
 	"github.com/golang/mock/gomock"
 
-	"github.com/greenplum-db/gpupgrade/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 )
 
 var _ = Describe("object count tests", func() {
-	var (
-		client *mockpb.MockAgentClient
-		ctrl   *gomock.Controller
-	)
-
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		client = mockpb.NewMockAgentClient(ctrl)
-	})
-
-	AfterEach(func() {
-		utils.System = utils.InitializeSystemFunctions()
-		ctrl.Finish()
-	})
-
 	Describe("GetDiskUsageFromSegmentHosts", func() {
 		It("returns err msg when unable to call CheckDiskSpaceOnAgents on segment host", func() {
 			var clients []services.ClientAndHostname

--- a/hub/services/hub_check_object_count_test.go
+++ b/hub/services/hub_check_object_count_test.go
@@ -5,9 +5,6 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/hub/services"
 
-	"github.com/greenplum-db/gp-common-go-libs/dbconn"
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"github.com/greenplum-db/gpupgrade/utils"
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 
 	. "github.com/onsi/ginkgo"
@@ -15,20 +12,6 @@ import (
 )
 
 var _ = Describe("hub", func() {
-	var (
-		dbConnector *dbconn.DBConn
-		mock        sqlmock.Sqlmock
-	)
-
-	BeforeEach(func() {
-		dbConnector, mock = testhelper.CreateAndConnectMockDB(1)
-	})
-
-	AfterEach(func() {
-		utils.System = utils.InitializeSystemFunctions()
-		dbConnector.Close()
-	})
-
 	Describe("GetCountsForDb", func() {
 		It("returns count for AO and HEAP tables", func() {
 			fakeResults := sqlmock.NewRows([]string{"count"}).

--- a/hub/services/hub_check_seginstall_test.go
+++ b/hub/services/hub_check_seginstall_test.go
@@ -15,15 +15,6 @@ import (
 )
 
 var _ = Describe("hub CheckSeginstall", func() {
-
-	var (
-		cm *testutils.MockChecklistManager
-	)
-
-	BeforeEach(func() {
-		cm = testutils.NewMockChecklistManager()
-	})
-
 	It("shells out to cluster and verifies gpupgrade_agent is installed on master and hosts", func() {
 		source, _ := testutils.CreateMultinodeSampleClusterPair("/tmp")
 		testExecutor := &testhelper.TestExecutor{}

--- a/hub/services/hub_ping_agents_test.go
+++ b/hub/services/hub_ping_agents_test.go
@@ -5,37 +5,26 @@ import (
 	"time"
 
 	pb "github.com/greenplum-db/gpupgrade/idl"
-	mockpb "github.com/greenplum-db/gpupgrade/mock_idl"
 
 	"github.com/golang/mock/gomock"
 
 	"github.com/greenplum-db/gpupgrade/hub/services"
 
-	"github.com/greenplum-db/gpupgrade/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("hub pings agents test", func() {
 	var (
-		client        *mockpb.MockAgentClient
-		ctrl          *gomock.Controller
 		pingerManager *services.PingerManager
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		client = mockpb.NewMockAgentClient(ctrl)
 		pingerManager = &services.PingerManager{
 			RPCClients:       []services.ClientAndHostname{{Client: client, Hostname: "doesnotexist"}},
 			NumRetries:       10,
 			PauseBeforeRetry: 1 * time.Millisecond,
 		}
-	})
-
-	AfterEach(func() {
-		utils.System = utils.InitializeSystemFunctions()
-		ctrl.Finish()
 	})
 
 	Describe("PingAllAgents", func() {

--- a/hub/services/hub_prepare_shutdown_clusters_test.go
+++ b/hub/services/hub_prepare_shutdown_clusters_test.go
@@ -8,24 +8,14 @@ import (
 	"github.com/greenplum-db/gpupgrade/utils"
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"github.com/greenplum-db/gpupgrade/testutils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("PrepareShutdownClusters", func() {
-	var (
-		source *utils.Cluster
-	)
 	BeforeEach(func() {
 		utils.System.RemoveAll = func(s string) error { return nil }
 		utils.System.MkdirAll = func(s string, perm os.FileMode) error { return nil }
-
-		source, _ = testutils.CreateSampleClusterPair()
-	})
-
-	AfterEach(func() {
-		utils.InitializeSystemFunctions()
 	})
 
 	It("isPostmasterRunning() succeeds", func() {

--- a/hub/services/hub_prepare_start_agents_test.go
+++ b/hub/services/hub_prepare_start_agents_test.go
@@ -15,15 +15,6 @@ import (
 )
 
 var _ = Describe("hub PrepareStartAgents", func() {
-
-	var (
-		cm *testutils.MockChecklistManager
-	)
-
-	BeforeEach(func() {
-		cm = testutils.NewMockChecklistManager()
-	})
-
 	It("shells out to cluster and runs gpupgrade_agent", func() {
 		source, _ := testutils.CreateMultinodeSampleClusterPair("/tmp")
 		testExecutor := &testhelper.TestExecutor{}

--- a/hub/services/hub_status_upgrade_test.go
+++ b/hub/services/hub_status_upgrade_test.go
@@ -2,7 +2,6 @@ package services_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -22,30 +21,13 @@ import (
 
 var _ = Describe("status upgrade", func() {
 	var (
-		hub                      *services.Hub
 		fakeStatusUpgradeRequest *pb.StatusUpgradeRequest
-		dir                      string
-		mockAgent                *testutils.MockAgentServer
-		source                   *utils.Cluster
-		target                   *utils.Cluster
 		testExecutor             *testhelper.TestExecutor
-		cm                       *testutils.MockChecklistManager
 	)
 
 	BeforeEach(func() {
-		var port int
-		mockAgent, port = testutils.NewMockAgentServer()
 		mockAgent.StatusConversionResponse = &pb.CheckConversionStatusReply{}
 
-		var err error
-		dir, err = ioutil.TempDir("", "")
-		Expect(err).ToNot(HaveOccurred())
-		conf := &services.HubConfig{
-			HubToAgentPort: port,
-			StateDir:       dir,
-		}
-
-		source, target = testutils.CreateSampleClusterPair()
 		testExecutor = &testhelper.TestExecutor{}
 		source.Executor = testExecutor
 
@@ -66,12 +48,7 @@ var _ = Describe("status upgrade", func() {
 		cm.AddStep(upgradestatus.CONVERT_PRIMARIES, pb.UpgradeSteps_CONVERT_PRIMARIES)
 		cm.AddStep(upgradestatus.RECONFIGURE_PORTS, pb.UpgradeSteps_RECONFIGURE_PORTS)
 
-		hub = services.NewHub(source, target, mockDialer, conf, cm)
-	})
-
-	AfterEach(func() {
-		utils.System = utils.InitializeSystemFunctions()
-		os.RemoveAll(dir)
+		hub = services.NewHub(source, target, mockDialer, hubConf, cm)
 	})
 
 	It("responds with the statuses of the steps based on checklist state", func() {

--- a/hub/services/hub_upgrade_convert_primaries_test.go
+++ b/hub/services/hub_upgrade_convert_primaries_test.go
@@ -2,63 +2,27 @@ package services_test
 
 import (
 	"errors"
-	"io/ioutil"
+	"path/filepath"
 
-	"github.com/greenplum-db/gpupgrade/hub/services"
 	pb "github.com/greenplum-db/gpupgrade/idl"
-	"github.com/greenplum-db/gpupgrade/testutils"
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"google.golang.org/grpc"
 
-	"github.com/greenplum-db/gpupgrade/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("hub.UpgradeConvertPrimaries()", func() {
-	var (
-		dir       string
-		hub       *services.Hub
-		mockAgent *testutils.MockAgentServer
-		port      int
-		source    *utils.Cluster
-		target    *utils.Cluster
-		cm        *testutils.MockChecklistManager
-	)
-
 	BeforeEach(func() {
-		testhelper.SetupTestLogger()
-
-		mockAgent, port = testutils.NewMockAgentServer()
-
-		var err error
-		dir, err = ioutil.TempDir("", "")
-		Expect(err).ToNot(HaveOccurred())
-		conf := &services.HubConfig{
-			StateDir:       dir,
-			HubToAgentPort: port,
-		}
-
-		source, target = testutils.CreateMultinodeSampleClusterPair("/tmp")
 		seg1 := target.Segments[0]
-		seg1.DataDir = "/tmp/seg1_upgrade"
+		seg1.DataDir = filepath.Join(dir, "seg1_upgrade")
 		seg1.Port = 27432
 		target.Segments[0] = seg1
 		seg2 := target.Segments[1]
-		seg2.DataDir = "/tmp/seg2_upgrade"
+		seg2.DataDir = filepath.Join(dir, "seg2_upgrade")
 		seg2.Port = 27433
 		target.Segments[1] = seg2
-
-		cm = testutils.NewMockChecklistManager()
-		hub = services.NewHub(source, target, grpc.DialContext, conf, cm)
 	})
-	AfterEach(func() {
-		utils.System = utils.InitializeSystemFunctions()
-		defer mockAgent.Stop()
-	})
-
 	It("returns nil error, and agent receives only expected segmentConfig values", func() {
 		_, err := hub.UpgradeConvertPrimaries(nil, &pb.UpgradeConvertPrimariesRequest{})
 		Expect(err).ToNot(HaveOccurred())
@@ -66,8 +30,8 @@ var _ = Describe("hub.UpgradeConvertPrimaries()", func() {
 		Expect(mockAgent.UpgradeConvertPrimarySegmentsRequest.OldBinDir).To(Equal("/source/bindir"))
 		Expect(mockAgent.UpgradeConvertPrimarySegmentsRequest.NewBinDir).To(Equal("/target/bindir"))
 		Expect(mockAgent.UpgradeConvertPrimarySegmentsRequest.DataDirPairs).To(ConsistOf([]*pb.DataDirPair{
-			{OldDataDir: "/tmp/seg1", NewDataDir: "/tmp/seg1_upgrade", Content: 0, OldPort: 25432, NewPort: 27432},
-			{OldDataDir: "/tmp/seg2", NewDataDir: "/tmp/seg2_upgrade", Content: 1, OldPort: 25433, NewPort: 27433},
+			{OldDataDir: filepath.Join(dir, "seg1"), NewDataDir: filepath.Join(dir, "seg1_upgrade"), Content: 0, OldPort: 25432, NewPort: 27432},
+			{OldDataDir: filepath.Join(dir, "seg2"), NewDataDir: filepath.Join(dir, "seg2_upgrade"), Content: 1, OldPort: 25433, NewPort: 27433},
 		}))
 	})
 

--- a/hub/services/hub_upgrade_reconfigure_ports_test.go
+++ b/hub/services/hub_upgrade_reconfigure_ports_test.go
@@ -3,16 +3,12 @@ package services_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"os"
+	"path/filepath"
 
-	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpupgrade/hub/services"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
-
-	"google.golang.org/grpc"
 
 	"github.com/greenplum-db/gpupgrade/utils"
 
@@ -22,17 +18,10 @@ import (
 
 var _ = Describe("UpgradeReconfigurePorts", func() {
 	var (
-		hub          *services.Hub
-		dir          string
 		testExecutor *testhelper.TestExecutor
-		cm           *testutils.MockChecklistManager
 	)
 
 	BeforeEach(func() {
-		var err error
-		dir, err = ioutil.TempDir("", "")
-		Expect(err).ToNot(HaveOccurred())
-
 		numInvocations := 0
 		utils.System.ReadFile = func(filename string) ([]byte, error) {
 			if numInvocations == 0 {
@@ -43,27 +32,18 @@ var _ = Describe("UpgradeReconfigurePorts", func() {
 			}
 		}
 
-		source, target := testutils.CreateSampleClusterPair()
 		testExecutor = &testhelper.TestExecutor{}
-		source.Segments[1] = cluster.SegConfig{Hostname: "hosttwo"}
 		source.Executor = testExecutor
-		hubConfig := &services.HubConfig{
-			StateDir: dir,
-		}
-		cm = testutils.NewMockChecklistManager()
-		hub = services.NewHub(source, target, grpc.DialContext, hubConfig, cm)
-	})
-
-	AfterEach(func() {
-		utils.System = utils.InitializeSystemFunctions()
-		os.RemoveAll(dir)
+		targetMaster := target.Segments[-1]
+		targetMaster.Port = 17432
+		target.Segments[-1] = targetMaster
 	})
 
 	It("reconfigures port in postgresql.conf on master", func() {
 		reply, err := hub.UpgradeReconfigurePorts(nil, &pb.UpgradeReconfigurePortsRequest{})
 		Expect(reply).To(Equal(&pb.UpgradeReconfigurePortsReply{}))
 		Expect(err).To(BeNil())
-		Expect(testExecutor.LocalCommands[0]).To(ContainSubstring(fmt.Sprintf(services.SedAndMvString, 35437, 25437, "/target/datadir")))
+		Expect(testExecutor.LocalCommands[0]).To(ContainSubstring(fmt.Sprintf(services.SedAndMvString, 17432, 15432, filepath.Join(dir, "seg-1"))))
 	})
 
 	It("returns err if reconfigure cmd fails", func() {
@@ -71,7 +51,7 @@ var _ = Describe("UpgradeReconfigurePorts", func() {
 		reply, err := hub.UpgradeReconfigurePorts(nil, &pb.UpgradeReconfigurePortsRequest{})
 		Expect(reply).To(BeNil())
 		Expect(err).ToNot(BeNil())
-		Expect(testExecutor.LocalCommands[0]).To(ContainSubstring(fmt.Sprintf(services.SedAndMvString, 35437, 25437, "/target/datadir")))
+		Expect(testExecutor.LocalCommands[0]).To(ContainSubstring(fmt.Sprintf(services.SedAndMvString, 17432, 15432, filepath.Join(dir, "seg-1"))))
 	})
 
 })

--- a/hub/services/hub_upgrade_share_oids_test.go
+++ b/hub/services/hub_upgrade_share_oids_test.go
@@ -3,50 +3,22 @@ package services_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"os"
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"github.com/greenplum-db/gpupgrade/hub/services"
 	pb "github.com/greenplum-db/gpupgrade/idl"
-	"github.com/greenplum-db/gpupgrade/testutils"
 
-	"google.golang.org/grpc"
-
-	"github.com/greenplum-db/gpupgrade/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("UpgradeShareOids", func() {
 	var (
-		hub          *services.Hub
-		dir          string
-		source       *utils.Cluster
-		target       *utils.Cluster
 		testExecutor *testhelper.TestExecutor
-		cm           *testutils.MockChecklistManager
 	)
 
 	BeforeEach(func() {
-		var err error
-		dir, err = ioutil.TempDir("", "")
-		Expect(err).ToNot(HaveOccurred())
-
-		source, target = testutils.CreateMultinodeSampleClusterPair(dir)
-
-		hubConfig := &services.HubConfig{
-			StateDir: dir,
-		}
 		testExecutor = &testhelper.TestExecutor{}
 		source.Executor = testExecutor
-		cm = testutils.NewMockChecklistManager()
-		hub = services.NewHub(source, target, grpc.DialContext, hubConfig, cm)
-	})
-
-	AfterEach(func() {
-		utils.System = utils.InitializeSystemFunctions()
-		os.RemoveAll(dir)
 	})
 
 	It("copies files to each host", func() {

--- a/hub/services/hub_upgrade_validate_start_cluster_test.go
+++ b/hub/services/hub_upgrade_validate_start_cluster_test.go
@@ -2,52 +2,24 @@ package services_test
 
 import (
 	"errors"
-	"io/ioutil"
-	"os"
+	"fmt"
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"github.com/greenplum-db/gpupgrade/hub/services"
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	pb "github.com/greenplum-db/gpupgrade/idl"
-	"github.com/greenplum-db/gpupgrade/testutils"
 
-	"google.golang.org/grpc"
-
-	"github.com/greenplum-db/gpupgrade/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("upgrade validate start cluster", func() {
 	var (
-		hub          *services.Hub
-		dir          string
-		source       *utils.Cluster
-		target       *utils.Cluster
 		testExecutor *testhelper.TestExecutor
-		cm           *testutils.MockChecklistManager
 	)
 
 	BeforeEach(func() {
-		var err error
-		dir, err = ioutil.TempDir("", "")
-		Expect(err).ToNot(HaveOccurred())
-
-		source, target = testutils.CreateSampleClusterPair()
-
 		testExecutor = &testhelper.TestExecutor{}
 		target.Executor = testExecutor
-
-		cm = testutils.NewMockChecklistManager()
-
-		hub = services.NewHub(source, target, grpc.DialContext, &services.HubConfig{
-			StateDir: dir,
-		}, cm)
-	})
-
-	AfterEach(func() {
-		utils.System = utils.InitializeSystemFunctions()
-		os.RemoveAll(dir)
 	})
 
 	It("sets status to COMPLETE when validate start cluster request has been made and returns no error", func() {
@@ -59,7 +31,7 @@ var _ = Describe("upgrade validate start cluster", func() {
 		Eventually(func() bool { return cm.IsComplete(upgradestatus.VALIDATE_START_CLUSTER) }).Should(BeTrue())
 		Expect(testExecutor.NumExecutions).To(Equal(1))
 		Expect(testExecutor.LocalCommands[0]).To(ContainSubstring("source /target/bindir/../greenplum_path.sh"))
-		Expect(testExecutor.LocalCommands[0]).To(ContainSubstring("/target/bindir/gpstart -a -d /target/datadir"))
+		Expect(testExecutor.LocalCommands[0]).To(ContainSubstring(fmt.Sprintf("/target/bindir/gpstart -a -d %s/seg-1", dir)))
 	})
 
 	It("sets status to FAILED when the validate start cluster request returns an error", func() {

--- a/hub/services/services_suite_test.go
+++ b/hub/services/services_suite_test.go
@@ -1,14 +1,38 @@
 package services_test
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/greenplum-db/gpupgrade/hub/services"
+	mockpb "github.com/greenplum-db/gpupgrade/mock_idl"
+	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/utils"
+	"google.golang.org/grpc"
+	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 
+	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+)
+
+var (
+	ctrl        *gomock.Controller
+	dbConnector *dbconn.DBConn
+	mock        sqlmock.Sqlmock
+	mockAgent   *testutils.MockAgentServer
+	client      *mockpb.MockAgentClient
+	cm          *testutils.MockChecklistManager
+	port        int
+	dir         string
+	hubConf     *services.HubConfig
+	source      *utils.Cluster
+	target      *utils.Cluster
+	hub         *services.Hub
 )
 
 func TestCommands(t *testing.T) {
@@ -18,8 +42,31 @@ func TestCommands(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	testhelper.SetupTestLogger()
+	utils.System = utils.InitializeSystemFunctions()
+})
+
+var _ = BeforeEach(func() {
+	ctrl = gomock.NewController(GinkgoT())
+	dbConnector, mock = testhelper.CreateAndConnectMockDB(1)
+	cm = testutils.NewMockChecklistManager()
+
+	var err error
+	dir, err = ioutil.TempDir("", "")
+	Expect(err).ToNot(HaveOccurred())
+
+	source, target = testutils.CreateMultinodeSampleClusterPair(dir)
+	mockAgent, port = testutils.NewMockAgentServer()
+	client = mockpb.NewMockAgentClient(ctrl)
+	hubConf = &services.HubConfig{
+		HubToAgentPort: port,
+		StateDir:       dir,
+	}
+	hub = services.NewHub(source, target, grpc.DialContext, hubConf, cm)
 })
 
 var _ = AfterEach(func() {
+	dbConnector.Close()
 	utils.System = utils.InitializeSystemFunctions()
+	ctrl.Finish()
+	os.RemoveAll(dir)
 })


### PR DESCRIPTION
Previously, every unit test file performed its own setup and teardown in
BeforeEach and AfterEach, most of which was just copy-pasted between test files,
so any refactor touching the hub or agent would generally involve making the
same change in lots of files.

In a similar manner to a previous commit[1], this one moves all the duplicated
logic to the BeforeEach and AfterEach in services_suite_test.go, so that the
initialization happens only once and refactors only need to make a given change
once.

[1] 01fba51a72708669f5b2afd8e275b933714edeef

This PR relies on code changes made in #44, and will be merged only after that PR is merged.