### PR TITLE
match mockgen version to mock package version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -21,12 +21,16 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:a62049a8fa554d688c8db4845c65ddcd5986b75f3a851e4fb563c6893d292e38"
+  digest = "1:5e14df5b9539151b485eeb3ebea90a2823347516732978b0911ff17acea2842c"
   name = "github.com/golang/mock"
-  packages = ["gomock"]
+  packages = [
+    "gomock",
+    "mockgen",
+    "mockgen/model",
+  ]
   pruneopts = "UT"
-  revision = "13f360950a79f5864a972c786a10a50e44b69541"
-  version = "v1.0.0"
+  revision = "9fa652df1129bef0e734c9cf9bf6dbae9ef3b9fa"
+  version = "1.3.1"
 
 [[projects]]
   digest = "1:583595482c6dfc7540c8761d1f00981843eb6dd7da332cae3f28b8651bae8436"
@@ -275,6 +279,24 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:43aa5407b49785c96b8dd04a785d59cd24e92216ce8b391ed34ff880d0b302fc"
+  name = "golang.org/x/tools"
+  packages = [
+    "go/ast/astutil",
+    "go/gcexportdata",
+    "go/internal/gcimporter",
+    "go/internal/packagesdriver",
+    "go/packages",
+    "go/types/typeutil",
+    "internal/fastwalk",
+    "internal/gopathwalk",
+    "internal/semver",
+  ]
+  pruneopts = "UT"
+  revision = "b29f5f60c37a1dd56e6942c2717b85b976e4a592"
+
+[[projects]]
+  branch = "master"
   digest = "1:cd018653a358d4b743a9d3bee89e825521f2ab2f2ec0770164bf7632d8d73ab7"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
