### PR TITLE
Migrate some execute tests to go style

### DIFF
--- a/hub/services/check_disk_space_test.go
+++ b/hub/services/check_disk_space_test.go
@@ -1,67 +1,99 @@
 package services_test
 
 import (
-	"github.com/greenplum-db/gpupgrade/idl"
-
-	"github.com/greenplum-db/gpupgrade/hub/services"
+	"strings"
+	"testing"
 
 	"github.com/golang/mock/gomock"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/pkg/errors"
+
+	"github.com/greenplum-db/gpupgrade/hub/services"
+	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
 )
 
-var _ = Describe("object count tests", func() {
-	Describe("GetDiskUsageFromSegmentHosts", func() {
-		It("returns err msg when unable to call CheckDiskSpaceOnAgents on segment host", func() {
-			var clients []services.ClientAndHostname
+func TestCheckDiskSpace(t *testing.T) {
+	testhelper.SetupTestLogger() // initialize gplog
 
-			client.EXPECT().CheckDiskSpaceOnAgents(
-				gomock.Any(),
-				&idl.CheckDiskSpaceRequestToAgent{},
-			).Return(&idl.CheckDiskSpaceReplyFromAgent{}, errors.New("couldn't connect to hub"))
-			clients = append(clients, services.ClientAndHostname{Client: client, Hostname: "doesnotexist"})
+	t.Run("returns err msg when unable to call CheckDiskSpaceOnAgents on segment host", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-			messages := services.GetDiskSpaceFromSegmentHosts(clients)
-			Expect(len(messages)).To(Equal(1))
-			Expect(messages[0]).To(ContainSubstring("Could not get disk usage from: "))
-		})
+		var clients []services.ClientAndHostname
 
-		It("lists filesystems above usage threshold", func() {
-			var clients []services.ClientAndHostname
+		client := mock_idl.NewMockAgentClient(ctrl)
+		client.EXPECT().CheckDiskSpaceOnAgents(
+			gomock.Any(),
+			&idl.CheckDiskSpaceRequestToAgent{},
+		).Return(&idl.CheckDiskSpaceReplyFromAgent{}, errors.New("couldn't connect to hub"))
+		clients = append(clients, services.ClientAndHostname{Client: client, Hostname: "doesnotexist"})
 
-			var expectedFilesystemsUsage []*idl.FileSysUsage
-			expectedFilesystemsUsage = append(expectedFilesystemsUsage, &idl.FileSysUsage{Filesystem: "first filesystem", Usage: 90.4})
-			expectedFilesystemsUsage = append(expectedFilesystemsUsage, &idl.FileSysUsage{Filesystem: "/second/filesystem", Usage: 24.2})
+		messages := services.GetDiskSpaceFromSegmentHosts(clients)
+		if len(messages) != 1 {
+			t.Fatalf("want exactly one message; returned %#v", messages)
+		}
 
-			client.EXPECT().CheckDiskSpaceOnAgents(
-				gomock.Any(),
-				&idl.CheckDiskSpaceRequestToAgent{},
-			).Return(&idl.CheckDiskSpaceReplyFromAgent{ListOfFileSysUsage: expectedFilesystemsUsage}, nil)
-			clients = append(clients, services.ClientAndHostname{Client: client, Hostname: "doesnotexist"})
+		expected := "Could not get disk usage from: "
+		if !strings.Contains(messages[0], expected) {
+			t.Errorf("returned %#v want prefix %#v", messages[0], expected)
+		}
 
-			messages := services.GetDiskSpaceFromSegmentHosts(clients)
-			Expect(len(messages)).To(Equal(1))
-			Expect(messages[0]).To(ContainSubstring("diskspace check - doesnotexist - WARNING first filesystem 90.4 use"))
-		})
-
-		It("lists hosts for which all filesystems are below usage threshold", func() {
-			var clients []services.ClientAndHostname
-
-			var expectedFilesystemsUsage []*idl.FileSysUsage
-			expectedFilesystemsUsage = append(expectedFilesystemsUsage, &idl.FileSysUsage{Filesystem: "first filesystem", Usage: 70.4})
-			expectedFilesystemsUsage = append(expectedFilesystemsUsage, &idl.FileSysUsage{Filesystem: "/second/filesystem", Usage: 24.2})
-
-			client.EXPECT().CheckDiskSpaceOnAgents(
-				gomock.Any(),
-				&idl.CheckDiskSpaceRequestToAgent{},
-			).Return(&idl.CheckDiskSpaceReplyFromAgent{ListOfFileSysUsage: expectedFilesystemsUsage}, nil)
-			clients = append(clients, services.ClientAndHostname{Client: client, Hostname: "doesnotexist"})
-
-			messages := services.GetDiskSpaceFromSegmentHosts(clients)
-			Expect(len(messages)).To(Equal(1))
-			Expect(messages[0]).To(ContainSubstring("diskspace check - doesnotexist - OK"))
-		})
 	})
-})
+
+	t.Run("lists filesystems above usage threshold", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		var clients []services.ClientAndHostname
+
+		var expectedFilesystemsUsage []*idl.FileSysUsage
+		expectedFilesystemsUsage = append(expectedFilesystemsUsage, &idl.FileSysUsage{Filesystem: "first filesystem", Usage: 90.4})
+		expectedFilesystemsUsage = append(expectedFilesystemsUsage, &idl.FileSysUsage{Filesystem: "/second/filesystem", Usage: 24.2})
+
+		client := mock_idl.NewMockAgentClient(ctrl)
+		client.EXPECT().CheckDiskSpaceOnAgents(
+			gomock.Any(),
+			&idl.CheckDiskSpaceRequestToAgent{},
+		).Return(&idl.CheckDiskSpaceReplyFromAgent{ListOfFileSysUsage: expectedFilesystemsUsage}, nil)
+		clients = append(clients, services.ClientAndHostname{Client: client, Hostname: "doesnotexist"})
+
+		messages := services.GetDiskSpaceFromSegmentHosts(clients)
+		if len(messages) != 1 {
+			t.Fatalf("want exactly one message; returned %#v", messages)
+		}
+
+		expected := "diskspace check - doesnotexist - WARNING first filesystem 90.4 use"
+		if !strings.Contains(messages[0], expected) {
+			t.Errorf("returned %#v want prefix %#v", messages[0], expected)
+		}
+	})
+
+	t.Run("lists hosts for which all filesystems are below usage threshold", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		var clients []services.ClientAndHostname
+
+		var expectedFilesystemsUsage []*idl.FileSysUsage
+		expectedFilesystemsUsage = append(expectedFilesystemsUsage, &idl.FileSysUsage{Filesystem: "first filesystem", Usage: 70.4})
+		expectedFilesystemsUsage = append(expectedFilesystemsUsage, &idl.FileSysUsage{Filesystem: "/second/filesystem", Usage: 24.2})
+
+		client := mock_idl.NewMockAgentClient(ctrl)
+		client.EXPECT().CheckDiskSpaceOnAgents(
+			gomock.Any(),
+			&idl.CheckDiskSpaceRequestToAgent{},
+		).Return(&idl.CheckDiskSpaceReplyFromAgent{ListOfFileSysUsage: expectedFilesystemsUsage}, nil)
+		clients = append(clients, services.ClientAndHostname{Client: client, Hostname: "doesnotexist"})
+
+		messages := services.GetDiskSpaceFromSegmentHosts(clients)
+		if len(messages) != 1 {
+			t.Fatalf("want exactly one message; returned %#v", messages)
+		}
+
+		expected := "diskspace check - doesnotexist - OK"
+		if !strings.Contains(messages[0], expected) {
+			t.Errorf("returned %#v want prefix %#v", messages[0], expected)
+		}
+	})
+}

