### PR TITLE
Remove upgradestatus.Step

### DIFF
--- a/hub/gpupgrade_hub_main.go
+++ b/hub/gpupgrade_hub_main.go
@@ -55,46 +55,39 @@ func main() {
 
 			hub := services.NewHub(source, target, grpc.DialContext, conf, cm)
 
+			// Set up the checklist steps in order.
+			//
 			// TODO: make sure the implementations here, and the Checklist below, are
 			// fully exercised in end-to-end tests. It feels like we should be able to
 			// pull these into a Hub method or helper function, but currently the
 			// interfaces aren't well componentized.
-			stateCheck := func(step upgradestatus.StateReader) pb.StepStatus {
-				checker := upgradestatus.StateCheck{
-					Path: filepath.Join(conf.StateDir, step.Name()),
-					Step: step.Code(),
-				}
-				return checker.GetStatus()
-			}
+			cm.AddWritableStep(upgradestatus.CONFIG, pb.UpgradeSteps_CONFIG)
+			cm.AddWritableStep(upgradestatus.SEGINSTALL, pb.UpgradeSteps_SEGINSTALL)
+			cm.AddWritableStep(upgradestatus.INIT_CLUSTER, pb.UpgradeSteps_INIT_CLUSTER)
 
-			shutDownStatus := func(step upgradestatus.StateReader) pb.StepStatus {
-				stepdir := filepath.Join(conf.StateDir, step.Name())
-				return upgradestatus.ClusterShutdownStatus(stepdir, source.Executor)
-			}
+			cm.AddReadOnlyStep(upgradestatus.SHUTDOWN_CLUSTERS, pb.UpgradeSteps_SHUTDOWN_CLUSTERS,
+				func(stepName string) pb.StepStatus {
+					stepdir := filepath.Join(conf.StateDir, stepName)
+					return upgradestatus.ClusterShutdownStatus(stepdir, source.Executor)
+				})
 
-			convertMasterStatus := func(step upgradestatus.StateReader) pb.StepStatus {
-				convertMasterPath := filepath.Join(conf.StateDir, step.Name())
-				sourceDataDir := source.MasterDataDir()
-				return upgradestatus.SegmentConversionStatus(convertMasterPath, sourceDataDir, source.Executor)
-			}
+			cm.AddReadOnlyStep(upgradestatus.CONVERT_MASTER, pb.UpgradeSteps_CONVERT_MASTER,
+				func(stepName string) pb.StepStatus {
+					convertMasterPath := filepath.Join(conf.StateDir, stepName)
+					sourceDataDir := source.MasterDataDir()
+					return upgradestatus.SegmentConversionStatus(convertMasterPath, sourceDataDir, source.Executor)
+				})
 
-			convertPrimariesStatus := func(step upgradestatus.StateReader) pb.StepStatus {
-				return services.PrimaryConversionStatus(hub)
-			}
+			cm.AddWritableStep(upgradestatus.START_AGENTS, pb.UpgradeSteps_START_AGENTS)
+			cm.AddWritableStep(upgradestatus.SHARE_OIDS, pb.UpgradeSteps_SHARE_OIDS)
 
-			// {Name_: *, Code_: *, Status_:, *}
-			cm.LoadSteps([]upgradestatus.Step{
-				{upgradestatus.CONFIG, pb.UpgradeSteps_CONFIG, stateCheck},
-				{upgradestatus.SEGINSTALL, pb.UpgradeSteps_SEGINSTALL, stateCheck},
-				{upgradestatus.INIT_CLUSTER, pb.UpgradeSteps_INIT_CLUSTER, stateCheck},
-				{upgradestatus.SHUTDOWN_CLUSTERS, pb.UpgradeSteps_SHUTDOWN_CLUSTERS, shutDownStatus},
-				{upgradestatus.CONVERT_MASTER, pb.UpgradeSteps_CONVERT_MASTER, convertMasterStatus},
-				{upgradestatus.START_AGENTS, pb.UpgradeSteps_START_AGENTS, stateCheck},
-				{upgradestatus.SHARE_OIDS, pb.UpgradeSteps_SHARE_OIDS, stateCheck},
-				{upgradestatus.CONVERT_PRIMARIES, pb.UpgradeSteps_CONVERT_PRIMARIES, convertPrimariesStatus},
-				{upgradestatus.VALIDATE_START_CLUSTER, pb.UpgradeSteps_VALIDATE_START_CLUSTER, stateCheck},
-				{upgradestatus.RECONFIGURE_PORTS, pb.UpgradeSteps_RECONFIGURE_PORTS, stateCheck},
-			})
+			cm.AddReadOnlyStep(upgradestatus.CONVERT_PRIMARIES, pb.UpgradeSteps_CONVERT_PRIMARIES,
+				func(stepName string) pb.StepStatus {
+					return services.PrimaryConversionStatus(hub)
+				})
+
+			cm.AddWritableStep(upgradestatus.VALIDATE_START_CLUSTER, pb.UpgradeSteps_VALIDATE_START_CLUSTER)
+			cm.AddWritableStep(upgradestatus.RECONFIGURE_PORTS, pb.UpgradeSteps_RECONFIGURE_PORTS)
 
 			if shouldDaemonize {
 				hub.MakeDaemon()

--- a/hub/services/hub_status_upgrade_test.go
+++ b/hub/services/hub_status_upgrade_test.go
@@ -55,19 +55,16 @@ var _ = Describe("status upgrade", func() {
 		}
 
 		cm = testutils.NewMockChecklistManager()
-		// XXX this is wrong
-		cm.LoadSteps([]upgradestatus.Step{
-			{Name_: upgradestatus.CONFIG, Code_: pb.UpgradeSteps_CONFIG, Status_: nil},
-			{Name_: upgradestatus.INIT_CLUSTER, Code_: pb.UpgradeSteps_INIT_CLUSTER, Status_: nil},
-			{Name_: upgradestatus.SEGINSTALL, Code_: pb.UpgradeSteps_SEGINSTALL, Status_: nil},
-			{Name_: upgradestatus.SHUTDOWN_CLUSTERS, Code_: pb.UpgradeSteps_SHUTDOWN_CLUSTERS, Status_: nil},
-			{Name_: upgradestatus.CONVERT_MASTER, Code_: pb.UpgradeSteps_CONVERT_MASTER, Status_: nil},
-			{Name_: upgradestatus.START_AGENTS, Code_: pb.UpgradeSteps_START_AGENTS, Status_: nil},
-			{Name_: upgradestatus.SHARE_OIDS, Code_: pb.UpgradeSteps_SHARE_OIDS, Status_: nil},
-			{Name_: upgradestatus.VALIDATE_START_CLUSTER, Code_: pb.UpgradeSteps_VALIDATE_START_CLUSTER, Status_: nil},
-			{Name_: upgradestatus.CONVERT_PRIMARIES, Code_: pb.UpgradeSteps_CONVERT_PRIMARIES, Status_: nil},
-			{Name_: upgradestatus.RECONFIGURE_PORTS, Code_: pb.UpgradeSteps_RECONFIGURE_PORTS, Status_: nil},
-		})
+		cm.AddStep(upgradestatus.CONFIG, pb.UpgradeSteps_CONFIG)
+		cm.AddStep(upgradestatus.INIT_CLUSTER, pb.UpgradeSteps_INIT_CLUSTER)
+		cm.AddStep(upgradestatus.SEGINSTALL, pb.UpgradeSteps_SEGINSTALL)
+		cm.AddStep(upgradestatus.SHUTDOWN_CLUSTERS, pb.UpgradeSteps_SHUTDOWN_CLUSTERS)
+		cm.AddStep(upgradestatus.CONVERT_MASTER, pb.UpgradeSteps_CONVERT_MASTER)
+		cm.AddStep(upgradestatus.START_AGENTS, pb.UpgradeSteps_START_AGENTS)
+		cm.AddStep(upgradestatus.SHARE_OIDS, pb.UpgradeSteps_SHARE_OIDS)
+		cm.AddStep(upgradestatus.VALIDATE_START_CLUSTER, pb.UpgradeSteps_VALIDATE_START_CLUSTER)
+		cm.AddStep(upgradestatus.CONVERT_PRIMARIES, pb.UpgradeSteps_CONVERT_PRIMARIES)
+		cm.AddStep(upgradestatus.RECONFIGURE_PORTS, pb.UpgradeSteps_RECONFIGURE_PORTS)
 
 		hub = services.NewHub(source, target, mockDialer, conf, cm)
 	})

--- a/hub/upgradestatus/checklist_manager_test.go
+++ b/hub/upgradestatus/checklist_manager_test.go
@@ -21,10 +21,24 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 	})
 
 	Describe("MarkInProgress", func() {
-		It("Leaves an in-progress file in the state dir", func() {
-			tempdir, _ := ioutil.TempDir("", "")
+		var (
+			tempdir string
+			cm      *upgradestatus.ChecklistManager
+		)
 
-			cm := upgradestatus.NewChecklistManager(filepath.Join(tempdir, ".gpupgrade"))
+		BeforeEach(func() {
+			var err error
+			tempdir, err = ioutil.TempDir("", "")
+			Expect(err).NotTo(HaveOccurred())
+
+			cm = upgradestatus.NewChecklistManager(filepath.Join(tempdir, ".gpupgrade"))
+		})
+
+		AfterEach(func() {
+			os.RemoveAll(tempdir)
+		})
+
+		It("Leaves an in-progress file in the state dir", func() {
 			step := cm.GetStepWriter("fancy_step")
 			step.ResetStateDir()
 			err := step.MarkInProgress()
@@ -35,9 +49,6 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 		})
 
 		It("still succeeds if file already exists", func() {
-			tempdir, _ := ioutil.TempDir("", "")
-
-			cm := upgradestatus.NewChecklistManager(filepath.Join(tempdir, ".gpupgrade"))
 			step := cm.GetStepWriter("fancy_step")
 			step.ResetStateDir()
 			step.MarkInProgress() // lay the file down once
@@ -53,9 +64,6 @@ var _ = Describe("upgradestatus/ChecklistManager", func() {
 				return nil, errors.New("Disk full or something")
 			}
 
-			tempdir, _ := ioutil.TempDir("", "")
-
-			cm := upgradestatus.NewChecklistManager(filepath.Join(tempdir, ".gpupgrade"))
 			step := cm.GetStepWriter("fancy_step")
 			step.ResetStateDir()
 			err := step.MarkInProgress()

--- a/integrations/status_command_test.go
+++ b/integrations/status_command_test.go
@@ -38,15 +38,10 @@ var _ = Describe("status", func() {
 		})
 	})
 
-	// FIXME: The LoadSteps() method is ugly. It kind of proves that this should
-	// be an end-to-end acceptance test, which ensures that `status upgrade`
-	// does something actually useful.
 	Describe("upgrade", func() {
 		It("Reports status from the hub Checklist", func() {
-			cm.LoadSteps([]upgradestatus.Step{
-				{Name_: upgradestatus.CONFIG, Code_: pb.UpgradeSteps_CONFIG, Status_: nil},
-				{Name_: upgradestatus.SEGINSTALL, Code_: pb.UpgradeSteps_SEGINSTALL, Status_: nil},
-			})
+			cm.AddStep(upgradestatus.CONFIG, pb.UpgradeSteps_CONFIG)
+			cm.AddStep(upgradestatus.SEGINSTALL, pb.UpgradeSteps_SEGINSTALL)
 
 			statusSession := runCommand("status", "upgrade")
 			Eventually(statusSession).Should(Exit(0))

--- a/integrations/upgrade_convert_primaries_test.go
+++ b/integrations/upgrade_convert_primaries_test.go
@@ -43,9 +43,7 @@ var _ = Describe("upgrade convert primaries", func() {
 			return err
 		}
 
-		cm.LoadSteps([]upgradestatus.Step{
-			{Name_: upgradestatus.CONVERT_PRIMARIES, Code_: pb.UpgradeSteps_CONVERT_PRIMARIES, Status_: nil},
-		})
+		cm.AddStep(upgradestatus.CONVERT_PRIMARIES, pb.UpgradeSteps_CONVERT_PRIMARIES)
 
 		Expect(runStatusUpgrade()).To(ContainSubstring("PENDING - Primary segment upgrade"))
 		testExecutor.LocalOutput = "TEST"
@@ -90,9 +88,7 @@ var _ = Describe("upgrade convert primaries", func() {
 
 	// Move this elsewhere; it's not testing what's useful anymore.
 	XIt("updates status to FAILED if convert primaries fails on at least 1 agent", func() {
-		cm.LoadSteps([]upgradestatus.Step{
-			{Name_: upgradestatus.CONVERT_PRIMARIES, Code_: pb.UpgradeSteps_CONVERT_PRIMARIES, Status_: nil},
-		})
+		cm.AddStep(upgradestatus.CONVERT_PRIMARIES, pb.UpgradeSteps_CONVERT_PRIMARIES)
 
 		Expect(runStatusUpgrade()).To(ContainSubstring("PENDING - Primary segment upgrade"))
 		setStateFile(testStateDir, "pg_upgrade/seg-0", "1.failed")

--- a/testutils/mock_checklist_manager.go
+++ b/testutils/mock_checklist_manager.go
@@ -29,14 +29,12 @@ func (cm *MockChecklistManager) GetStepReader(step string) upgradestatus.StateRe
 	return MockStepReader{step: step, code: cm.loadedCodes[step], manager: cm}
 }
 
-func (cm *MockChecklistManager) LoadSteps(steps []upgradestatus.Step) {
-	for _, step := range steps {
-		cm.loadedNames = append(cm.loadedNames, step.Name_)
-		cm.loadedCodes[step.Name_] = step.Code_
-	}
+func (cm *MockChecklistManager) AddStep(name string, code pb.UpgradeSteps) {
+	cm.loadedNames = append(cm.loadedNames, name)
+	cm.loadedCodes[name] = code
 }
 
-// Use LoadSteps() to store the list of steps that this mock should return from
+// Use AddStep() to store the list of steps that this mock should return from
 // AllSteps().
 func (cm *MockChecklistManager) AllSteps() []upgradestatus.StateReader {
 	steps := make([]upgradestatus.StateReader, len(cm.loadedNames))


### PR DESCRIPTION
This popped back onto my plate since [the linter started pointing out how ugly it was](https://github.com/greenplum-db/gpupgrade/pull/49). :smile: This patchset gets rid of `Step` as an exported struct and adds smart helper functions to register step intent as well as implementation (i.e. "is this step writable and backed on the filesystem, or is it read-only with a custom status function?")

With this change, `shutdown-clusters` now blows up as expected, since it's not supposed to be writing to a read-only step. There's some additional small cleanup of code as well.