### PR TITLE
CI: use 6X source to test 6X binaries

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -24,11 +24,11 @@ resources:
     uri: {{gpupgrade-git-remote}}
     branch: {{gpupgrade-git-branch}}
 
-- name: gpdb_src
+- name: gpdb6_src
   type: git
   source:
     uri: https://github.com/greenplum-db/gpdb
-    branch: master
+    branch: 6X_STABLE
 
 - name: bin_gpdb6_centos6
   type: gcs
@@ -184,6 +184,7 @@ jobs:
     - get: gpupgrade_src
       trigger: true
     - get: gpdb_src
+      resource: gpdb6_src
     - get: bats
     - get: bin_gpdb
       resource: bin_gpdb6_centos6


### PR DESCRIPTION
The install tests are failing because of an incompatibility with the GPDB master branch. While we do need to fix that incompatibility, the fact that we're relying on master at all is a mistake -- we're testing using 6X binaries and should be relying on 6X source.