### PR TITLE
gpupgrade: use target.BinDir for all gpupgrade binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ files in gpupgrade/ci/tasks, and some secrets in a private repository. To set a
 pipeline, run:
 
 ```
-fly -t [target-name] set-pipeline -p [pipeline-name] -c gpupgrade/ci/pipeline.yml -l path/to/secrets.yml
+make set-pipeline FLY_TARGET=<CONCOURSE_INSTANCE> GIT_URI=https://github.com/<GITHUB_USERNAME>/gpupgrade.git
 ```
 
 If you want to use the defaults and have access to the continuous-integration

--- a/hub/services/check_seginstall.go
+++ b/hub/services/check_seginstall.go
@@ -26,7 +26,7 @@ func (h *Hub) CheckSeginstall(ctx context.Context, in *idl.CheckSeginstallReques
 	go func() {
 		defer log.WritePanics()
 
-		if err := VerifyAgentsInstalled(h.source); err != nil {
+		if err := VerifyAgentsInstalled(h.source, h.target); err != nil {
 			gplog.Error(err.Error())
 			step.MarkFailed()
 		} else {
@@ -37,9 +37,9 @@ func (h *Hub) CheckSeginstall(ctx context.Context, in *idl.CheckSeginstallReques
 	return &idl.CheckSeginstallReply{}, nil
 }
 
-func VerifyAgentsInstalled(source *utils.Cluster) error {
+func VerifyAgentsInstalled(source *utils.Cluster, target *utils.Cluster) error {
 	logStr := "check gpupgrade_agent is installed in cluster's binary directory on master and hosts"
-	agentPath := filepath.Join(source.BinDir, "gpupgrade_agent")
+	agentPath := filepath.Join(target.BinDir, "gpupgrade_agent")
 	returnLsCommand := func(contentID int) string { return "ls " + agentPath }
 
 	remoteOutput, err := source.ExecuteOnAllHosts(logStr, returnLsCommand)

--- a/hub/services/check_seginstall_test.go
+++ b/hub/services/check_seginstall_test.go
@@ -16,17 +16,17 @@ import (
 
 var _ = Describe("VerifyAgentsInstalled", func() {
 	It("shells out to cluster and verifies gpupgrade_agent is installed on master and hosts", func() {
-		source, _ := testutils.CreateMultinodeSampleClusterPair("/tmp")
+		source, target := testutils.CreateMultinodeSampleClusterPair("/tmp")
 		testExecutor := &testhelper.TestExecutor{}
 		testExecutor.ClusterOutput = &cluster.RemoteOutput{}
 		source.Cluster.Executor = testExecutor
 
-		err := services.VerifyAgentsInstalled(source)
+		err := services.VerifyAgentsInstalled(source, target)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(testExecutor.NumExecutions).To(Equal(1))
 
-		lsCmd := fmt.Sprintf("ls %s/gpupgrade_agent", source.BinDir)
+		lsCmd := fmt.Sprintf("ls %s/gpupgrade_agent", target.BinDir)
 		clusterCommands := testExecutor.ClusterCommands[0]
 		for _, command := range clusterCommands {
 			Expect(command).To(ContainElement(lsCmd))
@@ -35,12 +35,13 @@ var _ = Describe("VerifyAgentsInstalled", func() {
 
 	It("returns an error if the source cluster is not initialized", func() {
 		source := &utils.Cluster{Cluster: &cluster.Cluster{}}
-		err := services.VerifyAgentsInstalled(source)
+		target := &utils.Cluster{Cluster: &cluster.Cluster{}}
+		err := services.VerifyAgentsInstalled(source, target)
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("returns an error if any agents report an error", func() {
-		source, _ := testutils.CreateMultinodeSampleClusterPair("/tmp")
+		source, target := testutils.CreateMultinodeSampleClusterPair("/tmp")
 		testExecutor := &testhelper.TestExecutor{}
 		testExecutor.ClusterOutput = &cluster.RemoteOutput{
 			NumErrors: 1,
@@ -51,7 +52,7 @@ var _ = Describe("VerifyAgentsInstalled", func() {
 		}
 		source.Cluster.Executor = testExecutor
 
-		err := services.VerifyAgentsInstalled(source)
+		err := services.VerifyAgentsInstalled(source, target)
 		Expect(err).To(HaveOccurred())
 	})
 })

--- a/hub/services/prepare_start_agents.go
+++ b/hub/services/prepare_start_agents.go
@@ -26,7 +26,7 @@ func (h *Hub) PrepareStartAgents(ctx context.Context, in *idl.PrepareStartAgents
 	go func() {
 		defer log.WritePanics()
 
-		if err := StartAgents(h.source); err != nil {
+		if err := StartAgents(h.source, h.target); err != nil {
 			gplog.Error(err.Error())
 			step.MarkFailed()
 		} else {
@@ -37,9 +37,9 @@ func (h *Hub) PrepareStartAgents(ctx context.Context, in *idl.PrepareStartAgents
 	return &idl.PrepareStartAgentsReply{}, nil
 }
 
-func StartAgents(source *utils.Cluster) error {
+func StartAgents(source *utils.Cluster, target *utils.Cluster) error {
 	logStr := "start agents on master and hosts"
-	agentPath := filepath.Join(source.BinDir, "gpupgrade_agent")
+	agentPath := filepath.Join(target.BinDir, "gpupgrade_agent")
 	runAgentCmd := func(contentID int) string { return agentPath + " --daemonize" }
 
 	errStr := "Failed to start all gpupgrade_agents"

--- a/hub/services/prepare_start_agents_test.go
+++ b/hub/services/prepare_start_agents_test.go
@@ -19,17 +19,17 @@ import (
 // Consolidate.
 var _ = Describe("StartAgents", func() {
 	It("shells out to cluster and runs gpupgrade_agent", func() {
-		source, _ := testutils.CreateMultinodeSampleClusterPair("/tmp")
+		source, target := testutils.CreateMultinodeSampleClusterPair("/tmp")
 		testExecutor := &testhelper.TestExecutor{}
 		testExecutor.ClusterOutput = &cluster.RemoteOutput{}
 		source.Executor = testExecutor
 
-		err := services.StartAgents(source)
+		err := services.StartAgents(source, target)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(testExecutor.NumExecutions).To(Equal(1))
 
-		startAgentsCmd := fmt.Sprintf("%s/gpupgrade_agent --daemonize", source.BinDir)
+		startAgentsCmd := fmt.Sprintf("%s/gpupgrade_agent --daemonize", target.BinDir)
 		clusterCommands := testExecutor.ClusterCommands[0]
 		for _, command := range clusterCommands {
 			Expect(command).To(ContainElement(startAgentsCmd))
@@ -38,12 +38,13 @@ var _ = Describe("StartAgents", func() {
 
 	It("returns an error if the source cluster is not initialized", func() {
 		source := &utils.Cluster{Cluster: &cluster.Cluster{}}
-		err := services.StartAgents(source)
+		target := &utils.Cluster{Cluster: &cluster.Cluster{}}
+		err := services.StartAgents(source, target)
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("returns an error if any agents report an error", func() {
-		source, _ := testutils.CreateMultinodeSampleClusterPair("/tmp")
+		source, target := testutils.CreateMultinodeSampleClusterPair("/tmp")
 		testExecutor := &testhelper.TestExecutor{}
 		testExecutor.ClusterOutput = &cluster.RemoteOutput{
 			NumErrors: 1,
@@ -54,7 +55,7 @@ var _ = Describe("StartAgents", func() {
 		}
 		source.Cluster.Executor = testExecutor
 
-		err := services.StartAgents(source)
+		err := services.StartAgents(source, target)
 		Expect(err).To(HaveOccurred())
 	})
 })

--- a/integrations/check_seginstall_test.go
+++ b/integrations/check_seginstall_test.go
@@ -28,7 +28,7 @@ var _ = Describe("check seginstall", func() {
 		// These assertions are identical to the ones in the hub_check_seginstall unit tests but just to be safe we are leaving it in.
 		Expect(testExecutor.NumExecutions).To(Equal(1))
 
-		lsCmd := fmt.Sprintf("ls %s/gpupgrade_agent", source.BinDir)
+		lsCmd := fmt.Sprintf("ls %s/gpupgrade_agent", target.BinDir)
 		clusterCommands := testExecutor.ClusterCommands[0]
 		for _, command := range clusterCommands {
 			Expect(command).To(ContainElement(lsCmd))

--- a/integrations/prepare_start_agents_test.go
+++ b/integrations/prepare_start_agents_test.go
@@ -19,7 +19,7 @@ var _ = Describe("prepare start-agents", func() {
 		// These assertions are identical to the ones in the prepare_start_agent unit tests but just to be safe we are leaving it in.
 		Expect(testExecutor.NumExecutions).To(Equal(1))
 
-		startAgentsCmd := fmt.Sprintf("%s/gpupgrade_agent --daemonize", source.BinDir)
+		startAgentsCmd := fmt.Sprintf("%s/gpupgrade_agent --daemonize", target.BinDir)
 		clusterCommands := testExecutor.ClusterCommands[0]
 		for _, command := range clusterCommands {
 			Expect(command).To(ContainElement(startAgentsCmd))


### PR DESCRIPTION
We were incorrectly using the source binary directory for gpupgrade_agent.

Since we want to use the target cluster's gpupgrade, we must use its gpupgrade.  Indeed, gpupgrade might not even be installed in source.

The README commit is unrelated but we might as well get it in, and it seemed too much overhead to PR it separately.

Co-authored-by: Mark Sliva <msliva@pivotal.io>