--- a/hub/services/execute_copy_master_sub_step.go
+++ b/hub/services/execute_copy_master_sub_step.go
@@ -46,12 +46,7 @@ func (h *Hub) CopyMasterDataDir(stream messageSender, log io.Writer) error {
 		}
 	}
 
-	agentConns, connErr := h.AgentConns()
-	if connErr != nil {
-		return multierror.Append(err, connErr)
-	}
-
-	copyErr := CopyMasterDirectoryToSegmentDirectories(agentConns, h.target, destinationDirName)
+	copyErr := CopyMasterDirectoryToSegmentDirectories(h.agentConns, h.target, destinationDirName)
 	if copyErr != nil {
 		return multierror.Append(err, copyErr)
 	}
@@ -71,23 +66,23 @@ func CopyMasterDirectoryToSegmentDirectories(agentConns []*Connection, target *u
 	errMsg := "Error copying master data directory to segment data directories"
 	wg := sync.WaitGroup{}
 	errChan := make(chan error, len(agentConns))
-	for _, agentConn := range agentConns {
+
+	for _, conn := range agentConns {
 		wg.Add(1)
-		go func(c *Connection) {
+
+		go func(conn *Connection) {
 			defer wg.Done()
 
-			client := idl.NewAgentClient(c.Conn)
-			_, err := client.CopyMasterDirectoryToSegmentDirectories(context.Background(),
+			_, err := conn.AgentClient.CopyMasterDirectoryToSegmentDirectories(context.Background(),
 				&idl.CopyMasterDirRequest{
 					MasterDir: destinationDirName,
-					Datadirs:  segmentDataDirMap[c.Hostname],
+					Datadirs:  segmentDataDirMap[conn.Hostname],
 				})
-
 			if err != nil {
-				gplog.Error("%s on host %s: %s", errMsg, c.Hostname, err.Error())
+				gplog.Error("%s on host %s: %s", errMsg, conn.Hostname, err.Error())
 				errChan <- err
 			}
-		}(agentConn)
+		}(conn)
 	}
 
 	wg.Wait()

--- a/hub/services/execute_copy_master_sub_step_test.go
+++ b/hub/services/execute_copy_master_sub_step_test.go
@@ -1,82 +1,135 @@
-package services_test
+package services
 
 import (
 	"bytes"
-	"path/filepath"
+	"testing"
 
 	"github.com/golang/mock/gomock"
+	"google.golang.org/grpc"
+
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 
+	"github.com/greenplum-db/gpupgrade/hub/upgradestatus"
+	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
+	"github.com/greenplum-db/gpupgrade/utils"
 
-	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("ExecuteCopyMasterSubStep", func() {
-	var (
-		mockOutput   *cluster.RemoteOutput
-		testExecutor *testhelper.TestExecutor
+func TestCopyMaster(t *testing.T) {
+	g := NewGomegaWithT(t)
 
-		ctrl       *gomock.Controller
-		mockStream *mock_idl.MockCliToHub_ExecuteServer
-		buf bytes.Buffer
-	)
+	testhelper.SetupTestLogger() // initialize gplog
 
-	BeforeEach(func() {
-		testExecutor = &testhelper.TestExecutor{}
-		mockOutput = &cluster.RemoteOutput{}
+	var buf bytes.Buffer
+
+	sourceNodes := cluster.NewCluster([]cluster.SegConfig{
+		cluster.SegConfig{ContentID: -1, DbID: 1, Port: 15432, Hostname: "localhost", DataDir: "/data/qddir/seg-1"},
+		cluster.SegConfig{ContentID: 0, DbID: 2, Port: 25432, Hostname: "host1", DataDir: "/data/dbfast1/seg1"},
+		cluster.SegConfig{ContentID: 1, DbID: 3, Port: 25433, Hostname: "host2", DataDir: "/data/dbfast2/seg2"},
+	})
+	sourceCluster := utils.Cluster{
+		Cluster:    sourceNodes,
+		BinDir:     "/source/bindir",
+		ConfigPath: "my/config/path",
+		Version:    dbconn.GPDBVersion{},
+	}
+
+	targetNodes := cluster.NewCluster([]cluster.SegConfig{
+		cluster.SegConfig{ContentID: -1, DbID: 1, Port: 15432, Hostname: "localhost", DataDir: "/data/qddir/seg-1"},
+		cluster.SegConfig{ContentID: 0, DbID: 2, Port: 25432, Hostname: "host1", DataDir: "/data/dbfast1/seg1"},
+		cluster.SegConfig{ContentID: 1, DbID: 3, Port: 25433, Hostname: "host2", DataDir: "/data/dbfast2/seg2"},
+
+	})
+	targetCluster := utils.Cluster{
+		Cluster:    targetNodes,
+		BinDir:     "/target/bindir",
+		ConfigPath: "my/config/path",
+		Version:    dbconn.GPDBVersion{},
+	}
+
+	hub := NewHub(&sourceCluster, &targetCluster, grpc.DialContext, &HubConfig{}, &upgradestatus.ChecklistManager{})
+
+	t.Run("copies the master data directory to each primary host", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockStream := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
+		mockStream.EXPECT().
+			Send(gomock.Any()).
+			AnyTimes()
+
+		testExecutor := &testhelper.TestExecutor{}
+		mockOutput := &cluster.RemoteOutput{}
 		testExecutor.ClusterOutput = mockOutput
-		source.Executor = testExecutor
+		sourceNodes.Executor = testExecutor
 
-		ctrl = gomock.NewController(GinkgoT())
-		mockStream = mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
-	})
+		client := mock_idl.NewMockAgentClient(ctrl)
+		client.EXPECT().CopyMasterDirectoryToSegmentDirectories(
+			gomock.Any(),
+			gomock.Any(),
+		).Return(&idl.CopyMasterDirReply{}, nil)
 
-	AfterEach(func() {
-		ctrl.Finish()
-	})
+		agentConns := []*Connection{
+			{nil, client, "host1", nil},
+		}
 
-	It("copies the master data directory to each primary host in 6.0 or later", func() {
-		mockStream.EXPECT().
-			Send(gomock.Any()).
-			AnyTimes()
+		hub.agentConns = agentConns
 
-		source.Version = dbconn.NewVersion("6.0.0")
 		err := hub.CopyMasterDataDir(mockStream, &buf)
-		Expect(err).ToNot(HaveOccurred())
+		g.Expect(err).ToNot(HaveOccurred())
 
-		Eventually(func() int { return testExecutor.NumExecutions }).Should(Equal(1))
+		g.Eventually(func() int { return testExecutor.NumExecutions }).Should(Equal(1))
 
-		masterDataDir := filepath.Clean(source.MasterDataDir()) + string(filepath.Separator)
-		resultMap := testExecutor.ClusterCommands[0]
-		Expect(resultMap[0]).To(Equal([]string{"rsync", "-rzpogt", masterDataDir, "host1:/tmp/masterDirCopy"}))
-		Expect(resultMap[1]).To(Equal([]string{"rsync", "-rzpogt", masterDataDir, "host2:/tmp/masterDirCopy"}))
+		expectedCmds := []map[int][]string{{
+			0: {"rsync", "-rzpogt", "/data/qddir/seg-1/", "host1:/tmp/masterDirCopy"},
+			1: {"rsync", "-rzpogt", "/data/qddir/seg-1/", "host2:/tmp/masterDirCopy"},
+		}}
+		g.Expect(testExecutor.ClusterCommands).To(Equal(expectedCmds))
 	})
 
-	It("copies the master data directory only once per host", func() {
+	t.Run("copies the master data directory only once per host", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockStream := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
 		mockStream.EXPECT().
 			Send(gomock.Any()).
 			AnyTimes()
 
-		target.Version = dbconn.NewVersion("6.0.0")
+		testExecutor := &testhelper.TestExecutor{}
+		mockOutput := &cluster.RemoteOutput{}
+		testExecutor.ClusterOutput = mockOutput
+		sourceNodes.Executor = testExecutor
+
+		client := mock_idl.NewMockAgentClient(ctrl)
+		client.EXPECT().CopyMasterDirectoryToSegmentDirectories(
+			gomock.Any(),
+			gomock.Any(),
+		).Return(&idl.CopyMasterDirReply{}, nil)
+
+		agentConns := []*Connection{
+			{nil, client, "localhost", nil},
+		}
+
+		hub.agentConns = agentConns
 
 		// Set all target segment hosts to be the same.
-		for content, segment := range target.Segments {
-			segment.Hostname = target.Segments[-1].Hostname
-			target.Segments[content] = segment
+		for content, segment := range targetCluster.Segments {
+			segment.Hostname = targetCluster.Segments[-1].Hostname
+			targetCluster.Segments[content] = segment
 		}
 
 		err := hub.CopyMasterDataDir(mockStream, &buf)
-		Expect(err).ToNot(HaveOccurred())
+		g.Expect(err).ToNot(HaveOccurred())
 
-		Eventually(func() int { return testExecutor.NumExecutions }).Should(Equal(1))
+		g.Eventually(func() int { return testExecutor.NumExecutions }).Should(Equal(1))
 
-		masterDataDir := filepath.Clean(source.MasterDataDir()) + string(filepath.Separator)
-		resultMap := testExecutor.ClusterCommands[0]
-		Expect(resultMap).To(HaveLen(1))
-		Expect(resultMap).To(ContainElement([]string{"rsync", "-rzpogt", masterDataDir, "localhost:/tmp/masterDirCopy"}))
+		expectedCmd := testExecutor.ClusterCommands[0]
+		g.Expect(expectedCmd).To(HaveLen(1))
+		g.Expect(expectedCmd).To(ContainElement([]string{"rsync", "-rzpogt", "/data/qddir/seg-1/", "localhost:/tmp/masterDirCopy"}))
 	})
-})
+}


### PR DESCRIPTION
This ports the following tests Go style from ginkgo:
- execute copy master
- check disk space
- check object count
- upgrade master
- execute_test

Note: This is an initial pass of simply porting the existing tests. There _may_ be some room for some further refactors or organization which is outside the scope of this current PR.

Namely, this does not bring up a real Agent Server and grpc Server which the services_suite_test did.

[test pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/kalen_port_copy_master_tests)