### PR TITLE
Fix "panic: version queue is empty" during dep ensure

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -81,6 +81,13 @@
   name = "github.com/hashicorp/go-multierror"
   version = "1.0.0"
 
+# Work around
+#     panic: version queue is empty, should not happen: gopkg.in/fsnotify.v1
+# (see https://github.com/golang/dep/issues/1799)
+[[override]]
+  name = "gopkg.in/fsnotify.v1"
+  source = "https://github.com/fsnotify/fsnotify.git"
+
 [prune]
   go-tests = true
   unused-packages = true


### PR DESCRIPTION
There seems to be a specific dependency resolution bug in `dep` that's explored in https://github.com/golang/dep/issues/1799. We've seen it every so often on our development machines. This commit introduces a suggested workaround for the problem, which seems to work on my box.