### PR TITLE
Makefile: correct bug in set-pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ set-pipeline:
 		-c ci/pipeline.yml \
 		-l ~/workspace/continuous-integration/secrets/$(SECRETS_FILE) \
 		-l ~/workspace/continuous-integration/secrets/gpdb_common-ci-secrets.yml \
-		-l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.yml
+		-l ~/workspace/continuous-integration/secrets/gpdb_master-ci-secrets.yml \
 		-v gpupgrade-git-remote=$(GIT_URI) \
 		-v gpupgrade-git-branch=$(BRANCH)
 


### PR DESCRIPTION
We weren't performing variable assignments due to a missed backslash.