### PR TITLE
remove conditional code based on pre-6 target GPDB versions

### DIFF
--- a/agent/services/convert_primary.go
+++ b/agent/services/convert_primary.go
@@ -5,18 +5,15 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/blang/semver"
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
-	"github.com/pkg/errors"
-
-	"github.com/greenplum-db/gp-common-go-libs/gplog"
 )
 
 func (s *AgentServer) UpgradeConvertPrimarySegments(ctx context.Context, in *idl.UpgradeConvertPrimarySegmentsRequest) (*idl.UpgradeConvertPrimarySegmentsReply, error) {
 	gplog.Info("got a request to convert primary from the hub")
 
-	err := s.UpgradeSegments(in.OldBinDir, in.NewBinDir, in.NewVersion, in.DataDirPairs)
+	err := s.UpgradeSegments(in.OldBinDir, in.NewBinDir, in.DataDirPairs)
 
 	if err != nil {
 		return &idl.UpgradeConvertPrimarySegmentsReply{}, err
@@ -25,44 +22,8 @@ func (s *AgentServer) UpgradeConvertPrimarySegments(ctx context.Context, in *idl
 	return &idl.UpgradeConvertPrimarySegmentsReply{}, nil
 }
 
-func (s *AgentServer) UpgradeSegments(oldBinDir, newBinDir, newVersion string, dataDirPairs []*idl.DataDirPair) error {
-	// OID files to copy from the master. Empty/unused in GPDB 6 and higher.
-	var oidFiles []string
-
-	targetVersion, err := semver.Parse(newVersion)
-	if err != nil {
-		gplog.Error("failed to parse new cluster version: %s", err)
-		return errors.Wrap(err, "failed to parse new cluster version")
-	}
-
-	if targetVersion.LT(semver.MustParse("6.0.0")) {
-		var err error // to prevent shadowing of oidFiles
-
-		// For GPDB 5.x and below, the pg_upgrade OID files have already been
-		// transferred from the master to the agent state directory.
-		filename := "pg_upgrade_dump_*_oids.sql"
-		shareOIDfilePath := filepath.Join(utils.PGUpgradeDirectory(s.conf.StateDir), filename)
-		oidFiles, err = utils.System.FilePathGlob(shareOIDfilePath)
-		if err != nil {
-			gplog.Error("ls OID files failed. Err: %v", err)
-			return err
-		}
-
-		if len(oidFiles) == 0 {
-			gplog.Error("Share OID files do not exist. Pattern was: %s", shareOIDfilePath)
-			return errors.New("No OID files found")
-		}
-	}
-
+func (s *AgentServer) UpgradeSegments(oldBinDir string, newBinDir string, dataDirPairs []*idl.DataDirPair) error {
 	// TODO: consolidate this logic with Hub.ConvertMaster().
-
-	// pg_upgrade changed its API in GPDB 6.0.
-	var modeStr string
-	if targetVersion.LT(semver.MustParse("6.0.0")) {
-		modeStr = "--progress"
-	} else {
-		modeStr = "--mode=segment --progress"
-	}
 
 	for _, segment := range dataDirPairs {
 		pathToSegment := utils.SegmentPGUpgradeDirectory(s.conf.StateDir, int(segment.Content))
@@ -72,17 +33,9 @@ func (s *AgentServer) UpgradeSegments(oldBinDir, newBinDir, newVersion string, d
 			return err
 		}
 
-		for _, oidFile := range oidFiles {
-			out, err := s.executor.ExecuteLocalCommand(fmt.Sprintf("cp %s %s", oidFile, pathToSegment))
-			if err != nil {
-				gplog.Error("Failed to copy OID files for segment %d. Output: %s", segment.Content, string(out))
-				return err
-			}
-		}
-
 		cmd := fmt.Sprintf("source %s; cd %s; unset PGHOST; unset PGPORT; "+
 			"%s --old-bindir=%s --old-datadir=%s --old-port=%d "+
-			"--new-bindir=%s --new-datadir=%s --new-port=%d %s",
+			"--new-bindir=%s --new-datadir=%s --new-port=%d --mode=segment --progress",
 			filepath.Join(newBinDir, "..", "greenplum_path.sh"),
 			pathToSegment,
 			filepath.Join(newBinDir, "pg_upgrade"),
@@ -91,8 +44,7 @@ func (s *AgentServer) UpgradeSegments(oldBinDir, newBinDir, newVersion string, d
 			segment.OldPort,
 			newBinDir,
 			segment.NewDataDir,
-			segment.NewPort,
-			modeStr)
+			segment.NewPort)
 
 		// TODO: do this synchronously.
 		err = utils.System.RunCommandAsync(cmd, filepath.Join(pathToSegment, "pg_upgrade_segment.log"))

--- a/hub/services/check_version.go
+++ b/hub/services/check_version.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	MINIMUM_VERSION = "4.3.9"
+	MINIMUM_VERSION = "5.0.0" // FIXME: set to minimum 5.X version we support
 )
 
 func (h *Hub) CheckVersion(ctx context.Context,

--- a/hub/services/upgrade_convert_master.go
+++ b/hub/services/upgrade_convert_master.go
@@ -43,17 +43,9 @@ func (h *Hub) ConvertMaster() error {
 		return errors.Wrapf(err, "mkdir %s failed", pathToUpgradeWD)
 	}
 
-	// pg_upgrade changed its API in GPDB 6.0.
-	var modeStr string
-	if h.target.Version.Before("6.0.0") {
-		modeStr = "--dispatcher-mode"
-	} else {
-		modeStr = "--mode=dispatcher"
-	}
-
 	pgUpgradeCmd := fmt.Sprintf("source %s; cd %s; unset PGHOST; unset PGPORT; "+
 		"%s --old-bindir=%s --old-datadir=%s --old-port=%d "+
-		"--new-bindir=%s --new-datadir=%s --new-port=%d %s",
+		"--new-bindir=%s --new-datadir=%s --new-port=%d --mode=dispatcher",
 		filepath.Join(h.target.BinDir, "..", "greenplum_path.sh"),
 		pathToUpgradeWD,
 		filepath.Join(h.target.BinDir, "pg_upgrade"),
@@ -62,8 +54,7 @@ func (h *Hub) ConvertMaster() error {
 		h.source.MasterPort(),
 		h.target.BinDir,
 		h.target.MasterDataDir(),
-		h.target.MasterPort(),
-		modeStr)
+		h.target.MasterPort())
 
 	gplog.Info("Convert Master upgrade command: %#v", pgUpgradeCmd)
 

--- a/hub/services/upgrade_convert_master_test.go
+++ b/hub/services/upgrade_convert_master_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpupgrade/utils"
 
@@ -34,19 +33,6 @@ var _ = Describe("ConvertMasterHub", func() {
 			fmt.Sprintf("--old-bindir=/source/bindir --old-datadir=%s/seg-1 --old-port=15432 ", dir) +
 			fmt.Sprintf("--new-bindir=/target/bindir --new-datadir=%s/seg-1 --new-port=15432 ", dir) +
 			"--mode=dispatcher"))
-	})
-
-	It("uses the correct pg_upgrade options for older DBs", func() {
-		target.Version = dbconn.NewVersion("5.0.0")
-
-		err := hub.ConvertMaster()
-		Expect(err).ToNot(HaveOccurred())
-
-		Expect(testExecutor.LocalCommands[0]).To(Equal("source /target/greenplum_path.sh; " +
-			fmt.Sprintf("cd %s; unset PGHOST; unset PGPORT; /target/bindir/pg_upgrade ", upgradeDir) +
-			fmt.Sprintf("--old-bindir=/source/bindir --old-datadir=%s/seg-1 --old-port=15432 ", dir) +
-			fmt.Sprintf("--new-bindir=/target/bindir --new-datadir=%s/seg-1 --new-port=15432 ", dir) +
-			"--dispatcher-mode"))
 	})
 
 	It("returns an error when convert master fails", func() {


### PR DESCRIPTION
We won't be supported pre-6 target clusters.

Co-authored-by Mark Sliva <msliva@pivotal.io>