### PR TITLE
shareOidFiles: only copy the MDD once per host

### DIFF
--- a/hub/services/upgrade_share_oids_test.go
+++ b/hub/services/upgrade_share_oids_test.go
@@ -39,6 +39,26 @@ var _ = Describe("UpgradeShareOids", func() {
 		Expect(resultMap[1]).To(Equal([]string{"rsync", "-rzpogt", masterDataDir, "host2:/tmp/masterDirCopy"}))
 	})
 
+	It("copies the master data directory only once per host", func() {
+		target.Version = dbconn.NewVersion("6.0.0")
+
+		// Set all target segment hosts to be the same.
+		for content, segment := range target.Segments {
+			segment.Hostname = target.Segments[-1].Hostname
+			target.Segments[content] = segment
+		}
+
+		_, err := hub.UpgradeShareOids(nil, &pb.UpgradeShareOidsRequest{})
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func() int { return testExecutor.NumExecutions }).Should(Equal(1))
+
+		masterDataDir := filepath.Clean(source.MasterDataDir()) + string(filepath.Separator)
+		resultMap := testExecutor.ClusterCommands[0]
+		Expect(resultMap).To(HaveLen(1))
+		Expect(resultMap).To(ContainElement([]string{"rsync", "-rzpogt", masterDataDir, "localhost:/tmp/masterDirCopy"}))
+	})
+
 	It("copies files to each primary host in 5.X or earlier", func() {
 		source.Version = dbconn.NewVersion("5.3.0")
 		_, err := hub.UpgradeShareOids(nil, &pb.UpgradeShareOidsRequest{})


### PR DESCRIPTION
Copying the same directory to the same destination multiple times in
parallel is sure to result in failure (as the dev pipeline is currently
showing). Use the new `contentsByHost()` helper to make sure we only copy
the master data directory once per host.

Co-authored-by: Shoaib Lari <slari@pivotal.io>