### PR TITLE
Update Gopkg.lock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -330,7 +330,6 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/blang/semver",
     "github.com/cloudfoundry/gosigar",
     "github.com/golang/mock/gomock",
     "github.com/golang/protobuf/proto",


### PR DESCRIPTION
Commit 026ed46d9e removed the last reference to semver, so we no longer have to vendor it.