### PR TITLE
execute: add verbose flag

### DIFF
--- a/ci/scripts/upgrade-cluster.bash
+++ b/ci/scripts/upgrade-cluster.bash
@@ -152,7 +152,7 @@ time ssh mdw GPHOME_OLD="${GPHOME_OLD}" GPHOME_NEW="${GPHOME_NEW}" bash <<"EOF"
               --old-bindir ${GPHOME_OLD}/fake-bin \
               --old-port 5432
 
-    gpupgrade execute
+    gpupgrade execute --verbose
 
     gpupgrade reconfigure-ports
 

--- a/cli/bash/bash-completion.sh
+++ b/cli/bash/bash-completion.sh
@@ -351,6 +351,8 @@ _gpupgrade_execute()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--verbose")
+    flags+=("-v")
 
     must_have_one_flag=()
     must_have_one_noun=()

--- a/cli/commanders/step_execute.go
+++ b/cli/commanders/step_execute.go
@@ -9,7 +9,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/idl"
 )
 
-func Execute(client idl.CliToHubClient) error {
+func Execute(client idl.CliToHubClient, verbose bool) error {
 	stream, err := client.Execute(context.Background(), &idl.ExecuteRequest{})
 	if err != nil {
 		// TODO: Change the logging message?
@@ -17,16 +17,21 @@ func Execute(client idl.CliToHubClient) error {
 		return err
 	}
 
+	os.Stdout.WriteString("Execute in progress")
+
 	for {
 		var chunk *idl.Chunk
 		chunk, err = stream.Recv()
 		if err != nil {
 			break
 		}
-		if chunk.Type == idl.Chunk_STDOUT {
-			os.Stdout.Write(chunk.Buffer)
-		} else if chunk.Type == idl.Chunk_STDERR {
-			os.Stderr.Write(chunk.Buffer)
+
+		if verbose {
+			if chunk.Type == idl.Chunk_STDOUT {
+				os.Stdout.Write(chunk.Buffer)
+			} else if chunk.Type == idl.Chunk_STDERR {
+				os.Stderr.Write(chunk.Buffer)
+			}
 		}
 	}
 

--- a/cli/commanders/step_execute_test.go
+++ b/cli/commanders/step_execute_test.go
@@ -62,13 +62,13 @@ func TestExecute(t *testing.T) {
 		go func() {
 			defer wOut.Close()
 			defer wErr.Close()
-			err := commanders.Execute(client)
+			err := commanders.Execute(client, true)
 			g.Expect(err).To(BeNil())
 		}()
 		actualOut, _ := ioutil.ReadAll(rOut)
 		actualErr, _ := ioutil.ReadAll(rErr)
 
-		g.Expect(string(actualOut)).To(Equal("my string1my string2"))
+		g.Expect(string(actualOut)).To(Equal("Execute in progressmy string1my string2"))
 		g.Expect(string(actualErr)).To(Equal("my error"))
 	})
 
@@ -87,7 +87,7 @@ func TestExecute(t *testing.T) {
 		).Return(clientStream, nil)
 		clientStream.EXPECT().Recv().Return(nil, io.ErrUnexpectedEOF)
 
-		err := commanders.Execute(client)
+		err := commanders.Execute(client, true)
 		g.Expect(err).To(Equal(io.ErrUnexpectedEOF))
 	})
 
@@ -105,7 +105,7 @@ func TestExecute(t *testing.T) {
 			&idl.ExecuteRequest{},
 		).Return(clientStream, expectedErr).Times(1)
 
-		err := commanders.Execute(client)
+		err := commanders.Execute(client, true)
 
 		if err != expectedErr {
 			t.Errorf("got error: %#v wanted: %#v", err, expectedErr)

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -52,7 +52,7 @@ func BuildRootCommand() *cobra.Command {
 
 	root.AddCommand(config, status, check, version)
 	root.AddCommand(initialize())
-	root.AddCommand(execute)
+	root.AddCommand(execute())
 	root.AddCommand(subUpgradeReconfigurePorts)
 
 	subConfigSet := createConfigSetSubcommand()
@@ -351,16 +351,25 @@ func initialize() *cobra.Command {
 }
 
 //////////////////////////////////////// Execute
-var execute = &cobra.Command{
-	Use:   "execute",
-	Short: "executes the upgrade",
-	Long:  "Executes the upgrade",
-	Run: func(cmd *cobra.Command, args []string) {
-		client := connectToHub()
-		err := commanders.Execute(client)
-		if err != nil {
-			gplog.Error(err.Error())
-			os.Exit(1)
-		}
-	},
+func execute() *cobra.Command {
+	var verbose bool
+
+
+	var subExecute = &cobra.Command{
+		Use:   "execute",
+		Short: "executes the upgrade",
+		Long:  "Executes the upgrade",
+		Run: func(cmd *cobra.Command, args []string) {
+			client := connectToHub()
+			err := commanders.Execute(client, verbose)
+			if err != nil {
+				gplog.Error(err.Error())
+				os.Exit(1)
+			}
+		},
+	}
+
+	subExecute.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
+
+	return subExecute
 }

--- a/installcheck.bats
+++ b/installcheck.bats
@@ -29,7 +29,7 @@ teardown() {
               --new-bindir "$GPHOME_NEW"/bin \
               --old-port 15432 3>&-
 
-    gpupgrade execute
+    gpupgrade execute --verbose
 
     gpupgrade reconfigure-ports
 }

--- a/test/execute.bats
+++ b/test/execute.bats
@@ -85,7 +85,7 @@ delete_cluster() {
         --new-bindir "$GPHOME/bin" \
         --old-port "$PGPORT" 3>&-
 
-    gpupgrade execute
+    gpupgrade execute --verbose
 
     # Make sure we clean up during teardown().
     NEW_CLUSTER="$newport $newmasterdir"


### PR DESCRIPTION
Add verbose flag to execute command to display streaming stdout and stderr while we display the in-progress sub steps.

[dev pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/kalen_execute-verbose)