### PR TITLE
Move closer to do-all: get as far as convert master

### DIFF
--- a/agent/services/conversion_status.go
+++ b/agent/services/conversion_status.go
@@ -19,7 +19,7 @@ func (s *AgentServer) CheckConversionStatus(ctx context.Context, in *pb.CheckCon
 	var replies []string
 	for _, segment := range in.GetSegments() {
 		status := upgradestatus.SegmentConversionStatus(
-			filepath.Join(s.conf.StateDir, "pg_upgrade", fmt.Sprintf("seg-%d", segment.GetContent())),
+			filepath.Join(s.conf.StateDir, upgradestatus.CONVERT_PRIMARIES, fmt.Sprintf("seg%d", segment.GetContent())),
 			segment.GetDataDir(),
 			s.executor,
 		)

--- a/agent/services/conversion_status_test.go
+++ b/agent/services/conversion_status_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
 
@@ -63,9 +64,9 @@ var _ = Describe("CommandListener", func() {
 	})
 
 	It("returns running for segments that have the upgrade in progress", func() {
-		err := os.MkdirAll(filepath.Join(dir, "pg_upgrade", "seg-1"), 0700)
+		err := os.MkdirAll(filepath.Join(dir, upgradestatus.CONVERT_PRIMARIES, "seg1"), 0700)
 		Expect(err).ToNot(HaveOccurred())
-		fd, err := os.Create(filepath.Join(dir, "pg_upgrade", "seg-1", ".inprogress"))
+		fd, err := os.Create(filepath.Join(dir, upgradestatus.CONVERT_PRIMARIES, "seg1", ".inprogress"))
 		Expect(err).ToNot(HaveOccurred())
 		fd.Close()
 
@@ -77,8 +78,8 @@ var _ = Describe("CommandListener", func() {
 				Dbid:    3,
 				DataDir: "/old/data/dir",
 			}, {
-				Content: -1,
-				Dbid:    1,
+				Content: 2,
+				Dbid:    4,
 				DataDir: "/old/dir",
 			}},
 			Hostname: "localhost",
@@ -87,14 +88,14 @@ var _ = Describe("CommandListener", func() {
 
 		Expect(status.GetStatuses()).To(Equal([]string{
 			"RUNNING - DBID 3 - CONTENT ID 1 - PRIMARY - localhost",
-			"PENDING - DBID 1 - CONTENT ID -1 - PRIMARY - localhost",
+			"PENDING - DBID 4 - CONTENT ID 2 - PRIMARY - localhost",
 		}))
 	})
 
 	It("returns COMPLETE for segments that have completed the upgrade", func() {
-		err := os.MkdirAll(filepath.Join(dir, "pg_upgrade", "seg--1"), 0700)
+		err := os.MkdirAll(filepath.Join(dir, upgradestatus.CONVERT_PRIMARIES, "seg2"), 0700)
 		Expect(err).ToNot(HaveOccurred())
-		fd, err := os.Create(filepath.Join(dir, "pg_upgrade", "seg--1", ".done"))
+		fd, err := os.Create(filepath.Join(dir, upgradestatus.CONVERT_PRIMARIES, "seg2", ".done"))
 		Expect(err).ToNot(HaveOccurred())
 		fd.WriteString("Upgrade complete\n")
 		fd.Close()
@@ -105,8 +106,8 @@ var _ = Describe("CommandListener", func() {
 				Dbid:    3,
 				DataDir: "/old/data/dir",
 			}, {
-				Content: -1,
-				Dbid:    1,
+				Content: 2,
+				Dbid:    4,
 				DataDir: "/old/dir",
 			}},
 			Hostname: "localhost",
@@ -115,7 +116,7 @@ var _ = Describe("CommandListener", func() {
 
 		Expect(status.GetStatuses()).To(Equal([]string{
 			"PENDING - DBID 3 - CONTENT ID 1 - PRIMARY - localhost",
-			"COMPLETE - DBID 1 - CONTENT ID -1 - PRIMARY - localhost",
+			"COMPLETE - DBID 4 - CONTENT ID 2 - PRIMARY - localhost",
 		}))
 	})
 

--- a/agent/services/convert_primary_test.go
+++ b/agent/services/convert_primary_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
 
@@ -37,10 +38,10 @@ var _ = Describe("CommandListener", func() {
 		agentConfig := services.AgentConfig{StateDir: dir}
 		agent = services.NewAgentServer(testExecutor, agentConfig)
 
-		err = os.MkdirAll(filepath.Join(dir, "pg_upgrade"), 0700)
+		err = os.MkdirAll(filepath.Join(dir, upgradestatus.CONVERT_MASTER), 0700)
 		Expect(err).ToNot(HaveOccurred())
 
-		oidFile = filepath.Join(dir, "pg_upgrade", "pg_upgrade_dump_seg1_oids.sql")
+		oidFile = filepath.Join(dir, upgradestatus.CONVERT_MASTER, "pg_upgrade_dump_seg1_oids.sql")
 		f, err := os.Create(oidFile)
 		Expect(err).ToNot(HaveOccurred())
 		f.Close()
@@ -68,10 +69,10 @@ var _ = Describe("CommandListener", func() {
 
 		Expect(testExecutor.NumExecutions).To(Equal(4))
 
-		Expect(testExecutor.LocalCommands).To(ContainElement(fmt.Sprintf("cp %s %s/pg_upgrade/seg-0", oidFile, dir)))
-		Expect(testExecutor.LocalCommands).To(ContainElement(fmt.Sprintf("cd %s/pg_upgrade/seg-0 && nohup /new/bin/pg_upgrade --old-bindir=/old/bin --old-datadir=old/datadir1 --new-bindir=/new/bin --new-datadir=new/datadir1 --old-port=1 --new-port=11 --progress", dir)))
-		Expect(testExecutor.LocalCommands).To(ContainElement(fmt.Sprintf("cp %s %s/pg_upgrade/seg-1", oidFile, dir)))
-		Expect(testExecutor.LocalCommands).To(ContainElement(fmt.Sprintf("cd %s/pg_upgrade/seg-1 && nohup /new/bin/pg_upgrade --old-bindir=/old/bin --old-datadir=old/datadir2 --new-bindir=/new/bin --new-datadir=new/datadir2 --old-port=2 --new-port=22 --progress", dir)))
+		Expect(testExecutor.LocalCommands).To(ContainElement(fmt.Sprintf("cp %s %s/convert-primaries/seg0", oidFile, dir)))
+		Expect(testExecutor.LocalCommands).To(ContainElement(fmt.Sprintf("cd %s/convert-primaries/seg0 && nohup /new/bin/pg_upgrade --old-bindir=/old/bin --old-datadir=old/datadir1 --new-bindir=/new/bin --new-datadir=new/datadir1 --old-port=1 --new-port=11 --progress", dir)))
+		Expect(testExecutor.LocalCommands).To(ContainElement(fmt.Sprintf("cp %s %s/convert-primaries/seg1", oidFile, dir)))
+		Expect(testExecutor.LocalCommands).To(ContainElement(fmt.Sprintf("cd %s/convert-primaries/seg1 && nohup /new/bin/pg_upgrade --old-bindir=/old/bin --old-datadir=old/datadir2 --new-bindir=/new/bin --new-datadir=new/datadir2 --old-port=2 --new-port=22 --progress", dir)))
 	})
 
 	It("returns an an error if the oid files glob fails", func() {

--- a/hub/gpupgrade_hub_main.go
+++ b/hub/gpupgrade_hub_main.go
@@ -66,16 +66,8 @@ func main() {
 			cm.AddWritableStep(upgradestatus.CONFIG, pb.UpgradeSteps_CONFIG)
 			cm.AddWritableStep(upgradestatus.SEGINSTALL, pb.UpgradeSteps_SEGINSTALL)
 			cm.AddWritableStep(upgradestatus.INIT_CLUSTER, pb.UpgradeSteps_INIT_CLUSTER)
-
 			cm.AddWritableStep(upgradestatus.SHUTDOWN_CLUSTERS, pb.UpgradeSteps_SHUTDOWN_CLUSTERS)
-
-			cm.AddReadOnlyStep(upgradestatus.CONVERT_MASTER, pb.UpgradeSteps_CONVERT_MASTER,
-				func(stepName string) pb.StepStatus {
-					convertMasterPath := filepath.Join(conf.StateDir, stepName)
-					sourceDataDir := source.MasterDataDir()
-					return upgradestatus.SegmentConversionStatus(convertMasterPath, sourceDataDir, source.Executor)
-				})
-
+			cm.AddWritableStep(upgradestatus.CONVERT_MASTER, pb.UpgradeSteps_CONVERT_MASTER)
 			cm.AddWritableStep(upgradestatus.START_AGENTS, pb.UpgradeSteps_START_AGENTS)
 			cm.AddWritableStep(upgradestatus.SHARE_OIDS, pb.UpgradeSteps_SHARE_OIDS)
 

--- a/hub/services/status_conversion.go
+++ b/hub/services/status_conversion.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
 
@@ -20,16 +19,6 @@ func (h *Hub) StatusConversion(ctx context.Context, in *pb.StatusConversionReque
 	if err != nil {
 		return &pb.StatusConversionReply{}, err
 	}
-
-	// Get the master status first, followed by primaries.
-	// XXX This is duplicated between agents and hub, and besides why are we
-	// returning strings instead of structs.
-	format := "%s - DBID %d - CONTENT ID %d - MASTER - %s"
-	status := h.checklist.GetStepReader(upgradestatus.CONVERT_MASTER).Status()
-	master := h.target.Segments[-1]
-	masterStatus := fmt.Sprintf(format, status.String(), master.DbID, master.ContentID, master.Hostname)
-
-	statuses = append(statuses, masterStatus)
 
 	primaryStatuses, err := GetConversionStatusFromPrimaries(agentConnections, h.target)
 	if err != nil {

--- a/hub/services/upgrade_convert_master.go
+++ b/hub/services/upgrade_convert_master.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	pb "github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
 
@@ -26,8 +27,7 @@ func (h *Hub) UpgradeConvertMaster(ctx context.Context, in *pb.UpgradeConvertMas
 }
 
 func (h *Hub) ConvertMaster() error {
-	upgradeFileName := "pg_upgrade"
-	pathToUpgradeWD := filepath.Join(h.conf.StateDir, upgradeFileName)
+	pathToUpgradeWD := filepath.Join(h.conf.StateDir, upgradestatus.CONVERT_MASTER)
 	err := utils.System.MkdirAll(pathToUpgradeWD, 0700)
 	if err != nil {
 		errMsg := fmt.Sprintf("mkdir %s failed: %v. Is there an pg_upgrade in progress?", pathToUpgradeWD, err)
@@ -40,7 +40,8 @@ func (h *Hub) ConvertMaster() error {
 		"--old-bindir=%s --old-datadir=%s --old-port=%d "+
 		"--new-bindir=%s --new-datadir=%s --new-port=%d "+
 		"--dispatcher-mode --progress",
-		pathToUpgradeWD, filepath.Join(h.target.BinDir, "pg_upgrade"),
+		pathToUpgradeWD,
+		filepath.Join(h.target.BinDir, "pg_upgrade"),
 		h.source.BinDir,
 		h.source.MasterDataDir(),
 		h.source.MasterPort(),

--- a/hub/services/upgrade_convert_master_test.go
+++ b/hub/services/upgrade_convert_master_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	"github.com/greenplum-db/gpupgrade/utils"
 
 	. "github.com/onsi/ginkgo"
@@ -28,8 +29,8 @@ var _ = Describe("ConvertMasterHub", func() {
 		err := hub.ConvertMaster()
 		Expect(err).ToNot(HaveOccurred())
 
-		pgupgrade_dir := filepath.Join(dir, "pg_upgrade")
-		Expect(actualCmdStr).To(Equal(fmt.Sprintf("unset PGHOST; unset PGPORT; cd %s && nohup /target/bindir/pg_upgrade ", pgupgrade_dir) +
+		convert_master_dir := filepath.Join(dir, upgradestatus.CONVERT_MASTER)
+		Expect(actualCmdStr).To(Equal(fmt.Sprintf("unset PGHOST; unset PGPORT; cd %s && nohup /target/bindir/pg_upgrade ", convert_master_dir) +
 			fmt.Sprintf("--old-bindir=/source/bindir --old-datadir=%s/seg-1 --old-port=15432 ", dir) +
 			fmt.Sprintf("--new-bindir=/target/bindir --new-datadir=%s/seg-1 --new-port=15432 ", dir) +
 			"--dispatcher-mode --progress"))

--- a/hub/services/upgrade_convert_master_test.go
+++ b/hub/services/upgrade_convert_master_test.go
@@ -3,11 +3,8 @@ package services_test
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 
-	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
-	"github.com/greenplum-db/gpupgrade/utils"
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -15,40 +12,33 @@ import (
 
 var _ = Describe("ConvertMasterHub", func() {
 	var (
-		actualCmdStr string
+		testExecutor *testhelper.TestExecutor
 	)
 
 	BeforeEach(func() {
-		utils.System.RunCommandAsync = func(cmdStr string, logFile string) error {
-			actualCmdStr = cmdStr
-			return nil
-		}
+		testExecutor = &testhelper.TestExecutor{}
+		source.Executor = testExecutor
 	})
 
 	It("returns with no error when convert master runs successfully", func() {
 		err := hub.ConvertMaster()
 		Expect(err).ToNot(HaveOccurred())
 
-		convert_master_dir := filepath.Join(dir, upgradestatus.CONVERT_MASTER)
-		Expect(actualCmdStr).To(Equal(fmt.Sprintf("unset PGHOST; unset PGPORT; cd %s && nohup /target/bindir/pg_upgrade ", convert_master_dir) +
+		Expect(testExecutor.LocalCommands[0]).To(Equal(fmt.Sprintf("unset PGHOST; unset PGPORT; /target/bindir/pg_upgrade ") +
 			fmt.Sprintf("--old-bindir=/source/bindir --old-datadir=%s/seg-1 --old-port=15432 ", dir) +
 			fmt.Sprintf("--new-bindir=/target/bindir --new-datadir=%s/seg-1 --new-port=15432 ", dir) +
-			"--dispatcher-mode --progress"))
+			"--mode=dispatcher"))
 	})
 
 	It("returns an error when convert master fails", func() {
-		utils.System.RunCommandAsync = func(cmdStr string, logFile string) error {
-			return errors.New("upgrade failed")
-		}
+		testExecutor.LocalError = errors.New("upgrade failed")
 
 		err := hub.ConvertMaster()
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("returns an error if the upgrade directory cannot be created", func() {
-		utils.System.MkdirAll = func(path string, perm os.FileMode) error {
-			return errors.New("failed to create directory")
-		}
+		testExecutor.LocalError = errors.New("failed to create directory")
 
 		err := hub.ConvertMaster()
 		Expect(err).To(HaveOccurred())

--- a/hub/services/upgrade_convert_primaries.go
+++ b/hub/services/upgrade_convert_primaries.go
@@ -38,7 +38,7 @@ func (h *Hub) UpgradeConvertPrimaries(ctx context.Context, in *pb.UpgradeConvert
 			})
 
 			if err != nil {
-				gplog.Error("Hub Upgrade Convert Primaries failed to call agent %s with error: ", c.Hostname, err)
+				gplog.Error("Hub Upgrade Convert Primaries failed to call agent %s with error: %v", c.Hostname, err)
 				agentErrs <- err
 			}
 		}(conn)

--- a/hub/services/upgrade_share_oids.go
+++ b/hub/services/upgrade_share_oids.go
@@ -38,11 +38,11 @@ func (h *Hub) shareOidFiles() {
 
 	user := "gpadmin"
 	rsyncFlags := "-rzpogt"
-	sourceDir := filepath.Join(h.conf.StateDir, "pg_upgrade")
+	sourceDir := filepath.Join(h.conf.StateDir, upgradestatus.CONVERT_MASTER)
 
 	anyFailed := false
 	for _, host := range hostnames {
-		destinationDirectory := user + "@" + host + ":" + filepath.Join(h.conf.StateDir, "pg_upgrade")
+		destinationDirectory := user + "@" + host + ":" + filepath.Join(h.conf.StateDir, upgradestatus.CONVERT_PRIMARIES)
 
 		rsyncCommand := strings.Join([]string{"rsync", rsyncFlags, filepath.Join(sourceDir, "pg_upgrade_dump_*_oids.sql"), destinationDirectory}, " ")
 		gplog.Info("share oids command: %+v", rsyncCommand)

--- a/hub/services/upgrade_share_oids_test.go
+++ b/hub/services/upgrade_share_oids_test.go
@@ -30,10 +30,10 @@ var _ = Describe("UpgradeShareOids", func() {
 
 		Eventually(func() int { return testExecutor.NumExecutions }).Should(Equal(len(hostnames)))
 
-		Expect(testExecutor.LocalCommands).To(ConsistOf([]string{
-			fmt.Sprintf("rsync -rzpogt %s/pg_upgrade/pg_upgrade_dump_*_oids.sql gpadmin@host1:%s/pg_upgrade", dir, dir),
-			fmt.Sprintf("rsync -rzpogt %s/pg_upgrade/pg_upgrade_dump_*_oids.sql gpadmin@host2:%s/pg_upgrade", dir, dir),
-		}))
+		Expect(testExecutor.LocalCommands).To(ConsistOf(
+			fmt.Sprintf("rsync -rzpogt %s/convert-master/pg_upgrade_dump_*_oids.sql gpadmin@host1:%s/convert-primaries", dir, dir),
+			fmt.Sprintf("rsync -rzpogt %s/convert-master/pg_upgrade_dump_*_oids.sql gpadmin@host2:%s/convert-primaries", dir, dir),
+		))
 	})
 
 	It("copies all files even if rsync fails for a host", func() {

--- a/hub/upgradestatus/utility_status_checker.go
+++ b/hub/upgradestatus/utility_status_checker.go
@@ -31,7 +31,7 @@ func GetUtilityStatus(binaryName, utilityStatePath, dataDir, progressFilePattern
 	switch {
 	case utils.System.IsNotExist(err):
 		return pb.StepStatus_PENDING
-	case isBinaryRunning(binaryName, dataDir, executor) && inProgressFilesExist(utilityStatePath, progressFilePattern):
+	case isBinaryRunning(binaryName, dataDir, executor):
 		return pb.StepStatus_RUNNING
 	case !inProgressFilesExist(utilityStatePath, progressFilePattern) && isCompleteFunc(utilityStatePath):
 		return pb.StepStatus_COMPLETE

--- a/installcheck.bats
+++ b/installcheck.bats
@@ -42,6 +42,9 @@ teardown() {
 
     ! ps -ef | grep -Gqw "[p]ostgres"
 
+    gpupgrade upgrade convert-master
+
+    EventuallyStepCompletes "Run pg_upgrade on master"
 }
 
 EventuallyStepCompletes() {
@@ -55,7 +58,10 @@ EventuallyStepCompletes() {
         statusLine=$(echo "$output" | grep "$cliStepMessage")
         echo "# $statusLine ($i/60)" 1>&3
 
-        [[ "$output" != *"FAILED"* ]]
+        if [[ "$statusLine" = *"FAILED"* ]]; then
+            break
+        fi
+
 
         if [[ "$output" = *"COMPLETE - $cliStepMessage"* ]]; then
             observed_complete="true"

--- a/integrations/status_command_test.go
+++ b/integrations/status_command_test.go
@@ -21,7 +21,7 @@ var _ = Describe("status", func() {
 	})
 	Describe("conversion", func() {
 		It("Displays status information for all segments", func() {
-			pathToSegUpgrade := filepath.Join(testStateDir, "pg_upgrade", "seg-0")
+			pathToSegUpgrade := filepath.Join(testStateDir, upgradestatus.CONVERT_PRIMARIES, "seg0")
 			err := os.MkdirAll(pathToSegUpgrade, 0700)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -33,7 +33,6 @@ var _ = Describe("status", func() {
 			statusSession := runCommand("status", "conversion")
 			Eventually(statusSession).Should(Exit(0))
 
-			Eventually(statusSession).Should(gbytes.Say("PENDING - DBID 1 - CONTENT ID -1 - MASTER - .+"))
 			Eventually(statusSession).Should(gbytes.Say("COMPLETE - DBID 2 - CONTENT ID 0 - PRIMARY - .+"))
 		})
 	})

--- a/integrations/upgrade_convert_primaries_test.go
+++ b/integrations/upgrade_convert_primaries_test.go
@@ -16,27 +16,38 @@ import (
 )
 
 var _ = Describe("upgrade convert primaries", func() {
+	/*
+	 * The two pending tests in this block are useful tests in theory, but
+	 * would rely on using an actual checklist manager over a mock checklist
+	 * manager due to the way status checking is done for pg_upgrade.
+	 *
+	 * If convert-primaries were modified to somehow use the actual checklist
+	 * manager, these tests would be meaningful and can be refactored and
+	 * fixed up appropriately.  Otherwise, it would make more sense to
+	 * replace these with end-to-end tests, as in that case they would grow
+	 * beyond the scope of integration tests due to a lack of mocking.
+	 *
+	 * TODO: Decide how to handle convert-primaries testing.
+	 */
 	var (
 		oidFile string
 	)
 
 	BeforeEach(func() {
 		var err error
-		segmentDataDir := os.Getenv("MASTER_DATA_DIRECTORY")
-		Expect(segmentDataDir).ToNot(Equal(""), "MASTER_DATA_DIRECTORY needs to be set!")
 
-		err = os.MkdirAll(filepath.Join(testStateDir, "pg_upgrade"), 0700)
+		err = os.MkdirAll(filepath.Join(testStateDir, "convert-master"), 0700)
 		Expect(err).ToNot(HaveOccurred())
-
-		oidFile = filepath.Join(testStateDir, "pg_upgrade", "pg_upgrade_dump_seg1_oids.sql")
-		f, err := os.Create(oidFile)
-		Expect(err).ToNot(HaveOccurred())
-		f.Close()
+		for i := range []int{0, 1, 2} {
+			oidFile = filepath.Join(testStateDir, "convert-master", fmt.Sprintf("pg_upgrade_dump_seg%d_oids.sql", i))
+			f, err := os.Create(oidFile)
+			Expect(err).ToNot(HaveOccurred())
+			f.Close()
+		}
 
 		go agent.Start()
 	})
 
-	// Move this elsewhere; it's not testing what's useful anymore.
 	XIt("updates status PENDING to RUNNING then to COMPLETE if successful", func() {
 		utils.System.RunCommandAsync = func(cmdStr string, logFile string) error {
 			_, err := agentExecutor.ExecuteLocalCommand(cmdStr)
@@ -45,7 +56,7 @@ var _ = Describe("upgrade convert primaries", func() {
 
 		cm.AddStep(upgradestatus.CONVERT_PRIMARIES, pb.UpgradeSteps_CONVERT_PRIMARIES)
 
-		Expect(runStatusUpgrade()).To(ContainSubstring("PENDING - Primary segment upgrade"))
+		Expect(runStatusUpgrade()).To(ContainSubstring("PENDING - Run pg_upgrade on primaries"))
 		testExecutor.LocalOutput = "TEST"
 
 		step := cm.GetStepWriter(upgradestatus.START_AGENTS)
@@ -57,16 +68,17 @@ var _ = Describe("upgrade convert primaries", func() {
 		upgradeConvertPrimaries := runCommand(
 			"upgrade",
 			"convert-primaries",
-			"--old-bindir", "/old/bindir",
-			"--new-bindir", "/new/bindir",
 		)
 		Expect(upgradeConvertPrimaries).To(Exit(0))
 
+		step = cm.GetStepWriter(upgradestatus.CONVERT_PRIMARIES)
+		step.MarkInProgress()
+
 		agentExecutor.LocalOutput = "pgrep for running pg_upgrade for segment"
-		Expect(runStatusUpgrade()).To(ContainSubstring("RUNNING - Primary segment upgrade"))
+		Expect(runStatusUpgrade()).To(ContainSubstring("RUNNING - Run pg_upgrade on primaries"))
 
 		for i := range []int{0, 1, 2} {
-			f, err := os.Create(filepath.Join(testStateDir, "pg_upgrade", fmt.Sprintf("seg-%d", i), ".done"))
+			f, err := os.Create(filepath.Join(testStateDir, upgradestatus.CONVERT_PRIMARIES, fmt.Sprintf("seg%d", i), ".done"))
 			Expect(err).ToNot(HaveOccurred())
 			f.Write([]byte("Upgrade complete\n"))
 			f.Close()
@@ -83,15 +95,14 @@ var _ = Describe("upgrade convert primaries", func() {
 
 		// Return no PIDs when pgrep checks if pg_upgrade is running
 		agentExecutor.LocalOutput = ""
-		Expect(runStatusUpgrade()).To(ContainSubstring("COMPLETE - Primary segment upgrade"))
+		Expect(runStatusUpgrade()).To(ContainSubstring("COMPLETE - Run pg_upgrade on primaries"))
 	})
 
-	// Move this elsewhere; it's not testing what's useful anymore.
 	XIt("updates status to FAILED if convert primaries fails on at least 1 agent", func() {
 		cm.AddStep(upgradestatus.CONVERT_PRIMARIES, pb.UpgradeSteps_CONVERT_PRIMARIES)
 
-		Expect(runStatusUpgrade()).To(ContainSubstring("PENDING - Primary segment upgrade"))
-		setStateFile(testStateDir, "pg_upgrade/seg-0", "1.failed")
+		Expect(runStatusUpgrade()).To(ContainSubstring("PENDING - Run pg_upgrade on primaries"))
+		setStateFile(testStateDir, "convert-primaries/seg0", "1.failed")
 
 		step := cm.GetStepWriter(upgradestatus.START_AGENTS)
 		step.MarkInProgress()
@@ -100,12 +111,10 @@ var _ = Describe("upgrade convert primaries", func() {
 		upgradeConvertPrimaries := runCommand(
 			"upgrade",
 			"convert-primaries",
-			"--old-bindir", "/old/bindir",
-			"--new-bindir", "/new/bindir",
 		)
 		Expect(upgradeConvertPrimaries).Should(Exit(0))
 
-		Expect(runStatusUpgrade()).To(ContainSubstring("FAILED - Primary segment upgrade"))
+		Expect(runStatusUpgrade()).To(ContainSubstring("FAILED - Run pg_upgrade on primaries"))
 	})
 })
 

--- a/utils/cluster.go
+++ b/utils/cluster.go
@@ -94,11 +94,11 @@ func (c *Cluster) PrimaryHostnames() []string {
 }
 
 // SegmentsOn returns the configurations of segments that are running on a given
-// host. An error will be returned for unknown hostnames.
+// host excluding the master. An error will be returned for unknown hostnames.
 func (c Cluster) SegmentsOn(hostname string) ([]cluster.SegConfig, error) {
 	var segments []cluster.SegConfig
 	for _, segment := range c.Segments {
-		if segment.Hostname == hostname {
+		if segment.Hostname == hostname && segment.ContentID != -1 {
 			segments = append(segments, segment)
 		}
 	}


### PR DESCRIPTION
Comments in commits tell the details of the story.  

The biggest change in design is that when the hub serviced the ConvertMaster request, it would attempt to `nohup` the `pg_upgrade` process.  The way this was implemented meant that we had difficulty knowing when the process failed.  We changed the pattern and "merely" execute the `ConvertMaster()` function from a goroutine, and have that function return an error.  This makes the `CONVERT_MASTER` step writeable.