### PR TITLE
Allow upgrade across different versions

### DIFF
--- a/installcheck.bats
+++ b/installcheck.bats
@@ -2,8 +2,12 @@
 
 load test/helpers
 
+# If GPHOME_NEW is not set, then it defaults to GPHOME, doing a upgrade to the
+#  samve version
+
 setup() {
     [ ! -z $GPHOME ]
+    GPHOME_NEW=${GPHOME_NEW:-$GPHOME}
     [ ! -z $MASTER_DATA_DIRECTORY ]
     echo "# SETUP"
     clean_target_cluster
@@ -21,8 +25,8 @@ teardown() {
 
 @test "gpugrade can make it as far as we currently know..." {
     gpupgrade prepare init \
-              --new-bindir "$GPHOME"/bin \
-              --old-bindir "$GPHOME"/bin
+              --old-bindir "$GPHOME"/bin \
+              --new-bindir "$GPHOME_NEW"/bin
 
     gpupgrade prepare start-hub 3>&-
 


### PR DESCRIPTION
By default the upgrade is performed to the version installed in $GPHOME.
However, if the script is invoked with $GPHOME_NEW set, then the
upgrade is done to the newer version.

Co-authored-by: Nikolaos Kalampalikis <nkalampalikis@pivotal.io>