### PR TITLE
convert-*: source greenplum_path.sh before upgrading

### DIFF
--- a/agent/services/convert_primary.go
+++ b/agent/services/convert_primary.go
@@ -80,9 +80,10 @@ func (s *AgentServer) UpgradeSegments(oldBinDir, newBinDir, newVersion string, d
 			}
 		}
 
-		cmd := fmt.Sprintf("cd %s; unset PGHOST; unset PGPORT; %s "+
-			"--old-bindir=%s --old-datadir=%s --old-port=%d "+
+		cmd := fmt.Sprintf("source %s; cd %s; unset PGHOST; unset PGPORT; "+
+			"%s --old-bindir=%s --old-datadir=%s --old-port=%d "+
 			"--new-bindir=%s --new-datadir=%s --new-port=%d %s",
+			filepath.Join(newBinDir, "..", "greenplum_path.sh"),
 			pathToSegment,
 			filepath.Join(newBinDir, "pg_upgrade"),
 			oldBinDir,

--- a/agent/services/convert_primary_test.go
+++ b/agent/services/convert_primary_test.go
@@ -73,8 +73,8 @@ var _ = Describe("UpgradeSegments", func() {
 		upgradeDir0 := utils.SegmentPGUpgradeDirectory(dir, 0)
 		upgradeDir1 := utils.SegmentPGUpgradeDirectory(dir, 1)
 
-		Expect(testExecutor.LocalCommands).To(ContainElement(fmt.Sprintf("cd %s; unset PGHOST; unset PGPORT; /new/bin/pg_upgrade --old-bindir=/old/bin --old-datadir=old/datadir1 --old-port=1 --new-bindir=/new/bin --new-datadir=new/datadir1 --new-port=11 --mode=segment --progress", upgradeDir0)))
-		Expect(testExecutor.LocalCommands).To(ContainElement(fmt.Sprintf("cd %s; unset PGHOST; unset PGPORT; /new/bin/pg_upgrade --old-bindir=/old/bin --old-datadir=old/datadir2 --old-port=2 --new-bindir=/new/bin --new-datadir=new/datadir2 --new-port=22 --mode=segment --progress", upgradeDir1)))
+		Expect(testExecutor.LocalCommands).To(ContainElement(fmt.Sprintf("source /new/greenplum_path.sh; cd %s; unset PGHOST; unset PGPORT; /new/bin/pg_upgrade --old-bindir=/old/bin --old-datadir=old/datadir1 --old-port=1 --new-bindir=/new/bin --new-datadir=new/datadir1 --new-port=11 --mode=segment --progress", upgradeDir0)))
+		Expect(testExecutor.LocalCommands).To(ContainElement(fmt.Sprintf("source /new/greenplum_path.sh; cd %s; unset PGHOST; unset PGPORT; /new/bin/pg_upgrade --old-bindir=/old/bin --old-datadir=old/datadir2 --old-port=2 --new-bindir=/new/bin --new-datadir=new/datadir2 --new-port=22 --mode=segment --progress", upgradeDir1)))
 	})
 
 	Context("for older Greenplum versions", func() {
@@ -94,9 +94,9 @@ var _ = Describe("UpgradeSegments", func() {
 			upgradeDir1 := utils.SegmentPGUpgradeDirectory(dir, 1)
 
 			Expect(testExecutor.LocalCommands).To(ContainElement(fmt.Sprintf("cp %s %s", oidFile, upgradeDir0)))
-			Expect(testExecutor.LocalCommands).To(ContainElement(fmt.Sprintf("cd %s; unset PGHOST; unset PGPORT; /new/bin/pg_upgrade --old-bindir=/old/bin --old-datadir=old/datadir1 --old-port=1 --new-bindir=/new/bin --new-datadir=new/datadir1 --new-port=11 --progress", upgradeDir0)))
+			Expect(testExecutor.LocalCommands).To(ContainElement(fmt.Sprintf("source /new/greenplum_path.sh; cd %s; unset PGHOST; unset PGPORT; /new/bin/pg_upgrade --old-bindir=/old/bin --old-datadir=old/datadir1 --old-port=1 --new-bindir=/new/bin --new-datadir=new/datadir1 --new-port=11 --progress", upgradeDir0)))
 			Expect(testExecutor.LocalCommands).To(ContainElement(fmt.Sprintf("cp %s %s", oidFile, upgradeDir1)))
-			Expect(testExecutor.LocalCommands).To(ContainElement(fmt.Sprintf("cd %s; unset PGHOST; unset PGPORT; /new/bin/pg_upgrade --old-bindir=/old/bin --old-datadir=old/datadir2 --old-port=2 --new-bindir=/new/bin --new-datadir=new/datadir2 --new-port=22 --progress", upgradeDir1)))
+			Expect(testExecutor.LocalCommands).To(ContainElement(fmt.Sprintf("source /new/greenplum_path.sh; cd %s; unset PGHOST; unset PGPORT; /new/bin/pg_upgrade --old-bindir=/old/bin --old-datadir=old/datadir2 --old-port=2 --new-bindir=/new/bin --new-datadir=new/datadir2 --new-port=22 --progress", upgradeDir1)))
 		})
 
 		It("returns an an error if the oid files glob fails", func() {

--- a/hub/services/upgrade_convert_master.go
+++ b/hub/services/upgrade_convert_master.go
@@ -58,9 +58,10 @@ func (h *Hub) ConvertMaster() error {
 		modeStr = "--mode=dispatcher"
 	}
 
-	pgUpgradeCmd := fmt.Sprintf("cd %s; unset PGHOST; unset PGPORT; %s "+
-		"--old-bindir=%s --old-datadir=%s --old-port=%d "+
+	pgUpgradeCmd := fmt.Sprintf("source %s; cd %s; unset PGHOST; unset PGPORT; "+
+		"%s --old-bindir=%s --old-datadir=%s --old-port=%d "+
 		"--new-bindir=%s --new-datadir=%s --new-port=%d %s",
+		filepath.Join(h.target.BinDir, "..", "greenplum_path.sh"),
 		pathToUpgradeWD,
 		filepath.Join(h.target.BinDir, "pg_upgrade"),
 		h.source.BinDir,

--- a/hub/services/upgrade_convert_master_test.go
+++ b/hub/services/upgrade_convert_master_test.go
@@ -29,7 +29,8 @@ var _ = Describe("ConvertMasterHub", func() {
 		err := hub.ConvertMaster()
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(testExecutor.LocalCommands[0]).To(Equal(fmt.Sprintf("cd %s; unset PGHOST; unset PGPORT; /target/bindir/pg_upgrade ", upgradeDir) +
+		Expect(testExecutor.LocalCommands[0]).To(Equal("source /target/greenplum_path.sh; " +
+			fmt.Sprintf("cd %s; unset PGHOST; unset PGPORT; /target/bindir/pg_upgrade ", upgradeDir) +
 			fmt.Sprintf("--old-bindir=/source/bindir --old-datadir=%s/seg-1 --old-port=15432 ", dir) +
 			fmt.Sprintf("--new-bindir=/target/bindir --new-datadir=%s/seg-1 --new-port=15432 ", dir) +
 			"--mode=dispatcher"))
@@ -41,7 +42,8 @@ var _ = Describe("ConvertMasterHub", func() {
 		err := hub.ConvertMaster()
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(testExecutor.LocalCommands[0]).To(Equal(fmt.Sprintf("cd %s; unset PGHOST; unset PGPORT; /target/bindir/pg_upgrade ", upgradeDir) +
+		Expect(testExecutor.LocalCommands[0]).To(Equal("source /target/greenplum_path.sh; " +
+			fmt.Sprintf("cd %s; unset PGHOST; unset PGPORT; /target/bindir/pg_upgrade ", upgradeDir) +
 			fmt.Sprintf("--old-bindir=/source/bindir --old-datadir=%s/seg-1 --old-port=15432 ", dir) +
 			fmt.Sprintf("--new-bindir=/target/bindir --new-datadir=%s/seg-1 --new-port=15432 ", dir) +
 			"--dispatcher-mode"))


### PR DESCRIPTION
The GPDB build of pg_upgrade is linked against libraries in the GPDB installation path, so it (unfortunately) needs the `LD_LIBRARY_PATH` modifications in greenplum_path.sh. This is true for both the hub and agent invocations of pg_upgrade, but it's more likely to show up as a problem for the agent, since the hub generally inherits the user's environment on start. (This, by the way, seems like a potential pitfall in the future...)

One day we'll use rpath like we should, but until then, source the environment script before running pg_upgrade.