### PR TITLE
Minor updates to GPDB version checking logic.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -46,22 +46,13 @@
     "operating",
     "testhelper"
   ]
-  revision = "a51003cc3ea7222978cb52aaab8232f8fffb5c27"
+  revision = "d77bf5c27646a07c35b4e7b9774297fe8702afbc"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/jmoiron/sqlx"
-  packages = [
-    ".",
-    "reflectx"
-  ]
-  revision = "cf35089a197953c69420c8d0cecda90809764b1d"
 
 [[projects]]
   branch = "master"

--- a/hub/services/check_object_count.go
+++ b/hub/services/check_object_count.go
@@ -25,7 +25,6 @@ func (h *Hub) CheckObjectCount(ctx context.Context,
 		gplog.Error(err.Error())
 		return &pb.CheckObjectCountReply{}, utils.DatabaseConnectionError{Parent: err}
 	}
-	dbConnector.Version.Initialize(dbConnector)
 	names, err := dbconn.SelectStringSlice(dbConnector, GET_DATABASE_NAMES)
 	if err != nil {
 		gplog.Error(err.Error())
@@ -42,7 +41,6 @@ func (h *Hub) CheckObjectCount(ctx context.Context,
 			gplog.Error(err.Error())
 			return &pb.CheckObjectCountReply{}, errors.New(err.Error())
 		}
-		dbConnector.Version.Initialize(dbConnector)
 
 		aocount, heapcount, errFromCounts := GetCountsForDb(dbConnector)
 		if errFromCounts != nil {

--- a/hub/services/check_version.go
+++ b/hub/services/check_version.go
@@ -27,7 +27,6 @@ func (h *Hub) CheckVersion(ctx context.Context,
 		gplog.Error(err.Error())
 		return &pb.CheckVersionReply{}, utils.DatabaseConnectionError{Parent: err}
 	}
-	dbConnector.Version.Initialize(dbConnector)
 
 	isVersionCompatible := dbConnector.Version.AtLeast(MINIMUM_VERSION)
 	return &pb.CheckVersionReply{IsVersionCompatible: isVersionCompatible}, nil

--- a/hub/services/prepare_init_cluster.go
+++ b/hub/services/prepare_init_cluster.go
@@ -66,7 +66,6 @@ func (h *Hub) InitCluster(sourceDBConn *dbconn.DBConn) (*dbconn.DBConn, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not connect to database")
 	}
-	sourceDBConn.Version.Initialize(sourceDBConn)
 	defer sourceDBConn.Close()
 
 	gpinitsystemConfig, err := h.CreateInitialInitsystemConfig()

--- a/hub/services/prepare_init_cluster_test.go
+++ b/hub/services/prepare_init_cluster_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/blang/semver"
 	"github.com/pkg/errors"
 
 	"github.com/greenplum-db/gpupgrade/hub/services"
@@ -34,16 +33,10 @@ var _ = Describe("Hub prepare init-cluster", func() {
 	BeforeEach(func() {
 		testExecutor = &testhelper.TestExecutor{}
 
-		version, err := semver.Make("6.0.0")
-		Expect(err).ToNot(HaveOccurred())
-
 		expectedCluster = &utils.Cluster{
 			Cluster: testutils.MockCluster(),
 			BinDir:  "/tmp",
-			Version: dbconn.GPDBVersion{
-				VersionString: version.String(),
-				SemVer:        version,
-			},
+			Version: dbconn.NewVersion("6.0.0"),
 		}
 
 		segDataDirMap = map[string][]string{
@@ -70,10 +63,7 @@ var _ = Describe("Hub prepare init-cluster", func() {
 		})
 
 		It("turns checksums off when upgrading from 4.x", func() {
-			source.Version = dbconn.GPDBVersion{
-				VersionString: "4.3.3",
-				SemVer:        semver.MustParse("4.3.3"),
-			}
+			source.Version = dbconn.NewVersion("4.3.3")
 
 			gpinitsystemConfig, err := hub.CreateInitialInitsystemConfig()
 			Expect(err).To(BeNil())

--- a/hub/services/upgrade_convert_master_test.go
+++ b/hub/services/upgrade_convert_master_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/blang/semver"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpupgrade/utils"
@@ -37,10 +36,7 @@ var _ = Describe("ConvertMasterHub", func() {
 	})
 
 	It("uses the correct pg_upgrade options for older DBs", func() {
-		target.Version = dbconn.GPDBVersion{
-			VersionString: "5.0.0",
-			SemVer:        semver.MustParse("5.0.0"),
-		}
+		target.Version = dbconn.NewVersion("5.0.0")
 
 		err := hub.ConvertMaster()
 		Expect(err).ToNot(HaveOccurred())

--- a/testutils/sql.go
+++ b/testutils/sql.go
@@ -1,8 +1,6 @@
 package testutils
 
 import (
-	"fmt"
-
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
@@ -35,16 +33,6 @@ func MockCluster() *cluster.Cluster {
 		},
 		Executor: &cluster.GPDBExecutor{},
 	}
-}
-
-func SetMockGPDBVersion(mock sqlmock.Sqlmock, version string) {
-	rows := sqlmock.NewRows([]string{"versionstring"})
-
-	versionStr := fmt.Sprintf(`PostgreSQL 9.2beta2 (Greenplum Database %s-alpha.0+dev.9374.gfb2a077e20 build dev-oss)`,
-		version)
-	rows.AddRow(versionStr)
-
-	mock.ExpectQuery(`SELECT version\(\) AS versionstring`).WillReturnRows(rows)
 }
 
 // CreateMockDBConn is just like testhelper.CreateAndConnectMockDB(), but it

--- a/testutils/test_utils.go
+++ b/testutils/test_utils.go
@@ -89,7 +89,6 @@ func CreateSampleClusterPair() (*utils.Cluster, *utils.Cluster) {
 func InitClusterPairFromDB() (*utils.Cluster, *utils.Cluster) {
 	conn := dbconn.NewDBConnFromEnvironment("postgres")
 	conn.MustConnect(1)
-	conn.Version.Initialize(conn)
 	segConfig := cluster.MustGetSegmentConfiguration(conn)
 	sourceCluster := cluster.NewCluster(segConfig)
 	targetCluster := cluster.NewCluster(segConfig)

--- a/utils/cluster.go
+++ b/utils/cluster.go
@@ -41,8 +41,6 @@ func ClusterFromDB(conn *dbconn.DBConn, binDir, configPath string) (*Cluster, er
 	}
 	defer conn.Close()
 
-	conn.Version.Initialize(conn)
-
 	c := new(Cluster)
 	c.Version = conn.Version
 

--- a/utils/sys_utils.go
+++ b/utils/sys_utils.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	//"github.com/jmoiron/sqlx"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"


### PR DESCRIPTION
Now that DBConn.Connect automatically retrieves GPDB version information, a
call to DBConn.Version.Initialize(DBConn) is no longer needed.

This commit also replaces direct GPDBVersion instantiation in tests with calls
to dbconn.NewVersion, and replaces calls to testutils.SetMockGPDBVersion with
calls to testhelper.ExpectVersionQuery.

And since this commit is updating Gopkg.lock anyway, it removes the no-longer-
necessary sqlx dependency from the lock file.