### PR TITLE
Use correct username for share-oids

### DIFF
--- a/hub/services/upgrade_share_oids.go
+++ b/hub/services/upgrade_share_oids.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	pb "github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/utils"
 
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 
@@ -36,7 +37,8 @@ func (h *Hub) shareOidFiles() {
 
 	hostnames := h.source.PrimaryHostnames()
 
-	user := "gpadmin"
+	user := utils.GetCurrentUser()
+
 	rsyncFlags := "-rzpogt"
 	sourceDir := filepath.Join(h.conf.StateDir, "pg_upgrade")
 

--- a/hub/services/upgrade_share_oids_test.go
+++ b/hub/services/upgrade_share_oids_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	pb "github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -30,9 +31,11 @@ var _ = Describe("UpgradeShareOids", func() {
 
 		Eventually(func() int { return testExecutor.NumExecutions }).Should(Equal(len(hostnames)))
 
+		user := utils.GetCurrentUser()
+
 		Expect(testExecutor.LocalCommands).To(ConsistOf([]string{
-			fmt.Sprintf("rsync -rzpogt %s/pg_upgrade/pg_upgrade_dump_*_oids.sql gpadmin@host1:%s/pg_upgrade", dir, dir),
-			fmt.Sprintf("rsync -rzpogt %s/pg_upgrade/pg_upgrade_dump_*_oids.sql gpadmin@host2:%s/pg_upgrade", dir, dir),
+			fmt.Sprintf("rsync -rzpogt %s/pg_upgrade/pg_upgrade_dump_*_oids.sql %s@host1:%s/pg_upgrade", dir, user, dir),
+			fmt.Sprintf("rsync -rzpogt %s/pg_upgrade/pg_upgrade_dump_*_oids.sql %s@host2:%s/pg_upgrade", dir, user, dir),
 		}))
 	})
 

--- a/utils/cluster.go
+++ b/utils/cluster.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
-	"github.com/greenplum-db/gp-common-go-libs/gplog"
-	"github.com/greenplum-db/gp-common-go-libs/operating"
 	"github.com/pkg/errors"
 )
 
@@ -143,18 +141,7 @@ func (c *Cluster) ExecuteOnAllHosts(desc string, cmd func(contentID int) string)
 }
 
 func (c *Cluster) NewDBConn() *dbconn.DBConn {
-	defaultUser := "gpadmin"
-
-	username := operating.System.Getenv("PGUSER")
-	if username == "" {
-		currentUser, err := operating.System.CurrentUser()
-		if err != nil {
-			gplog.Verbose("Error retrieving current os user, defaulting to %s", defaultUser)
-			username = defaultUser
-		} else {
-			username = currentUser.Username
-		}
-	}
+	username := GetCurrentUser()
 
 	return &dbconn.DBConn{
 		ConnPool: nil,

--- a/utils/cluster_test.go
+++ b/utils/cluster_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path"
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
@@ -177,17 +176,6 @@ var _ = Describe("Cluster", func() {
 			Expect(dbConnector.User).To(Equal(expectedUser))
 		})
 
-		It("sets the default user if neither PGUSER or current user are available", func() {
-			os.Unsetenv("PGUSER")
-
-			operating.System.CurrentUser = func() (*user.User, error) {
-				return nil, errors.New("Your systems is seriously borked if this fails")
-			}
-
-			dbConnector := c.NewDBConn()
-
-			Expect(dbConnector.User).To(Equal("gpadmin"))
-		})
 		// FIXME: protect against badly initialized clusters
 	})
 	Describe("RefreshConfig", func() {

--- a/utils/sys_utils.go
+++ b/utils/sys_utils.go
@@ -145,3 +145,19 @@ func WriteJSONFile(fileName string, contents interface{}) error {
 
 	return nil
 }
+
+func GetCurrentUser() string {
+	defaultUser := "gpadmin"
+
+	username := System.Getenv("PGUSER")
+	if username == "" {
+		currentUser, err := System.CurrentUser()
+		if err != nil {
+			gplog.Verbose("Error retrieving current os user, defaulting to %s", defaultUser)
+			username = defaultUser
+		} else {
+			username = currentUser.Username
+		}
+	}
+	return username
+}

--- a/utils/sys_utils_test.go
+++ b/utils/sys_utils_test.go
@@ -195,4 +195,41 @@ var _ = Describe("user utils", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+
+	Describe("GetCurrentUser", func() {
+		var saved string
+
+		BeforeEach(func() {
+			saved = os.Getenv("PGUSER")
+		})
+
+		AfterEach(func() {
+			os.Setenv("PGUSER", saved)
+		})
+
+		It("returns PGUSER if it is set", func() {
+			os.Setenv("PGUSER", "root")
+
+			user := GetCurrentUser()
+			Expect(user).To(Equal("root"))
+		})
+
+		It("returns system user if PGUSER not set", func() {
+			os.Unsetenv("PGUSER")
+
+			user := GetCurrentUser()
+			systemUser, _ := System.CurrentUser()
+			Expect(user).To(Equal(systemUser.Username))
+		})
+
+		It("returns gpadmin if system user and PGUSER are both not set", func() {
+			System.CurrentUser = func() (*user.User, error) {
+				return nil, errors.New("bad user")
+			}
+			os.Unsetenv("PGUSER")
+
+			user := GetCurrentUser()
+			Expect(user).To(Equal("gpadmin"))
+		})
+	})
 })


### PR DESCRIPTION
Use correct username for share-oids

Share-oids was using gpadmin to copy share-oid files.
This caused an error because gpadmin user was not guaranteed
to exist. Changed to use the user used to be the environment
variable PGUSER.

Small refactor to the logic that determines current user while we were in there.

Co-authored-by: Kevin Yeap <kyeap@pivotal.io>
Co-authored-by: Jamie McAtamney <jmcatamney@pivotal.io>