### PR TITLE
Fix and refactor init-cluster, take 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,13 @@ install: cli-package hub-package install_agent
 		cp -p $(CLI) $(GPHOME)/bin/$(CLI)
 		cp -p $(HUB) $(GPHOME)/bin/$(HUB)
 
+# We intentionally do not depend on install here -- the point of installcheck is
+# to test whatever has already been installed.
+installcheck:
+		@echo "--------------------------------------------------------------"
+		@echo "# FIXME: Make, if run in parallel, hangs after test completes."
+		./installcheck.bats -t
+
 clean:
 		# Build artifacts
 		rm -f $(AGENT)

--- a/hub/gpupgrade_hub_main.go
+++ b/hub/gpupgrade_hub_main.go
@@ -67,11 +67,7 @@ func main() {
 			cm.AddWritableStep(upgradestatus.SEGINSTALL, pb.UpgradeSteps_SEGINSTALL)
 			cm.AddWritableStep(upgradestatus.INIT_CLUSTER, pb.UpgradeSteps_INIT_CLUSTER)
 
-			cm.AddReadOnlyStep(upgradestatus.SHUTDOWN_CLUSTERS, pb.UpgradeSteps_SHUTDOWN_CLUSTERS,
-				func(stepName string) pb.StepStatus {
-					stepdir := filepath.Join(conf.StateDir, stepName)
-					return upgradestatus.ClusterShutdownStatus(stepdir, source.Executor)
-				})
+			cm.AddWritableStep(upgradestatus.SHUTDOWN_CLUSTERS, pb.UpgradeSteps_SHUTDOWN_CLUSTERS)
 
 			cm.AddReadOnlyStep(upgradestatus.CONVERT_MASTER, pb.UpgradeSteps_CONVERT_MASTER,
 				func(stepName string) pb.StepStatus {

--- a/hub/services/prepare_init_cluster.go
+++ b/hub/services/prepare_init_cluster.go
@@ -22,25 +22,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-// TODO: consolidate with RetrieveAndSaveOldConfig(); it's basically the same
-// code
-func SaveTargetClusterConfig(target *utils.Cluster, dbConnector *dbconn.DBConn, stateDir string) error {
-	err := os.MkdirAll(stateDir, 0700)
-	if err != nil {
-		return err
-	}
-
-	segConfigs, err := cluster.GetSegmentConfiguration(dbConnector)
-	if err != nil {
-		errMsg := fmt.Sprintf("Unable to get segment configuration for new cluster: %s", err.Error())
-		return errors.New(errMsg)
-	}
-	target.Cluster = cluster.NewCluster(segConfigs)
-
-	err = target.Commit()
-	return err
-}
-
 func (h *Hub) PrepareInitCluster(ctx context.Context, in *pb.PrepareInitClusterRequest) (*pb.PrepareInitClusterReply, error) {
 	gplog.Info("Running PrepareInitCluster()")
 	dbConnector := db.NewDBConn("localhost", int(h.source.MasterPort()),
@@ -109,6 +90,25 @@ func (h *Hub) InitCluster(dbConnector *dbconn.DBConn) error {
 		return errors.Wrap(err, "Could not save new cluster configuration")
 	}
 	return nil
+}
+
+// TODO: consolidate with RetrieveAndSaveOldConfig(); it's basically the same
+// code
+func SaveTargetClusterConfig(target *utils.Cluster, dbConnector *dbconn.DBConn, stateDir string) error {
+	err := os.MkdirAll(stateDir, 0700)
+	if err != nil {
+		return err
+	}
+
+	segConfigs, err := cluster.GetSegmentConfiguration(dbConnector)
+	if err != nil {
+		errMsg := fmt.Sprintf("Unable to get segment configuration for new cluster: %s", err.Error())
+		return errors.New(errMsg)
+	}
+	target.Cluster = cluster.NewCluster(segConfigs)
+
+	err = target.Commit()
+	return err
 }
 
 func initializeState(step upgradestatus.StateWriter) error {

--- a/hub/services/prepare_init_cluster.go
+++ b/hub/services/prepare_init_cluster.go
@@ -13,6 +13,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
+	"github.com/greenplum-db/gpupgrade/utils/log"
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
@@ -46,6 +47,8 @@ func (h *Hub) PrepareInitCluster(ctx context.Context, in *pb.PrepareInitClusterR
 		"template1")
 
 	go func() {
+		defer log.WritePanics()
+
 		step := h.checklist.GetStepWriter(upgradestatus.INIT_CLUSTER)
 		err := h.InitCluster(dbConnector)
 		if err != nil {

--- a/hub/services/prepare_init_cluster_test.go
+++ b/hub/services/prepare_init_cluster_test.go
@@ -86,9 +86,10 @@ var _ = Describe("Hub prepare init-cluster", func() {
 	host1~27432~%[1]s_upgrade/seg1~2~0~0
 	host2~27433~%[1]s_upgrade/seg2~3~1~0
 )`, dir)}
-			resultConfig, resultMap := hub.DeclareDataDirectories([]string{})
+			resultConfig, resultMap, port := hub.DeclareDataDirectories([]string{})
 			Expect(resultMap).To(Equal(segDataDirMap))
 			Expect(resultConfig).To(Equal(expectedConfig))
+			Expect(port).To(Equal(15433))
 		})
 	})
 	Describe("CreateAllDataDirectories", func() {

--- a/hub/services/prepare_shutdown_clusters.go
+++ b/hub/services/prepare_shutdown_clusters.go
@@ -6,6 +6,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
+	"github.com/greenplum-db/gpupgrade/utils/log"
 
 	"golang.org/x/net/context"
 
@@ -21,6 +22,8 @@ func (h *Hub) PrepareShutdownClusters(ctx context.Context, in *pb.PrepareShutdow
 }
 
 func (h *Hub) ShutdownClusters() {
+	defer log.WritePanics()
+
 	step := h.checklist.GetStepWriter(upgradestatus.SHUTDOWN_CLUSTERS)
 
 	step.ResetStateDir()

--- a/hub/upgradestatus/utility_status_checker.go
+++ b/hub/upgradestatus/utility_status_checker.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/greenplum-db/gpupgrade/hub/upgradestatus/file"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
 
@@ -25,16 +24,6 @@ import (
 */
 func SegmentConversionStatus(pgUpgradePath, oldDataDir string, executor cluster.Executor) pb.StepStatus {
 	return GetUtilityStatus("pg_upgrade", pgUpgradePath, oldDataDir, "*.inprogress", executor, isUpgradeComplete)
-}
-
-/*
- * There can be cases where gpstop is running but not as part of the pre-setup
- * in which case, we shouldn't be detecting that as a running state.
- * We only care if the inprogress file exists. We are relying on the hub to
- * never go down for this state processing to work.
- */
-func ClusterShutdownStatus(gpstopStatePath string, executor cluster.Executor) pb.StepStatus {
-	return GetUtilityStatus("gpstop", gpstopStatePath, "", "*/"+file.InProgress, executor, isStopComplete)
 }
 
 func GetUtilityStatus(binaryName, utilityStatePath, dataDir, progressFilePattern string, executor cluster.Executor, isCompleteFunc func(string) bool) pb.StepStatus {

--- a/hub/upgradestatus/utility_status_checker_test.go
+++ b/hub/upgradestatus/utility_status_checker_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
-	"github.com/greenplum-db/gpupgrade/hub/upgradestatus/file"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/utils"
@@ -116,81 +115,4 @@ var _ = Describe("utility status checker", func() {
 		Expect(status).To(Equal(pb.StepStatus_FAILED))
 	})
 
-	It("If gpstop dir does not exist, return status of PENDING", func() {
-		utils.System.Stat = func(name string) (os.FileInfo, error) {
-			return nil, nil
-		}
-		utils.System.IsNotExist = func(error) bool {
-			return true
-		}
-		status := upgradestatus.ClusterShutdownStatus("/tmp", testExecutor)
-		Expect(status).To(Equal(pb.StepStatus_PENDING))
-
-	})
-	It("If gpstop is running, return status of RUNNING", func() {
-		utils.System.Stat = func(name string) (os.FileInfo, error) {
-			return nil, nil
-		}
-		utils.System.IsNotExist = func(error) bool {
-			return false
-		}
-
-		testExecutor.LocalOutput = "I'm running"
-
-		utils.System.FilePathGlob = func(glob string) ([]string, error) {
-			if strings.Contains(glob, file.InProgress) {
-				return []string{"found something"}, nil
-			}
-			return nil, errors.New("Test not configured for this glob.")
-		}
-		status := upgradestatus.ClusterShutdownStatus("/tmp", testExecutor)
-		Expect(status).To(Equal(pb.StepStatus_RUNNING))
-	})
-	It("If gpstop is not running and .complete files exist and contain the string "+
-		"'Upgrade complete',return status of COMPLETED", func() {
-		utils.System.Stat = func(name string) (os.FileInfo, error) {
-			return nil, nil
-		}
-		utils.System.IsNotExist = func(error) bool {
-			return false
-		}
-
-		testExecutor.LocalError = errors.New("exit status 1")
-
-		utils.System.FilePathGlob = func(glob string) ([]string, error) {
-			if strings.Contains(glob, file.InProgress) {
-				return nil, errors.New("fake error")
-			} else if strings.Contains(glob, file.Complete) {
-				return []string{"old stop complete", "new stop complete"}, nil
-			}
-
-			return nil, errors.New("Test not configured for this glob.")
-		}
-		utils.System.Stat = func(filename string) (os.FileInfo, error) {
-			if strings.Contains(filename, "found something") {
-				return &testutils.FakeFileInfo{}, nil
-			}
-			return nil, nil
-		}
-		testhelper.MockFileContents("Upgrade complete")
-		defer operating.InitializeSystemFunctions()
-		status := upgradestatus.ClusterShutdownStatus("/tmp", testExecutor)
-		Expect(status).To(Equal(pb.StepStatus_COMPLETE))
-	})
-	// We are assuming that no inprogress actually exists in the path we're using,
-	// so we don't need to mock the checks out.
-	It("If gpstop not running and no .inprogress or .complete files exists, "+
-		"return status of FAILED", func() {
-		utils.System.Stat = func(name string) (os.FileInfo, error) {
-			return nil, nil
-		}
-		utils.System.IsNotExist = func(error) bool {
-			return false
-		}
-
-		testExecutor.LocalError = errors.New("gpstop failed")
-
-		status := upgradestatus.ClusterShutdownStatus("/tmp", testExecutor)
-		Expect(status).To(Equal(pb.StepStatus_FAILED))
-	})
 })

--- a/installcheck.bats
+++ b/installcheck.bats
@@ -1,0 +1,63 @@
+#! /usr/bin/env bats
+
+load test/helpers
+
+setup() {
+    [ ! -z $GPHOME ]
+    [ ! -z $MASTER_DATA_DIRECTORY ]
+    echo "# SETUP" 1>&3
+    clean_target_cluster
+    clean_statedir
+    kill_hub
+    kill_agents
+}
+
+@test "init-cluster can successfully create the target cluster and retrieve its configuration" {
+    gpupgrade prepare init \
+              --new-bindir "$GPHOME"/bin \
+              --old-bindir "$GPHOME"/bin
+
+    gpupgrade prepare start-hub 3>&-
+
+    gpupgrade check config
+    gpupgrade check version
+    gpupgrade check seginstall
+
+    gpupgrade prepare start-agents
+    sleep 1
+
+    run gpupgrade prepare init-cluster
+    [ "$status" -eq 0 ]
+
+    echo "# Waiting for init to complete" 1>&3
+    local observed_complete="false"
+    for i in {1..60}; do
+        echo "## checking status ($i/60)" 1>&3
+        run gpupgrade status upgrade
+        [ "$status" -eq 0 ]
+        [[ "$output" != *"FAILED"* ]]
+
+        if [[ "$output" = *"COMPLETE - Initialize upgrade target cluster"* ]]; then
+            observed_complete="true"
+            break
+        fi
+
+        sleep "$i"
+    done
+
+    [ "$observed_complete" != "false" ]
+
+    #TODO: gpupgrade prepare shutdown-clusters
+}
+
+clean_target_cluster() {
+    ps -ef | grep postgres | grep _upgrade | awk '{print $2}' | xargs kill || true
+    rm -rf "$MASTER_DATA_DIRECTORY"/../../*_upgrade
+    # TODO: Can we be less sketchy ^^
+    # gpdeletesystem -d "$MASTER_DATA_DIRECTORY"/../../*_upgrade #FORCE?
+}
+
+clean_statedir() {
+  rm -rf ~/.gpupgrade
+  rm -rf ~/gpAdminLogs/
+}

--- a/integrations/prepare_init_cluster_test.go
+++ b/integrations/prepare_init_cluster_test.go
@@ -4,26 +4,23 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
-	"github.com/greenplum-db/gpupgrade/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 // the `prepare start-hub` tests are currently in master_only_integration_test
-var _ = Describe("prepare", func() {
+var _ = Describe("InitCluster", func() {
 	BeforeEach(func() {
 		go agent.Start()
 	})
 	AfterEach(func() {
 		os.Remove(fmt.Sprintf("%s_upgrade", testWorkspaceDir))
 	})
-	It("can save the database configuration json under the name 'new cluster'", func() {
+	It("executes gpinitsystem and returns a target cluster connector", func() {
 		mockdb, mock := testhelper.CreateMockDB()
 		testDriver := testhelper.TestDriver{DB: mockdb, DBName: "testdb", User: "testrole"}
 		db := dbconn.NewDBConn(testDriver.DBName, testDriver.User, "fakehost", -1 /* not used */)
@@ -36,16 +33,14 @@ var _ = Describe("prepare", func() {
 		mock.ExpectQuery("SELECT .*server.*").WillReturnRows(encodingRow)
 		mock.ExpectQuery("SELECT (.*)").WillReturnRows(getFakeConfigRows())
 
-		err := hub.InitCluster(db)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(cm.WasReset(upgradestatus.INIT_CLUSTER)).To(BeTrue())
-		Expect(cm.IsInProgress(upgradestatus.INIT_CLUSTER)).To(BeTrue())
-
-		target := &utils.Cluster{ConfigPath: filepath.Join(testStateDir, utils.TARGET_CONFIG_FILENAME)}
-		err = target.Load()
+		targetConn, err := hub.InitCluster(db)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(len(target.Segments)).To(BeNumerically(">", 1))
+		Expect(targetConn.Host).To(Equal("localhost"))
+		Expect(targetConn.Port).To(Equal(15433))
+
+		Expect(testExecutor.NumExecutions).To(Equal(1))
+		Expect(testExecutor.LocalCommands[0]).To(ContainSubstring("gpinitsystem"))
 	})
 })
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -1,7 +1,7 @@
 # abort() is meant to be called from BATS tests. It will exit the process after
 # printing its arguments to the TAP stream.
 abort() {
-    echo "# fatal: $@" 1>&3
+    echo "# fatal: $*" 1>&3
     exit 1
 }
 
@@ -12,5 +12,12 @@ kill_hub() {
     pkill -9 gpupgrade_hub || true
     if ps -ef | grep -Gqw "[g]pupgrade_hub"; then
         abort "didn't kill running hub"
+    fi
+}
+
+kill_agents() {
+    pkill -9 gpupgrade_agent || true
+    if ps -ef | grep -Gqw "[g]pupgrade_agent"; then
+        echo "didn't kill running hub"
     fi
 }


### PR DESCRIPTION
This is a partial re-roll of #61 , intended to unblock those who are waiting for `prepare init-cluster` to work. It does not include many of the API refactorings that Jim has been working on; they are left as an exercise for him 😄 

Note that `install-check` has been renamed `installcheck` to match the typical Makefile convention, and it does not install for you (since the point of `installcheck` is to [test what is installed](https://www.gnu.org/software/make/manual/html_node/Standard-Targets.html), not what is currently in your source tree).