### PR TITLE
CI: use Go 1.12

### DIFF
--- a/ci/tasks/build.yml
+++ b/ci/tasks/build.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: '1.10.2'
+    tag: '1.12.7'
 
 inputs:
 - name: gpupgrade_src

--- a/ci/tasks/noinstall-tests.yml
+++ b/ci/tasks/noinstall-tests.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: '1.10.2'
+    tag: '1.12.7'
 
 inputs:
 - name: gpupgrade_src


### PR DESCRIPTION
noinstall-tests are failing because `exec.ExitError` does not have the `ExitCode` member defined; it was added to `os.ProcessState` in Go 1.12. The GPDB Docker images have already updated to 1.12.7, so use that version for now.