### PR TITLE
Error out if no segments are configured before seginstall/start-agents

### DIFF
--- a/agent/services/conversion_status.go
+++ b/agent/services/conversion_status.go
@@ -14,10 +14,9 @@ func (s *AgentServer) CheckConversionStatus(ctx context.Context, in *pb.CheckCon
 	if len(in.GetSegments()) == 0 {
 		return nil, errors.New("no segment information was passed to the agent")
 	}
-	format := "%s - DBID %d - CONTENT ID %d - %s - %s"
+	format := "%s - DBID %d - CONTENT ID %d - PRIMARY - %s"
 
 	var replies []string
-	var master string
 	for _, segment := range in.GetSegments() {
 		status := upgradestatus.SegmentConversionStatus(
 			filepath.Join(s.conf.StateDir, "pg_upgrade", fmt.Sprintf("seg-%d", segment.GetContent())),
@@ -26,14 +25,8 @@ func (s *AgentServer) CheckConversionStatus(ctx context.Context, in *pb.CheckCon
 		)
 
 		// FIXME: we have status codes; why convert to strings?
-		if segment.GetDbid() == 1 && segment.GetContent() == -1 {
-			master = fmt.Sprintf(format, status.String(), segment.GetDbid(), segment.GetContent(), "MASTER", in.GetHostname())
-		} else {
-			replies = append(replies, fmt.Sprintf(format, status.String(), segment.GetDbid(), segment.GetContent(), "PRIMARY", in.GetHostname()))
-		}
+		replies = append(replies, fmt.Sprintf(format, status.String(), segment.GetDbid(), segment.GetContent(), in.GetHostname()))
 	}
-
-	replies = append([]string{master}, replies...)
 
 	return &pb.CheckConversionStatusReply{
 		Statuses: replies,

--- a/agent/services/conversion_status_test.go
+++ b/agent/services/conversion_status_test.go
@@ -57,8 +57,8 @@ var _ = Describe("CommandListener", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(status.GetStatuses()).To(Equal([]string{
-			"PENDING - DBID 1 - CONTENT ID -1 - MASTER - localhost",
 			"PENDING - DBID 3 - CONTENT ID 1 - PRIMARY - localhost",
+			"PENDING - DBID 1 - CONTENT ID -1 - PRIMARY - localhost",
 		}))
 	})
 
@@ -86,8 +86,8 @@ var _ = Describe("CommandListener", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(status.GetStatuses()).To(Equal([]string{
-			"PENDING - DBID 1 - CONTENT ID -1 - MASTER - localhost",
 			"RUNNING - DBID 3 - CONTENT ID 1 - PRIMARY - localhost",
+			"PENDING - DBID 1 - CONTENT ID -1 - PRIMARY - localhost",
 		}))
 	})
 
@@ -114,8 +114,8 @@ var _ = Describe("CommandListener", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(status.GetStatuses()).To(Equal([]string{
-			"COMPLETE - DBID 1 - CONTENT ID -1 - MASTER - localhost",
 			"PENDING - DBID 3 - CONTENT ID 1 - PRIMARY - localhost",
+			"COMPLETE - DBID 1 - CONTENT ID -1 - PRIMARY - localhost",
 		}))
 	})
 

--- a/hub/services/hub.go
+++ b/hub/services/hub.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -217,18 +216,4 @@ func (h *Hub) closeConns() {
 		}
 		conn.Conn.WaitForStateChange(context.Background(), currState)
 	}
-}
-
-func (h *Hub) segmentsByHost() map[string][]cluster.SegConfig {
-	segmentsByHost := make(map[string][]cluster.SegConfig)
-	for _, segment := range h.source.Segments {
-		host := segment.Hostname
-		if len(segmentsByHost[host]) == 0 {
-			segmentsByHost[host] = []cluster.SegConfig{segment}
-		} else {
-			segmentsByHost[host] = append(segmentsByHost[host], segment)
-		}
-	}
-
-	return segmentsByHost
 }

--- a/hub/services/hub.go
+++ b/hub/services/hub.go
@@ -168,7 +168,7 @@ func (h *Hub) AgentConns() ([]*Connection, error) {
 		return h.agentConns, nil
 	}
 
