### PR TITLE
exectest: a new package for testing os/exec.Command

### DIFF
--- a/testutils/exectest/command.go
+++ b/testutils/exectest/command.go
@@ -116,13 +116,15 @@ func NewCommand(m Main, verifiers ...func(string, ...string)) Command {
 }
 
 // RegisterMains makes multiple Main functions available to Run in the test
-// subprocess. Call it only once from your test package's init function. Any
-// Main functions passed to NewCommand must be registered using this function.
+// subprocess. Call it only from your test package's init functions. Any Main
+// functions passed to NewCommand must be registered using this function.
 func RegisterMains(m ...Main) {
-	if mains != nil {
-		panic("RegisterMains() must be called only once, from your test package's init function")
+	if runCalled {
+		// Try to catch the most obvious failure mode, where a developer
+		// accidentally calls this from a test.
+		panic("RegisterMains() must be called only from a test package's init function")
 	}
-	mains = m
+	mains = append(mains, m...)
 }
 
 // Run is a wrapper for testing.M.Run() to use in conjunction with

--- a/testutils/exectest/command.go
+++ b/testutils/exectest/command.go
@@ -1,0 +1,173 @@
+// Package exectest provides helpers for test code that wants to mock out pieces
+// of the os/exec package, namely exec.Command().
+package exectest
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+// Main represents the main function of an executable.
+type Main func()
+
+// Command is a function that has an identical signature to exec.Command(). It
+// is created with a call to NewCommand().
+type Command func(string, ...string) *exec.Cmd
+
+// mains is populated by RegisterMains and used as a lookup table by Run and
+// NewCommand.
+var mains []Main
+
+// magicEnvVar is the environment variable that signals to Run() that it should
+// invoke a command and exit. It is expected to contain the integer index of the
+// Main function in mains that should be invoked.
+const magicEnvVar = "EXECTEST_MAIN_INDEX"
+
+// runCalled tracks whether or not Run() has been called by the test package.
+// It's a quick-and-dirty failsafe against developers forgetting to use the
+// handler (which would cause infinite recursion).
+var runCalled = false
+
+// NewCommand returns a drop-in replacement for os/exec.Command. The exec.Cmd
+// that the Command returns will invoke the passed Main function in a new test
+// subprocess. The original arguments passed to the returned Command will be
+// passed to the subprocess, beginning with os.Args[1].
+//
+// The intended use case is for test packages to replace exec.Command in the
+// packages they are testing with the resulting Command created by this
+// function.
+//
+// To use NewCommand, two pieces of test boilerplate are required. The first is
+// that any Main functions must be explicitly declared to the exectest package
+// by calling RegisterMains from the test package's init function:
+//
+//     func MyExecutable() {
+//         os.Exit(1)
+//     }
+//
+//     func init() {
+//         exectest.RegisterMains(
+//             MyExecutable,
+//         )
+//     }
+//
+// The second is that the test suite must be started using exectest.Run:
+//
+//     func TestMain(m *testing.M) {
+//         os.Exit(exectest.Run(m))
+//     }
+//
+// Once these conditions are met, the function handed back from NewCommand may
+// be used exactly like you would use exec.Command():
+//
+//     execCommand := exectest.NewCommand(MyExecutable)
+//
+//     cmd := execCommand("/bin/bash", "-c", "sleep 15")
+//     cmd.Run() // this invokes MyExecutable, not Bash
+//
+// If you'd like to explicitly test that an exec.Cmd is being created with the
+// arguments you expect, you may use an optional verifier function in your call
+// to NewCommand (technically any number may be passed, but you'll probably only
+// need one):
+//
+//     execCommand := exectest.NewCommand(MyExecutable,
+//         func(name string, arg ...string)) {
+//             if name != "/bin/bash" {
+//                 t.Errorf("didn't use Bash")
+//             }
+//         }
+//     )
+//
+//     execCommand("/bin/bash", "-c", "sleep 1") // succeeds
+//     execCommand("/bin/sh", "-c", "sleep 1")   // logs a test failure
+//
+func NewCommand(m Main, verifiers ...func(string, ...string)) Command {
+	// Sanity check. Ensure that our two boilerplate conditions have been met.
+	index := indexOf(m, mains)
+	if index < 0 {
+		// m is not in mains.
+		panic("Main functions must be registered using RegisterMains() in init()")
+	}
+	if !runCalled {
+		panic("test packages using NewCommand must invoke Run from TestMain()")
+	}
+
+	return func(executable string, args ...string) *exec.Cmd {
+		// Verify arguments if requested.
+		for _, v := range verifiers {
+			v(executable, args...)
+		}
+
+		// Pass the original arguments to the process. They'll show up as
+		// os.Args[1:].
+		a := []string{executable}
+		a = append(a, args...)
+
+		cmd := exec.Command(os.Args[0], a...)
+		cmd.Env = []string{fmt.Sprintf("%s=%d", magicEnvVar, index)}
+		return cmd
+	}
+}
+
+// RegisterMains makes multiple Main functions available to Run in the test
+// subprocess. Call it only once from your test package's init function. Any
+// Main functions passed to NewCommand must be registered using this function.
+func RegisterMains(m ...Main) {
+	if mains != nil {
+		panic("RegisterMains() must be called only once, from your test package's init function")
+	}
+	mains = m
+}
+
+// Run is a wrapper for testing.M.Run() to use in conjunction with
+// RegisterMains() and NewCommand().
+//
+// During the first run of the test executable, it simply calls m.Run() and
+// returns its exit code. When the test executable is reinvoked by a Command
+// implementation, it uses the magicEnvVar to execute a Main function instead.
+// In that case, Run will not return.
+func Run(m *testing.M) int {
+	// It's safe for code to call NewCommand now.
+	runCalled = true
+
+	val, ok := os.LookupEnv(magicEnvVar)
+	if !ok {
+		// Allow the test suite to continue.
+		return m.Run()
+	}
+
+	// Look up the desired Main function.
+	i, err := strconv.Atoi(val)
+	if err != nil || i < 0 {
+		panic(fmt.Sprintf("received invalid index %#v from %s", val, magicEnvVar))
+	} else if i >= len(mains) {
+		panic("Main functions must be registered using RegisterMains() in init()")
+	}
+
+	// Invoke. This may or may not return.
+	mains[i]()
+
+	// The invoked Main might exit itself, but if not we should exit here
+	// instead of returning control to the test suite.
+	os.Exit(0)
+	panic("unreachable")
+}
+
+func indexOf(m Main, list []Main) int {
+	// XXX Function pointers are not directly comparable in Go. We hack around
+	// this using reflection, but this is not guaranteed to work the same way
+	// in the future...
+	this := reflect.ValueOf(m).Pointer()
+
+	for i, candidate := range list {
+		that := reflect.ValueOf(candidate).Pointer()
+		if this == that {
+			return i
+		}
+	}
+	return -1 // not found
+}

--- a/testutils/exectest/command_test.go
+++ b/testutils/exectest/command_test.go
@@ -47,6 +47,14 @@ func init() {
 	RegisterMains(
 		SuccessfulMain,
 		FailedMain,
+		// UnregisteredMain is intentionally missing
+	)
+}
+
+// Ensure that multiple calls to RegisterMains() from multiple init() functions
+// work as expected.
+func init() {
+	RegisterMains(
 		ArgumentCheckingMain,
 		EnvironmentMain,
 		// UnregisteredMain is intentionally missing
@@ -190,7 +198,7 @@ func TestNewCommand(t *testing.T) {
 }
 
 func TestRegisterMains(t *testing.T) {
-	t.Run("panics if called twice", func(t *testing.T) {
+	t.Run("panics if called from Run", func(t *testing.T) {
 		defer func() {
 			if r := recover(); r == nil {
 				t.Errorf("did not panic")

--- a/testutils/exectest/command_test.go
+++ b/testutils/exectest/command_test.go
@@ -1,0 +1,174 @@
+package exectest
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+	"testing"
+)
+
+const successfulStdout = "stdout for SuccessfulMain"
+
+func SuccessfulMain() {
+	fmt.Print(successfulStdout)
+}
+
+const failedStderr = "stderr for FailedMain"
+const failedCode = 1
+
+func FailedMain() {
+	fmt.Fprint(os.Stderr, failedStderr)
+	os.Exit(failedCode)
+}
+
+var expectedCheckedArgs = []string{"arg1", "arg2", "arg3"}
+
+// ArgumentCheckingMain expects to be executed with the expectedCheckedArgs
+// above. If not it will print the difference and exit with an error.
+func ArgumentCheckingMain() {
+	args := os.Args[1:]
+	if !reflect.DeepEqual(args, expectedCheckedArgs) {
+		fmt.Fprintf(os.Stderr, "got args %#v want %#v", args, expectedCheckedArgs)
+		os.Exit(1)
+	}
+}
+
+func UnregisteredMain() {}
+
+func init() {
+	RegisterMains(
+		SuccessfulMain,
+		FailedMain,
+		ArgumentCheckingMain,
+		// UnregisteredMain is intentionally missing
+	)
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(Run(m))
+}
+
+func TestNewCommand(t *testing.T) {
+	t.Run("panics if Main isn't registered", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("did not panic")
+			}
+		}()
+
+		NewCommand(UnregisteredMain)
+	})
+
+	t.Run("panics if not called from Run()", func(t *testing.T) {
+		// We're obviously being called from Run() inside this test, so fake the
+		// situation by unsetting the flag that tracks it.
+		runCalled = false
+
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("did not panic")
+			}
+			runCalled = true // reset the flag
+		}()
+
+		NewCommand(SuccessfulMain)
+	})
+
+	t.Run("invokes passed Main", func(t *testing.T) {
+		// SuccessfulMain prints to stdout and exits with code zero.
+		cmd := NewCommand(SuccessfulMain)("/unused/path")
+
+		outb, err := cmd.Output()
+		out := string(outb)
+
+		if err != nil {
+			t.Errorf("Output() returned error: %v", err)
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				t.Errorf("subprocess stderr follows:\n%s", string(exitErr.Stderr))
+			}
+		}
+		if out != successfulStdout {
+			t.Errorf("Output() = %#v want %#v", out, successfulStdout)
+		}
+	})
+
+	t.Run("handles common error conditions", func(t *testing.T) {
+		// SuccessfulMain prints to stderr and exits with code 1.
+		cmd := NewCommand(FailedMain)("/unused/path")
+
+		outb, err := cmd.Output()
+		out := string(outb)
+
+		if out != "" {
+			t.Errorf("unexpected output %#v", out)
+		}
+
+		exitErr, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("unexpected error %#v", err)
+		}
+		if exitErr.ExitCode() != failedCode {
+			t.Errorf("exit code %d want %d", exitErr.ExitCode(), failedCode)
+		}
+
+		stderr := string(exitErr.Stderr)
+		if stderr != failedStderr {
+			t.Errorf("stderr %#v want %#v", stderr, failedStderr)
+		}
+	})
+
+	t.Run("passes arguments to its Main process", func(t *testing.T) {
+		cmdFunc := NewCommand(ArgumentCheckingMain)
+		cmd := cmdFunc(expectedCheckedArgs[0], expectedCheckedArgs[1:]...)
+
+		_, err := cmd.Output()
+		if err != nil {
+			t.Errorf("Output() returned error: %v", err)
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				t.Errorf("subprocess stderr follows:\n%s", string(exitErr.Stderr))
+			}
+		}
+	})
+
+	t.Run("runs verifiers when Command is called", func(t *testing.T) {
+		executable := "/bin/echo"
+		args := []string{"hello", "there"}
+		verifierCalls := 0
+
+		v := func(e string, a ...string) {
+			verifierCalls++
+
+			if e != executable {
+				t.Errorf("executable = %#v want %#v", e, executable)
+			}
+			if !reflect.DeepEqual(a, args) {
+				t.Errorf("args = %#v want %#v", a, args)
+			}
+		}
+
+		cmdFunc := NewCommand(SuccessfulMain, v, v)
+
+		if verifierCalls != 0 {
+			t.Errorf("verifiers called prematurely")
+		}
+
+		cmdFunc(executable, args...)
+
+		if verifierCalls != 2 {
+			t.Errorf("verifier called %d time(s) want 2", verifierCalls)
+		}
+	})
+}
+
+func TestRegisterMains(t *testing.T) {
+	t.Run("panics if called twice", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("did not panic")
+			}
+		}()
+
+		RegisterMains()
+	})
+}


### PR DESCRIPTION
Mocking out `exec.Command()` [is very difficult](https://npf.io/2015/06/testing-exec-command/
). Our current solution (`cluster.Executor`) hides all of the power of `exec.Command()` behind an overly simplistic synchronous interface that is no longer adequate for our use cases.

Instead of mocking the `exec.Command()` API, `exectest.NewCommand()` swaps out the executable that the resulting `*exec.Cmd` will actually run, redirecting to the test binary itself with an implementation inspired by posts from [Nate Finch](https://npf.io/2015/06/testing-exec-command/), [Joe Shaw](https://www.joeshaw.org/testing-with-os-exec-and-testmain/), and [Chris Hines](http://cs-guy.com/blog/2015/01/test-main/).

Try it! Break it! Tear it apart. I tried to use more idiomatic Go, both in the implementation and in the tests, but I'm rusty. So bring out the red pencils.

`godoc -http=localhost:6060` should also be able to generate the actual documentation. I tried to document the package fully, so suggestions for greater clarity would be great too. 