### PR TITLE
Fix make depend-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ depend-dev: depend
 		go install ./vendor/github.com/golang/protobuf/protoc-gen-go
 		go install ./vendor/github.com/golang/mock/mockgen
 		go get golang.org/x/tools/cmd/goimports
-		go get github.com/golang/lint/golint
+		go get golang.org/x/lint/golint
 		go get github.com/alecthomas/gometalinter
 		gometalinter --install
 


### PR DESCRIPTION
Update the lint dependency to one that works.
Fixes this error:
```
make depend-dev
go get github.com/onsi/ginkgo/ginkgo
go get github.com/golang/dep/cmd/dep
dep ensure
go install ./vendor/github.com/golang/protobuf/protoc-gen-go
go install ./vendor/github.com/golang/mock/mockgen
go get golang.org/x/tools/cmd/goimports
go get github.com/golang/lint/golint
can't load package: package github.com/golang/lint/golint: code in directory ~/go/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
make: *** [depend-dev] Error 1
```
https://github.com/golang/lint/issues/415