### PR TITLE
shutdown-clusters: make command synchronous

### DIFF
--- a/cli/commanders/preparer.go
+++ b/cli/commanders/preparer.go
@@ -34,9 +34,10 @@ func (p Preparer) ShutdownClusters() error {
 	_, err := p.client.PrepareShutdownClusters(context.Background(),
 		&idl.PrepareShutdownClustersRequest{})
 	if err != nil {
-		gplog.Error(err.Error())
+		return err
 	}
-	gplog.Info("request to shutdown clusters sent to hub")
+
+	fmt.Println("clusters shut down successfully")
 	return nil
 }
 

--- a/cli/commanders/preparer_test.go
+++ b/cli/commanders/preparer_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/greenplum-db/gpupgrade/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
 )
 
 var _ = Describe("preparer", func() {
@@ -82,20 +81,6 @@ var _ = Describe("preparer", func() {
 		})
 	})
 
-	Describe("PrepareShutdownCluster", func() {
-		It("returns successfully", func() {
-			testStdout, _, _ := testhelper.SetupTestLogger()
-
-			client.EXPECT().PrepareShutdownClusters(
-				gomock.Any(),
-				&idl.PrepareShutdownClustersRequest{},
-			).Return(&idl.PrepareShutdownClustersReply{}, nil)
-			preparer := commanders.NewPreparer(client)
-			err := preparer.ShutdownClusters()
-			Expect(err).To(BeNil())
-			Eventually(testStdout).Should(gbytes.Say("request to shutdown clusters sent to hub"))
-		})
-	})
 	Describe("DoInit", func() {
 		var (
 			sourceBinDir string = "/old/does/not/exist"

--- a/hub/services/prepare_shutdown_clusters.go
+++ b/hub/services/prepare_shutdown_clusters.go
@@ -9,7 +9,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
-	"github.com/greenplum-db/gpupgrade/utils/log"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 )
@@ -23,18 +22,15 @@ func (h *Hub) PrepareShutdownClusters(ctx context.Context, in *idl.PrepareShutdo
 		return &idl.PrepareShutdownClustersReply{}, err
 	}
 
-	go func() {
-		defer log.WritePanics()
+	err = h.ShutdownClusters()
+	if err != nil {
+		gplog.Error(err.Error())
+		step.MarkFailed()
+	} else {
+		step.MarkComplete()
+	}
 
-		if err := h.ShutdownClusters(); err != nil {
-			gplog.Error(err.Error())
-			step.MarkFailed()
-		} else {
-			step.MarkComplete()
-		}
-	}()
-
-	return &idl.PrepareShutdownClustersReply{}, nil
+	return &idl.PrepareShutdownClustersReply{}, err
 }
 
 func (h *Hub) ShutdownClusters() error {

--- a/installcheck.bats
+++ b/installcheck.bats
@@ -39,7 +39,6 @@ teardown() {
     gpupgrade prepare init-cluster
 
     gpupgrade prepare shutdown-clusters
-    EventuallyStepCompletes "Shutdown clusters"
 
     ! ps -ef | grep -Gqw "[p]ostgres"
 

--- a/integrations/prepare_shutdown_clusters_test.go
+++ b/integrations/prepare_shutdown_clusters_test.go
@@ -50,7 +50,7 @@ var _ = Describe("prepare shutdown-clusters", func() {
 		testExecutorNew.LocalError = errors.New("stop failed")
 
 		prepareShutdownClustersSession := runCommand("prepare", "shutdown-clusters")
-		Eventually(prepareShutdownClustersSession).Should(Exit(0))
+		Eventually(prepareShutdownClustersSession).Should(Exit(1))
 
 		Expect(testExecutorOld.NumExecutions).To(Equal(2))
 		Expect(testExecutorOld.LocalCommands[0]).To(ContainSubstring("pgrep"))


### PR DESCRIPTION
In the same line as the previous commits, bubble up any failures synchronously to the CLI during cluster shutdown. The existing minimal test for this feature has been removed, to be replaced with useful end-to-end tests.

This, along with the previous two synchronous PRs, unblocks testing of the upgrade-master step.