-	hostnames := h.source.GetHostnames()
+	hostnames := h.source.PrimaryHostnames()
 	for _, host := range hostnames {
 		ctx, cancelFunc := context.WithTimeout(context.Background(), DialTimeout)
 		conn, err := h.grpcDialer(ctx,

--- a/hub/services/hub_check_seginstall_test.go
+++ b/hub/services/hub_check_seginstall_test.go
@@ -7,31 +7,51 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 
 	"github.com/greenplum-db/gpupgrade/hub/services"
-	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
+	"github.com/greenplum-db/gpupgrade/utils"
 
 	"github.com/greenplum-db/gpupgrade/testutils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("hub CheckSeginstall", func() {
+var _ = Describe("VerifyAgentsInstalled", func() {
 	It("shells out to cluster and verifies gpupgrade_agent is installed on master and hosts", func() {
 		source, _ := testutils.CreateMultinodeSampleClusterPair("/tmp")
 		testExecutor := &testhelper.TestExecutor{}
 		testExecutor.ClusterOutput = &cluster.RemoteOutput{}
 		source.Cluster.Executor = testExecutor
 
-		step := cm.GetStepWriter(upgradestatus.SEGINSTALL)
-		step.MarkInProgress()
-		services.VerifyAgentsInstalled(source, step)
+		err := services.VerifyAgentsInstalled(source)
+		Expect(err).NotTo(HaveOccurred())
 
 		Expect(testExecutor.NumExecutions).To(Equal(1))
-		Expect(cm.IsComplete(upgradestatus.SEGINSTALL)).To(BeTrue())
 
 		lsCmd := fmt.Sprintf("ls %s/gpupgrade_agent", source.BinDir)
 		clusterCommands := testExecutor.ClusterCommands[0]
 		for _, command := range clusterCommands {
 			Expect(command).To(ContainElement(lsCmd))
 		}
+	})
+
+	It("returns an error if the source cluster is not initialized", func() {
+		source := &utils.Cluster{Cluster: &cluster.Cluster{}}
+		err := services.VerifyAgentsInstalled(source)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("returns an error if any agents report an error", func() {
+		source, _ := testutils.CreateMultinodeSampleClusterPair("/tmp")
+		testExecutor := &testhelper.TestExecutor{}
+		testExecutor.ClusterOutput = &cluster.RemoteOutput{
+			NumErrors: 1,
+			Errors:    map[int]error{0: fmt.Errorf("error")},
+			Stdouts:   map[int]string{0: ""},
+			Stderrs:   map[int]string{0: ""},
+			CmdStrs:   map[int]string{0: ""},
+		}
+		source.Cluster.Executor = testExecutor
+
+		err := services.VerifyAgentsInstalled(source)
+		Expect(err).To(HaveOccurred())
 	})
 })

--- a/hub/services/hub_prepare_init_cluster_test.go
+++ b/hub/services/hub_prepare_init_cluster_test.go
@@ -45,12 +45,9 @@ var _ = Describe("Hub prepare init-cluster", func() {
 		}
 
 		segDataDirMap = map[string][]string{
-			"localhost":     {fmt.Sprintf("%s_upgrade", dir)},
-			"not_localhost": {fmt.Sprintf("%s_upgrade", dir)},
+			"host1": {fmt.Sprintf("%s_upgrade", dir)},
+			"host2": {fmt.Sprintf("%s_upgrade", dir)},
 		}
-		seg0 := source.Segments[0]
-		seg0.Hostname = "not_localhost"
-		source.Segments[0] = seg0
 
 		cm := testutils.NewMockChecklistManager()
 		hub = services.NewHub(source, target, grpc.DialContext, hubConf, cm)
@@ -86,8 +83,8 @@ var _ = Describe("Hub prepare init-cluster", func() {
 		It("successfully declares all directories", func() {
 			expectedConfig := []string{fmt.Sprintf("QD_PRIMARY_ARRAY=localhost~15433~%[1]s_upgrade/seg-1~1~-1~0", dir),
 				fmt.Sprintf(`declare -a PRIMARY_ARRAY=(
-	not_localhost~27432~%[1]s_upgrade/seg1~2~0~0
-	localhost~27433~%[1]s_upgrade/seg2~3~1~0
+	host1~27432~%[1]s_upgrade/seg1~2~0~0
+	host2~27433~%[1]s_upgrade/seg2~3~1~0
 )`, dir)}
 			resultConfig, resultMap := hub.DeclareDataDirectories([]string{})
 			Expect(resultMap).To(Equal(segDataDirMap))

--- a/hub/services/hub_prepare_start_agents.go
+++ b/hub/services/hub_prepare_start_agents.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/pkg/errors"
+
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
@@ -31,37 +32,40 @@ func (h *Hub) PrepareStartAgents(ctx context.Context, in *idl.PrepareStartAgents
 		return &idl.PrepareStartAgentsReply{}, err
 	}
 
-	go StartAgents(h.source, step)
+	go func() {
+		err := StartAgents(h.source)
+		if err != nil {
+			gplog.Error(err.Error())
+			step.MarkFailed()
+		} else {
+			step.MarkComplete()
+		}
+	}()
 
 	return &idl.PrepareStartAgentsReply{}, nil
 }
 
-func StartAgents(source *utils.Cluster, step upgradestatus.StateWriter) {
-	var err error
-
-	// TODO: if this finds nothing, should we err out? do a fallback check based on $GPHOME?
+func StartAgents(source *utils.Cluster) error {
 	logStr := "start agents on master and hosts"
 	agentPath := filepath.Join(source.BinDir, "gpupgrade_agent")
 	runAgentCmd := func(contentID int) string { return agentPath + " --daemonize" }
-	remoteOutput := source.GenerateAndExecuteCommand(logStr, runAgentCmd, cluster.ON_HOSTS_AND_MASTER)
 
 	errStr := "Failed to start all gpupgrade_agents"
+
+	remoteOutput, err := source.ExecuteOnAllHosts(logStr, runAgentCmd)
+	if err != nil {
+		return errors.Wrap(err, errStr)
+	}
+
 	errMessage := func(contentID int) string {
 		return fmt.Sprintf("Could not start gpupgrade_agent on segment with contentID %d", contentID)
 	}
 	source.CheckClusterError(remoteOutput, errStr, errMessage, true)
 
 	if remoteOutput.NumErrors > 0 {
-		err = step.MarkFailed()
-		if err != nil {
-			gplog.Error(err.Error())
-			return
-		}
+		// CheckClusterError() will have already logged each error.
+		return errors.New("could not start agents on segment hosts; see log for details")
 	}
 
-	err = step.MarkComplete()
-	if err != nil {
-		gplog.Error(err.Error())
-		return
-	}
+	return nil
 }

--- a/hub/services/hub_prepare_start_agents_test.go
+++ b/hub/services/hub_prepare_start_agents_test.go
@@ -7,31 +7,54 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 
 	"github.com/greenplum-db/gpupgrade/hub/services"
-	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
+	"github.com/greenplum-db/gpupgrade/utils"
 
 	"github.com/greenplum-db/gpupgrade/testutils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("hub PrepareStartAgents", func() {
+// XXX This, and the implementation of StartAgents(), are pretty much
+// copy-pasted from hub_check_seginstall_test.go and VerifyAgentsInstalled().
+// Consolidate.
+var _ = Describe("StartAgents", func() {
 	It("shells out to cluster and runs gpupgrade_agent", func() {
 		source, _ := testutils.CreateMultinodeSampleClusterPair("/tmp")
 		testExecutor := &testhelper.TestExecutor{}
 		testExecutor.ClusterOutput = &cluster.RemoteOutput{}
 		source.Executor = testExecutor
 
-		step := cm.GetStepWriter(upgradestatus.START_AGENTS)
-		step.MarkInProgress()
-		services.StartAgents(source, step)
+		err := services.StartAgents(source)
+		Expect(err).NotTo(HaveOccurred())
 
 		Expect(testExecutor.NumExecutions).To(Equal(1))
-		Expect(cm.IsComplete(upgradestatus.START_AGENTS)).To(BeTrue())
 
 		startAgentsCmd := fmt.Sprintf("%s/gpupgrade_agent --daemonize", source.BinDir)
 		clusterCommands := testExecutor.ClusterCommands[0]
 		for _, command := range clusterCommands {
 			Expect(command).To(ContainElement(startAgentsCmd))
 		}
+	})
+
+	It("returns an error if the source cluster is not initialized", func() {
+		source := &utils.Cluster{Cluster: &cluster.Cluster{}}
+		err := services.StartAgents(source)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("returns an error if any agents report an error", func() {
+		source, _ := testutils.CreateMultinodeSampleClusterPair("/tmp")
+		testExecutor := &testhelper.TestExecutor{}
+		testExecutor.ClusterOutput = &cluster.RemoteOutput{
+			NumErrors: 1,
+			Errors:    map[int]error{0: fmt.Errorf("error")},
+			Stdouts:   map[int]string{0: ""},
+			Stderrs:   map[int]string{0: ""},
+			CmdStrs:   map[int]string{0: ""},
+		}
+		source.Cluster.Executor = testExecutor
+
+		err := services.StartAgents(source)
+		Expect(err).To(HaveOccurred())
 	})
 })

--- a/hub/services/hub_status_conversion.go
+++ b/hub/services/hub_status_conversion.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	pb "github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/utils"
 
-	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -20,9 +21,6 @@ func (h *Hub) StatusConversion(ctx context.Context, in *pb.StatusConversionReque
 		return &pb.StatusConversionReply{}, err
 	}
 
-	// FIXME why are we using the source cluster's segments?
-	segments := h.segmentsByHost()
-
 	// Get the master status first, followed by primaries.
 	// XXX This is duplicated between agents and hub, and besides why are we
 	// returning strings instead of structs.
@@ -33,7 +31,7 @@ func (h *Hub) StatusConversion(ctx context.Context, in *pb.StatusConversionReque
 
 	statuses = append(statuses, masterStatus)
 
-	primaryStatuses, err := GetConversionStatusFromPrimaries(agentConnections, segments)
+	primaryStatuses, err := GetConversionStatusFromPrimaries(agentConnections, h.target)
 	if err != nil {
 		err := fmt.Errorf("Could not get conversion status from primaries. Err: \"%v\"", err)
 		gplog.Error(err.Error())
@@ -49,12 +47,18 @@ func (h *Hub) StatusConversion(ctx context.Context, in *pb.StatusConversionReque
 
 // Helper function to make grpc calls to all agents on primaries for their status
 // TODO: Check conversion statuses in parallel
-func GetConversionStatusFromPrimaries(conns []*Connection, segments map[string][]cluster.SegConfig) ([]string, error) {
+func GetConversionStatusFromPrimaries(conns []*Connection, target *utils.Cluster) ([]string, error) {
 	var statuses []string
 	for _, conn := range conns {
 		// Build a list of segments on the host in which the agent resides on.
 		var agentSegments []*pb.SegmentInfo
-		for _, segment := range segments[conn.Hostname] {
+
+		segments, err := target.SegmentsOn(conn.Hostname)
+		if err != nil {
+			return nil, errors.Wrap(err, "couldn't retrieve target cluster segments")
+		}
+
+		for _, segment := range segments {
 			agentSegments = append(agentSegments, &pb.SegmentInfo{
 				Content: int32(segment.ContentID),
 				Dbid:    int32(segment.DbID),

--- a/hub/services/hub_status_upgrade_test.go
+++ b/hub/services/hub_status_upgrade_test.go
@@ -1,7 +1,6 @@
 package services_test
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 
@@ -11,9 +10,6 @@ import (
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/utils"
-	"golang.org/x/net/context"
-
-	"google.golang.org/grpc"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -31,11 +27,6 @@ var _ = Describe("status upgrade", func() {
 		testExecutor = &testhelper.TestExecutor{}
 		source.Executor = testExecutor
 
-		// Mock so statusConversion doesn't need to wait 3 seconds before erroring out.
-		mockDialer := func(ctx context.Context, target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-			return nil, errors.New("grpc dial err")
-		}
-
 		cm = testutils.NewMockChecklistManager()
 		cm.AddStep(upgradestatus.CONFIG, pb.UpgradeSteps_CONFIG)
 		cm.AddStep(upgradestatus.INIT_CLUSTER, pb.UpgradeSteps_INIT_CLUSTER)
@@ -48,7 +39,7 @@ var _ = Describe("status upgrade", func() {
 		cm.AddStep(upgradestatus.CONVERT_PRIMARIES, pb.UpgradeSteps_CONVERT_PRIMARIES)
 		cm.AddStep(upgradestatus.RECONFIGURE_PORTS, pb.UpgradeSteps_RECONFIGURE_PORTS)
 
-		hub = services.NewHub(source, target, mockDialer, hubConf, cm)
+		hub = services.NewHub(source, target, dialer, hubConf, cm)
 	})
 
 	It("responds with the statuses of the steps based on checklist state", func() {

--- a/hub/services/hub_upgrade_convert_primaries_test.go
+++ b/hub/services/hub_upgrade_convert_primaries_test.go
@@ -13,17 +13,26 @@ import (
 )
 
 var _ = Describe("hub.UpgradeConvertPrimaries()", func() {
-	BeforeEach(func() {
+	It("returns nil error, and agent receives only expected segmentConfig values", func() {
 		seg1 := target.Segments[0]
 		seg1.DataDir = filepath.Join(dir, "seg1_upgrade")
 		seg1.Port = 27432
 		target.Segments[0] = seg1
+
 		seg2 := target.Segments[1]
 		seg2.DataDir = filepath.Join(dir, "seg2_upgrade")
 		seg2.Port = 27433
+
+		// Set up both segments to be on the same host (but still distinct from
+		// the master host).
+		seg2.Hostname = seg1.Hostname
 		target.Segments[1] = seg2
-	})
-	It("returns nil error, and agent receives only expected segmentConfig values", func() {
+
+		// Source hostnames must match the target.
+		sourceSeg2 := source.Segments[1]
+		sourceSeg2.Hostname = seg2.Hostname
+		source.Segments[1] = sourceSeg2
+
 		_, err := hub.UpgradeConvertPrimaries(nil, &pb.UpgradeConvertPrimariesRequest{})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -68,7 +77,7 @@ var _ = Describe("hub.UpgradeConvertPrimaries()", func() {
 			&pb.UpgradeConvertPrimariesRequest{})
 		Expect(err).To(HaveOccurred())
 
-		Expect(mockAgent.NumberOfCalls()).To(Equal(1))
+		Expect(mockAgent.NumberOfCalls()).To(Equal(2))
 	})
 })
 

--- a/hub/services/hub_upgrade_share_oids.go
+++ b/hub/services/hub_upgrade_share_oids.go
@@ -34,7 +34,7 @@ func (h *Hub) shareOidFiles() {
 		return
 	}
 
-	hostnames := h.source.GetHostnames()
+	hostnames := h.source.PrimaryHostnames()
 
 	user := "gpadmin"
 	rsyncFlags := "-rzpogt"

--- a/hub/services/hub_upgrade_share_oids_test.go
+++ b/hub/services/hub_upgrade_share_oids_test.go
@@ -21,21 +21,18 @@ var _ = Describe("UpgradeShareOids", func() {
 		source.Executor = testExecutor
 	})
 
-	It("copies files to each host", func() {
-		seg1 := source.Segments[1]
-		seg1.Hostname = "not_localhost"
-		source.Segments[1] = seg1
+	It("copies files to each primary host", func() {
 		_, err := hub.UpgradeShareOids(nil, &pb.UpgradeShareOidsRequest{})
 		Expect(err).ToNot(HaveOccurred())
 
-		hostnames := source.GetHostnames()
+		hostnames := source.PrimaryHostnames()
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func() int { return testExecutor.NumExecutions }).Should(Equal(len(hostnames)))
 
 		Expect(testExecutor.LocalCommands).To(ConsistOf([]string{
-			fmt.Sprintf("rsync -rzpogt %s/pg_upgrade/pg_upgrade_dump_*_oids.sql gpadmin@localhost:%s/pg_upgrade", dir, dir),
-			fmt.Sprintf("rsync -rzpogt %s/pg_upgrade/pg_upgrade_dump_*_oids.sql gpadmin@not_localhost:%s/pg_upgrade", dir, dir),
+			fmt.Sprintf("rsync -rzpogt %s/pg_upgrade/pg_upgrade_dump_*_oids.sql gpadmin@host1:%s/pg_upgrade", dir, dir),
+			fmt.Sprintf("rsync -rzpogt %s/pg_upgrade/pg_upgrade_dump_*_oids.sql gpadmin@host2:%s/pg_upgrade", dir, dir),
 		}))
 	})
 
@@ -45,7 +42,7 @@ var _ = Describe("UpgradeShareOids", func() {
 		_, err := hub.UpgradeShareOids(nil, &pb.UpgradeShareOidsRequest{})
 		Expect(err).ToNot(HaveOccurred())
 
-		hostnames := source.GetHostnames()
+		hostnames := source.PrimaryHostnames()
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func() int { return testExecutor.NumExecutions }).Should(Equal(len(hostnames)))

--- a/hub/services/services_suite_test.go
+++ b/hub/services/services_suite_test.go
@@ -10,7 +10,6 @@ import (
 	mockpb "github.com/greenplum-db/gpupgrade/mock_idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/utils"
-	"google.golang.org/grpc"
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
@@ -25,6 +24,7 @@ var (
 	dbConnector *dbconn.DBConn
 	mock        sqlmock.Sqlmock
 	mockAgent   *testutils.MockAgentServer
+	dialer      services.Dialer
 	client      *mockpb.MockAgentClient
 	cm          *testutils.MockChecklistManager
 	port        int
@@ -55,13 +55,13 @@ var _ = BeforeEach(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	source, target = testutils.CreateMultinodeSampleClusterPair(dir)
-	mockAgent, port = testutils.NewMockAgentServer()
+	mockAgent, dialer, port = testutils.NewMockAgentServer()
 	client = mockpb.NewMockAgentClient(ctrl)
 	hubConf = &services.HubConfig{
 		HubToAgentPort: port,
 		StateDir:       dir,
 	}
-	hub = services.NewHub(source, target, grpc.DialContext, hubConf, cm)
+	hub = services.NewHub(source, target, dialer, hubConf, cm)
 })
 
 var _ = AfterEach(func() {

--- a/integrations/prepare_shutdown_clusters_test.go
+++ b/integrations/prepare_shutdown_clusters_test.go
@@ -5,8 +5,7 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
-	pb "github.com/greenplum-db/gpupgrade/idl"
-	"github.com/greenplum-db/gpupgrade/testutils"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
@@ -14,29 +13,18 @@ import (
 
 var _ = Describe("prepare shutdown-clusters", func() {
 	var (
-		mockAgent       *testutils.MockAgentServer
 		testExecutorOld *testhelper.TestExecutor
 		testExecutorNew *testhelper.TestExecutor
 	)
 
 	BeforeEach(func() {
-		mockAgent, hubToAgentPort = testutils.NewMockAgentServer()
-
 		testExecutorOld = &testhelper.TestExecutor{}
 		testExecutorNew = &testhelper.TestExecutor{}
 		source.Executor = testExecutorOld
 		target.Executor = testExecutorNew
 	})
 
-	AfterEach(func() {
-		mockAgent.Stop()
-	})
-
 	It("updates status PENDING, RUNNING then COMPLETE if successful", func() {
-		mockAgent.StatusConversionResponse = &pb.CheckConversionStatusReply{
-			Statuses: []string{},
-		}
-
 		Expect(cm.IsPending(upgradestatus.SHUTDOWN_CLUSTERS)).To(BeTrue())
 
 		prepareShutdownClustersSession := runCommand("prepare", "shutdown-clusters")
@@ -54,10 +42,6 @@ var _ = Describe("prepare shutdown-clusters", func() {
 	})
 
 	It("updates status to FAILED if it fails to run", func() {
-		mockAgent.StatusConversionResponse = &pb.CheckConversionStatusReply{
-			Statuses: []string{},
-		}
-
 		Expect(cm.IsPending(upgradestatus.SHUTDOWN_CLUSTERS)).To(BeTrue())
 
 		testExecutorOld.ErrorOnExecNum = 2

--- a/test/out-of-order.bats
+++ b/test/out-of-order.bats
@@ -1,4 +1,7 @@
 #! /usr/bin/env bats
+#
+# This file provides negative test cases for when the user does not execute
+# upgrade steps in the correct order after starting the hub.
 
 load helpers
 
@@ -20,4 +23,10 @@ teardown() {
     gpupgrade check seginstall
     run gpupgrade status upgrade
     [[ "$output" = *"FAILED - Install binaries on segments"* ]]
+}
+
+@test "start-agents requires segments to have been loaded into the configuration" {
+    gpupgrade prepare start-agents
+    run gpupgrade status upgrade
+    [[ "$output" = *"FAILED - Agents Started on Cluster"* ]]
 }

--- a/test/seginstall.bats
+++ b/test/seginstall.bats
@@ -1,0 +1,23 @@
+#! /usr/bin/env bats
+
+load helpers
+
+setup() {
+    STATE_DIR=`mktemp -d`
+    export GPUPGRADE_HOME="${STATE_DIR}/gpupgrade"
+    gpupgrade prepare init --old-bindir /dummy --new-bindir /dummy
+
+    kill_hub
+    gpupgrade prepare start-hub
+}
+
+teardown() {
+    kill_hub
+    rm -r "${STATE_DIR}"
+}
+
+@test "seginstall requires segments to have been loaded into the configuration" {
+    gpupgrade check seginstall
+    run gpupgrade status upgrade
+    [[ "$output" = *"FAILED - Install binaries on segments"* ]]
+}

--- a/testutils/test_utils.go
+++ b/testutils/test_utils.go
@@ -58,8 +58,8 @@ func CreateMultinodeSampleCluster(baseDir string) *cluster.Cluster {
 		ContentIDs: []int{-1, 0, 1},
 		Segments: map[int]cluster.SegConfig{
 			-1: cluster.SegConfig{ContentID: -1, DbID: 1, Port: 15432, Hostname: "localhost", DataDir: baseDir + "/seg-1"},
-			0:  cluster.SegConfig{ContentID: 0, DbID: 2, Port: 25432, Hostname: "localhost", DataDir: baseDir + "/seg1"},
-			1:  cluster.SegConfig{ContentID: 1, DbID: 3, Port: 25433, Hostname: "localhost", DataDir: baseDir + "/seg2"},
+			0:  cluster.SegConfig{ContentID: 0, DbID: 2, Port: 25432, Hostname: "host1", DataDir: baseDir + "/seg1"},
+			1:  cluster.SegConfig{ContentID: 1, DbID: 3, Port: 25433, Hostname: "host2", DataDir: baseDir + "/seg2"},
 		},
 	}
 }

--- a/utils/cluster.go
+++ b/utils/cluster.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -107,4 +108,16 @@ func (c Cluster) SegmentsOn(hostname string) ([]cluster.SegConfig, error) {
 	}
 
 	return segments, nil
+}
+
+// ExecuteOnAllHosts is a convenience wrapper for
+// Cluster.GenerateAndExecuteCommand(..., ON_HOSTS_AND_MASTER). It will error
+// out if the cluster doesn't have any loaded segments yet.
+func (c *Cluster) ExecuteOnAllHosts(desc string, cmd func(contentID int) string) (*cluster.RemoteOutput, error) {
+	if len(c.Segments) == 0 {
+		return nil, errors.New("cluster has no loaded segments")
+	}
+
+	remoteOutput := c.GenerateAndExecuteCommand(desc, cmd, cluster.ON_HOSTS_AND_MASTER)
+	return remoteOutput, nil
 }

--- a/utils/cluster.go
+++ b/utils/cluster.go
@@ -73,3 +73,20 @@ func (c *Cluster) GetHostnames() []string {
 	}
 	return hostnames
 }
+
+func (c *Cluster) PrimaryHostnames() []string {
+	hostnames := make(map[string]bool, 0)
+	for _, seg := range c.Segments {
+		// Ignore the master.
+		if seg.ContentID >= 0 {
+			hostnames[seg.Hostname] = true
+		}
+	}
+
+	var list []string
+	for host := range hostnames {
+		list = append(list, host)
+	}
+
+	return list
+}

--- a/utils/cluster.go
+++ b/utils/cluster.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 )
@@ -89,4 +90,21 @@ func (c *Cluster) PrimaryHostnames() []string {
 	}
 
 	return list
+}
+
+// SegmentsOn returns the configurations of segments that are running on a given
+// host. An error will be returned for unknown hostnames.
+func (c Cluster) SegmentsOn(hostname string) ([]cluster.SegConfig, error) {
+	var segments []cluster.SegConfig
+	for _, segment := range c.Segments {
+		if segment.Hostname == hostname {
+			segments = append(segments, segment)
+		}
+	}
+
+	if len(segments) == 0 {
+		return nil, fmt.Errorf("cluster has no segments on host '%s'", hostname)
+	}
+
+	return segments, nil
 }

--- a/utils/cluster_test.go
+++ b/utils/cluster_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/utils"
 
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -57,6 +58,50 @@ var _ = Describe("Cluster", func() {
 		It("returns a list of hosts for only the primaries", func() {
 			hostnames := expectedCluster.PrimaryHostnames()
 			Expect(hostnames).To(ConsistOf([]string{"host1", "host2"}))
+		})
+	})
+
+	Describe("SegmentsOn", func() {
+		It("returns an error for an unknown hostname", func() {
+			c := utils.Cluster{Cluster: &cluster.Cluster{}}
+			_, err := c.SegmentsOn("notahost")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("maps all hosts to segment configurations", func() {
+			expected := map[string][]cluster.SegConfig{
+				"localhost": {expectedCluster.Segments[-1]},
+				"host1":     {expectedCluster.Segments[0]},
+				"host2":     {expectedCluster.Segments[1]},
+			}
+			for host, expectedSegments := range expected {
+				segments, err := expectedCluster.SegmentsOn(host)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(segments).To(ConsistOf(expectedSegments))
+			}
+		})
+
+		It("groups all segments by hostname", func() {
+			c := utils.Cluster{
+				Cluster: &cluster.Cluster{
+					ContentIDs: []int{-1, 0, 1},
+					Segments: map[int]cluster.SegConfig{
+						-1: {ContentID: -1, DbID: 1, Port: 15432, Hostname: "mdw", DataDir: "/seg-1"},
+						0:  {ContentID: 0, DbID: 2, Port: 25432, Hostname: "sdw1", DataDir: "/seg1"},
+						1:  {ContentID: 1, DbID: 3, Port: 25433, Hostname: "sdw1", DataDir: "/seg2"},
+					},
+				},
+			}
+
+			expected := map[string][]cluster.SegConfig{
+				"mdw":  {c.Segments[-1]},
+				"sdw1": {c.Segments[0], c.Segments[1]},
+			}
+			for host, expectedSegments := range expected {
+				segments, err := c.SegmentsOn(host)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(segments).To(ConsistOf(expectedSegments))
+			}
 		})
 	})
 })

--- a/utils/cluster_test.go
+++ b/utils/cluster_test.go
@@ -52,4 +52,11 @@ var _ = Describe("Cluster", func() {
 			Expect(expectedCluster).To(Equal(givenCluster))
 		})
 	})
+
+	Describe("PrimaryHostnames", func() {
+		It("returns a list of hosts for only the primaries", func() {
+			hostnames := expectedCluster.PrimaryHostnames()
+			Expect(hostnames).To(ConsistOf([]string{"host1", "host2"}))
+		})
+	})
 })


### PR DESCRIPTION
We should not "succeed" if, when executing remote commands, there are no segments to execute those commands on. The two examples are
```sh
gpupgrade start-hub
gpupgrade start-agents
```
and
```sh
gpupgrade start-hub
gpupgrade check seginstall
```
In both cases, `status upgrade` would return `COMPLETE` for the respective steps, even though nothing had been done.

In fixing this, we ran into several bugs that were flushed out by the helper utilities (see the commit messages for details). Tests have been added as appropriate.