### PR TITLE
 protobuf: match protoc-gen-go to the protobuf version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -29,11 +29,16 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:14834e04828af9e53954f1be45ea7f190c4c26d746009c2ab07c5828595539e9"
+  digest = "1:583595482c6dfc7540c8761d1f00981843eb6dd7da332cae3f28b8651bae8436"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
+    "protoc-gen-go",
     "protoc-gen-go/descriptor",
+    "protoc-gen-go/generator",
+    "protoc-gen-go/generator/internal/remap",
+    "protoc-gen-go/grpc",
+    "protoc-gen-go/plugin",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
@@ -333,6 +338,7 @@
     "github.com/cloudfoundry/gosigar",
     "github.com/golang/mock/gomock",
     "github.com/golang/protobuf/proto",
+    "github.com/golang/protobuf/protoc-gen-go",
     "github.com/greenplum-db/gp-common-go-libs/cluster",
     "github.com/greenplum-db/gp-common-go-libs/dbconn",
     "github.com/greenplum-db/gp-common-go-libs/gplog",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,6 +24,11 @@
 #   go-tests = true
 #   unused-packages = true
 
+# Tool dependencies. In general we want to control our dependencies via
+# Gopkg.lock instead of having `go get` pull in the latest master versions.
+required = [
+  "github.com/golang/protobuf/protoc-gen-go"
+]
 
 [[constraint]]
   name = "github.com/cloudfoundry/gosigar"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -81,6 +81,13 @@
   name = "github.com/hashicorp/go-multierror"
   version = "1.0.0"
 
+# Work around
+#     panic: version queue is empty, should not happen: gopkg.in/fsnotify.v1
+# (see https://github.com/golang/dep/issues/1799)
+[[override]]
+  name = "gopkg.in/fsnotify.v1"
+  source = "https://github.com/fsnotify/fsnotify.git"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ depend:
 		dep ensure
 
 depend-dev: depend
-		go get -u github.com/golang/protobuf/protoc-gen-go
+		go install ./vendor/github.com/golang/protobuf/protoc-gen-go
 		go get golang.org/x/tools/cmd/goimports
 		go get github.com/golang/lint/golint
 		go get github.com/alecthomas/gometalinter

