### PR TITLE
Execute: stream output for single-host steps

### DIFF
--- a/hub/services/execute.go
+++ b/hub/services/execute.go
@@ -1,16 +1,20 @@
 package services
 
 import (
+	"io"
+	"sync"
+
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpupgrade/idl"
 )
 
 func (h *Hub) Execute (request *idl.ExecuteRequest, stream idl.CliToHub_ExecuteServer) error {
-	err := h.ExecuteInitTargetClusterSubStep()
+	err := h.ExecuteInitTargetClusterSubStep(stream)
 	if err != nil {
 		return err
 	}
 
-	err = h.ExecuteShutdownClustersSubStep()
+	err = h.ExecuteShutdownClustersSubStep(stream)
 	if err != nil {
 		return err
 	}
@@ -30,6 +34,61 @@ func (h *Hub) Execute (request *idl.ExecuteRequest, stream idl.CliToHub_ExecuteS
 		return err
 	}
 
-	err = h.ExecuteStartTargetClusterSubStep()
+	err = h.ExecuteStartTargetClusterSubStep(stream)
 	return err
+}
+
+// multiplexedStream provides io.Writers that wrap both gRPC stream and a parallel
+// io.Writer (in case the gRPC stream closes) and safely serialize any
+// simultaneous writes.
+type multiplexedStream struct {
+	stream idl.CliToHub_ExecuteServer
+	writer io.Writer
+	mutex  sync.Mutex
+}
+
+func newMultiplexedStream(stream idl.CliToHub_ExecuteServer, writer io.Writer) *multiplexedStream {
+	return &multiplexedStream{
+		stream: stream,
+		writer: writer,
+	}
+}
+
+func (m *multiplexedStream) NewStreamWriter(cType idl.Chunk_Type) io.Writer {
+	return &streamWriter{
+		multiplexedStream: m,
+		cType:             cType,
+	}
+}
+
+type streamWriter struct {
+	*multiplexedStream
+	cType idl.Chunk_Type
+}
+
+func (w *streamWriter) Write(p []byte) (int, error) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	n, err := w.writer.Write(p)
+	if err != nil {
+		return n, err
+	}
+
+	if w.stream != nil {
+		// Attempt to send the chunk to the client. Since the client may close
+		// the connection at any point, errors here are logged and otherwise
+		// ignored. After the first send error, no more attempts are made.
+		err = w.stream.Send(&idl.Chunk{
+			Buffer: p,
+			Type:   w.cType,
+		})
+
+		if err != nil {
+			gplog.Info("halting client stream: %v", err)
+			w.stream = nil
+		}
+	}
+
+	return len(p), nil
 }

