### PR TITLE
start-agents: make command synchronous

### DIFF
--- a/agent/services/agent_server.go
+++ b/agent/services/agent_server.go
@@ -74,8 +74,13 @@ func (a *AgentServer) Start() {
 	reflection.Register(server)
 
 	if a.daemon {
-		fmt.Printf("Agent started on port %d (pid %d)\n", a.conf.Port, os.Getpid())
+		// Send an identifier string back to the hub, and log it locally for
+		// easier debugging.
+		info := fmt.Sprintf("Agent started on port %d (pid %d)", a.conf.Port, os.Getpid())
+
+		fmt.Println(info)
 		daemon.Daemonize()
+		gplog.Info(info)
 	}
 
 	err = server.Serve(lis)

--- a/ci/scripts/cluster-upgrade.bash
+++ b/ci/scripts/cluster-upgrade.bash
@@ -112,7 +112,6 @@ time ssh mdw bash <<"EOF"
     gpupgrade check seginstall
 
     gpupgrade prepare start-agents
-    sleep 1 # XXX make the above synchronous
 
     gpupgrade prepare init-cluster
     wait_for_step "Initialize new cluster"

--- a/cli/commanders/preparer.go
+++ b/cli/commanders/preparer.go
@@ -91,7 +91,7 @@ func (p Preparer) StartAgents() error {
 		return err
 	}
 
-	gplog.Info("Started Agents in progress, check gpupgrade_agent logs for details")
+	fmt.Println("agents started successfully")
 	return nil
 }
 

--- a/cli/commanders/preparer_test.go
+++ b/cli/commanders/preparer_test.go
@@ -96,20 +96,6 @@ var _ = Describe("preparer", func() {
 			Eventually(testStdout).Should(gbytes.Say("request to shutdown clusters sent to hub"))
 		})
 	})
-	Describe("PrepareStartAgents", func() {
-		It("returns successfully", func() {
-			testStdout, _, _ := testhelper.SetupTestLogger()
-
-			client.EXPECT().PrepareStartAgents(
-				gomock.Any(),
-				&idl.PrepareStartAgentsRequest{},
-			).Return(&idl.PrepareStartAgentsReply{}, nil)
-			preparer := commanders.NewPreparer(client)
-			err := preparer.StartAgents()
-			Expect(err).To(BeNil())
-			Eventually(testStdout).Should(gbytes.Say("Started Agents in progress, check gpupgrade_agent logs for details"))
-		})
-	})
 	Describe("DoInit", func() {
 		var (
 			sourceBinDir string = "/old/does/not/exist"

--- a/installcheck.bats
+++ b/installcheck.bats
@@ -36,8 +36,6 @@ teardown() {
 
     gpupgrade prepare start-agents
 
-    sleep 1
-
     gpupgrade prepare init-cluster
 
     gpupgrade prepare shutdown-clusters

--- a/test/out-of-order.bats
+++ b/test/out-of-order.bats
@@ -26,7 +26,9 @@ teardown() {
 }
 
 @test "start-agents requires segments to have been loaded into the configuration" {
-    gpupgrade prepare start-agents
+    run gpupgrade prepare start-agents
+    [[ "$output" = *"cluster has no loaded segments"* ]]
+
     run gpupgrade status upgrade
     [[ "$output" = *"FAILED - Agents Started on Cluster"* ]]
 }


### PR DESCRIPTION
First in what is hopefully a chain of many.

The hub will now wait to send its response until after the agents have been started. This means that any errors encountered during the parallel start are immediately bubbled up to the CLI. Started agents now log their port and PID to file to ease debugging, and the hub also logs the same agent responses so that the logs can be correlated across hosts.

The PrepareStartAgents "unit" test, which ensured that the CLI's standard output matched a hardcoded message, has been removed entirely.