### PR TITLE
run integration tests in ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GOFLAGS := -gcflags="all=-N -l"
 depend:
 		go get github.com/onsi/ginkgo/ginkgo
 		go get github.com/golang/dep/cmd/dep
-		dep ensure
+		dep ensure -v
 
 depend-dev: depend
 		go get -u github.com/golang/protobuf/protoc-gen-go
@@ -117,7 +117,7 @@ clean:
 # dependency on this marker to run a `dep ensure` (if necessary) before your
 # recipe is run.
 .Gopkg.updated: Gopkg.lock Gopkg.toml
-	dep ensure
+	dep ensure -v
 	touch $@
 
 # You can override these from the command line.
@@ -142,6 +142,8 @@ set-pipeline:
 	fly -t $(FLY_TARGET) set-pipeline -p $(PIPELINE_NAME) \
 		-c ci/pipeline.yml \
 		-l ~/workspace/continuous-integration/secrets/$(SECRETS_FILE) \
+		-l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
+		-l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.yml
 		-v gpupgrade-git-remote=$(GIT_URI) \
 		-v gpupgrade-git-branch=$(BRANCH)
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -13,19 +13,49 @@ resources:
     uri: {{gpupgrade-git-remote}}
     branch: {{gpupgrade-git-branch}}
 
+- name: gpdb_src
+  type: git
+  source:
+    uri: https://github.com/greenplum-db/gpdb
+    branch: master
+
 - name: slack-alert
   type: slack-notification
   source:
     url: {{cm_webhook_url}}
 
+- name: bin_gpdb_centos6
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    versioned_file: {{bin_gpdb_centos_versioned_file}}
+
+
 jobs:
 - name: unit-tests
   plan:
-  - get: gpupgrade
-    resource: gpupgrade_src
+  - get: gpupgrade_src
     trigger: true
   - task: unit-tests
-    file: gpupgrade/ci/tasks/unit-tests.yml
+    file: gpupgrade_src/ci/tasks/unit-tests.yml
+    on_failure:
+      do:
+      - *slack_alert
+
+- name: integration-tests
+  plan:
+  - aggregate:
+    - get: gpupgrade_src
+      trigger: true
+    - get: gpdb_src
+    - get: bin_gpdb
+      resource: bin_gpdb_centos6
+      trigger: true
+  - task: integration-tests
+    file: gpupgrade_src/ci/tasks/integration-tests.yml
     on_failure:
       do:
       - *slack_alert

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -28,10 +28,10 @@ resources:
   type: s3
   source:
     access_key_id: {{bucket-access-key-id}}
-    bucket: {{bucket-name}}
+    bucket: {{gpdb-stable-builds-bucket-name}}
     region_name: {{aws-region}}
     secret_access_key: {{bucket-secret-access-key}}
-    versioned_file: {{bin_gpdb_centos_versioned_file}}
+    versioned_file: release_candidates/bin_gpdb_centos6/gpdb6/debug/bin_gpdb.tar.gz
 
 
 jobs:

--- a/ci/scripts/integration-tests.bash
+++ b/ci/scripts/integration-tests.bash
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -ex
+
+# make depend fails if run as gpadmin with a dep ensure git-remote-https signal 11 failure
+GOPATH="$PWD/go" PATH="$PWD/go/bin:$PATH" make -C go/src/github.com/greenplum-db/gpupgrade depend
+
+source gpdb_src/concourse/scripts/common.bash
+time install_gpdb
+time ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash "centos"
+time make_cluster
+
+time chown -R gpadmin:gpadmin go
+
+su gpadmin <<'EOF'
+export GOPATH=$PWD/go
+export PATH=$GOPATH/bin:$PATH
+source /usr/local/greenplum-db-devel/greenplum_path.sh
+source gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+make -C $GOPATH/src/github.com/greenplum-db/gpupgrade integration
+EOF
+

--- a/ci/tasks/integration-tests.yml
+++ b/ci/tasks/integration-tests.yml
@@ -1,0 +1,16 @@
+PLATFORM: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: pivotaldata/centos-gpdb-dev
+    tag: "6-gcc6.2-llvm3.7"
+
+inputs:
+- name: gpupgrade_src
+  path: go/src/github.com/greenplum-db/gpupgrade
+- name: gpdb_src
+- name: bin_gpdb
+
+run:
+  path: go/src/github.com/greenplum-db/gpupgrade/ci/scripts/integration-tests.bash

--- a/ci/tasks/unit-tests.yml
+++ b/ci/tasks/unit-tests.yml
@@ -7,7 +7,7 @@ image_resource:
     tag: '1.10.2'
 
 inputs:
-- name: gpupgrade
+- name: gpupgrade_src
   path: ../../../go/src/github.com/greenplum-db/gpupgrade
 
 run:


### PR DESCRIPTION
Currently the binaries being consumed are from the release candidates buckets. Eventually we would most likely want to use the most up to date binaries from the latest green commit. 