--- a/hub/services/execute_init_target_cluster_sub_step.go
+++ b/hub/services/execute_init_target_cluster_sub_step.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
@@ -19,7 +20,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func (h *Hub) ExecuteInitTargetClusterSubStep() error {
+func (h *Hub) ExecuteInitTargetClusterSubStep(stream idl.CliToHub_ExecuteServer) error {
 	gplog.Info("starting %s", upgradestatus.INIT_CLUSTER)
 
 	step, err := h.InitializeStep(upgradestatus.INIT_CLUSTER)
@@ -28,7 +29,7 @@ func (h *Hub) ExecuteInitTargetClusterSubStep() error {
 		return err
 	}
 
-	err = h.CreateTargetCluster()
+	err = h.CreateTargetCluster(stream)
 	if err != nil {
 		gplog.Error(err.Error())
 		step.MarkFailed()
@@ -39,59 +40,70 @@ func (h *Hub) ExecuteInitTargetClusterSubStep() error {
 	return err
 }
 
-func (h *Hub) CreateTargetCluster() error {
+func (h *Hub) CreateTargetCluster(stream idl.CliToHub_ExecuteServer) error {
 	sourceDBConn := db.NewDBConn("localhost", int(h.source.MasterPort()), "template1")
 
-	targetDBConn, err := h.InitTargetCluster(sourceDBConn)
+	targetPort, err := h.InitTargetCluster(stream, sourceDBConn)
 	if err != nil {
-		return errors.Wrap(err, "failed to connect to old database")
+		gplog.Error("failed to initialize new cluster due to %s", err.Error())
+		return errors.Wrap(err, "failed to initialize the new cluster")
 	}
 
+	targetDBConn := db.NewDBConn("localhost", targetPort, "template1")
 	return ReloadAndCommitCluster(h.target, targetDBConn)
 }
 
-func (h *Hub) InitTargetCluster(sourceDBConn *dbconn.DBConn) (*dbconn.DBConn, error) {
+func (h *Hub) InitTargetCluster(stream idl.CliToHub_ExecuteServer, sourceDBConn *dbconn.DBConn) (int, error) {
 	err := sourceDBConn.Connect(1)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not connect to database")
+		return -1, errors.Wrap(err, "could not connect to database")
 	}
 	defer sourceDBConn.Close()
 
-	gpinitsystemConfig, err := h.CreateInitialInitsystemConfig()
+	gpinitsystemConfig, err := CreateInitialInitsystemConfig(h.source.MasterDataDir())
 	if err != nil {
-		return nil, err
+		return -1, err
 	}
 
 	gpinitsystemConfig, err = GetCheckpointSegmentsAndEncoding(gpinitsystemConfig, sourceDBConn)
 	if err != nil {
-		return nil, err
+		return -1, err
 	}
 
 	agentConns := []*Connection{}
 	agentConns, err = h.AgentConns()
 	if err != nil {
-		return nil, errors.Wrap(err, "Could not get/create agents")
+		return -1, errors.Wrap(err, "Could not get/create agents")
 	}
 
-	gpinitsystemConfig, segmentDataDirMap, targetPort := h.DeclareDataDirectories(gpinitsystemConfig)
-	err = h.CreateAllDataDirectories(agentConns, segmentDataDirMap)
+	gpinitsystemConfig, segmentDataDirMap, targetPort := DeclareDataDirectories(h.source, gpinitsystemConfig)
+	err = CreateAllDataDirectories(h.source.MasterDataDir(), agentConns, segmentDataDirMap)
 	if err != nil {
-		return nil, err
+		return -1, err
 	}
 
 	gpinitsystemFilepath := filepath.Join(h.conf.StateDir, "gpinitsystem_config")
 	err = WriteInitsystemFile(gpinitsystemConfig, gpinitsystemFilepath)
 	if err != nil {
-		return nil, err
+		return -1, err
 	}
 
-	err = h.RunInitsystemForTargetCluster(gpinitsystemFilepath)
-	if err != nil {
-		return nil, err
+	err = RunInitsystemForTargetCluster(stream, gpinitsystemFilepath, h.target.BinDir)
+
+	var gpinitsystemWarning bool
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		// gpinitsystem exits with 1 on warnings and 2 on errors. Continue gpupgrade even when gpinitsystem has warnings.
+		gpinitsystemWarning = exitErr.ExitCode() == 1
+		if gpinitsystemWarning {
+			gplog.Warn("gpinitsystem had warnings and exited with status %d", exitErr.ExitCode())
+		}
 	}
 
-	targetDBConn := db.NewDBConn("localhost", targetPort, "template1")
-	return targetDBConn, nil
+	if err != nil && !gpinitsystemWarning {
+		return -1, err
+	}
+
+	return targetPort, nil
 }
 
 func GetCheckpointSegmentsAndEncoding(gpinitsystemConfig []string, dbConnector *dbconn.DBConn) ([]string, error) {
@@ -109,18 +121,15 @@ func GetCheckpointSegmentsAndEncoding(gpinitsystemConfig []string, dbConnector *
 	return gpinitsystemConfig, nil
 }
 
-func (h *Hub) CreateInitialInitsystemConfig() ([]string, error) {
+func CreateInitialInitsystemConfig(sourceClusterMasterDataDir string) ([]string, error) {
 	gpinitsystemConfig := []string{`ARRAY_NAME="gp_upgrade cluster"`}
 
-	//seg prefix
-	sourceDataDir := h.source.MasterDataDir()
-
-	segPrefix, err := GetMasterSegPrefix(sourceDataDir)
+	segPrefix, err := GetMasterSegPrefix(sourceClusterMasterDataDir)
 	if err != nil {
 		return gpinitsystemConfig, errors.Wrap(err, "Could not get master segment prefix")
 	}
 
-	gplog.Info("Data Dir: %s", sourceDataDir)
+	gplog.Info("Data Dir: %s", sourceClusterMasterDataDir)
 	gplog.Info("segPrefix: %v", segPrefix)
 	gpinitsystemConfig = append(gpinitsystemConfig, "SEG_PREFIX="+segPrefix, "TRUSTED_SHELL=ssh")
 
@@ -137,9 +146,9 @@ func WriteInitsystemFile(gpinitsystemConfig []string, gpinitsystemFilepath strin
 	return nil
 }
 
-func (h *Hub) DeclareDataDirectories(gpinitsystemConfig []string) ([]string, map[string][]string, int) {
+func DeclareDataDirectories(sourceCluster *utils.Cluster, gpinitsystemConfig []string) ([]string, map[string][]string, int) {
 	// declare master data directory
-	master := h.source.Segments[-1]
+	master := sourceCluster.Segments[-1]
 	master.Port++
 	master.DataDir = fmt.Sprintf("%s_upgrade/%s", path.Dir(master.DataDir), path.Base(master.DataDir))
 	datadirDeclare := fmt.Sprintf("QD_PRIMARY_ARRAY=%s~%d~%s~%d~%d~0",
@@ -148,9 +157,9 @@ func (h *Hub) DeclareDataDirectories(gpinitsystemConfig []string) ([]string, map
 	// declare segment data directories
 	segmentDataDirMap := map[string][]string{}
 	segmentDeclarations := []string{}
-	for _, content := range h.source.ContentIDs {
+	for _, content := range sourceCluster.ContentIDs {
 		if content != -1 {
-			segment := h.source.Segments[content]
+			segment := sourceCluster.Segments[content]
 			// FIXME: Arbitrary assumption.	 Do something smarter later
 			segment.Port += 4000
 			datadir := fmt.Sprintf("%s_upgrade", path.Dir(segment.DataDir))
@@ -167,9 +176,9 @@ func (h *Hub) DeclareDataDirectories(gpinitsystemConfig []string) ([]string, map
 	return gpinitsystemConfig, segmentDataDirMap, master.Port
 }
 
-func (h *Hub) CreateAllDataDirectories(agentConns []*Connection, segmentDataDirMap map[string][]string) error {
+func CreateAllDataDirectories(sourceClusterMasterDataDir string, agentConns []*Connection, segmentDataDirMap map[string][]string) error {
 	// create master data directory for gpinitsystem if it doesn't exist
-	targetDataDir := path.Dir(h.source.MasterDataDir()) + "_upgrade"
+	targetDataDir := path.Dir(sourceClusterMasterDataDir) + "_upgrade"
 	_, err := utils.System.Stat(targetDataDir)
 	if os.IsNotExist(err) {
 		err = utils.System.MkdirAll(targetDataDir, 0755)
@@ -182,29 +191,26 @@ func (h *Hub) CreateAllDataDirectories(agentConns []*Connection, segmentDataDirM
 	// create segment data directories for gpinitsystem if they don't exist
 	err = CreateSegmentDataDirectories(agentConns, segmentDataDirMap)
 	if err != nil {
-		return errors.Wrap(err, "Could not create segment data directories")
+		return errors.Wrap(err, "failed to create segment data directories")
 	}
 	return nil
 }
 
-func (h *Hub) RunInitsystemForTargetCluster(gpinitsystemFilepath string) error {
-	// gpinitsystem the new cluster
-	gphome := filepath.Dir(path.Clean(h.target.BinDir)) //works around https://github.com/golang/go/issues/4837 in go10.4
-	cmdStr := fmt.Sprintf("source %s/greenplum_path.sh; %s/gpinitsystem -a -I %s",
-		gphome,
-		h.target.BinDir,
-		gpinitsystemFilepath)
+func RunInitsystemForTargetCluster(stream idl.CliToHub_ExecuteServer, gpinitsystemFilepath string, targetBinDir string) error {
+	gphome := filepath.Dir(path.Clean(targetBinDir)) //works around https://github.com/golang/go/issues/4837 in go10.4
 
-	output, err := h.source.Executor.ExecuteLocalCommand(cmdStr)
-	if err != nil {
-		// gpinitsystem has a return code of 1 for warnings, so we can ignore that return code
-		if err.Error() == "exit status 1" {
-			gplog.Warn("gpinitsystem completed with warnings")
-			return nil
-		}
-		return errors.Wrapf(err, "gpinitsystem failed: %s", output)
-	}
-	return nil
+	cmd := execCommand("bash", "-c",
+		fmt.Sprintf("source %s/greenplum_path.sh && %s/bin/gpinitsystem -a -I %s",
+			gphome,
+			gphome,
+			gpinitsystemFilepath,
+		))
+
+	mux := newMultiplexedStream(stream, ioutil.Discard)
+	cmd.Stdout = mux.NewStreamWriter(idl.Chunk_STDOUT)
+	cmd.Stderr = mux.NewStreamWriter(idl.Chunk_STDERR)
+
+	return cmd.Run()
 }
 
 func GetMasterSegPrefix(datadir string) (string, error) {

--- a/hub/services/execute_init_target_cluster_sub_step_test.go
+++ b/hub/services/execute_init_target_cluster_sub_step_test.go
@@ -170,14 +170,6 @@ var _ = Describe("Hub prepare init-cluster", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		//It("successfully runs gpinitsystem", func() {
-		//	testExecutor.LocalError = errors.New("exit status 1")
-		//	err := hub.RunInitsystemForTargetCluster(mockStream, "filepath")
-		//
-		//	Expect(err).To(BeNil())
-		//	testhelper.ExpectRegexp(stdout, "[WARNING]:-gpinitsystem completed with warnings")
-		//})
-
 		It("gpinitsystem fails", func() {
 			execCommand = exectest.NewCommand(FailedMain)
 

--- a/hub/services/execute_shutdown_clusters_sub_step.go
+++ b/hub/services/execute_shutdown_clusters_sub_step.go
@@ -2,15 +2,22 @@ package services
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os/exec"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
-	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
-	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
+	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/utils"
 )
 
-func (h *Hub) ExecuteShutdownClustersSubStep() error {
+var execCommandStopCluster = exec.Command
+var execCommandIsPostmasterRunning = exec.Command
+
+func (h *Hub) ExecuteShutdownClustersSubStep(stream idl.CliToHub_ExecuteServer) error {
 	gplog.Info("starting %s", upgradestatus.SHUTDOWN_CLUSTERS)
 
 	step, err := h.InitializeStep(upgradestatus.SHUTDOWN_CLUSTERS)
@@ -19,7 +26,7 @@ func (h *Hub) ExecuteShutdownClustersSubStep() error {
 		return err
 	}
 
-	err = h.ShutdownClusters()
+	err = h.ShutdownClusters(stream)
 	if err != nil {
 		gplog.Error(err.Error())
 		step.MarkFailed()
@@ -30,49 +37,50 @@ func (h *Hub) ExecuteShutdownClustersSubStep() error {
 	return err
 }
 
-func (h *Hub) ShutdownClusters() error {
+func (h *Hub) ShutdownClusters(stream idl.CliToHub_ExecuteServer) error {
 	var shutdownErr error
 
-	err := StopCluster(h.source)
+	err := StopCluster(stream, h.source)
 	if err != nil {
-		shutdownErr = multierror.Append(shutdownErr, errors.Wrap(err, "failed to stop source cluster"))
+		shutdownErr = multierror.Append(shutdownErr, errors.Wrap(err, "failed to stop old cluster"))
 	}
 
-	err = StopCluster(h.target)
+	err = StopCluster(stream, h.target)
 	if err != nil {
-		shutdownErr = multierror.Append(shutdownErr, errors.Wrap(err, "failed to stop target cluster"))
+		shutdownErr = multierror.Append(shutdownErr, errors.Wrap(err, "failed to stop new cluster"))
 	}
 
 	return shutdownErr
 }
 
-func StopCluster(c *utils.Cluster) error {
-	if !IsPostmasterRunning(c) {
-		return nil
-	}
-
-	masterDataDir := c.MasterDataDir()
-	gpstopShellArgs := fmt.Sprintf("source %[1]s/../greenplum_path.sh; %[1]s/gpstop -a -d %[2]s", c.BinDir, masterDataDir)
-
-	gplog.Info("gpstop args: %+v", gpstopShellArgs)
-	_, err := c.ExecuteLocalCommand(gpstopShellArgs)
+func StopCluster(stream idl.CliToHub_ExecuteServer, c *utils.Cluster) error {
+	err := IsPostmasterRunning(stream, c)
 	if err != nil {
 		return err
 	}
 
-	return nil
+	cmd := execCommandStopCluster("bash", "-c",
+			fmt.Sprintf("source %[1]s/../greenplum_path.sh && %[1]s/gpstop -a -d %[2]s",
+				c.BinDir,
+				c.MasterDataDir(),
+			))
+
+	mux := newMultiplexedStream(stream, ioutil.Discard)
+	cmd.Stdout = mux.NewStreamWriter(idl.Chunk_STDOUT)
+	cmd.Stderr = mux.NewStreamWriter(idl.Chunk_STDERR)
+
+	return cmd.Run()
 }
 
-func IsPostmasterRunning(c *utils.Cluster) bool {
-	masterDataDir := c.MasterDataDir()
-	checkPidCmd := fmt.Sprintf("pgrep -F %s/postmaster.pid", masterDataDir)
+func IsPostmasterRunning(stream idl.CliToHub_ExecuteServer, c *utils.Cluster) error {
+	cmd := execCommandIsPostmasterRunning("bash", "-c",
+		fmt.Sprintf("pgrep -F %s/postmaster.pid",
+			c.MasterDataDir(),
+		))
 
-	_, err := c.ExecuteLocalCommand(checkPidCmd)
-	if err != nil {
-		gplog.Error("Could not determine whether the cluster with MASTER_DATA_DIRECTORY: %s is running: %+v",
-			masterDataDir, err)
-		return false
-	}
+	mux := newMultiplexedStream(stream, ioutil.Discard)
+	cmd.Stdout = mux.NewStreamWriter(idl.Chunk_STDOUT)
+	cmd.Stderr = mux.NewStreamWriter(idl.Chunk_STDERR)
 
-	return true
+	return cmd.Run()
 }

--- a/hub/services/execute_shutdown_clusters_sub_step_test.go
+++ b/hub/services/execute_shutdown_clusters_sub_step_test.go
@@ -1,64 +1,109 @@
-package services_test
+package services
 
 import (
-	"errors"
 	"os"
 
-	"github.com/greenplum-db/gpupgrade/hub/services"
+	"github.com/golang/mock/gomock"
+
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/greenplum-db/gp-common-go-libs/dbconn"
+
+	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
+	"github.com/greenplum-db/gpupgrade/testutils/exectest"
 	"github.com/greenplum-db/gpupgrade/utils"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
+func FailedMain() {
+	os.Exit(1)
+}
+
+func init() {
+	exectest.RegisterMains(
+		EmptyMain,
+		FailedMain,
+	)
+}
+
 var _ = Describe("ExecuteShutdownClustersSubStep", func() {
+	var ctrl       *gomock.Controller
+	var mockStream *mock_idl.MockCliToHub_ExecuteServer
+	var source     *utils.Cluster
+
 	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockStream = mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
+		cluster := cluster.NewCluster([]cluster.SegConfig{cluster.SegConfig{ContentID: -1, DbID: 1, Port: 15432, Hostname: "localhost", DataDir: "basedir/seg-1"}})
+		source = &utils.Cluster{
+			Cluster:    cluster,
+			BinDir:     "/source/bindir",
+			ConfigPath: "my/config/path",
+			Version:    dbconn.GPDBVersion{},
+		}
 		utils.System.RemoveAll = func(s string) error { return nil }
 		utils.System.MkdirAll = func(s string, perm os.FileMode) error { return nil }
+
+		mockStream := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
+
+		mockStream.EXPECT().
+			Send(gomock.Any()).
+			AnyTimes()
+
+		execCommandIsPostmasterRunning = nil
+		execCommandStopCluster = nil
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	It("isPostmasterRunning() succeeds", func() {
-		testExecutor := &testhelper.TestExecutor{}
-		source.Executor = testExecutor
+		execCommandIsPostmasterRunning = exectest.NewCommandWithVerifier(EmptyMain,
+			func(path string, args ...string) {
+				Expect(path).To(Equal("bash"))
+				Expect(args).To(Equal([]string{"-c", "pgrep -F basedir/seg-1/postmaster.pid"}))
+			})
 
-		postmasterRunning := services.IsPostmasterRunning(source)
-		Expect(testExecutor.LocalCommands[0]).To(ContainSubstring("pgrep"))
-		Expect(postmasterRunning).To(BeTrue())
+		err := IsPostmasterRunning(mockStream, source)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("isPostmasterRunning() fails", func() {
-		testExecutor := &testhelper.TestExecutor{}
-		testExecutor.LocalError = errors.New("some error message")
-		source.Executor = testExecutor
+		execCommandIsPostmasterRunning = exectest.NewCommand(FailedMain)
 
-		postmasterRunning := services.IsPostmasterRunning(source)
-		Expect(testExecutor.LocalCommands[0]).To(ContainSubstring("pgrep"))
-		Expect(postmasterRunning).To(BeFalse())
+		err := IsPostmasterRunning(mockStream, source)
+		Expect(err).To(HaveOccurred())
 	})
 
-	It("stopCluster() succeesfully shuts down cluster", func() {
-		testExecutor := &testhelper.TestExecutor{}
-		source.Executor = testExecutor
+	It("stopCluster() successfully shuts down cluster", func() {
+		execCommandIsPostmasterRunning = exectest.NewCommandWithVerifier(EmptyMain,
+			func(path string, args ...string) {
+				Expect(path).To(Equal("bash"))
+				Expect(args).To(Equal([]string{"-c", "pgrep -F basedir/seg-1/postmaster.pid"}))
+			})
 
-		err := services.StopCluster(source)
+		execCommandStopCluster = exectest.NewCommandWithVerifier(EmptyMain,
+			func(path string, args ...string) {
+				Expect(path).To(Equal("bash"))
+				Expect(args).To(Equal([]string{"-c", "source /source/bindir/../greenplum_path.sh && /source/bindir/gpstop -a -d basedir/seg-1"}))
+			})
 
-		Expect(testExecutor.NumExecutions).To(Equal(2))
-		Expect(testExecutor.LocalCommands[0]).To(ContainSubstring("pgrep"))
-		Expect(testExecutor.LocalCommands[1]).To(ContainSubstring("gpstop"))
+		err := StopCluster(mockStream, source)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("stopCluster() detects that cluster is already shutdown", func() {
-		testExecutor := &testhelper.TestExecutor{}
-		testExecutor.LocalError = errors.New("some error message")
-		source.Executor = testExecutor
+		execCommandIsPostmasterRunning = exectest.NewCommand(FailedMain)
+		var skippedStopClusterCommand = true
+		execCommandStopCluster = exectest.NewCommandWithVerifier(EmptyMain,
+			func(path string, args ...string) {
+				skippedStopClusterCommand = false
+			})
 
-		err := services.StopCluster(source)
-
-		Expect(testExecutor.NumExecutions).To(Equal(1))
-		Expect(testExecutor.LocalCommands[0]).To(ContainSubstring("pgrep"))
-		Expect(err).ToNot(HaveOccurred())
+		err := StopCluster(mockStream, source)
+		Expect(err).To(HaveOccurred())
+		Expect(skippedStopClusterCommand).To(Equal(true))
 	})
-
 })

--- a/hub/services/execute_test.go
+++ b/hub/services/execute_test.go
@@ -1,0 +1,250 @@
+package services
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+
+	"github.com/golang/mock/gomock"
+	"github.com/onsi/gomega/gbytes"
+
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
+	"github.com/greenplum-db/gpupgrade/testutils/exectest"
+	"github.com/greenplum-db/gpupgrade/utils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const StreamingMainStdout = "expected\nstdout\n"
+const StreamingMainStderr = "process\nstderr\n"
+
+// Streams the above stdout/err constants to the corresponding standard file
+// descriptors, alternately interleaving five-byte chunks.
+func StreamingMain() {
+	stdout := bytes.NewBufferString(StreamingMainStdout)
+	stderr := bytes.NewBufferString(StreamingMainStderr)
+
+	for stdout.Len() > 0 || stderr.Len() > 0 {
+		os.Stdout.Write(stdout.Next(5))
+		os.Stderr.Write(stderr.Next(5))
+	}
+}
+
+// Streams exactly ten bytes ('O' on stdout and 'E' on stderr) per standard
+// stream.
+func TenByteMain() {
+	for i := 0; i < 10; i++ {
+		os.Stdout.Write([]byte{'O'})
+		os.Stderr.Write([]byte{'E'})
+	}
+}
+
+// Writes to stdout and ignores any failure to do so.
+func BlindlyWritingMain() {
+	// Ignore SIGPIPE. Note that the obvious signal.Ignore(syscall.SIGPIPE)
+	// doesn't work as expected; see https://github.com/golang/go/issues/32386.
+	signal.Notify(make(chan os.Signal), syscall.SIGPIPE)
+
+	fmt.Println("blah blah blah blah")
+	fmt.Println("blah blah blah blah")
+	fmt.Println("blah blah blah blah")
+}
+
+
+
+func init() {
+	exectest.RegisterMains(
+		StreamingMain,
+		TenByteMain,
+		BlindlyWritingMain,
+	)
+}
+
+// NewFailingWriter creates an io.Writer that will fail with the given error.
+func NewFailingWriter(err error) io.Writer {
+	return &failingWriter{
+		err: err,
+	}
+}
+
+type failingWriter struct {
+	err error
+}
+
+func (f *failingWriter) Write(_ []byte) (int, error) {
+	return 0, f.err
+}
+
+var _ = Describe("multiplex stream", func() {
+	var pair clusterPair   // the unit under test
+	var log *gbytes.Buffer // contains gplog output
+
+	BeforeEach(func() {
+		// Disable exec.Command. This way, if a test forgets to mock it out, we
+		// crash the test instead of executing code on a dev system.
+		execCommand = nil
+
+		// Store gplog output.
+		_, _, log = testhelper.SetupTestLogger()
+
+		// Initialize the sample cluster pair.
+		pair = clusterPair{
+			Source: &utils.Cluster{
+				BinDir: "/old/bin",
+				Cluster: &cluster.Cluster{
+					ContentIDs: []int{-1},
+					Segments: map[int]cluster.SegConfig{
+						-1: cluster.SegConfig{
+							Port:    5432,
+							DataDir: "/data/old",
+						},
+					},
+				},
+			},
+			Target: &utils.Cluster{
+				BinDir: "/new/bin",
+				Cluster: &cluster.Cluster{
+					ContentIDs: []int{-1},
+					Segments: map[int]cluster.SegConfig{
+						-1: cluster.SegConfig{
+							Port:    5433,
+							DataDir: "/data/new",
+						},
+					},
+				},
+			},
+		}
+	})
+
+	AfterEach(func() {
+		execCommand = exec.Command
+	})
+
+	It("streams stdout and stderr to the client", func() {
+		ctrl := gomock.NewController(GinkgoT())
+		defer ctrl.Finish()
+
+		// We can't rely on each write from the subprocess to result in exactly
+		// one call to stream.Send(). Instead, concatenate the byte buffers as
+		// they are sent and compare them at the end.
+		mockStream := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+
+		mockStream.EXPECT().
+			Send(gomock.Any()).
+			AnyTimes(). // Send will be called an indeterminate number of times
+			DoAndReturn(func(c *idl.Chunk) error {
+				defer GinkgoRecover()
+
+				var buf *bytes.Buffer
+
+				switch c.Type {
+				case idl.Chunk_STDOUT:
+					buf = &stdout
+				case idl.Chunk_STDERR:
+					buf = &stderr
+				default:
+					Fail("unexpected chunk type")
+				}
+
+				buf.Write(c.Buffer)
+				return nil
+			})
+
+		execCommand = exectest.NewCommand(StreamingMain)
+
+		err := pair.ConvertMaster(mockStream, ioutil.Discard, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(stdout.String()).To(Equal(StreamingMainStdout))
+		Expect(stderr.String()).To(Equal(StreamingMainStderr))
+	})
+
+	It("also writes all data to a local io.Writer", func() {
+		ctrl := gomock.NewController(GinkgoT())
+		defer ctrl.Finish()
+
+		mockStream := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
+		mockStream.EXPECT().
+			Send(gomock.Any()).
+			AnyTimes()
+
+		// Write ten bytes each to stdout/err.
+		execCommand = exectest.NewCommand(TenByteMain)
+
+		var buf bytes.Buffer
+		err := pair.ConvertMaster(mockStream, &buf, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Stdout and stderr are not guaranteed to interleave in any particular
+		// order. Just count the number of bytes in each that we see (there
+		// should be exactly ten).
+		numO := 0
+		numE := 0
+		for _, b := range buf.Bytes() {
+			switch b {
+			case 'O':
+				numO++
+			case 'E':
+				numE++
+			default:
+				Fail(fmt.Sprintf("unexpected byte %#v in output %#v", b, buf.String()))
+			}
+		}
+
+		Expect(numO).To(Equal(10))
+		Expect(numE).To(Equal(10))
+	})
+
+	It("returns an error if the command succeeds but the io.Writer fails", func() {
+		ctrl := gomock.NewController(GinkgoT())
+		defer ctrl.Finish()
+
+		mockStream := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
+		mockStream.EXPECT().
+			Send(gomock.Any()).
+			AnyTimes()
+
+		// Don't fail in the subprocess even when the stdout stream is closed.
+		execCommand = exectest.NewCommand(BlindlyWritingMain)
+
+		expectedErr := errors.New("write failed!")
+		err := pair.ConvertMaster(mockStream, NewFailingWriter(expectedErr), "")
+
+		Expect(err).To(Equal(expectedErr))
+	})
+
+	It("continues writing to the local io.Writer even if Send fails", func() {
+		ctrl := gomock.NewController(GinkgoT())
+		defer ctrl.Finish()
+
+		// Return an error during Send.
+		mockStream := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
+		mockStream.EXPECT().
+			Send(gomock.Any()).
+			Return(errors.New("error during send")).
+			Times(1) // we expect only one failed attempt to Send
+
+		// Write ten bytes each to stdout/err.
+		execCommand = exectest.NewCommand(TenByteMain)
+
+		var buf bytes.Buffer
+		err := pair.ConvertMaster(mockStream, &buf, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		// The Writer should not have been affected in any way.
+		Expect(buf.Bytes()).To(HaveLen(20))
+		Expect(log).To(gbytes.Say("halting client stream: error during send"))
+	})
+})

--- a/hub/services/execute_upgrade_master_sub_step_test.go
+++ b/hub/services/execute_upgrade_master_sub_step_test.go
@@ -3,65 +3,23 @@ package services
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path/filepath"
-	"syscall"
 
 	"github.com/golang/mock/gomock"
-
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"github.com/greenplum-db/gpupgrade/idl"
+
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
 	"github.com/greenplum-db/gpupgrade/utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
 )
-
-const StreamingMainStdout = "expected\nstdout\n"
-const StreamingMainStderr = "process\nstderr\n"
-
-// Streams the above stdout/err constants to the corresponding standard file
-// descriptors, alternately interleaving five-byte chunks.
-func StreamingMain() {
-	stdout := bytes.NewBufferString(StreamingMainStdout)
-	stderr := bytes.NewBufferString(StreamingMainStderr)
-
-	for stdout.Len() > 0 || stderr.Len() > 0 {
-		os.Stdout.Write(stdout.Next(5))
-		os.Stderr.Write(stderr.Next(5))
-	}
-}
-
-// Streams exactly ten bytes ('O' on stdout and 'E' on stderr) per standard
-// stream.
-func TenByteMain() {
-	for i := 0; i < 10; i++ {
-		os.Stdout.Write([]byte{'O'})
-		os.Stderr.Write([]byte{'E'})
-	}
-}
-
-// Writes to stdout and ignores any failure to do so.
-func BlindlyWritingMain() {
-	// Ignore SIGPIPE. Note that the obvious signal.Ignore(syscall.SIGPIPE)
-	// doesn't work as expected; see https://github.com/golang/go/issues/32386.
-	signal.Notify(make(chan os.Signal), syscall.SIGPIPE)
-
-	fmt.Println("blah blah blah blah")
-	fmt.Println("blah blah blah blah")
-	fmt.Println("blah blah blah blah")
-}
 
 // Does nothing.
 func EmptyMain() {}
@@ -86,41 +44,19 @@ func EnvironmentMain() {
 
 func init() {
 	exectest.RegisterMains(
-		StreamingMain,
-		TenByteMain,
-		BlindlyWritingMain,
 		EmptyMain,
 		WorkingDirectoryMain,
 		EnvironmentMain,
 	)
 }
 
-// NewFailingWriter creates an io.Writer that will fail with the given error.
-func NewFailingWriter(err error) io.Writer {
-	return &failingWriter{
-		err: err,
-	}
-}
-
-type failingWriter struct {
-	err error
-}
-
-func (f *failingWriter) Write(_ []byte) (int, error) {
-	return 0, f.err
-}
-
 var _ = Describe("ConvertMaster", func() {
 	var pair clusterPair   // the unit under test
-	var log *gbytes.Buffer // contains gplog output
 
 	BeforeEach(func() {
 		// Disable exec.Command. This way, if a test forgets to mock it out, we
 		// crash the test instead of executing code on a dev system.
 		execCommand = nil
-
-		// Store gplog output.
-		_, _, log = testhelper.SetupTestLogger()
 
 		// Initialize the sample cluster pair.
 		pair = clusterPair{
@@ -153,124 +89,6 @@ var _ = Describe("ConvertMaster", func() {
 
 	AfterEach(func() {
 		execCommand = exec.Command
-	})
-
-	It("streams stdout and stderr to the client", func() {
-		ctrl := gomock.NewController(GinkgoT())
-		defer ctrl.Finish()
-
-		// We can't rely on each write from the subprocess to result in exactly
-		// one call to stream.Send(). Instead, concatenate the byte buffers as
-		// they are sent and compare them at the end.
-		mockStream := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
-		var stdout bytes.Buffer
-		var stderr bytes.Buffer
-
-		mockStream.EXPECT().
-			Send(gomock.Any()).
-			AnyTimes(). // Send will be called an indeterminate number of times
-			DoAndReturn(func(c *idl.Chunk) error {
-				defer GinkgoRecover()
-
-				var buf *bytes.Buffer
-
-				switch c.Type {
-				case idl.Chunk_STDOUT:
-					buf = &stdout
-				case idl.Chunk_STDERR:
-					buf = &stderr
-				default:
-					Fail("unexpected chunk type")
-				}
-
-				buf.Write(c.Buffer)
-				return nil
-			})
-
-		execCommand = exectest.NewCommand(StreamingMain)
-
-		err := pair.ConvertMaster(mockStream, ioutil.Discard, "")
-		Expect(err).NotTo(HaveOccurred())
-
-		Expect(stdout.String()).To(Equal(StreamingMainStdout))
-		Expect(stderr.String()).To(Equal(StreamingMainStderr))
-	})
-
-	It("also writes all data to a local io.Writer", func() {
-		ctrl := gomock.NewController(GinkgoT())
-		defer ctrl.Finish()
-
-		mockStream := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
-		mockStream.EXPECT().
-			Send(gomock.Any()).
-			AnyTimes()
-
-		// Write ten bytes each to stdout/err.
-		execCommand = exectest.NewCommand(TenByteMain)
-
-		var buf bytes.Buffer
-		err := pair.ConvertMaster(mockStream, &buf, "")
-		Expect(err).NotTo(HaveOccurred())
-
-		// Stdout and stderr are not guaranteed to interleave in any particular
-		// order. Just count the number of bytes in each that we see (there
-		// should be exactly ten).
-		numO := 0
-		numE := 0
-		for _, b := range buf.Bytes() {
-			switch b {
-			case 'O':
-				numO++
-			case 'E':
-				numE++
-			default:
-				Fail(fmt.Sprintf("unexpected byte %#v in output %#v", b, buf.String()))
-			}
-		}
-
-		Expect(numO).To(Equal(10))
-		Expect(numE).To(Equal(10))
-	})
-
-	It("returns an error if the command succeeds but the io.Writer fails", func() {
-		ctrl := gomock.NewController(GinkgoT())
-		defer ctrl.Finish()
-
-		mockStream := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
-		mockStream.EXPECT().
-			Send(gomock.Any()).
-			AnyTimes()
-
-		// Don't fail in the subprocess even when the stdout stream is closed.
-		execCommand = exectest.NewCommand(BlindlyWritingMain)
-
-		expectedErr := errors.New("write failed!")
-		err := pair.ConvertMaster(mockStream, NewFailingWriter(expectedErr), "")
-
-		Expect(err).To(Equal(expectedErr))
-	})
-
-	It("continues writing to the local io.Writer even if Send fails", func() {
-		ctrl := gomock.NewController(GinkgoT())
-		defer ctrl.Finish()
-
-		// Return an error during Send.
-		mockStream := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
-		mockStream.EXPECT().
-			Send(gomock.Any()).
-			Return(errors.New("error during send")).
-			Times(1) // we expect only one failed attempt to Send
-
-		// Write ten bytes each to stdout/err.
-		execCommand = exectest.NewCommand(TenByteMain)
-
-		var buf bytes.Buffer
-		err := pair.ConvertMaster(mockStream, &buf, "")
-		Expect(err).NotTo(HaveOccurred())
-
-		// The Writer should not have been affected in any way.
-		Expect(buf.Bytes()).To(HaveLen(20))
-		Expect(log).To(gbytes.Say("halting client stream: error during send"))
 	})
 
 	It("calls pg_upgrade with the expected options", func() {

--- a/hub/services/execute_upgrade_primaries_sub_step.go
+++ b/hub/services/execute_upgrade_primaries_sub_step.go
@@ -7,10 +7,10 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 
-	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
 	"github.com/greenplum-db/gpupgrade/idl"
 )

--- a/hub/services/execute_upgrade_primaries_sub_step_test.go
+++ b/hub/services/execute_upgrade_primaries_sub_step_test.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"path/filepath"
 
-	"github.com/greenplum-db/gpupgrade/idl"
-
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
+
+	"github.com/greenplum-db/gpupgrade/idl"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/hub/services/services_suite_test.go
+++ b/hub/services/services_suite_test.go
@@ -24,6 +24,7 @@ var (
 	ctrl        *gomock.Controller
 	dbConnector *dbconn.DBConn
 	mock        sqlmock.Sqlmock
+	mockStream  *mock_idl.MockCliToHub_ExecuteServer
 	mockAgent   *testutils.MockAgentServer
 	dialer      services.Dialer
 	client      *mock_idl.MockAgentClient
@@ -56,6 +57,7 @@ var _ = BeforeEach(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	source, target = testutils.CreateMultinodeSampleClusterPair(dir)
+	mockStream = mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
 	mockAgent, dialer, port = testutils.NewMockAgentServer()
 	client = mock_idl.NewMockAgentClient(ctrl)
 	hubConf = &services.HubConfig{


### PR DESCRIPTION
Stream stdout and stderr for execute sub-steps that don't need to stream from multiple hosts.

InitTargetCluster had to be refactored to ignore warnings from gpinitsystem instead of failing, because those warnings result in an exit code of 1. This caused gpupgrade to incorrectly fail. This special logic will be removed when gpinitsystem is fixed.
