### PR TITLE
Add log.WritePanics() to help with panic logging

### DIFF
--- a/agent/gpupgrade_agent_main.go
+++ b/agent/gpupgrade_agent_main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/agent/services"
 	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/greenplum-db/gpupgrade/utils/daemon"
+	"github.com/greenplum-db/gpupgrade/utils/log"
 	"github.com/spf13/cobra"
 )
 
@@ -28,6 +29,7 @@ func main() {
 		Long:  `Start the Command Listener (blocks)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gplog.InitializeLogging("gpupgrade_agent", logdir)
+			defer log.WritePanics()
 
 			conf := services.AgentConfig{
 				Port:     6416,

--- a/hub/gpupgrade_hub_main.go
+++ b/hub/gpupgrade_hub_main.go
@@ -11,6 +11,7 @@ import (
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/greenplum-db/gpupgrade/utils/daemon"
+	"github.com/greenplum-db/gpupgrade/utils/log"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -30,6 +31,7 @@ func main() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gplog.InitializeLogging("gpupgrade_hub", logdir)
 			debug.SetTraceback("all")
+			defer log.WritePanics()
 
 			conf := &services.HubConfig{
 				CliToHubPort:   7527,

--- a/utils/log/log_suite_test.go
+++ b/utils/log/log_suite_test.go
@@ -1,0 +1,13 @@
+package log_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestLog(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Log Suite")
+}

--- a/utils/log/panic.go
+++ b/utils/log/panic.go
@@ -1,0 +1,20 @@
+package log
+
+import (
+	"runtime/debug"
+
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
+)
+
+// WritePanics is a deferrable helper function that will log a DEBUG stack trace
+// if a panic is encountered. It then re-panics with the recovered value.
+func WritePanics() {
+	if r := recover(); r != nil {
+		// Why not gplog.Error()? Because we're going to re-panic, and there's
+		// no need to spam the terminal twice. gplog.Debug() will push the
+		// errors to the log without writing again to the standard streams.
+		gplog.Debug("encountered panic (%#v); stack trace follows:\n%s", r, debug.Stack())
+
+		panic(r)
+	}
+}

--- a/utils/log/panic_test.go
+++ b/utils/log/panic_test.go
@@ -1,0 +1,39 @@
+package log_test
+
+import (
+	"github.com/greenplum-db/gpupgrade/utils/log"
+
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+)
+
+var _ = Describe("WritePanics", func() {
+	It("does not swallow panics", func() {
+		panicFunc := func() {
+			defer log.WritePanics()
+			panic("ahhh")
+		}
+		Expect(panicFunc).To(Panic())
+	})
+
+	It("writes panic information to the gplog file only", func() {
+		oldLogger := gplog.GetLogger()
+		defer func() { gplog.SetLogger(oldLogger) }()
+
+		testout, testerr, testlog := testhelper.SetupTestLogger()
+
+		panicMsg := "aaahhhhh"
+		Expect(func() {
+			defer log.WritePanics()
+			panic(panicMsg)
+		}).To(Panic())
+
+		Expect(testout.Contents()).To(BeEmpty())
+		Expect(testerr.Contents()).To(BeEmpty())
+		Expect(testlog).To(Say(`encountered panic \("%s"\); stack trace follows`, panicMsg))
+	})
+})


### PR DESCRIPTION
Panic logging can now be enabled from any server goroutine with the following code:

    defer log.WritePanics()

This has been added to both the top-level goroutines for the hub and agent, as well as every gRPC handler goroutine via the use of a `UnaryServerInterceptor`.

Goroutines spawned from handlers are not covered yet; I want to do some more refactoring first.