### PR TITLE
initialize: fix BATS test debug output

### DIFF
--- a/test/initialize.bats
+++ b/test/initialize.bats
@@ -131,13 +131,12 @@ outputContains() {
     # Run every subcommand.
     for command in "${commands[@]}"; do
         run gpupgrade $command
-        echo "$status"
-        [ "$status" -eq 1 ]
-        outputContains "could not connect to the upgrade hub (did you run 'gpupgrade initialize'?)"
 
         # Trace which command we're on to make debugging easier.
-        echo "\$ gpupgrade $command"
+        echo "\$ gpupgrade $command -> $status"
         echo "$output"
 
+        [ "$status" -eq 1 ]
+        outputContains "could not connect to the upgrade hub (did you run 'gpupgrade initialize'?)"
     done
 }


### PR DESCRIPTION
Commit 8cfd3c0c broke the debug output by performing the test (which will exit on failure) before the output that tells us which test fails. Fix that up.