### PR TITLE
ci: use tmp dir for utils cluster_config.json

### DIFF
--- a/utils/cluster_test.go
+++ b/utils/cluster_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/utils"
 
-	"github.com/greenplum-db/gp-common-go-libs/structmatcher"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -46,7 +45,11 @@ var _ = Describe("Cluster", func() {
 			}
 			err = givenCluster.Load()
 			Expect(err).ToNot(HaveOccurred())
-			structmatcher.ExpectStructsToMatchExcluding(expectedCluster.Cluster, givenCluster.Cluster, "Executor")
+
+			// We don't serialize the Executor
+			givenCluster.Executor = expectedCluster.Executor
+
+			Expect(expectedCluster).To(Equal(givenCluster))
 		})
 	})
 })

--- a/utils/cluster_test.go
+++ b/utils/cluster_test.go
@@ -2,6 +2,8 @@ package utils_test
 
 import (
 	"io/ioutil"
+	"os"
+	"path"
 
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/utils"
@@ -27,8 +29,12 @@ var _ = Describe("Cluster", func() {
 		expectedCluster = &utils.Cluster{
 			Cluster:    testutils.CreateMultinodeSampleCluster("/tmp"),
 			BinDir:     "/fake/path",
-			ConfigPath: "cluster_config.json",
+			ConfigPath: path.Join(testStateDir, "cluster_config.json"),
 		}
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(testStateDir)
 	})
 
 	Describe("Commit and Load", func() {
@@ -36,7 +42,7 @@ var _ = Describe("Cluster", func() {
 			err := expectedCluster.Commit()
 			Expect(err).ToNot(HaveOccurred())
 			givenCluster := &utils.Cluster{
-				ConfigPath: "cluster_config.json",
+				ConfigPath: path.Join(testStateDir, "cluster_config.json"),
 			}
 			err = givenCluster.Load()
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Before this commit, a file that was created as part of the utils
cluster_config test was being dropped in the utils directory.  This
commit moves that file to a temporary location that is different on each
test run.

Authored-by: Jim Doty <jdoty@pivotal.io>