### PR TITLE
Change usages of gpdb_master-ci-secrets.yml to use .prod suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ set-pipeline:
 		-c ci/pipeline.yml \
 		-l ~/workspace/gp-continuous-integration/secrets/gpupgrade.$(DEPLOY_TYPE).yml \
 		-l ~/workspace/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml \
-		-l ~/workspace/gp-continuous-integration/secrets/gpdb_master-ci-secrets.yml \
+		-l ~/workspace/gp-continuous-integration/secrets/gpdb_master-ci-secrets.prod.yml \
 		-l ~/workspace/gp-continuous-integration/secrets/ccp_ci_secrets_gpdb-$(DEPLOY_TYPE).yml \
 		-v gpupgrade-git-remote=$(GIT_URI) \
 		-v gpupgrade-git-branch=$(BRANCH)


### PR DESCRIPTION
We are in the process of renaming the secrets files in
gp-continuous-integration to use the .prod suffix consistently.

Co-authored-by: Sambitesh Dash <sdash@pivotal.io>
Co-authored-by: Ben Christel <bchristel@pivotal.io>