### PR TITLE
adding issue template and code of conduct

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,50 @@
+# Code of Conduct
+
+## Intro
+
+Standing on the shoulders of the giants means not only leveraging the code base of the most successful open source relational database (PostgreSQL) but also taking a page out of one of the most successful open source governance bodies: Apache Software Foundation (ASF). Greenplum Database developer community has adopted not only the Apache License but also the following code of conduct heavily borrowing from an ASF’s:
+
+This code of conduct applies to all spaces that are associated with the participation in the Greenplum Database open source project, including chat, all public and private mailing lists, issue trackers, wikis, blogs, Twitter, and any other communication channel used by our community. A code of conduct which is specific to in-person events (ie., conferences, meetups, etc.) is expected to be a superset of this document covering additional principles put forward by the organizers of the event(s) and landlords of the space where the event is held.
+
+We expect this code of conduct to be honored by everyone who participates in the Greenplum Database community formally or informally, or claims any affiliation with the project, in any activities and especially when representing the Greenplum Database project, in any role.
+
+This code is not exhaustive or complete. It serves to distil our common understanding of a collaborative, shared environment and goals. We expect it to be followed in spirit as much as in the letter so that it can enrich all of us and the technical communities in which we participate.
+
+## Specific guidelines
+
+We strive to:
+1. **Be open** We invite anyone to participate in our community. We preferably use public methods of communication for project-related messages, unless discussing something sensitive. This applies to messages for help or project-related support, too; not only is a public support request much more likely to result in an answer to a question, it also makes sure that any inadvertent mistakes made by people answering will be more easily detected and corrected.
+2. **Be empathetic**, welcoming, friendly, and patient. We work together to resolve conflict, assume good intentions, and do our best to act in an empathetic fashion. We may all experience some frustration from time to time, but we do not allow frustration to turn into a personal attack. A community where people feel uncomfortable or threatened is not a productive one. We should be respectful when dealing with other community members as well as with people outside our community.
+3. **Be collaborative**. Our work will be used by other people, and in turn will depend on the work of others. When we make something for the benefit of the project, we are willing to explain to others how it works, so that they can build on the work to make it even better. Any decision we make will affect users and colleagues, and we take those consequences seriously when making decisions.
+4. **Be inquisitive**. Nobody knows everything! Asking questions early avoids many problems later, so questions are encouraged, though they may be directed to the appropriate forum. Those who are asked should be responsive and helpful, within the context of our shared goal of improving Greenplum Database project code.
+5. **Be careful in the words that we choose**. Whether we are participating as professionals or volunteers, we value professionalism in all interactions, and take responsibility for our own speech. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behaviour are not acceptable. This includes, but is not limited to:
+    * Violent threats or language directed against another person.
+    * Sexist, racist, or otherwise discriminatory jokes and language.
+    * Posting sexually explicit or violent material.
+    * Posting (or threatening to post) other people's personally identifying information ("doxing").
+    * Sharing private content, such as emails sent privately or non-publicly, or unlogged forums such as IRC channel history.
+    * Personal insults, especially those using racist or sexist terms.
+    * Unwelcome sexual attention.
+    * Excessive or unnecessary profanity.
+    * Repeated harassment of others. In general, if someone asks you to stop, then stop.
+    * Advocating for, or encouraging, any of the above behaviour.
+6. **Be concise**. Keep in mind that what you write once will be read by hundreds of persons. Writing a short email means people can understand the conversation as efficiently as possible. Short emails should always strive to be empathetic, welcoming, friendly and patient. When a long explanation is necessary, consider adding a summary.
+    Try to bring new ideas to a conversation so that each mail adds something unique to the thread, keeping in mind that the rest of the thread still contains the other messages with arguments that have already been made.
+     Try to stay on topic, especially in discussions that are already fairly large.
+7. **Step down considerately**. Members of every project come and go. When somebody leaves or disengages from the project they should tell people they are leaving and take the proper steps to ensure that others can pick up where they left off. In doing so, they should remain respectful of those who continue to participate in the project and should not misrepresent the project's goals or achievements. Likewise, community members should respect any individual's choice to leave the project.
+
+## Diversity statement
+
+Greenplum Database project welcomes and encourages participation by everyone. We are committed to being a community that everyone feels good about joining. Although we may not be able to satisfy everyone, we will always work to treat everyone well.
+
+No matter how you identify yourself or how others perceive you: we welcome you. Though no list can hope to be comprehensive, we explicitly honour diversity in: age, culture, ethnicity, genotype, gender identity or expression, language, national origin, neurotype, phenotype, political beliefs, profession, race, religion, sexual orientation, socioeconomic status, subculture and technical ability.
+
+Though we welcome people fluent in all languages, Greenplum Database project development is conducted in English.
+
+Standards for behaviour in this community are detailed in the Code of Conduct above. We expect participants in our community to meet these standards in all their interactions and to help others to do so as well.
+
+## Reporting guidelines
+
+While this code of conduct should be adhered to by participants, we recognize that sometimes people may have a bad day, or be unaware of some of the guidelines in this code of conduct. When that happens, you may reply to them and point out this code of conduct. Such messages may be in public or in private, whatever is most appropriate. However, regardless of whether the message is public or not, it should still adhere to the relevant parts of this code of conduct; in particular, it should not be abusive or disrespectful.
+
+If you believe someone is violating this code of conduct, you may reply to them and point out this code of conduct. Assume good faith; it is more likely that participants are unaware of their bad behaviour than that they intentionally try to degrade the quality of the discussion. Should there be difficulties in dealing with the situation, you may report your compliance issues in confidence to coc@greenplum.org. This will go to an individual who is entrusted with your report.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,13 @@
+### gpupgrade version or build
+
+### OS version and uname -a
+
+### go version
+
+### Greenplum version or versions if used
+
+### Expected behavior
+
+### Actual behavior
+
+### Step to reproduce the behavior


### PR DESCRIPTION
Adding in some of the basic pieces for github. Issue template to try to prompt for the information we need in order to reproduce a problem. Also adding the code of conduct, taking from the main GPDB repo.