@@ -337,6 +359,7 @@
   input-imports = [
     "github.com/cloudfoundry/gosigar",
     "github.com/golang/mock/gomock",
+    "github.com/golang/mock/mockgen",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/protoc-gen-go",
     "github.com/greenplum-db/gp-common-go-libs/cluster",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,8 @@
 # Tool dependencies. In general we want to control our dependencies via
 # Gopkg.lock instead of having `go get` pull in the latest master versions.
 required = [
-  "github.com/golang/protobuf/protoc-gen-go"
+  "github.com/golang/protobuf/protoc-gen-go",
+  "github.com/golang/mock/mockgen"
 ]
 
 [[constraint]]
@@ -36,7 +37,7 @@ required = [
 
 [[constraint]]
   name = "github.com/golang/mock"
-  version = "1.0.0"
+  version = "1.0.1"
 
 [[constraint]]
   name = "github.com/golang/protobuf"

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ depend:
 
 depend-dev: depend
 		go install ./vendor/github.com/golang/protobuf/protoc-gen-go
+		go install ./vendor/github.com/golang/mock/mockgen
 		go get golang.org/x/tools/cmd/goimports
 		go get github.com/golang/lint/golint
 		go get github.com/alecthomas/gometalinter
@@ -69,7 +70,6 @@ sshd_build:
 
 protobuf:
 		protoc -I idl/ idl/*.proto --go_out=plugins=grpc:idl
-		go get github.com/golang/mock/mockgen
 		mockgen -source idl/cli_to_hub.pb.go  > mock_idl/cli_to_hub_mock.pb.go
 		mockgen -source idl/hub_to_agent.pb.go  > mock_idl/hub_to_agent_mock.pb.go
 

--- a/mock_idl/cli_to_hub_mock.pb.go
+++ b/mock_idl/cli_to_hub_mock.pb.go
@@ -37,6 +37,7 @@ func (m *MockCliToHubClient) EXPECT() *MockCliToHubClientMockRecorder {
 
 // Ping mocks base method
 func (m *MockCliToHubClient) Ping(ctx context.Context, in *idl.PingRequest, opts ...grpc.CallOption) (*idl.PingReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -49,12 +50,14 @@ func (m *MockCliToHubClient) Ping(ctx context.Context, in *idl.PingRequest, opts
 
 // Ping indicates an expected call of Ping
 func (mr *MockCliToHubClientMockRecorder) Ping(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockCliToHubClient)(nil).Ping), varargs...)
 }
 
 // StatusUpgrade mocks base method
 func (m *MockCliToHubClient) StatusUpgrade(ctx context.Context, in *idl.StatusUpgradeRequest, opts ...grpc.CallOption) (*idl.StatusUpgradeReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -67,12 +70,14 @@ func (m *MockCliToHubClient) StatusUpgrade(ctx context.Context, in *idl.StatusUp
 
 // StatusUpgrade indicates an expected call of StatusUpgrade
 func (mr *MockCliToHubClientMockRecorder) StatusUpgrade(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatusUpgrade", reflect.TypeOf((*MockCliToHubClient)(nil).StatusUpgrade), varargs...)
 }
 
 // StatusConversion mocks base method
 func (m *MockCliToHubClient) StatusConversion(ctx context.Context, in *idl.StatusConversionRequest, opts ...grpc.CallOption) (*idl.StatusConversionReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -85,12 +90,14 @@ func (m *MockCliToHubClient) StatusConversion(ctx context.Context, in *idl.Statu
 
 // StatusConversion indicates an expected call of StatusConversion
 func (mr *MockCliToHubClientMockRecorder) StatusConversion(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatusConversion", reflect.TypeOf((*MockCliToHubClient)(nil).StatusConversion), varargs...)
 }
 
 // CheckConfig mocks base method
 func (m *MockCliToHubClient) CheckConfig(ctx context.Context, in *idl.CheckConfigRequest, opts ...grpc.CallOption) (*idl.CheckConfigReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -103,12 +110,14 @@ func (m *MockCliToHubClient) CheckConfig(ctx context.Context, in *idl.CheckConfi
 
 // CheckConfig indicates an expected call of CheckConfig
 func (mr *MockCliToHubClientMockRecorder) CheckConfig(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckConfig", reflect.TypeOf((*MockCliToHubClient)(nil).CheckConfig), varargs...)
 }
 
 // CheckSeginstall mocks base method
 func (m *MockCliToHubClient) CheckSeginstall(ctx context.Context, in *idl.CheckSeginstallRequest, opts ...grpc.CallOption) (*idl.CheckSeginstallReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -121,12 +130,14 @@ func (m *MockCliToHubClient) CheckSeginstall(ctx context.Context, in *idl.CheckS
 
 // CheckSeginstall indicates an expected call of CheckSeginstall
 func (mr *MockCliToHubClientMockRecorder) CheckSeginstall(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckSeginstall", reflect.TypeOf((*MockCliToHubClient)(nil).CheckSeginstall), varargs...)
 }
 
 // CheckObjectCount mocks base method
 func (m *MockCliToHubClient) CheckObjectCount(ctx context.Context, in *idl.CheckObjectCountRequest, opts ...grpc.CallOption) (*idl.CheckObjectCountReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -139,12 +150,14 @@ func (m *MockCliToHubClient) CheckObjectCount(ctx context.Context, in *idl.Check
 
 // CheckObjectCount indicates an expected call of CheckObjectCount
 func (mr *MockCliToHubClientMockRecorder) CheckObjectCount(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckObjectCount", reflect.TypeOf((*MockCliToHubClient)(nil).CheckObjectCount), varargs...)
 }
 
 // CheckVersion mocks base method
 func (m *MockCliToHubClient) CheckVersion(ctx context.Context, in *idl.CheckVersionRequest, opts ...grpc.CallOption) (*idl.CheckVersionReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -157,12 +170,14 @@ func (m *MockCliToHubClient) CheckVersion(ctx context.Context, in *idl.CheckVers
 
 // CheckVersion indicates an expected call of CheckVersion
 func (mr *MockCliToHubClientMockRecorder) CheckVersion(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckVersion", reflect.TypeOf((*MockCliToHubClient)(nil).CheckVersion), varargs...)
 }
 
 // CheckDiskSpace mocks base method
 func (m *MockCliToHubClient) CheckDiskSpace(ctx context.Context, in *idl.CheckDiskSpaceRequest, opts ...grpc.CallOption) (*idl.CheckDiskSpaceReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -175,12 +190,14 @@ func (m *MockCliToHubClient) CheckDiskSpace(ctx context.Context, in *idl.CheckDi
 
 // CheckDiskSpace indicates an expected call of CheckDiskSpace
 func (mr *MockCliToHubClientMockRecorder) CheckDiskSpace(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDiskSpace", reflect.TypeOf((*MockCliToHubClient)(nil).CheckDiskSpace), varargs...)
 }
 
 // PrepareInitCluster mocks base method
 func (m *MockCliToHubClient) PrepareInitCluster(ctx context.Context, in *idl.PrepareInitClusterRequest, opts ...grpc.CallOption) (*idl.PrepareInitClusterReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -193,12 +210,14 @@ func (m *MockCliToHubClient) PrepareInitCluster(ctx context.Context, in *idl.Pre
 
 // PrepareInitCluster indicates an expected call of PrepareInitCluster
 func (mr *MockCliToHubClientMockRecorder) PrepareInitCluster(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareInitCluster", reflect.TypeOf((*MockCliToHubClient)(nil).PrepareInitCluster), varargs...)
 }
 
 // PrepareShutdownClusters mocks base method
 func (m *MockCliToHubClient) PrepareShutdownClusters(ctx context.Context, in *idl.PrepareShutdownClustersRequest, opts ...grpc.CallOption) (*idl.PrepareShutdownClustersReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -211,12 +230,14 @@ func (m *MockCliToHubClient) PrepareShutdownClusters(ctx context.Context, in *id
 
 // PrepareShutdownClusters indicates an expected call of PrepareShutdownClusters
 func (mr *MockCliToHubClientMockRecorder) PrepareShutdownClusters(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareShutdownClusters", reflect.TypeOf((*MockCliToHubClient)(nil).PrepareShutdownClusters), varargs...)
 }
 
 // UpgradeConvertMaster mocks base method
 func (m *MockCliToHubClient) UpgradeConvertMaster(ctx context.Context, in *idl.UpgradeConvertMasterRequest, opts ...grpc.CallOption) (*idl.UpgradeConvertMasterReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -229,12 +250,14 @@ func (m *MockCliToHubClient) UpgradeConvertMaster(ctx context.Context, in *idl.U
 
 // UpgradeConvertMaster indicates an expected call of UpgradeConvertMaster
 func (mr *MockCliToHubClientMockRecorder) UpgradeConvertMaster(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeConvertMaster", reflect.TypeOf((*MockCliToHubClient)(nil).UpgradeConvertMaster), varargs...)
 }
 
 // PrepareStartAgents mocks base method
 func (m *MockCliToHubClient) PrepareStartAgents(ctx context.Context, in *idl.PrepareStartAgentsRequest, opts ...grpc.CallOption) (*idl.PrepareStartAgentsReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -247,12 +270,14 @@ func (m *MockCliToHubClient) PrepareStartAgents(ctx context.Context, in *idl.Pre
 
 // PrepareStartAgents indicates an expected call of PrepareStartAgents
 func (mr *MockCliToHubClientMockRecorder) PrepareStartAgents(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareStartAgents", reflect.TypeOf((*MockCliToHubClient)(nil).PrepareStartAgents), varargs...)
 }
 
 // UpgradeCopyMasterDataDir mocks base method
 func (m *MockCliToHubClient) UpgradeCopyMasterDataDir(ctx context.Context, in *idl.UpgradeCopyMasterDataDirRequest, opts ...grpc.CallOption) (*idl.UpgradeCopyMasterDataDirReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -265,12 +290,14 @@ func (m *MockCliToHubClient) UpgradeCopyMasterDataDir(ctx context.Context, in *i
 
 // UpgradeCopyMasterDataDir indicates an expected call of UpgradeCopyMasterDataDir
 func (mr *MockCliToHubClientMockRecorder) UpgradeCopyMasterDataDir(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeCopyMasterDataDir", reflect.TypeOf((*MockCliToHubClient)(nil).UpgradeCopyMasterDataDir), varargs...)
 }
 
 // UpgradeValidateStartCluster mocks base method
 func (m *MockCliToHubClient) UpgradeValidateStartCluster(ctx context.Context, in *idl.UpgradeValidateStartClusterRequest, opts ...grpc.CallOption) (*idl.UpgradeValidateStartClusterReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -283,12 +310,14 @@ func (m *MockCliToHubClient) UpgradeValidateStartCluster(ctx context.Context, in
 
 // UpgradeValidateStartCluster indicates an expected call of UpgradeValidateStartCluster
 func (mr *MockCliToHubClientMockRecorder) UpgradeValidateStartCluster(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeValidateStartCluster", reflect.TypeOf((*MockCliToHubClient)(nil).UpgradeValidateStartCluster), varargs...)
 }
 
 // UpgradeConvertPrimaries mocks base method
 func (m *MockCliToHubClient) UpgradeConvertPrimaries(ctx context.Context, in *idl.UpgradeConvertPrimariesRequest, opts ...grpc.CallOption) (*idl.UpgradeConvertPrimariesReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -301,12 +330,14 @@ func (m *MockCliToHubClient) UpgradeConvertPrimaries(ctx context.Context, in *id
 
 // UpgradeConvertPrimaries indicates an expected call of UpgradeConvertPrimaries
 func (mr *MockCliToHubClientMockRecorder) UpgradeConvertPrimaries(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeConvertPrimaries", reflect.TypeOf((*MockCliToHubClient)(nil).UpgradeConvertPrimaries), varargs...)
 }
 
 // UpgradeReconfigurePorts mocks base method
 func (m *MockCliToHubClient) UpgradeReconfigurePorts(ctx context.Context, in *idl.UpgradeReconfigurePortsRequest, opts ...grpc.CallOption) (*idl.UpgradeReconfigurePortsReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -319,12 +350,14 @@ func (m *MockCliToHubClient) UpgradeReconfigurePorts(ctx context.Context, in *id
 
 // UpgradeReconfigurePorts indicates an expected call of UpgradeReconfigurePorts
 func (mr *MockCliToHubClientMockRecorder) UpgradeReconfigurePorts(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeReconfigurePorts", reflect.TypeOf((*MockCliToHubClient)(nil).UpgradeReconfigurePorts), varargs...)
 }
 
 // SetConfig mocks base method
 func (m *MockCliToHubClient) SetConfig(ctx context.Context, in *idl.SetConfigRequest, opts ...grpc.CallOption) (*idl.SetConfigReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -337,12 +370,14 @@ func (m *MockCliToHubClient) SetConfig(ctx context.Context, in *idl.SetConfigReq
 
 // SetConfig indicates an expected call of SetConfig
 func (mr *MockCliToHubClientMockRecorder) SetConfig(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockCliToHubClient)(nil).SetConfig), varargs...)
 }
 
 // GetConfig mocks base method
 func (m *MockCliToHubClient) GetConfig(ctx context.Context, in *idl.GetConfigRequest, opts ...grpc.CallOption) (*idl.GetConfigReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -355,6 +390,7 @@ func (m *MockCliToHubClient) GetConfig(ctx context.Context, in *idl.GetConfigReq
 
 // GetConfig indicates an expected call of GetConfig
 func (mr *MockCliToHubClientMockRecorder) GetConfig(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfig", reflect.TypeOf((*MockCliToHubClient)(nil).GetConfig), varargs...)
 }
@@ -384,6 +420,7 @@ func (m *MockCliToHubServer) EXPECT() *MockCliToHubServerMockRecorder {
 
 // Ping mocks base method
 func (m *MockCliToHubServer) Ping(arg0 context.Context, arg1 *idl.PingRequest) (*idl.PingReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Ping", arg0, arg1)
 	ret0, _ := ret[0].(*idl.PingReply)
 	ret1, _ := ret[1].(error)
@@ -392,11 +429,13 @@ func (m *MockCliToHubServer) Ping(arg0 context.Context, arg1 *idl.PingRequest) (
 
 // Ping indicates an expected call of Ping
 func (mr *MockCliToHubServerMockRecorder) Ping(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockCliToHubServer)(nil).Ping), arg0, arg1)
 }
 
 // StatusUpgrade mocks base method
 func (m *MockCliToHubServer) StatusUpgrade(arg0 context.Context, arg1 *idl.StatusUpgradeRequest) (*idl.StatusUpgradeReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StatusUpgrade", arg0, arg1)
 	ret0, _ := ret[0].(*idl.StatusUpgradeReply)
 	ret1, _ := ret[1].(error)
@@ -405,11 +444,13 @@ func (m *MockCliToHubServer) StatusUpgrade(arg0 context.Context, arg1 *idl.Statu
 
 // StatusUpgrade indicates an expected call of StatusUpgrade
 func (mr *MockCliToHubServerMockRecorder) StatusUpgrade(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatusUpgrade", reflect.TypeOf((*MockCliToHubServer)(nil).StatusUpgrade), arg0, arg1)
 }
 
 // StatusConversion mocks base method
 func (m *MockCliToHubServer) StatusConversion(arg0 context.Context, arg1 *idl.StatusConversionRequest) (*idl.StatusConversionReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StatusConversion", arg0, arg1)
 	ret0, _ := ret[0].(*idl.StatusConversionReply)
 	ret1, _ := ret[1].(error)
@@ -418,11 +459,13 @@ func (m *MockCliToHubServer) StatusConversion(arg0 context.Context, arg1 *idl.St
 
 // StatusConversion indicates an expected call of StatusConversion
 func (mr *MockCliToHubServerMockRecorder) StatusConversion(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatusConversion", reflect.TypeOf((*MockCliToHubServer)(nil).StatusConversion), arg0, arg1)
 }
 
 // CheckConfig mocks base method
 func (m *MockCliToHubServer) CheckConfig(arg0 context.Context, arg1 *idl.CheckConfigRequest) (*idl.CheckConfigReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckConfig", arg0, arg1)
 	ret0, _ := ret[0].(*idl.CheckConfigReply)
 	ret1, _ := ret[1].(error)
@@ -431,11 +474,13 @@ func (m *MockCliToHubServer) CheckConfig(arg0 context.Context, arg1 *idl.CheckCo
 
 // CheckConfig indicates an expected call of CheckConfig
 func (mr *MockCliToHubServerMockRecorder) CheckConfig(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckConfig", reflect.TypeOf((*MockCliToHubServer)(nil).CheckConfig), arg0, arg1)
 }
 
 // CheckSeginstall mocks base method
 func (m *MockCliToHubServer) CheckSeginstall(arg0 context.Context, arg1 *idl.CheckSeginstallRequest) (*idl.CheckSeginstallReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckSeginstall", arg0, arg1)
 	ret0, _ := ret[0].(*idl.CheckSeginstallReply)
 	ret1, _ := ret[1].(error)
@@ -444,11 +489,13 @@ func (m *MockCliToHubServer) CheckSeginstall(arg0 context.Context, arg1 *idl.Che
 
 // CheckSeginstall indicates an expected call of CheckSeginstall
 func (mr *MockCliToHubServerMockRecorder) CheckSeginstall(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckSeginstall", reflect.TypeOf((*MockCliToHubServer)(nil).CheckSeginstall), arg0, arg1)
 }
 
 // CheckObjectCount mocks base method
 func (m *MockCliToHubServer) CheckObjectCount(arg0 context.Context, arg1 *idl.CheckObjectCountRequest) (*idl.CheckObjectCountReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckObjectCount", arg0, arg1)
 	ret0, _ := ret[0].(*idl.CheckObjectCountReply)
 	ret1, _ := ret[1].(error)
@@ -457,11 +504,13 @@ func (m *MockCliToHubServer) CheckObjectCount(arg0 context.Context, arg1 *idl.Ch
 
 // CheckObjectCount indicates an expected call of CheckObjectCount
 func (mr *MockCliToHubServerMockRecorder) CheckObjectCount(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckObjectCount", reflect.TypeOf((*MockCliToHubServer)(nil).CheckObjectCount), arg0, arg1)
 }
 
 // CheckVersion mocks base method
 func (m *MockCliToHubServer) CheckVersion(arg0 context.Context, arg1 *idl.CheckVersionRequest) (*idl.CheckVersionReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckVersion", arg0, arg1)
 	ret0, _ := ret[0].(*idl.CheckVersionReply)
 	ret1, _ := ret[1].(error)
@@ -470,11 +519,13 @@ func (m *MockCliToHubServer) CheckVersion(arg0 context.Context, arg1 *idl.CheckV
 
 // CheckVersion indicates an expected call of CheckVersion
 func (mr *MockCliToHubServerMockRecorder) CheckVersion(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckVersion", reflect.TypeOf((*MockCliToHubServer)(nil).CheckVersion), arg0, arg1)
 }
 
 // CheckDiskSpace mocks base method
 func (m *MockCliToHubServer) CheckDiskSpace(arg0 context.Context, arg1 *idl.CheckDiskSpaceRequest) (*idl.CheckDiskSpaceReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckDiskSpace", arg0, arg1)
 	ret0, _ := ret[0].(*idl.CheckDiskSpaceReply)
 	ret1, _ := ret[1].(error)
@@ -483,11 +534,13 @@ func (m *MockCliToHubServer) CheckDiskSpace(arg0 context.Context, arg1 *idl.Chec
 
 // CheckDiskSpace indicates an expected call of CheckDiskSpace
 func (mr *MockCliToHubServerMockRecorder) CheckDiskSpace(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDiskSpace", reflect.TypeOf((*MockCliToHubServer)(nil).CheckDiskSpace), arg0, arg1)
 }
 
 // PrepareInitCluster mocks base method
 func (m *MockCliToHubServer) PrepareInitCluster(arg0 context.Context, arg1 *idl.PrepareInitClusterRequest) (*idl.PrepareInitClusterReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareInitCluster", arg0, arg1)
 	ret0, _ := ret[0].(*idl.PrepareInitClusterReply)
 	ret1, _ := ret[1].(error)
@@ -496,11 +549,13 @@ func (m *MockCliToHubServer) PrepareInitCluster(arg0 context.Context, arg1 *idl.
 
 // PrepareInitCluster indicates an expected call of PrepareInitCluster
 func (mr *MockCliToHubServerMockRecorder) PrepareInitCluster(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareInitCluster", reflect.TypeOf((*MockCliToHubServer)(nil).PrepareInitCluster), arg0, arg1)
 }
 
 // PrepareShutdownClusters mocks base method
 func (m *MockCliToHubServer) PrepareShutdownClusters(arg0 context.Context, arg1 *idl.PrepareShutdownClustersRequest) (*idl.PrepareShutdownClustersReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareShutdownClusters", arg0, arg1)
 	ret0, _ := ret[0].(*idl.PrepareShutdownClustersReply)
 	ret1, _ := ret[1].(error)
@@ -509,11 +564,13 @@ func (m *MockCliToHubServer) PrepareShutdownClusters(arg0 context.Context, arg1 
 
 // PrepareShutdownClusters indicates an expected call of PrepareShutdownClusters
 func (mr *MockCliToHubServerMockRecorder) PrepareShutdownClusters(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareShutdownClusters", reflect.TypeOf((*MockCliToHubServer)(nil).PrepareShutdownClusters), arg0, arg1)
 }
 
 // UpgradeConvertMaster mocks base method
 func (m *MockCliToHubServer) UpgradeConvertMaster(arg0 context.Context, arg1 *idl.UpgradeConvertMasterRequest) (*idl.UpgradeConvertMasterReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeConvertMaster", arg0, arg1)
 	ret0, _ := ret[0].(*idl.UpgradeConvertMasterReply)
 	ret1, _ := ret[1].(error)
@@ -522,11 +579,13 @@ func (m *MockCliToHubServer) UpgradeConvertMaster(arg0 context.Context, arg1 *id
 
 // UpgradeConvertMaster indicates an expected call of UpgradeConvertMaster
 func (mr *MockCliToHubServerMockRecorder) UpgradeConvertMaster(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeConvertMaster", reflect.TypeOf((*MockCliToHubServer)(nil).UpgradeConvertMaster), arg0, arg1)
 }
 
 // PrepareStartAgents mocks base method
 func (m *MockCliToHubServer) PrepareStartAgents(arg0 context.Context, arg1 *idl.PrepareStartAgentsRequest) (*idl.PrepareStartAgentsReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareStartAgents", arg0, arg1)
 	ret0, _ := ret[0].(*idl.PrepareStartAgentsReply)
 	ret1, _ := ret[1].(error)
@@ -535,11 +594,13 @@ func (m *MockCliToHubServer) PrepareStartAgents(arg0 context.Context, arg1 *idl.
 
 // PrepareStartAgents indicates an expected call of PrepareStartAgents
 func (mr *MockCliToHubServerMockRecorder) PrepareStartAgents(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareStartAgents", reflect.TypeOf((*MockCliToHubServer)(nil).PrepareStartAgents), arg0, arg1)
 }
 
 // UpgradeCopyMasterDataDir mocks base method
 func (m *MockCliToHubServer) UpgradeCopyMasterDataDir(arg0 context.Context, arg1 *idl.UpgradeCopyMasterDataDirRequest) (*idl.UpgradeCopyMasterDataDirReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeCopyMasterDataDir", arg0, arg1)
 	ret0, _ := ret[0].(*idl.UpgradeCopyMasterDataDirReply)
 	ret1, _ := ret[1].(error)
@@ -548,11 +609,13 @@ func (m *MockCliToHubServer) UpgradeCopyMasterDataDir(arg0 context.Context, arg1
 
 // UpgradeCopyMasterDataDir indicates an expected call of UpgradeCopyMasterDataDir
 func (mr *MockCliToHubServerMockRecorder) UpgradeCopyMasterDataDir(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeCopyMasterDataDir", reflect.TypeOf((*MockCliToHubServer)(nil).UpgradeCopyMasterDataDir), arg0, arg1)
 }
 
 // UpgradeValidateStartCluster mocks base method
 func (m *MockCliToHubServer) UpgradeValidateStartCluster(arg0 context.Context, arg1 *idl.UpgradeValidateStartClusterRequest) (*idl.UpgradeValidateStartClusterReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeValidateStartCluster", arg0, arg1)
 	ret0, _ := ret[0].(*idl.UpgradeValidateStartClusterReply)
 	ret1, _ := ret[1].(error)
@@ -561,11 +624,13 @@ func (m *MockCliToHubServer) UpgradeValidateStartCluster(arg0 context.Context, a
 
 // UpgradeValidateStartCluster indicates an expected call of UpgradeValidateStartCluster
 func (mr *MockCliToHubServerMockRecorder) UpgradeValidateStartCluster(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeValidateStartCluster", reflect.TypeOf((*MockCliToHubServer)(nil).UpgradeValidateStartCluster), arg0, arg1)
 }
 
 // UpgradeConvertPrimaries mocks base method
 func (m *MockCliToHubServer) UpgradeConvertPrimaries(arg0 context.Context, arg1 *idl.UpgradeConvertPrimariesRequest) (*idl.UpgradeConvertPrimariesReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeConvertPrimaries", arg0, arg1)
 	ret0, _ := ret[0].(*idl.UpgradeConvertPrimariesReply)
 	ret1, _ := ret[1].(error)
@@ -574,11 +639,13 @@ func (m *MockCliToHubServer) UpgradeConvertPrimaries(arg0 context.Context, arg1 
 
 // UpgradeConvertPrimaries indicates an expected call of UpgradeConvertPrimaries
 func (mr *MockCliToHubServerMockRecorder) UpgradeConvertPrimaries(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeConvertPrimaries", reflect.TypeOf((*MockCliToHubServer)(nil).UpgradeConvertPrimaries), arg0, arg1)
 }
 
 // UpgradeReconfigurePorts mocks base method
 func (m *MockCliToHubServer) UpgradeReconfigurePorts(arg0 context.Context, arg1 *idl.UpgradeReconfigurePortsRequest) (*idl.UpgradeReconfigurePortsReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeReconfigurePorts", arg0, arg1)
 	ret0, _ := ret[0].(*idl.UpgradeReconfigurePortsReply)
 	ret1, _ := ret[1].(error)
@@ -587,11 +654,13 @@ func (m *MockCliToHubServer) UpgradeReconfigurePorts(arg0 context.Context, arg1 
 
 // UpgradeReconfigurePorts indicates an expected call of UpgradeReconfigurePorts
 func (mr *MockCliToHubServerMockRecorder) UpgradeReconfigurePorts(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeReconfigurePorts", reflect.TypeOf((*MockCliToHubServer)(nil).UpgradeReconfigurePorts), arg0, arg1)
 }
 
 // SetConfig mocks base method
 func (m *MockCliToHubServer) SetConfig(arg0 context.Context, arg1 *idl.SetConfigRequest) (*idl.SetConfigReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetConfig", arg0, arg1)
 	ret0, _ := ret[0].(*idl.SetConfigReply)
 	ret1, _ := ret[1].(error)
@@ -600,11 +669,13 @@ func (m *MockCliToHubServer) SetConfig(arg0 context.Context, arg1 *idl.SetConfig
 
 // SetConfig indicates an expected call of SetConfig
 func (mr *MockCliToHubServerMockRecorder) SetConfig(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockCliToHubServer)(nil).SetConfig), arg0, arg1)
 }
 
 // GetConfig mocks base method
 func (m *MockCliToHubServer) GetConfig(arg0 context.Context, arg1 *idl.GetConfigRequest) (*idl.GetConfigReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConfig", arg0, arg1)
 	ret0, _ := ret[0].(*idl.GetConfigReply)
 	ret1, _ := ret[1].(error)
@@ -613,5 +684,6 @@ func (m *MockCliToHubServer) GetConfig(arg0 context.Context, arg1 *idl.GetConfig
 
 // GetConfig indicates an expected call of GetConfig
 func (mr *MockCliToHubServerMockRecorder) GetConfig(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfig", reflect.TypeOf((*MockCliToHubServer)(nil).GetConfig), arg0, arg1)
 }

--- a/mock_idl/hub_to_agent_mock.pb.go
+++ b/mock_idl/hub_to_agent_mock.pb.go
@@ -37,6 +37,7 @@ func (m *MockAgentClient) EXPECT() *MockAgentClientMockRecorder {
 
 // CheckUpgradeStatus mocks base method
 func (m *MockAgentClient) CheckUpgradeStatus(ctx context.Context, in *idl.CheckUpgradeStatusRequest, opts ...grpc.CallOption) (*idl.CheckUpgradeStatusReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -49,12 +50,14 @@ func (m *MockAgentClient) CheckUpgradeStatus(ctx context.Context, in *idl.CheckU
 
 // CheckUpgradeStatus indicates an expected call of CheckUpgradeStatus
 func (mr *MockAgentClientMockRecorder) CheckUpgradeStatus(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckUpgradeStatus", reflect.TypeOf((*MockAgentClient)(nil).CheckUpgradeStatus), varargs...)
 }
 
 // CheckConversionStatus mocks base method
 func (m *MockAgentClient) CheckConversionStatus(ctx context.Context, in *idl.CheckConversionStatusRequest, opts ...grpc.CallOption) (*idl.CheckConversionStatusReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -67,12 +70,14 @@ func (m *MockAgentClient) CheckConversionStatus(ctx context.Context, in *idl.Che
 
 // CheckConversionStatus indicates an expected call of CheckConversionStatus
 func (mr *MockAgentClientMockRecorder) CheckConversionStatus(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckConversionStatus", reflect.TypeOf((*MockAgentClient)(nil).CheckConversionStatus), varargs...)
 }
 
 // CheckDiskSpaceOnAgents mocks base method
 func (m *MockAgentClient) CheckDiskSpaceOnAgents(ctx context.Context, in *idl.CheckDiskSpaceRequestToAgent, opts ...grpc.CallOption) (*idl.CheckDiskSpaceReplyFromAgent, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -85,12 +90,14 @@ func (m *MockAgentClient) CheckDiskSpaceOnAgents(ctx context.Context, in *idl.Ch
 
 // CheckDiskSpaceOnAgents indicates an expected call of CheckDiskSpaceOnAgents
 func (mr *MockAgentClientMockRecorder) CheckDiskSpaceOnAgents(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDiskSpaceOnAgents", reflect.TypeOf((*MockAgentClient)(nil).CheckDiskSpaceOnAgents), varargs...)
 }
 
 // PingAgents mocks base method
 func (m *MockAgentClient) PingAgents(ctx context.Context, in *idl.PingAgentsRequest, opts ...grpc.CallOption) (*idl.PingAgentsReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -103,12 +110,14 @@ func (m *MockAgentClient) PingAgents(ctx context.Context, in *idl.PingAgentsRequ
 
 // PingAgents indicates an expected call of PingAgents
 func (mr *MockAgentClientMockRecorder) PingAgents(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PingAgents", reflect.TypeOf((*MockAgentClient)(nil).PingAgents), varargs...)
 }
 
 // UpgradeConvertPrimarySegments mocks base method
 func (m *MockAgentClient) UpgradeConvertPrimarySegments(ctx context.Context, in *idl.UpgradeConvertPrimarySegmentsRequest, opts ...grpc.CallOption) (*idl.UpgradeConvertPrimarySegmentsReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -121,12 +130,14 @@ func (m *MockAgentClient) UpgradeConvertPrimarySegments(ctx context.Context, in 
 
 // UpgradeConvertPrimarySegments indicates an expected call of UpgradeConvertPrimarySegments
 func (mr *MockAgentClientMockRecorder) UpgradeConvertPrimarySegments(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeConvertPrimarySegments", reflect.TypeOf((*MockAgentClient)(nil).UpgradeConvertPrimarySegments), varargs...)
 }
 
 // CreateSegmentDataDirectories mocks base method
 func (m *MockAgentClient) CreateSegmentDataDirectories(ctx context.Context, in *idl.CreateSegmentDataDirRequest, opts ...grpc.CallOption) (*idl.CreateSegmentDataDirReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -139,12 +150,14 @@ func (m *MockAgentClient) CreateSegmentDataDirectories(ctx context.Context, in *
 
 // CreateSegmentDataDirectories indicates an expected call of CreateSegmentDataDirectories
 func (mr *MockAgentClientMockRecorder) CreateSegmentDataDirectories(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSegmentDataDirectories", reflect.TypeOf((*MockAgentClient)(nil).CreateSegmentDataDirectories), varargs...)
 }
 
 // CopyMasterDirectoryToSegmentDirectories mocks base method
 func (m *MockAgentClient) CopyMasterDirectoryToSegmentDirectories(ctx context.Context, in *idl.CopyMasterDirRequest, opts ...grpc.CallOption) (*idl.CopyMasterDirReply, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -157,6 +170,7 @@ func (m *MockAgentClient) CopyMasterDirectoryToSegmentDirectories(ctx context.Co
 
 // CopyMasterDirectoryToSegmentDirectories indicates an expected call of CopyMasterDirectoryToSegmentDirectories
 func (mr *MockAgentClientMockRecorder) CopyMasterDirectoryToSegmentDirectories(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyMasterDirectoryToSegmentDirectories", reflect.TypeOf((*MockAgentClient)(nil).CopyMasterDirectoryToSegmentDirectories), varargs...)
 }
@@ -186,6 +200,7 @@ func (m *MockAgentServer) EXPECT() *MockAgentServerMockRecorder {
 
 // CheckUpgradeStatus mocks base method
 func (m *MockAgentServer) CheckUpgradeStatus(arg0 context.Context, arg1 *idl.CheckUpgradeStatusRequest) (*idl.CheckUpgradeStatusReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckUpgradeStatus", arg0, arg1)
 	ret0, _ := ret[0].(*idl.CheckUpgradeStatusReply)
 	ret1, _ := ret[1].(error)
@@ -194,11 +209,13 @@ func (m *MockAgentServer) CheckUpgradeStatus(arg0 context.Context, arg1 *idl.Che
 
 // CheckUpgradeStatus indicates an expected call of CheckUpgradeStatus
 func (mr *MockAgentServerMockRecorder) CheckUpgradeStatus(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckUpgradeStatus", reflect.TypeOf((*MockAgentServer)(nil).CheckUpgradeStatus), arg0, arg1)
 }
 
 // CheckConversionStatus mocks base method
 func (m *MockAgentServer) CheckConversionStatus(arg0 context.Context, arg1 *idl.CheckConversionStatusRequest) (*idl.CheckConversionStatusReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckConversionStatus", arg0, arg1)
 	ret0, _ := ret[0].(*idl.CheckConversionStatusReply)
 	ret1, _ := ret[1].(error)
@@ -207,11 +224,13 @@ func (m *MockAgentServer) CheckConversionStatus(arg0 context.Context, arg1 *idl.
 
 // CheckConversionStatus indicates an expected call of CheckConversionStatus
 func (mr *MockAgentServerMockRecorder) CheckConversionStatus(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckConversionStatus", reflect.TypeOf((*MockAgentServer)(nil).CheckConversionStatus), arg0, arg1)
 }
 
 // CheckDiskSpaceOnAgents mocks base method
 func (m *MockAgentServer) CheckDiskSpaceOnAgents(arg0 context.Context, arg1 *idl.CheckDiskSpaceRequestToAgent) (*idl.CheckDiskSpaceReplyFromAgent, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckDiskSpaceOnAgents", arg0, arg1)
 	ret0, _ := ret[0].(*idl.CheckDiskSpaceReplyFromAgent)
 	ret1, _ := ret[1].(error)
@@ -220,11 +239,13 @@ func (m *MockAgentServer) CheckDiskSpaceOnAgents(arg0 context.Context, arg1 *idl
 
 // CheckDiskSpaceOnAgents indicates an expected call of CheckDiskSpaceOnAgents
 func (mr *MockAgentServerMockRecorder) CheckDiskSpaceOnAgents(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDiskSpaceOnAgents", reflect.TypeOf((*MockAgentServer)(nil).CheckDiskSpaceOnAgents), arg0, arg1)
 }
 
 // PingAgents mocks base method
 func (m *MockAgentServer) PingAgents(arg0 context.Context, arg1 *idl.PingAgentsRequest) (*idl.PingAgentsReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PingAgents", arg0, arg1)
 	ret0, _ := ret[0].(*idl.PingAgentsReply)
 	ret1, _ := ret[1].(error)
@@ -233,11 +254,13 @@ func (m *MockAgentServer) PingAgents(arg0 context.Context, arg1 *idl.PingAgentsR
 
 // PingAgents indicates an expected call of PingAgents
 func (mr *MockAgentServerMockRecorder) PingAgents(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PingAgents", reflect.TypeOf((*MockAgentServer)(nil).PingAgents), arg0, arg1)
 }
 
 // UpgradeConvertPrimarySegments mocks base method
 func (m *MockAgentServer) UpgradeConvertPrimarySegments(arg0 context.Context, arg1 *idl.UpgradeConvertPrimarySegmentsRequest) (*idl.UpgradeConvertPrimarySegmentsReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeConvertPrimarySegments", arg0, arg1)
 	ret0, _ := ret[0].(*idl.UpgradeConvertPrimarySegmentsReply)
 	ret1, _ := ret[1].(error)
@@ -246,11 +269,13 @@ func (m *MockAgentServer) UpgradeConvertPrimarySegments(arg0 context.Context, ar
 
 // UpgradeConvertPrimarySegments indicates an expected call of UpgradeConvertPrimarySegments
 func (mr *MockAgentServerMockRecorder) UpgradeConvertPrimarySegments(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeConvertPrimarySegments", reflect.TypeOf((*MockAgentServer)(nil).UpgradeConvertPrimarySegments), arg0, arg1)
 }
 
 // CreateSegmentDataDirectories mocks base method
 func (m *MockAgentServer) CreateSegmentDataDirectories(arg0 context.Context, arg1 *idl.CreateSegmentDataDirRequest) (*idl.CreateSegmentDataDirReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSegmentDataDirectories", arg0, arg1)
 	ret0, _ := ret[0].(*idl.CreateSegmentDataDirReply)
 	ret1, _ := ret[1].(error)
@@ -259,11 +284,13 @@ func (m *MockAgentServer) CreateSegmentDataDirectories(arg0 context.Context, arg
 
 // CreateSegmentDataDirectories indicates an expected call of CreateSegmentDataDirectories
 func (mr *MockAgentServerMockRecorder) CreateSegmentDataDirectories(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSegmentDataDirectories", reflect.TypeOf((*MockAgentServer)(nil).CreateSegmentDataDirectories), arg0, arg1)
 }
 
 // CopyMasterDirectoryToSegmentDirectories mocks base method
 func (m *MockAgentServer) CopyMasterDirectoryToSegmentDirectories(arg0 context.Context, arg1 *idl.CopyMasterDirRequest) (*idl.CopyMasterDirReply, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CopyMasterDirectoryToSegmentDirectories", arg0, arg1)
 	ret0, _ := ret[0].(*idl.CopyMasterDirReply)
 	ret1, _ := ret[1].(error)
@@ -272,5 +299,6 @@ func (m *MockAgentServer) CopyMasterDirectoryToSegmentDirectories(arg0 context.C
 
 // CopyMasterDirectoryToSegmentDirectories indicates an expected call of CopyMasterDirectoryToSegmentDirectories
 func (mr *MockAgentServerMockRecorder) CopyMasterDirectoryToSegmentDirectories(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyMasterDirectoryToSegmentDirectories", reflect.TypeOf((*MockAgentServer)(nil).CopyMasterDirectoryToSegmentDirectories), arg0, arg1)
 }


### PR DESCRIPTION
This is a followup to commit 0296161adc to also ensure the mockgen version matches the mock package version being used. We also bumped the mock version in Gopkg.toml to fix a compile bug.

