### PR TITLE
init-cluster: make command synchronous

### DIFF
--- a/cli/commanders/preparer.go
+++ b/cli/commanders/preparer.go
@@ -72,7 +72,7 @@ func (p Preparer) InitCluster() error {
 		return err
 	}
 
-	gplog.Info("Starting new cluster initialization")
+	fmt.Println("cluster successfully initialized")
 	return nil
 }
 

--- a/cli/commanders/preparer_test.go
+++ b/cli/commanders/preparer_test.go
@@ -82,19 +82,6 @@ var _ = Describe("preparer", func() {
 		})
 	})
 
-	Describe("PrepareInitCluster", func() {
-		It("returns successfully if hub gets the request", func() {
-			testStdout, _, _ := testhelper.SetupTestLogger()
-			client.EXPECT().PrepareInitCluster(
-				gomock.Any(),
-				&idl.PrepareInitClusterRequest{},
-			).Return(&idl.PrepareInitClusterReply{}, nil)
-			preparer := commanders.NewPreparer(client)
-			err := preparer.InitCluster()
-			Expect(err).To(BeNil())
-			Eventually(testStdout).Should(gbytes.Say("Starting new cluster initialization"))
-		})
-	})
 	Describe("PrepareShutdownCluster", func() {
 		It("returns successfully", func() {
 			testStdout, _, _ := testhelper.SetupTestLogger()

--- a/hub/services/prepare_init_cluster.go
+++ b/hub/services/prepare_init_cluster.go
@@ -15,7 +15,6 @@ import (
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
-	"github.com/greenplum-db/gpupgrade/utils/log"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -29,18 +28,15 @@ func (h *Hub) PrepareInitCluster(ctx context.Context, in *idl.PrepareInitCluster
 		return &idl.PrepareInitClusterReply{}, err
 	}
 
-	go func() {
-		defer log.WritePanics()
+	err = h.CreateTargetCluster()
+	if err != nil {
+		gplog.Error(err.Error())
+		step.MarkFailed()
+	} else {
+		step.MarkComplete()
+	}
 
-		if err := h.CreateTargetCluster(); err != nil {
-			gplog.Error(err.Error())
-			step.MarkFailed()
-		} else {
-			step.MarkComplete()
-		}
-	}()
-
-	return &idl.PrepareInitClusterReply{}, nil
+	return &idl.PrepareInitClusterReply{}, err
 }
 
 func (h *Hub) CreateTargetCluster() error {

--- a/installcheck.bats
+++ b/installcheck.bats
@@ -39,7 +39,6 @@ teardown() {
     sleep 1
 
     gpupgrade prepare init-cluster
-    EventuallyStepCompletes "Initialize new cluster"
 
     gpupgrade prepare shutdown-clusters
     EventuallyStepCompletes "Shutdown clusters"


### PR DESCRIPTION
Errors now bubble up to the CLI.

The PrepareInitCluster "unit" test has been removed as it was checking hardcoded command output. This could be migrated as an end-to-end test.

