### PR TITLE
Fix share oids

### DIFF
--- a/hub/services/upgrade_share_oids.go
+++ b/hub/services/upgrade_share_oids.go
@@ -36,13 +36,12 @@ func (h *Hub) shareOidFiles() {
 
 	hostnames := h.source.PrimaryHostnames()
 
-	user := "gpadmin"
 	rsyncFlags := "-rzpogt"
 	sourceDir := filepath.Join(h.conf.StateDir, upgradestatus.CONVERT_MASTER)
 
 	anyFailed := false
 	for _, host := range hostnames {
-		destinationDirectory := user + "@" + host + ":" + filepath.Join(h.conf.StateDir, upgradestatus.CONVERT_PRIMARIES)
+		destinationDirectory := host + ":" + filepath.Join(h.conf.StateDir, upgradestatus.CONVERT_PRIMARIES)
 
 		rsyncCommand := strings.Join([]string{"rsync", rsyncFlags, filepath.Join(sourceDir, "pg_upgrade_dump_*_oids.sql"), destinationDirectory}, " ")
 		gplog.Info("share oids command: %+v", rsyncCommand)

--- a/hub/services/upgrade_share_oids_test.go
+++ b/hub/services/upgrade_share_oids_test.go
@@ -31,8 +31,8 @@ var _ = Describe("UpgradeShareOids", func() {
 		Eventually(func() int { return testExecutor.NumExecutions }).Should(Equal(len(hostnames)))
 
 		Expect(testExecutor.LocalCommands).To(ConsistOf(
-			fmt.Sprintf("rsync -rzpogt %s/convert-master/pg_upgrade_dump_*_oids.sql gpadmin@host1:%s/convert-primaries", dir, dir),
-			fmt.Sprintf("rsync -rzpogt %s/convert-master/pg_upgrade_dump_*_oids.sql gpadmin@host2:%s/convert-primaries", dir, dir),
+			fmt.Sprintf("rsync -rzpogt %s/convert-master/pg_upgrade_dump_*_oids.sql host1:%s/convert-primaries", dir, dir),
+			fmt.Sprintf("rsync -rzpogt %s/convert-master/pg_upgrade_dump_*_oids.sql host2:%s/convert-primaries", dir, dir),
 		))
 	})
 


### PR DESCRIPTION
Previously we hardcoded the username to `gpadmin`, but now we are going to remove that, and rely on the fact that rsync will assume that the username corresponds to the user that owns the process, which in this case is the username used to spawn the hub.

This is a re-roll of #63, that was much smaller due to several previous refactors that have gone into master since it was opened the first time.