--- a/idl/cli_to_hub.pb.go
+++ b/idl/cli_to_hub.pb.go
@@ -436,10 +436,10 @@ func (m *StatusConversionRequest) XXX_DiscardUnknown() {
 var xxx_messageInfo_StatusConversionRequest proto.InternalMessageInfo
 
 type PrimaryStatus struct {
-	Status               StepStatus `protobuf:"varint,1,opt,name=Status,proto3,enum=idl.StepStatus" json:"Status,omitempty"`
-	Dbid                 int32      `protobuf:"varint,2,opt,name=Dbid,proto3" json:"Dbid,omitempty"`
-	Content              int32      `protobuf:"varint,3,opt,name=Content,proto3" json:"Content,omitempty"`
-	Hostname             string     `protobuf:"bytes,4,opt,name=Hostname,proto3" json:"Hostname,omitempty"`
+	Status               StepStatus `protobuf:"varint,1,opt,name=Status,enum=idl.StepStatus" json:"Status,omitempty"`
+	Dbid                 int32      `protobuf:"varint,2,opt,name=Dbid" json:"Dbid,omitempty"`
+	Content              int32      `protobuf:"varint,3,opt,name=Content" json:"Content,omitempty"`
+	Hostname             string     `protobuf:"bytes,4,opt,name=Hostname" json:"Hostname,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}   `json:"-"`
 	XXX_unrecognized     []byte     `json:"-"`
 	XXX_sizecache        int32      `json:"-"`
@@ -498,7 +498,7 @@ func (m *PrimaryStatus) GetHostname() string {
 }
 
 type StatusConversionReply struct {
-	ConversionStatuses   []*PrimaryStatus `protobuf:"bytes,1,rep,name=conversionStatuses,proto3" json:"conversionStatuses,omitempty"`
+	ConversionStatuses   []*PrimaryStatus `protobuf:"bytes,1,rep,name=conversionStatuses" json:"conversionStatuses,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
 	XXX_unrecognized     []byte           `json:"-"`
 	XXX_sizecache        int32            `json:"-"`
@@ -566,7 +566,7 @@ func (m *StatusUpgradeRequest) XXX_DiscardUnknown() {
 var xxx_messageInfo_StatusUpgradeRequest proto.InternalMessageInfo
 
 type StatusUpgradeReply struct {
-	ListOfUpgradeStepStatuses []*UpgradeStepStatus `protobuf:"bytes,1,rep,name=listOfUpgradeStepStatuses,proto3" json:"listOfUpgradeStepStatuses,omitempty"`
+	ListOfUpgradeStepStatuses []*UpgradeStepStatus `protobuf:"bytes,1,rep,name=listOfUpgradeStepStatuses" json:"listOfUpgradeStepStatuses,omitempty"`
 	XXX_NoUnkeyedLiteral      struct{}             `json:"-"`
 	XXX_unrecognized          []byte               `json:"-"`
 	XXX_sizecache             int32                `json:"-"`
@@ -604,8 +604,8 @@ func (m *StatusUpgradeReply) GetListOfUpgradeStepStatuses() []*UpgradeStepStatus
 }
 
 type UpgradeStepStatus struct {
-	Step                 UpgradeSteps `protobuf:"varint,1,opt,name=step,proto3,enum=idl.UpgradeSteps" json:"step,omitempty"`
-	Status               StepStatus   `protobuf:"varint,2,opt,name=status,proto3,enum=idl.StepStatus" json:"status,omitempty"`
+	Step                 UpgradeSteps `protobuf:"varint,1,opt,name=step,enum=idl.UpgradeSteps" json:"step,omitempty"`
+	Status               StepStatus   `protobuf:"varint,2,opt,name=status,enum=idl.StepStatus" json:"status,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
 	XXX_unrecognized     []byte       `json:"-"`
 	XXX_sizecache        int32        `json:"-"`
@@ -681,7 +681,7 @@ var xxx_messageInfo_CheckConfigRequest proto.InternalMessageInfo
 
 // Consider removing the status as errors are/should be put on the error field.
 type CheckConfigReply struct {
-	ConfigStatus         string   `protobuf:"bytes,1,opt,name=ConfigStatus,proto3" json:"ConfigStatus,omitempty"`
+	ConfigStatus         string   `protobuf:"bytes,1,opt,name=ConfigStatus" json:"ConfigStatus,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -839,9 +839,9 @@ func (m *PrepareStartAgentsReply) XXX_DiscardUnknown() {
 var xxx_messageInfo_PrepareStartAgentsReply proto.InternalMessageInfo
 
 type CountPerDb struct {
-	DbName               string   `protobuf:"bytes,1,opt,name=DbName,proto3" json:"DbName,omitempty"`
-	AoCount              int32    `protobuf:"varint,2,opt,name=AoCount,proto3" json:"AoCount,omitempty"`
-	HeapCount            int32    `protobuf:"varint,3,opt,name=HeapCount,proto3" json:"HeapCount,omitempty"`
+	DbName               string   `protobuf:"bytes,1,opt,name=DbName" json:"DbName,omitempty"`
+	AoCount              int32    `protobuf:"varint,2,opt,name=AoCount" json:"AoCount,omitempty"`
+	HeapCount            int32    `protobuf:"varint,3,opt,name=HeapCount" json:"HeapCount,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -923,7 +923,7 @@ func (m *CheckObjectCountRequest) XXX_DiscardUnknown() {
 var xxx_messageInfo_CheckObjectCountRequest proto.InternalMessageInfo
 
 type CheckObjectCountReply struct {
-	ListOfCounts         []*CountPerDb `protobuf:"bytes,1,rep,name=ListOfCounts,proto3" json:"ListOfCounts,omitempty"`
+	ListOfCounts         []*CountPerDb `protobuf:"bytes,1,rep,name=ListOfCounts" json:"ListOfCounts,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`
@@ -991,7 +991,7 @@ func (m *CheckVersionRequest) XXX_DiscardUnknown() {
 var xxx_messageInfo_CheckVersionRequest proto.InternalMessageInfo
 
 type CheckVersionReply struct {
-	IsVersionCompatible  bool     `protobuf:"varint,1,opt,name=IsVersionCompatible,proto3" json:"IsVersionCompatible,omitempty"`
+	IsVersionCompatible  bool     `protobuf:"varint,1,opt,name=IsVersionCompatible" json:"IsVersionCompatible,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -1059,7 +1059,7 @@ func (m *CheckDiskSpaceRequest) XXX_DiscardUnknown() {
 var xxx_messageInfo_CheckDiskSpaceRequest proto.InternalMessageInfo
 
 type CheckDiskSpaceReply struct {
-	SegmentFileSysUsage  []string `protobuf:"bytes,1,rep,name=SegmentFileSysUsage,proto3" json:"SegmentFileSysUsage,omitempty"`
+	SegmentFileSysUsage  []string `protobuf:"bytes,1,rep,name=SegmentFileSysUsage" json:"SegmentFileSysUsage,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -1277,8 +1277,8 @@ func (m *UpgradeConvertMasterReply) XXX_DiscardUnknown() {
 var xxx_messageInfo_UpgradeConvertMasterReply proto.InternalMessageInfo
 
 type SetConfigRequest struct {
-	Name                 string   `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Value                string   `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	Name                 string   `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
+	Value                string   `protobuf:"bytes,2,opt,name=value" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -1353,7 +1353,7 @@ func (m *SetConfigReply) XXX_DiscardUnknown() {
 var xxx_messageInfo_SetConfigReply proto.InternalMessageInfo
 
 type GetConfigRequest struct {
-	Name                 string   `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Name                 string   `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -1391,7 +1391,7 @@ func (m *GetConfigRequest) GetName() string {
 }
 
 type GetConfigReply struct {
-	Value                string   `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"`
+	Value                string   `protobuf:"bytes,1,opt,name=value" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -1480,9 +1480,8 @@ var _ grpc.ClientConn
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion4
 
-// CliToHubClient is the client API for CliToHub service.
-//
-// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+// Client API for CliToHub service
+
 type CliToHubClient interface {
 	Ping(ctx context.Context, in *PingRequest, opts ...grpc.CallOption) (*PingReply, error)
 	StatusUpgrade(ctx context.Context, in *StatusUpgradeRequest, opts ...grpc.CallOption) (*StatusUpgradeReply, error)
@@ -1514,7 +1513,7 @@ func NewCliToHubClient(cc *grpc.ClientConn) CliToHubClient {
 
 func (c *cliToHubClient) Ping(ctx context.Context, in *PingRequest, opts ...grpc.CallOption) (*PingReply, error) {
 	out := new(PingReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/Ping", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/Ping", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1523,7 +1522,7 @@ func (c *cliToHubClient) Ping(ctx context.Context, in *PingRequest, opts ...grpc
 
 func (c *cliToHubClient) StatusUpgrade(ctx context.Context, in *StatusUpgradeRequest, opts ...grpc.CallOption) (*StatusUpgradeReply, error) {
 	out := new(StatusUpgradeReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/StatusUpgrade", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/StatusUpgrade", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1532,7 +1531,7 @@ func (c *cliToHubClient) StatusUpgrade(ctx context.Context, in *StatusUpgradeReq
 
 func (c *cliToHubClient) StatusConversion(ctx context.Context, in *StatusConversionRequest, opts ...grpc.CallOption) (*StatusConversionReply, error) {
 	out := new(StatusConversionReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/StatusConversion", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/StatusConversion", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1541,7 +1540,7 @@ func (c *cliToHubClient) StatusConversion(ctx context.Context, in *StatusConvers
 
 func (c *cliToHubClient) CheckConfig(ctx context.Context, in *CheckConfigRequest, opts ...grpc.CallOption) (*CheckConfigReply, error) {
 	out := new(CheckConfigReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/CheckConfig", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/CheckConfig", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1550,7 +1549,7 @@ func (c *cliToHubClient) CheckConfig(ctx context.Context, in *CheckConfigRequest
 
 func (c *cliToHubClient) CheckSeginstall(ctx context.Context, in *CheckSeginstallRequest, opts ...grpc.CallOption) (*CheckSeginstallReply, error) {
 	out := new(CheckSeginstallReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/CheckSeginstall", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/CheckSeginstall", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1559,7 +1558,7 @@ func (c *cliToHubClient) CheckSeginstall(ctx context.Context, in *CheckSeginstal
 
 func (c *cliToHubClient) CheckObjectCount(ctx context.Context, in *CheckObjectCountRequest, opts ...grpc.CallOption) (*CheckObjectCountReply, error) {
 	out := new(CheckObjectCountReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/CheckObjectCount", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/CheckObjectCount", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1568,7 +1567,7 @@ func (c *cliToHubClient) CheckObjectCount(ctx context.Context, in *CheckObjectCo
 
 func (c *cliToHubClient) CheckVersion(ctx context.Context, in *CheckVersionRequest, opts ...grpc.CallOption) (*CheckVersionReply, error) {
 	out := new(CheckVersionReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/CheckVersion", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/CheckVersion", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1577,7 +1576,7 @@ func (c *cliToHubClient) CheckVersion(ctx context.Context, in *CheckVersionReque
 
 func (c *cliToHubClient) CheckDiskSpace(ctx context.Context, in *CheckDiskSpaceRequest, opts ...grpc.CallOption) (*CheckDiskSpaceReply, error) {
 	out := new(CheckDiskSpaceReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/CheckDiskSpace", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/CheckDiskSpace", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1586,7 +1585,7 @@ func (c *cliToHubClient) CheckDiskSpace(ctx context.Context, in *CheckDiskSpaceR
 
 func (c *cliToHubClient) PrepareInitCluster(ctx context.Context, in *PrepareInitClusterRequest, opts ...grpc.CallOption) (*PrepareInitClusterReply, error) {
 	out := new(PrepareInitClusterReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/PrepareInitCluster", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/PrepareInitCluster", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1595,7 +1594,7 @@ func (c *cliToHubClient) PrepareInitCluster(ctx context.Context, in *PrepareInit
 
 func (c *cliToHubClient) PrepareShutdownClusters(ctx context.Context, in *PrepareShutdownClustersRequest, opts ...grpc.CallOption) (*PrepareShutdownClustersReply, error) {
 	out := new(PrepareShutdownClustersReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/PrepareShutdownClusters", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/PrepareShutdownClusters", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1604,7 +1603,7 @@ func (c *cliToHubClient) PrepareShutdownClusters(ctx context.Context, in *Prepar
 
 func (c *cliToHubClient) UpgradeConvertMaster(ctx context.Context, in *UpgradeConvertMasterRequest, opts ...grpc.CallOption) (*UpgradeConvertMasterReply, error) {
 	out := new(UpgradeConvertMasterReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/UpgradeConvertMaster", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/UpgradeConvertMaster", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1613,7 +1612,7 @@ func (c *cliToHubClient) UpgradeConvertMaster(ctx context.Context, in *UpgradeCo
 
 func (c *cliToHubClient) PrepareStartAgents(ctx context.Context, in *PrepareStartAgentsRequest, opts ...grpc.CallOption) (*PrepareStartAgentsReply, error) {
 	out := new(PrepareStartAgentsReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/PrepareStartAgents", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/PrepareStartAgents", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1622,7 +1621,7 @@ func (c *cliToHubClient) PrepareStartAgents(ctx context.Context, in *PrepareStar
 
 func (c *cliToHubClient) UpgradeShareOids(ctx context.Context, in *UpgradeShareOidsRequest, opts ...grpc.CallOption) (*UpgradeShareOidsReply, error) {
 	out := new(UpgradeShareOidsReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/UpgradeShareOids", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/UpgradeShareOids", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1631,7 +1630,7 @@ func (c *cliToHubClient) UpgradeShareOids(ctx context.Context, in *UpgradeShareO
 
 func (c *cliToHubClient) UpgradeValidateStartCluster(ctx context.Context, in *UpgradeValidateStartClusterRequest, opts ...grpc.CallOption) (*UpgradeValidateStartClusterReply, error) {
 	out := new(UpgradeValidateStartClusterReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/UpgradeValidateStartCluster", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/UpgradeValidateStartCluster", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1640,7 +1639,7 @@ func (c *cliToHubClient) UpgradeValidateStartCluster(ctx context.Context, in *Up
 
 func (c *cliToHubClient) UpgradeConvertPrimaries(ctx context.Context, in *UpgradeConvertPrimariesRequest, opts ...grpc.CallOption) (*UpgradeConvertPrimariesReply, error) {
 	out := new(UpgradeConvertPrimariesReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/UpgradeConvertPrimaries", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/UpgradeConvertPrimaries", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1649,7 +1648,7 @@ func (c *cliToHubClient) UpgradeConvertPrimaries(ctx context.Context, in *Upgrad
 
 func (c *cliToHubClient) UpgradeReconfigurePorts(ctx context.Context, in *UpgradeReconfigurePortsRequest, opts ...grpc.CallOption) (*UpgradeReconfigurePortsReply, error) {
 	out := new(UpgradeReconfigurePortsReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/UpgradeReconfigurePorts", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/UpgradeReconfigurePorts", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1658,7 +1657,7 @@ func (c *cliToHubClient) UpgradeReconfigurePorts(ctx context.Context, in *Upgrad
 
 func (c *cliToHubClient) SetConfig(ctx context.Context, in *SetConfigRequest, opts ...grpc.CallOption) (*SetConfigReply, error) {
 	out := new(SetConfigReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/SetConfig", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/SetConfig", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1667,14 +1666,15 @@ func (c *cliToHubClient) SetConfig(ctx context.Context, in *SetConfigRequest, op
 
 func (c *cliToHubClient) GetConfig(ctx context.Context, in *GetConfigRequest, opts ...grpc.CallOption) (*GetConfigReply, error) {
 	out := new(GetConfigReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/GetConfig", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/GetConfig", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// CliToHubServer is the server API for CliToHub service.
+// Server API for CliToHub service
+
 type CliToHubServer interface {
 	Ping(context.Context, *PingRequest) (*PingReply, error)
 	StatusUpgrade(context.Context, *StatusUpgradeRequest) (*StatusUpgradeReply, error)

--- a/idl/hub_to_agent.pb.go
+++ b/idl/hub_to_agent.pb.go
@@ -24,10 +24,10 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 type UpgradeConvertPrimarySegmentsRequest struct {
-	OldBinDir            string         `protobuf:"bytes,1,opt,name=OldBinDir,proto3" json:"OldBinDir,omitempty"`
-	NewBinDir            string         `protobuf:"bytes,2,opt,name=NewBinDir,proto3" json:"NewBinDir,omitempty"`
-	NewVersion           string         `protobuf:"bytes,3,opt,name=NewVersion,proto3" json:"NewVersion,omitempty"`
-	DataDirPairs         []*DataDirPair `protobuf:"bytes,4,rep,name=DataDirPairs,proto3" json:"DataDirPairs,omitempty"`
+	OldBinDir            string         `protobuf:"bytes,1,opt,name=OldBinDir" json:"OldBinDir,omitempty"`
+	NewBinDir            string         `protobuf:"bytes,2,opt,name=NewBinDir" json:"NewBinDir,omitempty"`
+	NewVersion           string         `protobuf:"bytes,3,opt,name=NewVersion" json:"NewVersion,omitempty"`
+	DataDirPairs         []*DataDirPair `protobuf:"bytes,4,rep,name=DataDirPairs" json:"DataDirPairs,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
 	XXX_unrecognized     []byte         `json:"-"`
 	XXX_sizecache        int32          `json:"-"`
@@ -86,11 +86,11 @@ func (m *UpgradeConvertPrimarySegmentsRequest) GetDataDirPairs() []*DataDirPair 
 }
 
 type DataDirPair struct {
-	OldDataDir           string   `protobuf:"bytes,1,opt,name=OldDataDir,proto3" json:"OldDataDir,omitempty"`
-	NewDataDir           string   `protobuf:"bytes,2,opt,name=NewDataDir,proto3" json:"NewDataDir,omitempty"`
-	OldPort              int32    `protobuf:"varint,3,opt,name=OldPort,proto3" json:"OldPort,omitempty"`
-	NewPort              int32    `protobuf:"varint,4,opt,name=NewPort,proto3" json:"NewPort,omitempty"`
-	Content              int32    `protobuf:"varint,5,opt,name=Content,proto3" json:"Content,omitempty"`
+	OldDataDir           string   `protobuf:"bytes,1,opt,name=OldDataDir" json:"OldDataDir,omitempty"`
+	NewDataDir           string   `protobuf:"bytes,2,opt,name=NewDataDir" json:"NewDataDir,omitempty"`
+	OldPort              int32    `protobuf:"varint,3,opt,name=OldPort" json:"OldPort,omitempty"`
+	NewPort              int32    `protobuf:"varint,4,opt,name=NewPort" json:"NewPort,omitempty"`
+	Content              int32    `protobuf:"varint,5,opt,name=Content" json:"Content,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -276,7 +276,7 @@ func (m *CheckUpgradeStatusRequest) XXX_DiscardUnknown() {
 var xxx_messageInfo_CheckUpgradeStatusRequest proto.InternalMessageInfo
 
 type CheckUpgradeStatusReply struct {
-	ProcessList          string   `protobuf:"bytes,1,opt,name=ProcessList,proto3" json:"ProcessList,omitempty"`
+	ProcessList          string   `protobuf:"bytes,1,opt,name=ProcessList" json:"ProcessList,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -314,8 +314,8 @@ func (m *CheckUpgradeStatusReply) GetProcessList() string {
 }
 
 type CheckConversionStatusRequest struct {
-	Segments             []*SegmentInfo `protobuf:"bytes,1,rep,name=Segments,proto3" json:"Segments,omitempty"`
-	Hostname             string         `protobuf:"bytes,2,opt,name=Hostname,proto3" json:"Hostname,omitempty"`
+	Segments             []*SegmentInfo `protobuf:"bytes,1,rep,name=Segments" json:"Segments,omitempty"`
+	Hostname             string         `protobuf:"bytes,2,opt,name=Hostname" json:"Hostname,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
 	XXX_unrecognized     []byte         `json:"-"`
 	XXX_sizecache        int32          `json:"-"`
@@ -360,9 +360,9 @@ func (m *CheckConversionStatusRequest) GetHostname() string {
 }
 
 type SegmentInfo struct {
-	Content              int32    `protobuf:"varint,1,opt,name=Content,proto3" json:"Content,omitempty"`
-	Dbid                 int32    `protobuf:"varint,2,opt,name=Dbid,proto3" json:"Dbid,omitempty"`
-	DataDir              string   `protobuf:"bytes,3,opt,name=DataDir,proto3" json:"DataDir,omitempty"`
+	Content              int32    `protobuf:"varint,1,opt,name=Content" json:"Content,omitempty"`
+	Dbid                 int32    `protobuf:"varint,2,opt,name=Dbid" json:"Dbid,omitempty"`
+	DataDir              string   `protobuf:"bytes,3,opt,name=DataDir" json:"DataDir,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -414,7 +414,7 @@ func (m *SegmentInfo) GetDataDir() string {
 }
 
 type CheckConversionStatusReply struct {
-	Statuses             []*PrimaryStatus `protobuf:"bytes,1,rep,name=Statuses,proto3" json:"Statuses,omitempty"`
+	Statuses             []*PrimaryStatus `protobuf:"bytes,1,rep,name=Statuses" json:"Statuses,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
 	XXX_unrecognized     []byte           `json:"-"`
 	XXX_sizecache        int32            `json:"-"`
@@ -452,8 +452,8 @@ func (m *CheckConversionStatusReply) GetStatuses() []*PrimaryStatus {
 }
 
 type FileSysUsage struct {
-	Filesystem           string   `protobuf:"bytes,1,opt,name=Filesystem,proto3" json:"Filesystem,omitempty"`
-	Usage                float64  `protobuf:"fixed64,2,opt,name=Usage,proto3" json:"Usage,omitempty"`
+	Filesystem           string   `protobuf:"bytes,1,opt,name=Filesystem" json:"Filesystem,omitempty"`
+	Usage                float64  `protobuf:"fixed64,2,opt,name=Usage" json:"Usage,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -528,7 +528,7 @@ func (m *CheckDiskSpaceRequestToAgent) XXX_DiscardUnknown() {
 var xxx_messageInfo_CheckDiskSpaceRequestToAgent proto.InternalMessageInfo
 
 type CheckDiskSpaceReplyFromAgent struct {
-	ListOfFileSysUsage   []*FileSysUsage `protobuf:"bytes,1,rep,name=ListOfFileSysUsage,proto3" json:"ListOfFileSysUsage,omitempty"`
+	ListOfFileSysUsage   []*FileSysUsage `protobuf:"bytes,1,rep,name=ListOfFileSysUsage" json:"ListOfFileSysUsage,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
 	XXX_unrecognized     []byte          `json:"-"`
 	XXX_sizecache        int32           `json:"-"`
@@ -566,7 +566,7 @@ func (m *CheckDiskSpaceReplyFromAgent) GetListOfFileSysUsage() []*FileSysUsage {
 }
 
 type CreateSegmentDataDirRequest struct {
-	Datadirs             []string `protobuf:"bytes,1,rep,name=datadirs,proto3" json:"datadirs,omitempty"`
+	Datadirs             []string `protobuf:"bytes,1,rep,name=datadirs" json:"datadirs,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -634,8 +634,8 @@ func (m *CreateSegmentDataDirReply) XXX_DiscardUnknown() {
 var xxx_messageInfo_CreateSegmentDataDirReply proto.InternalMessageInfo
 
 type CopyMasterDirRequest struct {
-	MasterDir            string   `protobuf:"bytes,1,opt,name=masterDir,proto3" json:"masterDir,omitempty"`
-	Datadirs             []string `protobuf:"bytes,2,rep,name=datadirs,proto3" json:"datadirs,omitempty"`
+	MasterDir            string   `protobuf:"bytes,1,opt,name=masterDir" json:"masterDir,omitempty"`
+	Datadirs             []string `protobuf:"bytes,2,rep,name=datadirs" json:"datadirs,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -737,9 +737,8 @@ var _ grpc.ClientConn
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion4
 
-// AgentClient is the client API for Agent service.
-//
-// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+// Client API for Agent service
+
 type AgentClient interface {
 	CheckUpgradeStatus(ctx context.Context, in *CheckUpgradeStatusRequest, opts ...grpc.CallOption) (*CheckUpgradeStatusReply, error)
 	CheckConversionStatus(ctx context.Context, in *CheckConversionStatusRequest, opts ...grpc.CallOption) (*CheckConversionStatusReply, error)
@@ -760,7 +759,7 @@ func NewAgentClient(cc *grpc.ClientConn) AgentClient {
 
 func (c *agentClient) CheckUpgradeStatus(ctx context.Context, in *CheckUpgradeStatusRequest, opts ...grpc.CallOption) (*CheckUpgradeStatusReply, error) {
 	out := new(CheckUpgradeStatusReply)
-	err := c.cc.Invoke(ctx, "/idl.Agent/CheckUpgradeStatus", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.Agent/CheckUpgradeStatus", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -769,7 +768,7 @@ func (c *agentClient) CheckUpgradeStatus(ctx context.Context, in *CheckUpgradeSt
 
 func (c *agentClient) CheckConversionStatus(ctx context.Context, in *CheckConversionStatusRequest, opts ...grpc.CallOption) (*CheckConversionStatusReply, error) {
 	out := new(CheckConversionStatusReply)
-	err := c.cc.Invoke(ctx, "/idl.Agent/CheckConversionStatus", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.Agent/CheckConversionStatus", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -778,7 +777,7 @@ func (c *agentClient) CheckConversionStatus(ctx context.Context, in *CheckConver
 
 func (c *agentClient) CheckDiskSpaceOnAgents(ctx context.Context, in *CheckDiskSpaceRequestToAgent, opts ...grpc.CallOption) (*CheckDiskSpaceReplyFromAgent, error) {
 	out := new(CheckDiskSpaceReplyFromAgent)
-	err := c.cc.Invoke(ctx, "/idl.Agent/CheckDiskSpaceOnAgents", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.Agent/CheckDiskSpaceOnAgents", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -787,7 +786,7 @@ func (c *agentClient) CheckDiskSpaceOnAgents(ctx context.Context, in *CheckDiskS
 
 func (c *agentClient) PingAgents(ctx context.Context, in *PingAgentsRequest, opts ...grpc.CallOption) (*PingAgentsReply, error) {
 	out := new(PingAgentsReply)
-	err := c.cc.Invoke(ctx, "/idl.Agent/PingAgents", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.Agent/PingAgents", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -796,7 +795,7 @@ func (c *agentClient) PingAgents(ctx context.Context, in *PingAgentsRequest, opt
 
 func (c *agentClient) UpgradeConvertPrimarySegments(ctx context.Context, in *UpgradeConvertPrimarySegmentsRequest, opts ...grpc.CallOption) (*UpgradeConvertPrimarySegmentsReply, error) {
 	out := new(UpgradeConvertPrimarySegmentsReply)
-	err := c.cc.Invoke(ctx, "/idl.Agent/UpgradeConvertPrimarySegments", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.Agent/UpgradeConvertPrimarySegments", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -805,7 +804,7 @@ func (c *agentClient) UpgradeConvertPrimarySegments(ctx context.Context, in *Upg
 
 func (c *agentClient) CreateSegmentDataDirectories(ctx context.Context, in *CreateSegmentDataDirRequest, opts ...grpc.CallOption) (*CreateSegmentDataDirReply, error) {
 	out := new(CreateSegmentDataDirReply)
-	err := c.cc.Invoke(ctx, "/idl.Agent/CreateSegmentDataDirectories", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.Agent/CreateSegmentDataDirectories", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -814,14 +813,15 @@ func (c *agentClient) CreateSegmentDataDirectories(ctx context.Context, in *Crea
 
 func (c *agentClient) CopyMasterDirectoryToSegmentDirectories(ctx context.Context, in *CopyMasterDirRequest, opts ...grpc.CallOption) (*CopyMasterDirReply, error) {
 	out := new(CopyMasterDirReply)
-	err := c.cc.Invoke(ctx, "/idl.Agent/CopyMasterDirectoryToSegmentDirectories", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.Agent/CopyMasterDirectoryToSegmentDirectories", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// AgentServer is the server API for Agent service.
+// Server API for Agent service
+
 type AgentServer interface {
 	CheckUpgradeStatus(context.Context, *CheckUpgradeStatusRequest) (*CheckUpgradeStatusReply, error)
 	CheckConversionStatus(context.Context, *CheckConversionStatusRequest) (*CheckConversionStatusReply, error)


### PR DESCRIPTION
The Go protoc plugin (protoc-gen-go) and the protobuf package itself need to match versions. The previous Makefile installed the master version of the plugin, but dep pinned protobuf itself to 1.1.0, and now we're seeing problems on some developer machines where protobuf complains about a mismatch.

This commit fixes the problem using an implementation from developer discussion on golang/protobuf#763 and regenerates the protobuf using the new (old) plugin.

Fixes #99. This PR also contains the commit in https://github.com/greenplum-db/gpupgrade/pull/107 so I can run a dev pipeline.