### PR TITLE
Fix pipeline and update code to work with latest version of go

### DIFF
--- a/agent/services/agent_server.go
+++ b/agent/services/agent_server.go
@@ -80,7 +80,7 @@ func (a *AgentServer) Start() {
 
 	err = server.Serve(lis)
 	if err != nil {
-		gplog.Fatal(err, "failed to serve", err)
+		gplog.Fatal(err, "failed to serve: %s", err)
 	}
 
 	a.stopped <- struct{}{}

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,5 +1,10 @@
 ---
 resource_types:
+- name: gcs
+  type: docker-image
+  source:
+    repository: frodenas/gcs-resource
+
 - name: slack-notification
   type: docker-image
   source:
@@ -38,13 +43,11 @@ resources:
     url: {{cm_webhook_url}}
 
 - name: bin_gpdb_centos6
-  type: s3
+  type: gcs
   source:
-    access_key_id: {{bucket-access-key-id}}
-    bucket: {{bucket-name}}
-    region_name: {{aws-region}}
-    secret_access_key: {{bucket-secret-access-key}}
-    versioned_file: {{bin_gpdb_centos_versioned_file}}
+    bucket: {{gcs-bucket}}
+    json_key: {{concourse-gcs-resources-service-account-key}}
+    regexp: server/published/gpdb6/server-rc-(.*)-rhel6_x86_64.debug.tar.gz
 
 - name: ccp_src
   type: git

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -10,6 +10,7 @@ resource_types:
   type: docker-image
   source:
     repository: ljfranklin/terraform-resource
+    tag: 0.11.14
 
 resources:
 - name: gpupgrade_src

--- a/ci/scripts/install-tests.bash
+++ b/ci/scripts/install-tests.bash
@@ -9,7 +9,9 @@ set -ex
 GOPATH="$PWD/go" PATH="$PWD/go/bin:$PATH" make -C go/src/github.com/greenplum-db/gpupgrade depend
 
 source gpdb_src/concourse/scripts/common.bash
-time install_gpdb
+mkdir -p /usr/local/greenplum-db-devel
+tar -xzf bin_gpdb/*.tar.gz -C /usr/local/greenplum-db-devel
+
 time ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash "centos"
 time make_cluster
 

--- a/hub/services/hub.go
+++ b/hub/services/hub.go
@@ -161,7 +161,7 @@ func (h *Hub) AgentConns() ([]*Connection, error) {
 	if h.agentConns != nil {
 		err := EnsureConnsAreReady(h.agentConns)
 		if err != nil {
-			gplog.Error("ensureConnsAreReady failed: ", err)
+			gplog.Error("ensureConnsAreReady failed: %s", err)
 			return nil, err
 		}
 

--- a/hub/upgradestatus/utility_status_checker.go
+++ b/hub/upgradestatus/utility_status_checker.go
@@ -65,7 +65,7 @@ func inProgressFilesExist(utilityStatePath, progressFilePattern string) bool {
 	}
 
 	if err != nil {
-		gplog.Error("Error determining step status: ", err)
+		gplog.Error("Error determining step status: %s", err)
 		return false
 	}
 


### PR DESCRIPTION
We have made the following changes to gupgrade.
- Use the correct credentials depending on the fly target
- Use the latest docker image for terraform resource that works
- use bin_gpdb from a bucket that is regularly built
- update gupgrade go code to be compatible with go 1.12
