### PR TITLE
fixup: fix up linter warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ format:
 		goimports -w .
 
 lint:
-		! gofmt -l agent/ cli/ db/ helpers/ hub/ install/ integrations/ shellparsers/ testutils/ utils/ | read
+		! gofmt -l agent/ cli/ db/ hub/ install/ integrations/ shellparsers/ testutils/ utils/ | read
 		gometalinter --config=gometalinter.config -s vendor ./...
 
 unit:

--- a/agent/gpupgrade_agent_main.go
+++ b/agent/gpupgrade_agent_main.go
@@ -53,7 +53,7 @@ func main() {
 	daemon.MakeDaemonizable(RootCmd, &shouldDaemonize)
 
 	err := RootCmd.Execute()
-	if err != nil && err != daemon.SuccessfullyDaemonized {
+	if err != nil && err != daemon.ErrSuccessfullyDaemonized {
 		if gplog.GetLogger() == nil {
 			// In case we didn't get through RootCmd.Execute(), set up logging
 			// here. Otherwise we crash.

--- a/hub/gpupgrade_hub_main.go
+++ b/hub/gpupgrade_hub_main.go
@@ -82,6 +82,7 @@ func main() {
 				return services.PrimaryConversionStatus(hub)
 			}
 
+			// {Name_: *, Code_: *, Status_:, *}
 			cm.LoadSteps([]upgradestatus.Step{
 				{upgradestatus.CONFIG, pb.UpgradeSteps_CONFIG, stateCheck},
 				{upgradestatus.SEGINSTALL, pb.UpgradeSteps_SEGINSTALL, stateCheck},

--- a/hub/gpupgrade_hub_main.go
+++ b/hub/gpupgrade_hub_main.go
@@ -116,7 +116,7 @@ func main() {
 	daemon.MakeDaemonizable(RootCmd, &shouldDaemonize)
 
 	err := RootCmd.Execute()
-	if err != nil && err != daemon.SuccessfullyDaemonized {
+	if err != nil && err != daemon.ErrSuccessfullyDaemonized {
 		if gplog.GetLogger() == nil {
 			// In case we didn't get through RootCmd.Execute(), set up logging
 			// here. Otherwise we crash.

--- a/hub/services/hub.go
+++ b/hub/services/hub.go
@@ -27,7 +27,7 @@ import (
 var DialTimeout = 3 * time.Second
 
 // Returned from Hub.Start() if Hub.Stop() has already been called.
-var HubStopped = errors.New("hub is stopped")
+var ErrHubStopped = errors.New("hub is stopped")
 
 type Dialer func(ctx context.Context, target string, opts ...grpc.DialOption) (*grpc.ClientConn, error)
 
@@ -101,7 +101,7 @@ func (h *Hub) Start() error {
 	if h.stopped == nil {
 		// Stop() has already been called; return without serving.
 		h.mu.Unlock()
-		return HubStopped
+		return ErrHubStopped
 	}
 	h.server = server
 	h.lis = lis
@@ -168,7 +168,7 @@ func (h *Hub) AgentConns() ([]*Connection, error) {
 			host+":"+strconv.Itoa(h.conf.HubToAgentPort),
 			grpc.WithInsecure(), grpc.WithBlock())
 		if err != nil {
-			err = errors.New(fmt.Sprintf("grpcDialer failed: %s", err.Error()))
+			err = errors.Errorf("grpcDialer failed: %s", err.Error())
 			gplog.Error(err.Error())
 			cancelFunc()
 			return nil, err

--- a/hub/services/hub_check_config.go
+++ b/hub/services/hub_check_config.go
@@ -27,7 +27,7 @@ func (h *Hub) CheckConfig(ctx context.Context, _ *pb.CheckConfigRequest) (*pb.Ch
 		gplog.Error("error from MarkInProgress " + err.Error())
 	}
 
-	err = RetrieveAndSaveSourceConfig(h.conf.StateDir, h.source)
+	err = RetrieveAndSaveSourceConfig(h.source)
 	if err != nil {
 		step.MarkFailed()
 		gplog.Error(err.Error())
@@ -43,7 +43,7 @@ func (h *Hub) CheckConfig(ctx context.Context, _ *pb.CheckConfigRequest) (*pb.Ch
 // RetrieveAndSaveSourceConfig() fills in the rest of the clusterPair.OldCluster by
 // querying the database located at its host and port. The results will
 // additionally be written to disk.
-func RetrieveAndSaveSourceConfig(stateDir string, source *utils.Cluster) error {
+func RetrieveAndSaveSourceConfig(source *utils.Cluster) error {
 	dbConnector := db.NewDBConn("localhost", 0, "template1")
 	err := dbConnector.Connect(1)
 	if err != nil {

--- a/hub/services/hub_prepare_init_cluster.go
+++ b/hub/services/hub_prepare_init_cluster.go
@@ -89,7 +89,7 @@ func (h *Hub) InitCluster(dbConnector *dbconn.DBConn) error {
 		return errors.Wrap(err, "Could not get/create agents")
 	}
 	gpinitsystemConfig, segmentDataDirMap = h.DeclareDataDirectories(gpinitsystemConfig)
-	err = h.CreateAllDataDirectories(gpinitsystemConfig, agentConns, segmentDataDirMap)
+	err = h.CreateAllDataDirectories(agentConns, segmentDataDirMap)
 	if err != nil {
 		return err
 	}
@@ -194,7 +194,7 @@ func (h *Hub) DeclareDataDirectories(gpinitsystemConfig []string) ([]string, map
 	return gpinitsystemConfig, segmentDataDirMap
 }
 
-func (h *Hub) CreateAllDataDirectories(gpinitsystemConfig []string, agentConns []*Connection, segmentDataDirMap map[string][]string) error {
+func (h *Hub) CreateAllDataDirectories(agentConns []*Connection, segmentDataDirMap map[string][]string) error {
 	// create master data directory for gpinitsystem if it doesn't exist
 	targetDataDir := path.Dir(h.source.MasterDataDir()) + "_upgrade"
 	_, err := utils.System.Stat(targetDataDir)

--- a/hub/services/hub_prepare_init_cluster.go
+++ b/hub/services/hub_prepare_init_cluster.go
@@ -167,7 +167,7 @@ func WriteInitsystemFile(gpinitsystemConfig []string, gpinitsystemFilepath strin
 func (h *Hub) DeclareDataDirectories(gpinitsystemConfig []string) ([]string, map[string][]string) {
 	// declare master data directory
 	master := h.source.Segments[-1]
-	master.Port += 1
+	master.Port++
 	master.DataDir = fmt.Sprintf("%s_upgrade/%s", path.Dir(master.DataDir), path.Base(master.DataDir))
 	datadirDeclare := fmt.Sprintf("QD_PRIMARY_ARRAY=%s~%d~%s~%d~%d~0",
 		master.Hostname, master.Port, master.DataDir, master.DbID, master.ContentID)

--- a/hub/services/hub_prepare_init_cluster.go
+++ b/hub/services/hub_prepare_init_cluster.go
@@ -255,12 +255,12 @@ func CreateSegmentDataDirectories(agentConns []*Connection, dataDirMap map[strin
 			client := pb.NewAgentClient(c.Conn)
 			_, err := client.CreateSegmentDataDirectories(context.Background(),
 				&pb.CreateSegmentDataDirRequest{
-					Datadirs: dataDirMap[agentConn.Hostname],
+					Datadirs: dataDirMap[c.Hostname],
 				})
 
 			if err != nil {
 				gplog.Error("Error creating segment data directories on host %s: %s",
-					agentConn.Hostname, err.Error())
+					c.Hostname, err.Error())
 				errChan <- err
 			}
 		}(agentConn)

--- a/hub/services/hub_prepare_init_cluster_test.go
+++ b/hub/services/hub_prepare_init_cluster_test.go
@@ -32,12 +32,11 @@ var _ = Describe("Hub prepare init-cluster", func() {
 		err         error
 		queryResult = `{"SegConfigs":[{"DbID":1,"ContentID":-1,"Port":15432,"Hostname":"mdw","DataDir":"/data/master/gpseg-1"},` +
 			`{"DbID":2,"ContentID":0,"Port":25432,"Hostname":"sdw1","DataDir":"/data/primary/gpseg0"}],"BinDir":"/target/bindir"}`
-		source             *utils.Cluster
-		target             *utils.Cluster
-		expectedCluster    *utils.Cluster
-		hub                *services.Hub
-		gpinitsystemConfig []string
-		segDataDirMap      map[string][]string
+		source          *utils.Cluster
+		target          *utils.Cluster
+		expectedCluster *utils.Cluster
+		hub             *services.Hub
+		segDataDirMap   map[string][]string
 	)
 
 	BeforeEach(func() {
@@ -71,7 +70,6 @@ var _ = Describe("Hub prepare init-cluster", func() {
 
 		cm := testutils.NewMockChecklistManager()
 		hub = services.NewHub(source, target, grpc.DialContext, conf, cm)
-		gpinitsystemConfig = []string{}
 	})
 
 	Describe("CreateInitialInitsystemConfig", func() {
@@ -125,7 +123,7 @@ var _ = Describe("Hub prepare init-cluster", func() {
 				return nil
 			}
 			fakeConns := []*services.Connection{}
-			err := hub.CreateAllDataDirectories(gpinitsystemConfig, fakeConns, segDataDirMap)
+			err := hub.CreateAllDataDirectories(fakeConns, segDataDirMap)
 			Expect(err).To(BeNil())
 			Expect(statCalls).To(Equal([]string{fmt.Sprintf("%s_upgrade", dir)}))
 			Expect(mkdirCalls).To(Equal([]string{fmt.Sprintf("%s_upgrade", dir)}))
@@ -136,7 +134,7 @@ var _ = Describe("Hub prepare init-cluster", func() {
 			}
 			fakeConns := []*services.Connection{}
 			expectedErr := errors.Errorf("Error statting new directory %s_upgrade: permission denied", dir)
-			err := hub.CreateAllDataDirectories(gpinitsystemConfig, fakeConns, segDataDirMap)
+			err := hub.CreateAllDataDirectories(fakeConns, segDataDirMap)
 			Expect(err.Error()).To(Equal(expectedErr.Error()))
 		})
 		It("cannot create the master data directory", func() {
@@ -148,7 +146,7 @@ var _ = Describe("Hub prepare init-cluster", func() {
 			}
 			fakeConns := []*services.Connection{}
 			expectedErr := errors.New("Could not create new directory: permission denied")
-			err := hub.CreateAllDataDirectories(gpinitsystemConfig, fakeConns, segDataDirMap)
+			err := hub.CreateAllDataDirectories(fakeConns, segDataDirMap)
 			Expect(err.Error()).To(Equal(expectedErr.Error()))
 		})
 		It("cannot create the segment data directories", func() {
@@ -160,7 +158,7 @@ var _ = Describe("Hub prepare init-cluster", func() {
 			}
 			badConnection, _ := grpc.DialContext(context.Background(), "localhost:6416", grpc.WithInsecure())
 			fakeConns := []*services.Connection{{badConnection, nil, "localhost", func() {}}}
-			err := hub.CreateAllDataDirectories(gpinitsystemConfig, fakeConns, segDataDirMap)
+			err := hub.CreateAllDataDirectories(fakeConns, segDataDirMap)
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/hub/services/hub_status_upgrade_test.go
+++ b/hub/services/hub_status_upgrade_test.go
@@ -57,16 +57,16 @@ var _ = Describe("status upgrade", func() {
 		cm = testutils.NewMockChecklistManager()
 		// XXX this is wrong
 		cm.LoadSteps([]upgradestatus.Step{
-			{upgradestatus.CONFIG, pb.UpgradeSteps_CONFIG, nil},
-			{upgradestatus.INIT_CLUSTER, pb.UpgradeSteps_INIT_CLUSTER, nil},
-			{upgradestatus.SEGINSTALL, pb.UpgradeSteps_SEGINSTALL, nil},
-			{upgradestatus.SHUTDOWN_CLUSTERS, pb.UpgradeSteps_SHUTDOWN_CLUSTERS, nil},
-			{upgradestatus.CONVERT_MASTER, pb.UpgradeSteps_CONVERT_MASTER, nil},
-			{upgradestatus.START_AGENTS, pb.UpgradeSteps_START_AGENTS, nil},
-			{upgradestatus.SHARE_OIDS, pb.UpgradeSteps_SHARE_OIDS, nil},
-			{upgradestatus.VALIDATE_START_CLUSTER, pb.UpgradeSteps_VALIDATE_START_CLUSTER, nil},
-			{upgradestatus.CONVERT_PRIMARIES, pb.UpgradeSteps_CONVERT_PRIMARIES, nil},
-			{upgradestatus.RECONFIGURE_PORTS, pb.UpgradeSteps_RECONFIGURE_PORTS, nil},
+			{Name_: upgradestatus.CONFIG, Code_: pb.UpgradeSteps_CONFIG, Status_: nil},
+			{Name_: upgradestatus.INIT_CLUSTER, Code_: pb.UpgradeSteps_INIT_CLUSTER, Status_: nil},
+			{Name_: upgradestatus.SEGINSTALL, Code_: pb.UpgradeSteps_SEGINSTALL, Status_: nil},
+			{Name_: upgradestatus.SHUTDOWN_CLUSTERS, Code_: pb.UpgradeSteps_SHUTDOWN_CLUSTERS, Status_: nil},
+			{Name_: upgradestatus.CONVERT_MASTER, Code_: pb.UpgradeSteps_CONVERT_MASTER, Status_: nil},
+			{Name_: upgradestatus.START_AGENTS, Code_: pb.UpgradeSteps_START_AGENTS, Status_: nil},
+			{Name_: upgradestatus.SHARE_OIDS, Code_: pb.UpgradeSteps_SHARE_OIDS, Status_: nil},
+			{Name_: upgradestatus.VALIDATE_START_CLUSTER, Code_: pb.UpgradeSteps_VALIDATE_START_CLUSTER, Status_: nil},
+			{Name_: upgradestatus.CONVERT_PRIMARIES, Code_: pb.UpgradeSteps_CONVERT_PRIMARIES, Status_: nil},
+			{Name_: upgradestatus.RECONFIGURE_PORTS, Code_: pb.UpgradeSteps_RECONFIGURE_PORTS, Status_: nil},
 		})
 
 		hub = services.NewHub(source, target, mockDialer, conf, cm)

--- a/hub/services/hub_test.go
+++ b/hub/services/hub_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Hub", func() {
 			err = hub.Start()
 		}()
 		//Using Eventually ensures the test will not stall forever if this test fails.
-		Eventually(func() error { return err }).Should(Equal(services.HubStopped))
+		Eventually(func() error { return err }).Should(Equal(services.ErrHubStopped))
 	})
 
 	It("will return an error from Start() if it cannot listen on a port", func() {

--- a/hub/services/hub_upgrade_validate_start_cluster_test.go
+++ b/hub/services/hub_upgrade_validate_start_cluster_test.go
@@ -22,8 +22,6 @@ var _ = Describe("upgrade validate start cluster", func() {
 	var (
 		hub          *services.Hub
 		dir          string
-		errChan      chan error
-		outChan      chan []byte
 		source       *utils.Cluster
 		target       *utils.Cluster
 		testExecutor *testhelper.TestExecutor
@@ -35,13 +33,13 @@ var _ = Describe("upgrade validate start cluster", func() {
 		dir, err = ioutil.TempDir("", "")
 		Expect(err).ToNot(HaveOccurred())
 
-		errChan = make(chan error, 1)
-		outChan = make(chan []byte, 1)
-
 		source, target = testutils.CreateSampleClusterPair()
+
 		testExecutor = &testhelper.TestExecutor{}
 		target.Executor = testExecutor
+
 		cm = testutils.NewMockChecklistManager()
+
 		hub = services.NewHub(source, target, grpc.DialContext, &services.HubConfig{
 			StateDir: dir,
 		}, cm)

--- a/hub/upgradestatus/file/constants.go
+++ b/hub/upgradestatus/file/constants.go
@@ -1,5 +1,5 @@
 /*
-The file package simply exposes our filename constants for upgrade status
+Package file simply exposes our filename constants for upgrade status
 monitoring.
 */
 package file

--- a/hub/upgradestatus/state_checker_test.go
+++ b/hub/upgradestatus/state_checker_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Upgradestatus/Seginstall", func() {
 	})
 
 	It("Reports PENDING if no directory exists", func() {
-		stateChecker := upgradestatus.StateCheck{"/fake/path", pb.UpgradeSteps_SEGINSTALL}
+		stateChecker := upgradestatus.StateCheck{Path: "/fake/path", Step: pb.UpgradeSteps_SEGINSTALL}
 		upgradeStepStatus := stateChecker.GetStatus()
 		Expect(upgradeStepStatus).To(Equal(pb.StepStatus_PENDING))
 	})
@@ -49,7 +49,7 @@ var _ = Describe("Upgradestatus/Seginstall", func() {
 			}
 			return nil, errors.New("didn't match expected glob pattern")
 		}
-		stateChecker := upgradestatus.StateCheck{fakePath, pb.UpgradeSteps_SEGINSTALL}
+		stateChecker := upgradestatus.StateCheck{Path: fakePath, Step: pb.UpgradeSteps_SEGINSTALL}
 		upgradeStepStatus := stateChecker.GetStatus()
 		Expect(upgradeStepStatus).To(Equal(pb.StepStatus_RUNNING))
 	})
@@ -67,7 +67,7 @@ var _ = Describe("Upgradestatus/Seginstall", func() {
 			}
 			return nil, errors.New("didn't match expected glob pattern")
 		}
-		stateChecker := upgradestatus.StateCheck{fakePath, pb.UpgradeSteps_SEGINSTALL}
+		stateChecker := upgradestatus.StateCheck{Path: fakePath, Step: pb.UpgradeSteps_SEGINSTALL}
 		upgradeStepStatus := stateChecker.GetStatus()
 		Expect(upgradeStepStatus).To(Equal(pb.StepStatus_FAILED))
 	})
@@ -87,7 +87,7 @@ var _ = Describe("Upgradestatus/Seginstall", func() {
 			}
 			return nil, errors.New("didn't match expected glob pattern")
 		}
-		stateChecker := upgradestatus.StateCheck{overabundantDirectory, pb.UpgradeSteps_SEGINSTALL}
+		stateChecker := upgradestatus.StateCheck{Path: overabundantDirectory, Step: pb.UpgradeSteps_SEGINSTALL}
 		upgradeStepStatus := stateChecker.GetStatus()
 
 		// This is a little brittle, sorry...

--- a/integrations/status_command_test.go
+++ b/integrations/status_command_test.go
@@ -44,8 +44,8 @@ var _ = Describe("status", func() {
 	Describe("upgrade", func() {
 		It("Reports status from the hub Checklist", func() {
 			cm.LoadSteps([]upgradestatus.Step{
-				{upgradestatus.CONFIG, pb.UpgradeSteps_CONFIG, nil},
-				{upgradestatus.SEGINSTALL, pb.UpgradeSteps_SEGINSTALL, nil},
+				{Name_: upgradestatus.CONFIG, Code_: pb.UpgradeSteps_CONFIG, Status_: nil},
+				{Name_: upgradestatus.SEGINSTALL, Code_: pb.UpgradeSteps_SEGINSTALL, Status_: nil},
 			})
 
 			statusSession := runCommand("status", "upgrade")

--- a/integrations/upgrade_convert_primaries_test.go
+++ b/integrations/upgrade_convert_primaries_test.go
@@ -44,7 +44,7 @@ var _ = Describe("upgrade convert primaries", func() {
 		}
 
 		cm.LoadSteps([]upgradestatus.Step{
-			{upgradestatus.CONVERT_PRIMARIES, pb.UpgradeSteps_CONVERT_PRIMARIES, nil},
+			{Name_: upgradestatus.CONVERT_PRIMARIES, Code_: pb.UpgradeSteps_CONVERT_PRIMARIES, Status_: nil},
 		})
 
 		Expect(runStatusUpgrade()).To(ContainSubstring("PENDING - Primary segment upgrade"))
@@ -91,7 +91,7 @@ var _ = Describe("upgrade convert primaries", func() {
 	// Move this elsewhere; it's not testing what's useful anymore.
 	XIt("updates status to FAILED if convert primaries fails on at least 1 agent", func() {
 		cm.LoadSteps([]upgradestatus.Step{
-			{upgradestatus.CONVERT_PRIMARIES, pb.UpgradeSteps_CONVERT_PRIMARIES, nil},
+			{Name_: upgradestatus.CONVERT_PRIMARIES, Code_: pb.UpgradeSteps_CONVERT_PRIMARIES, Status_: nil},
 		})
 
 		Expect(runStatusUpgrade()).To(ContainSubstring("PENDING - Primary segment upgrade"))

--- a/mock_idl/cli_to_hub_mock.pb.go
+++ b/mock_idl/cli_to_hub_mock.pb.go
@@ -5,11 +5,12 @@
 package mock_idl
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	idl "github.com/greenplum-db/gpupgrade/idl"
 	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
-	reflect "reflect"
 )
 
 // MockCliToHubClient is a mock of CliToHubClient interface

--- a/mock_idl/hub_to_agent_mock.pb.go
+++ b/mock_idl/hub_to_agent_mock.pb.go
@@ -5,11 +5,12 @@
 package mock_idl
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	idl "github.com/greenplum-db/gpupgrade/idl"
 	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
-	reflect "reflect"
 )
 
 // MockAgentClient is a mock of AgentClient interface

--- a/utils/daemon/daemon_test.go
+++ b/utils/daemon/daemon_test.go
@@ -16,9 +16,7 @@ type basicReadCloser struct {
 	io.Reader
 }
 
-func (_ basicReadCloser) Close() error {
-	return nil
-}
+func (basicReadCloser) Close() error { return nil }
 
 // NewReadCloser is a very simple wrapper around bytes.NewReader which returns
 // an io.ReadCloser instead of an io.Reader. The Close() method on this struct
@@ -34,9 +32,7 @@ type errorReadCloser struct {
 	ReadErr error
 }
 
-func (_ errorReadCloser) Close() error {
-	return nil
-}
+func (errorReadCloser) Close() error { return nil }
 
 func (e errorReadCloser) Read(p []byte) (int, error) {
 	for i := 0; i < len(p); i++ {

--- a/utils/sys_utils_test.go
+++ b/utils/sys_utils_test.go
@@ -141,13 +141,13 @@ var _ = Describe("user utils", func() {
 			f, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			Expect(err).ToNot(HaveOccurred())
 
-			brother_says := `...And Saint Attila raised the hand grenade up on high,
+			brotherSays := `...And Saint Attila raised the hand grenade up on high,
 			saying, "O LORD, bless this Thy hand grenade that with it Thou mayest
 			blow Thine enemies to tiny bits, in Thy mercy." And the LORD did grin and
 			the people did feast upon the lambs and sloths and carp and anchovies and
 			orangutans and breakfast cereals, and fruit bats and large chu ---`
 
-			_, err = f.Write([]byte(brother_says))
+			_, err = f.Write([]byte(brotherSays))
 			Expect(err).ToNot(HaveOccurred())
 
 			err = f.Close()


### PR DESCRIPTION
At the start of this there were many linting warnings/errors.  This set of commits address all but a few.

Up for discussion in particular are the won't fixes: 

-----

```
hub/upgradestatus/checklist_manager.go:53:2:warning: don't use underscores in Go names; struct field Name_ should be Name (golint)
hub/upgradestatus/checklist_manager.go:54:2:warning: don't use underscores in Go names; struct field Code_ should be Code (golint)
hub/upgradestatus/checklist_manager.go:55:2:warning: don't use underscores in Go names; struct field Status_ should be Status (golint)
```
These are named this way to avoid type `Step` having both field and method named `Name`.

-----
```
utils/daemon/daemon_test.go:19:1:warning: receiver name should not be an underscore (golint)
utils/daemon/daemon_test.go:37:1:warning: receiver name should not be an underscore (golint)
```
~~The test just needs the helper function doesn't need the receiver, so we don't give it a name~~ figured this one out.

-----
```
utils/daemon/daemon.go:213:75:warning: parameter timeout always receives 2000000000 (unparam)
```
the linter does not seem to recognize that we are using the timeout in the tests.