### PR TITLE
add gpupgrade initialize --ports

### DIFF
--- a/cli/bash/bash-completion.sh
+++ b/cli/bash/bash-completion.sh
@@ -339,6 +339,8 @@ _gpupgrade_initialize()
     flags+=("--new-bindir=")
     flags+=("--old-bindir=")
     flags+=("--old-port=")
+    flags+=("--ports=")
+    local_nonpersistent_flags+=("--ports=")
     flags+=("--verbose")
     flags+=("-v")
 

--- a/cli/commanders/steps.go
+++ b/cli/commanders/steps.go
@@ -59,8 +59,11 @@ func Initialize(client idl.CliToHubClient, oldBinDir, newBinDir string, oldPort 
 	return nil
 }
 
-func InitializeCreateCluster(client idl.CliToHubClient, verbose bool) (err error) {
-	stream, err := client.InitializeCreateCluster(context.Background(), &idl.InitializeCreateClusterRequest{})
+func InitializeCreateCluster(client idl.CliToHubClient, verbose bool, ports []uint32) (err error) {
+	stream, err := client.InitializeCreateCluster(context.Background(),
+		&idl.InitializeCreateClusterRequest{
+			Ports: ports,
+		})
 	if err != nil {
 		return errors.Wrap(err, "initializing hub2")
 	}

--- a/cli/commands/commands_test.go
+++ b/cli/commands/commands_test.go
@@ -1,0 +1,55 @@
+package commands
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParsePorts(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected []uint32
+	}{
+		{"", []uint32(nil)},
+		{"1", []uint32{1}},
+		{"1,3,5", []uint32{1, 3, 5}},
+		/* ranges */
+		{"1-5", []uint32{1, 2, 3, 4, 5}},
+		{"1-5,6-10", []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+		{"1-5,10,12,15-15", []uint32{1, 2, 3, 4, 5, 10, 12, 15}},
+	}
+
+	for _, c := range cases {
+		actual, err := parsePorts(c.input)
+		if err != nil {
+			t.Errorf("parsePorts(%q) returned error %#v", c.input, err)
+		}
+		if !reflect.DeepEqual(actual, c.expected) {
+			t.Errorf("parsePorts(%q) returned %v, want %v", c.input, actual, c.expected)
+		}
+	}
+
+	errorCases := []string{
+		"1, 3, 5",
+		"sdklfjds",
+		"-1",
+		"5-1",
+		"1--5",
+		"1-3-5",
+		"1,,2",
+		"1,a",
+		"1-a",
+		"a-1",
+		"900000",
+		"1-900000",
+		"900000-1000000",
+		",1",
+	}
+
+	for _, c := range errorCases {
+		actual, err := parsePorts(c)
+		if err == nil {
+			t.Errorf("parsePorts(%q) returned %v instead of an error", c, actual)
+		}
+	}
+}

--- a/idl/cli_to_hub.pb.go
+++ b/idl/cli_to_hub.pb.go
@@ -3,13 +3,14 @@
 
 package idl
 
-import proto "github.com/golang/protobuf/proto"
-import fmt "fmt"
-import math "math"
-
 import (
-	context "golang.org/x/net/context"
+	context "context"
+	fmt "fmt"
+	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -21,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type UpgradeSteps int32
 
@@ -56,6 +57,7 @@ var UpgradeSteps_name = map[int32]string{
 	11: "START_TARGET_CLUSTER",
 	12: "RECONFIGURE_PORTS",
 }
+
 var UpgradeSteps_value = map[string]int32{
 	"UNKNOWN_STEP":            0,
 	"CONFIG":                  1,
@@ -75,8 +77,9 @@ var UpgradeSteps_value = map[string]int32{
 func (x UpgradeSteps) String() string {
 	return proto.EnumName(UpgradeSteps_name, int32(x))
 }
+
 func (UpgradeSteps) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{0}
+	return fileDescriptor_631e66a01873be02, []int{0}
 }
 
 type StepStatus int32
@@ -96,6 +99,7 @@ var StepStatus_name = map[int32]string{
 	3: "COMPLETE",
 	4: "FAILED",
 }
+
 var StepStatus_value = map[string]int32{
 	"UNKNOWN_STATUS": 0,
 	"PENDING":        1,
@@ -107,8 +111,9 @@ var StepStatus_value = map[string]int32{
 func (x StepStatus) String() string {
 	return proto.EnumName(StepStatus_name, int32(x))
 }
+
 func (StepStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{1}
+	return fileDescriptor_631e66a01873be02, []int{1}
 }
 
 type Chunk_Type int32
@@ -124,6 +129,7 @@ var Chunk_Type_name = map[int32]string{
 	1: "STDOUT",
 	2: "STDERR",
 }
+
 var Chunk_Type_value = map[string]int32{
 	"UNKNOWN": 0,
 	"STDOUT":  1,
@@ -133,14 +139,15 @@ var Chunk_Type_value = map[string]int32{
 func (x Chunk_Type) String() string {
 	return proto.EnumName(Chunk_Type_name, int32(x))
 }
+
 func (Chunk_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{15, 0}
+	return fileDescriptor_631e66a01873be02, []int{15, 0}
 }
 
 type InitializeRequest struct {
-	OldBinDir            string   `protobuf:"bytes,1,opt,name=oldBinDir" json:"oldBinDir,omitempty"`
-	NewBinDir            string   `protobuf:"bytes,2,opt,name=newBinDir" json:"newBinDir,omitempty"`
-	OldPort              int32    `protobuf:"varint,3,opt,name=oldPort" json:"oldPort,omitempty"`
+	OldBinDir            string   `protobuf:"bytes,1,opt,name=oldBinDir,proto3" json:"oldBinDir,omitempty"`
+	NewBinDir            string   `protobuf:"bytes,2,opt,name=newBinDir,proto3" json:"newBinDir,omitempty"`
+	OldPort              int32    `protobuf:"varint,3,opt,name=oldPort,proto3" json:"oldPort,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -150,16 +157,17 @@ func (m *InitializeRequest) Reset()         { *m = InitializeRequest{} }
 func (m *InitializeRequest) String() string { return proto.CompactTextString(m) }
 func (*InitializeRequest) ProtoMessage()    {}
 func (*InitializeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{0}
+	return fileDescriptor_631e66a01873be02, []int{0}
 }
+
 func (m *InitializeRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_InitializeRequest.Unmarshal(m, b)
 }
 func (m *InitializeRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_InitializeRequest.Marshal(b, m, deterministic)
 }
-func (dst *InitializeRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_InitializeRequest.Merge(dst, src)
+func (m *InitializeRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_InitializeRequest.Merge(m, src)
 }
 func (m *InitializeRequest) XXX_Size() int {
 	return xxx_messageInfo_InitializeRequest.Size(m)
@@ -192,6 +200,7 @@ func (m *InitializeRequest) GetOldPort() int32 {
 }
 
 type InitializeCreateClusterRequest struct {
+	Ports                []uint32 `protobuf:"varint,1,rep,packed,name=ports,proto3" json:"ports,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -201,16 +210,17 @@ func (m *InitializeCreateClusterRequest) Reset()         { *m = InitializeCreate
 func (m *InitializeCreateClusterRequest) String() string { return proto.CompactTextString(m) }
 func (*InitializeCreateClusterRequest) ProtoMessage()    {}
 func (*InitializeCreateClusterRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{1}
+	return fileDescriptor_631e66a01873be02, []int{1}
 }
+
 func (m *InitializeCreateClusterRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_InitializeCreateClusterRequest.Unmarshal(m, b)
 }
 func (m *InitializeCreateClusterRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_InitializeCreateClusterRequest.Marshal(b, m, deterministic)
 }
-func (dst *InitializeCreateClusterRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_InitializeCreateClusterRequest.Merge(dst, src)
+func (m *InitializeCreateClusterRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_InitializeCreateClusterRequest.Merge(m, src)
 }
 func (m *InitializeCreateClusterRequest) XXX_Size() int {
 	return xxx_messageInfo_InitializeCreateClusterRequest.Size(m)
@@ -220,6 +230,13 @@ func (m *InitializeCreateClusterRequest) XXX_DiscardUnknown() {
 }
 
 var xxx_messageInfo_InitializeCreateClusterRequest proto.InternalMessageInfo
+
+func (m *InitializeCreateClusterRequest) GetPorts() []uint32 {
+	if m != nil {
+		return m.Ports
+	}
+	return nil
+}
 
 type ExecuteRequest struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -231,16 +248,17 @@ func (m *ExecuteRequest) Reset()         { *m = ExecuteRequest{} }
 func (m *ExecuteRequest) String() string { return proto.CompactTextString(m) }
 func (*ExecuteRequest) ProtoMessage()    {}
 func (*ExecuteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{2}
+	return fileDescriptor_631e66a01873be02, []int{2}
 }
+
 func (m *ExecuteRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ExecuteRequest.Unmarshal(m, b)
 }
 func (m *ExecuteRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ExecuteRequest.Marshal(b, m, deterministic)
 }
-func (dst *ExecuteRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ExecuteRequest.Merge(dst, src)
+func (m *ExecuteRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ExecuteRequest.Merge(m, src)
 }
 func (m *ExecuteRequest) XXX_Size() int {
 	return xxx_messageInfo_ExecuteRequest.Size(m)
@@ -261,16 +279,17 @@ func (m *FinalizeRequest) Reset()         { *m = FinalizeRequest{} }
 func (m *FinalizeRequest) String() string { return proto.CompactTextString(m) }
 func (*FinalizeRequest) ProtoMessage()    {}
 func (*FinalizeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{3}
+	return fileDescriptor_631e66a01873be02, []int{3}
 }
+
 func (m *FinalizeRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FinalizeRequest.Unmarshal(m, b)
 }
 func (m *FinalizeRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FinalizeRequest.Marshal(b, m, deterministic)
 }
-func (dst *FinalizeRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FinalizeRequest.Merge(dst, src)
+func (m *FinalizeRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FinalizeRequest.Merge(m, src)
 }
 func (m *FinalizeRequest) XXX_Size() int {
 	return xxx_messageInfo_FinalizeRequest.Size(m)
@@ -291,16 +310,17 @@ func (m *RestartAgentsRequest) Reset()         { *m = RestartAgentsRequest{} }
 func (m *RestartAgentsRequest) String() string { return proto.CompactTextString(m) }
 func (*RestartAgentsRequest) ProtoMessage()    {}
 func (*RestartAgentsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{4}
+	return fileDescriptor_631e66a01873be02, []int{4}
 }
+
 func (m *RestartAgentsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RestartAgentsRequest.Unmarshal(m, b)
 }
 func (m *RestartAgentsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RestartAgentsRequest.Marshal(b, m, deterministic)
 }
-func (dst *RestartAgentsRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RestartAgentsRequest.Merge(dst, src)
+func (m *RestartAgentsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RestartAgentsRequest.Merge(m, src)
 }
 func (m *RestartAgentsRequest) XXX_Size() int {
 	return xxx_messageInfo_RestartAgentsRequest.Size(m)
@@ -312,7 +332,7 @@ func (m *RestartAgentsRequest) XXX_DiscardUnknown() {
 var xxx_messageInfo_RestartAgentsRequest proto.InternalMessageInfo
 
 type RestartAgentsReply struct {
-	AgentHosts           []string `protobuf:"bytes,1,rep,name=agentHosts" json:"agentHosts,omitempty"`
+	AgentHosts           []string `protobuf:"bytes,1,rep,name=agentHosts,proto3" json:"agentHosts,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -322,16 +342,17 @@ func (m *RestartAgentsReply) Reset()         { *m = RestartAgentsReply{} }
 func (m *RestartAgentsReply) String() string { return proto.CompactTextString(m) }
 func (*RestartAgentsReply) ProtoMessage()    {}
 func (*RestartAgentsReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{5}
+	return fileDescriptor_631e66a01873be02, []int{5}
 }
+
 func (m *RestartAgentsReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RestartAgentsReply.Unmarshal(m, b)
 }
 func (m *RestartAgentsReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RestartAgentsReply.Marshal(b, m, deterministic)
 }
-func (dst *RestartAgentsReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RestartAgentsReply.Merge(dst, src)
+func (m *RestartAgentsReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RestartAgentsReply.Merge(m, src)
 }
 func (m *RestartAgentsReply) XXX_Size() int {
 	return xxx_messageInfo_RestartAgentsReply.Size(m)
@@ -359,16 +380,17 @@ func (m *StopServicesRequest) Reset()         { *m = StopServicesRequest{} }
 func (m *StopServicesRequest) String() string { return proto.CompactTextString(m) }
 func (*StopServicesRequest) ProtoMessage()    {}
 func (*StopServicesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{6}
+	return fileDescriptor_631e66a01873be02, []int{6}
 }
+
 func (m *StopServicesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StopServicesRequest.Unmarshal(m, b)
 }
 func (m *StopServicesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StopServicesRequest.Marshal(b, m, deterministic)
 }
-func (dst *StopServicesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StopServicesRequest.Merge(dst, src)
+func (m *StopServicesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StopServicesRequest.Merge(m, src)
 }
 func (m *StopServicesRequest) XXX_Size() int {
 	return xxx_messageInfo_StopServicesRequest.Size(m)
@@ -389,16 +411,17 @@ func (m *StopServicesReply) Reset()         { *m = StopServicesReply{} }
 func (m *StopServicesReply) String() string { return proto.CompactTextString(m) }
 func (*StopServicesReply) ProtoMessage()    {}
 func (*StopServicesReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{7}
+	return fileDescriptor_631e66a01873be02, []int{7}
 }
+
 func (m *StopServicesReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StopServicesReply.Unmarshal(m, b)
 }
 func (m *StopServicesReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StopServicesReply.Marshal(b, m, deterministic)
 }
-func (dst *StopServicesReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StopServicesReply.Merge(dst, src)
+func (m *StopServicesReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StopServicesReply.Merge(m, src)
 }
 func (m *StopServicesReply) XXX_Size() int {
 	return xxx_messageInfo_StopServicesReply.Size(m)
@@ -410,8 +433,8 @@ func (m *StopServicesReply) XXX_DiscardUnknown() {
 var xxx_messageInfo_StopServicesReply proto.InternalMessageInfo
 
 type UpgradeStepStatus struct {
-	Step                 UpgradeSteps `protobuf:"varint,1,opt,name=step,enum=idl.UpgradeSteps" json:"step,omitempty"`
-	Status               StepStatus   `protobuf:"varint,2,opt,name=status,enum=idl.StepStatus" json:"status,omitempty"`
+	Step                 UpgradeSteps `protobuf:"varint,1,opt,name=step,proto3,enum=idl.UpgradeSteps" json:"step,omitempty"`
+	Status               StepStatus   `protobuf:"varint,2,opt,name=status,proto3,enum=idl.StepStatus" json:"status,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
 	XXX_unrecognized     []byte       `json:"-"`
 	XXX_sizecache        int32        `json:"-"`
@@ -421,16 +444,17 @@ func (m *UpgradeStepStatus) Reset()         { *m = UpgradeStepStatus{} }
 func (m *UpgradeStepStatus) String() string { return proto.CompactTextString(m) }
 func (*UpgradeStepStatus) ProtoMessage()    {}
 func (*UpgradeStepStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{8}
+	return fileDescriptor_631e66a01873be02, []int{8}
 }
+
 func (m *UpgradeStepStatus) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UpgradeStepStatus.Unmarshal(m, b)
 }
 func (m *UpgradeStepStatus) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UpgradeStepStatus.Marshal(b, m, deterministic)
 }
-func (dst *UpgradeStepStatus) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UpgradeStepStatus.Merge(dst, src)
+func (m *UpgradeStepStatus) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UpgradeStepStatus.Merge(m, src)
 }
 func (m *UpgradeStepStatus) XXX_Size() int {
 	return xxx_messageInfo_UpgradeStepStatus.Size(m)
@@ -465,16 +489,17 @@ func (m *CheckVersionRequest) Reset()         { *m = CheckVersionRequest{} }
 func (m *CheckVersionRequest) String() string { return proto.CompactTextString(m) }
 func (*CheckVersionRequest) ProtoMessage()    {}
 func (*CheckVersionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{9}
+	return fileDescriptor_631e66a01873be02, []int{9}
 }
+
 func (m *CheckVersionRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CheckVersionRequest.Unmarshal(m, b)
 }
 func (m *CheckVersionRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CheckVersionRequest.Marshal(b, m, deterministic)
 }
-func (dst *CheckVersionRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CheckVersionRequest.Merge(dst, src)
+func (m *CheckVersionRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CheckVersionRequest.Merge(m, src)
 }
 func (m *CheckVersionRequest) XXX_Size() int {
 	return xxx_messageInfo_CheckVersionRequest.Size(m)
@@ -486,7 +511,7 @@ func (m *CheckVersionRequest) XXX_DiscardUnknown() {
 var xxx_messageInfo_CheckVersionRequest proto.InternalMessageInfo
 
 type CheckVersionReply struct {
-	IsVersionCompatible  bool     `protobuf:"varint,1,opt,name=IsVersionCompatible" json:"IsVersionCompatible,omitempty"`
+	IsVersionCompatible  bool     `protobuf:"varint,1,opt,name=IsVersionCompatible,proto3" json:"IsVersionCompatible,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -496,16 +521,17 @@ func (m *CheckVersionReply) Reset()         { *m = CheckVersionReply{} }
 func (m *CheckVersionReply) String() string { return proto.CompactTextString(m) }
 func (*CheckVersionReply) ProtoMessage()    {}
 func (*CheckVersionReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{10}
+	return fileDescriptor_631e66a01873be02, []int{10}
 }
+
 func (m *CheckVersionReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CheckVersionReply.Unmarshal(m, b)
 }
 func (m *CheckVersionReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CheckVersionReply.Marshal(b, m, deterministic)
 }
-func (dst *CheckVersionReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CheckVersionReply.Merge(dst, src)
+func (m *CheckVersionReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CheckVersionReply.Merge(m, src)
 }
 func (m *CheckVersionReply) XXX_Size() int {
 	return xxx_messageInfo_CheckVersionReply.Size(m)
@@ -524,7 +550,7 @@ func (m *CheckVersionReply) GetIsVersionCompatible() bool {
 }
 
 type CheckDiskSpaceRequest struct {
-	Ratio                float64  `protobuf:"fixed64,1,opt,name=ratio" json:"ratio,omitempty"`
+	Ratio                float64  `protobuf:"fixed64,1,opt,name=ratio,proto3" json:"ratio,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -534,16 +560,17 @@ func (m *CheckDiskSpaceRequest) Reset()         { *m = CheckDiskSpaceRequest{} }
 func (m *CheckDiskSpaceRequest) String() string { return proto.CompactTextString(m) }
 func (*CheckDiskSpaceRequest) ProtoMessage()    {}
 func (*CheckDiskSpaceRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{11}
+	return fileDescriptor_631e66a01873be02, []int{11}
 }
+
 func (m *CheckDiskSpaceRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CheckDiskSpaceRequest.Unmarshal(m, b)
 }
 func (m *CheckDiskSpaceRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CheckDiskSpaceRequest.Marshal(b, m, deterministic)
 }
-func (dst *CheckDiskSpaceRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CheckDiskSpaceRequest.Merge(dst, src)
+func (m *CheckDiskSpaceRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CheckDiskSpaceRequest.Merge(m, src)
 }
 func (m *CheckDiskSpaceRequest) XXX_Size() int {
 	return xxx_messageInfo_CheckDiskSpaceRequest.Size(m)
@@ -562,7 +589,7 @@ func (m *CheckDiskSpaceRequest) GetRatio() float64 {
 }
 
 type CheckDiskSpaceReply struct {
-	Failed               map[string]*CheckDiskSpaceReply_DiskUsage `protobuf:"bytes,1,rep,name=failed" json:"failed,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Failed               map[string]*CheckDiskSpaceReply_DiskUsage `protobuf:"bytes,1,rep,name=failed,proto3" json:"failed,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}                                  `json:"-"`
 	XXX_unrecognized     []byte                                    `json:"-"`
 	XXX_sizecache        int32                                     `json:"-"`
@@ -572,16 +599,17 @@ func (m *CheckDiskSpaceReply) Reset()         { *m = CheckDiskSpaceReply{} }
 func (m *CheckDiskSpaceReply) String() string { return proto.CompactTextString(m) }
 func (*CheckDiskSpaceReply) ProtoMessage()    {}
 func (*CheckDiskSpaceReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{12}
+	return fileDescriptor_631e66a01873be02, []int{12}
 }
+
 func (m *CheckDiskSpaceReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CheckDiskSpaceReply.Unmarshal(m, b)
 }
 func (m *CheckDiskSpaceReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CheckDiskSpaceReply.Marshal(b, m, deterministic)
 }
-func (dst *CheckDiskSpaceReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CheckDiskSpaceReply.Merge(dst, src)
+func (m *CheckDiskSpaceReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CheckDiskSpaceReply.Merge(m, src)
 }
 func (m *CheckDiskSpaceReply) XXX_Size() int {
 	return xxx_messageInfo_CheckDiskSpaceReply.Size(m)
@@ -600,8 +628,8 @@ func (m *CheckDiskSpaceReply) GetFailed() map[string]*CheckDiskSpaceReply_DiskUs
 }
 
 type CheckDiskSpaceReply_DiskUsage struct {
-	Available            uint64   `protobuf:"varint,1,opt,name=available" json:"available,omitempty"`
-	Required             uint64   `protobuf:"varint,2,opt,name=required" json:"required,omitempty"`
+	Available            uint64   `protobuf:"varint,1,opt,name=available,proto3" json:"available,omitempty"`
+	Required             uint64   `protobuf:"varint,2,opt,name=required,proto3" json:"required,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -611,16 +639,17 @@ func (m *CheckDiskSpaceReply_DiskUsage) Reset()         { *m = CheckDiskSpaceRep
 func (m *CheckDiskSpaceReply_DiskUsage) String() string { return proto.CompactTextString(m) }
 func (*CheckDiskSpaceReply_DiskUsage) ProtoMessage()    {}
 func (*CheckDiskSpaceReply_DiskUsage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{12, 0}
+	return fileDescriptor_631e66a01873be02, []int{12, 0}
 }
+
 func (m *CheckDiskSpaceReply_DiskUsage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CheckDiskSpaceReply_DiskUsage.Unmarshal(m, b)
 }
 func (m *CheckDiskSpaceReply_DiskUsage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CheckDiskSpaceReply_DiskUsage.Marshal(b, m, deterministic)
 }
-func (dst *CheckDiskSpaceReply_DiskUsage) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CheckDiskSpaceReply_DiskUsage.Merge(dst, src)
+func (m *CheckDiskSpaceReply_DiskUsage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CheckDiskSpaceReply_DiskUsage.Merge(m, src)
 }
 func (m *CheckDiskSpaceReply_DiskUsage) XXX_Size() int {
 	return xxx_messageInfo_CheckDiskSpaceReply_DiskUsage.Size(m)
@@ -655,16 +684,17 @@ func (m *PrepareInitClusterRequest) Reset()         { *m = PrepareInitClusterReq
 func (m *PrepareInitClusterRequest) String() string { return proto.CompactTextString(m) }
 func (*PrepareInitClusterRequest) ProtoMessage()    {}
 func (*PrepareInitClusterRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{13}
+	return fileDescriptor_631e66a01873be02, []int{13}
 }
+
 func (m *PrepareInitClusterRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PrepareInitClusterRequest.Unmarshal(m, b)
 }
 func (m *PrepareInitClusterRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_PrepareInitClusterRequest.Marshal(b, m, deterministic)
 }
-func (dst *PrepareInitClusterRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_PrepareInitClusterRequest.Merge(dst, src)
+func (m *PrepareInitClusterRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PrepareInitClusterRequest.Merge(m, src)
 }
 func (m *PrepareInitClusterRequest) XXX_Size() int {
 	return xxx_messageInfo_PrepareInitClusterRequest.Size(m)
@@ -685,16 +715,17 @@ func (m *PrepareInitClusterReply) Reset()         { *m = PrepareInitClusterReply
 func (m *PrepareInitClusterReply) String() string { return proto.CompactTextString(m) }
 func (*PrepareInitClusterReply) ProtoMessage()    {}
 func (*PrepareInitClusterReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{14}
+	return fileDescriptor_631e66a01873be02, []int{14}
 }
+
 func (m *PrepareInitClusterReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PrepareInitClusterReply.Unmarshal(m, b)
 }
 func (m *PrepareInitClusterReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_PrepareInitClusterReply.Marshal(b, m, deterministic)
 }
-func (dst *PrepareInitClusterReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_PrepareInitClusterReply.Merge(dst, src)
+func (m *PrepareInitClusterReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PrepareInitClusterReply.Merge(m, src)
 }
 func (m *PrepareInitClusterReply) XXX_Size() int {
 	return xxx_messageInfo_PrepareInitClusterReply.Size(m)
@@ -707,7 +738,7 @@ var xxx_messageInfo_PrepareInitClusterReply proto.InternalMessageInfo
 
 type Chunk struct {
 	Buffer               []byte     `protobuf:"bytes,1,opt,name=buffer,proto3" json:"buffer,omitempty"`
-	Type                 Chunk_Type `protobuf:"varint,2,opt,name=type,enum=idl.Chunk_Type" json:"type,omitempty"`
+	Type                 Chunk_Type `protobuf:"varint,2,opt,name=type,proto3,enum=idl.Chunk_Type" json:"type,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}   `json:"-"`
 	XXX_unrecognized     []byte     `json:"-"`
 	XXX_sizecache        int32      `json:"-"`
@@ -717,16 +748,17 @@ func (m *Chunk) Reset()         { *m = Chunk{} }
 func (m *Chunk) String() string { return proto.CompactTextString(m) }
 func (*Chunk) ProtoMessage()    {}
 func (*Chunk) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{15}
+	return fileDescriptor_631e66a01873be02, []int{15}
 }
+
 func (m *Chunk) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Chunk.Unmarshal(m, b)
 }
 func (m *Chunk) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Chunk.Marshal(b, m, deterministic)
 }
-func (dst *Chunk) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Chunk.Merge(dst, src)
+func (m *Chunk) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Chunk.Merge(m, src)
 }
 func (m *Chunk) XXX_Size() int {
 	return xxx_messageInfo_Chunk.Size(m)
@@ -765,16 +797,17 @@ func (m *Message) Reset()         { *m = Message{} }
 func (m *Message) String() string { return proto.CompactTextString(m) }
 func (*Message) ProtoMessage()    {}
 func (*Message) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{16}
+	return fileDescriptor_631e66a01873be02, []int{16}
 }
+
 func (m *Message) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Message.Unmarshal(m, b)
 }
 func (m *Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Message.Marshal(b, m, deterministic)
 }
-func (dst *Message) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Message.Merge(dst, src)
+func (m *Message) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Message.Merge(m, src)
 }
 func (m *Message) XXX_Size() int {
 	return xxx_messageInfo_Message.Size(m)
@@ -790,13 +823,15 @@ type isMessage_Contents interface {
 }
 
 type Message_Chunk struct {
-	Chunk *Chunk `protobuf:"bytes,1,opt,name=chunk,oneof"`
-}
-type Message_Status struct {
-	Status *UpgradeStepStatus `protobuf:"bytes,2,opt,name=status,oneof"`
+	Chunk *Chunk `protobuf:"bytes,1,opt,name=chunk,proto3,oneof"`
 }
 
-func (*Message_Chunk) isMessage_Contents()  {}
+type Message_Status struct {
+	Status *UpgradeStepStatus `protobuf:"bytes,2,opt,name=status,proto3,oneof"`
+}
+
+func (*Message_Chunk) isMessage_Contents() {}
+
 func (*Message_Status) isMessage_Contents() {}
 
 func (m *Message) GetContents() isMessage_Contents {
@@ -820,83 +855,17 @@ func (m *Message) GetStatus() *UpgradeStepStatus {
 	return nil
 }
 
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*Message) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _Message_OneofMarshaler, _Message_OneofUnmarshaler, _Message_OneofSizer, []interface{}{
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*Message) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
 		(*Message_Chunk)(nil),
 		(*Message_Status)(nil),
 	}
 }
 
-func _Message_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*Message)
-	// contents
-	switch x := m.Contents.(type) {
-	case *Message_Chunk:
-		b.EncodeVarint(1<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Chunk); err != nil {
-			return err
-		}
-	case *Message_Status:
-		b.EncodeVarint(2<<3 | proto.WireBytes)
-		if err := b.EncodeMessage(x.Status); err != nil {
-			return err
-		}
-	case nil:
-	default:
-		return fmt.Errorf("Message.Contents has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _Message_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*Message)
-	switch tag {
-	case 1: // contents.chunk
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(Chunk)
-		err := b.DecodeMessage(msg)
-		m.Contents = &Message_Chunk{msg}
-		return true, err
-	case 2: // contents.status
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		msg := new(UpgradeStepStatus)
-		err := b.DecodeMessage(msg)
-		m.Contents = &Message_Status{msg}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _Message_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*Message)
-	// contents
-	switch x := m.Contents.(type) {
-	case *Message_Chunk:
-		s := proto.Size(x.Chunk)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case *Message_Status:
-		s := proto.Size(x.Status)
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(s))
-		n += s
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
-}
-
 type SetConfigRequest struct {
-	Name                 string   `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
-	Value                string   `protobuf:"bytes,2,opt,name=value" json:"value,omitempty"`
+	Name                 string   `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Value                string   `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -906,16 +875,17 @@ func (m *SetConfigRequest) Reset()         { *m = SetConfigRequest{} }
 func (m *SetConfigRequest) String() string { return proto.CompactTextString(m) }
 func (*SetConfigRequest) ProtoMessage()    {}
 func (*SetConfigRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{17}
+	return fileDescriptor_631e66a01873be02, []int{17}
 }
+
 func (m *SetConfigRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SetConfigRequest.Unmarshal(m, b)
 }
 func (m *SetConfigRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SetConfigRequest.Marshal(b, m, deterministic)
 }
-func (dst *SetConfigRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SetConfigRequest.Merge(dst, src)
+func (m *SetConfigRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SetConfigRequest.Merge(m, src)
 }
 func (m *SetConfigRequest) XXX_Size() int {
 	return xxx_messageInfo_SetConfigRequest.Size(m)
@@ -950,16 +920,17 @@ func (m *SetConfigReply) Reset()         { *m = SetConfigReply{} }
 func (m *SetConfigReply) String() string { return proto.CompactTextString(m) }
 func (*SetConfigReply) ProtoMessage()    {}
 func (*SetConfigReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{18}
+	return fileDescriptor_631e66a01873be02, []int{18}
 }
+
 func (m *SetConfigReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SetConfigReply.Unmarshal(m, b)
 }
 func (m *SetConfigReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SetConfigReply.Marshal(b, m, deterministic)
 }
-func (dst *SetConfigReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SetConfigReply.Merge(dst, src)
+func (m *SetConfigReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SetConfigReply.Merge(m, src)
 }
 func (m *SetConfigReply) XXX_Size() int {
 	return xxx_messageInfo_SetConfigReply.Size(m)
@@ -971,7 +942,7 @@ func (m *SetConfigReply) XXX_DiscardUnknown() {
 var xxx_messageInfo_SetConfigReply proto.InternalMessageInfo
 
 type GetConfigRequest struct {
-	Name                 string   `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
+	Name                 string   `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -981,16 +952,17 @@ func (m *GetConfigRequest) Reset()         { *m = GetConfigRequest{} }
 func (m *GetConfigRequest) String() string { return proto.CompactTextString(m) }
 func (*GetConfigRequest) ProtoMessage()    {}
 func (*GetConfigRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{19}
+	return fileDescriptor_631e66a01873be02, []int{19}
 }
+
 func (m *GetConfigRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetConfigRequest.Unmarshal(m, b)
 }
 func (m *GetConfigRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GetConfigRequest.Marshal(b, m, deterministic)
 }
-func (dst *GetConfigRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetConfigRequest.Merge(dst, src)
+func (m *GetConfigRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetConfigRequest.Merge(m, src)
 }
 func (m *GetConfigRequest) XXX_Size() int {
 	return xxx_messageInfo_GetConfigRequest.Size(m)
@@ -1009,7 +981,7 @@ func (m *GetConfigRequest) GetName() string {
 }
 
 type GetConfigReply struct {
-	Value                string   `protobuf:"bytes,1,opt,name=value" json:"value,omitempty"`
+	Value                string   `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -1019,16 +991,17 @@ func (m *GetConfigReply) Reset()         { *m = GetConfigReply{} }
 func (m *GetConfigReply) String() string { return proto.CompactTextString(m) }
 func (*GetConfigReply) ProtoMessage()    {}
 func (*GetConfigReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{20}
+	return fileDescriptor_631e66a01873be02, []int{20}
 }
+
 func (m *GetConfigReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetConfigReply.Unmarshal(m, b)
 }
 func (m *GetConfigReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GetConfigReply.Marshal(b, m, deterministic)
 }
-func (dst *GetConfigReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetConfigReply.Merge(dst, src)
+func (m *GetConfigReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetConfigReply.Merge(m, src)
 }
 func (m *GetConfigReply) XXX_Size() int {
 	return xxx_messageInfo_GetConfigReply.Size(m)
@@ -1047,6 +1020,9 @@ func (m *GetConfigReply) GetValue() string {
 }
 
 func init() {
+	proto.RegisterEnum("idl.UpgradeSteps", UpgradeSteps_name, UpgradeSteps_value)
+	proto.RegisterEnum("idl.StepStatus", StepStatus_name, StepStatus_value)
+	proto.RegisterEnum("idl.Chunk_Type", Chunk_Type_name, Chunk_Type_value)
 	proto.RegisterType((*InitializeRequest)(nil), "idl.InitializeRequest")
 	proto.RegisterType((*InitializeCreateClusterRequest)(nil), "idl.InitializeCreateClusterRequest")
 	proto.RegisterType((*ExecuteRequest)(nil), "idl.ExecuteRequest")
@@ -1070,9 +1046,78 @@ func init() {
 	proto.RegisterType((*SetConfigReply)(nil), "idl.SetConfigReply")
 	proto.RegisterType((*GetConfigRequest)(nil), "idl.GetConfigRequest")
 	proto.RegisterType((*GetConfigReply)(nil), "idl.GetConfigReply")
-	proto.RegisterEnum("idl.UpgradeSteps", UpgradeSteps_name, UpgradeSteps_value)
-	proto.RegisterEnum("idl.StepStatus", StepStatus_name, StepStatus_value)
-	proto.RegisterEnum("idl.Chunk_Type", Chunk_Type_name, Chunk_Type_value)
+}
+
+func init() { proto.RegisterFile("cli_to_hub.proto", fileDescriptor_631e66a01873be02) }
+
+var fileDescriptor_631e66a01873be02 = []byte{
+	// 1053 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x56, 0x5d, 0x6f, 0xe2, 0x56,
+	0x13, 0xc6, 0x7c, 0x33, 0x10, 0x62, 0x0e, 0xf9, 0x20, 0xec, 0xab, 0x55, 0xe4, 0x7d, 0xbb, 0x8d,
+	0xb6, 0x6a, 0x14, 0xd1, 0x6a, 0xb5, 0x5b, 0xed, 0x0d, 0x31, 0x27, 0x80, 0x36, 0x01, 0x74, 0x6c,
+	0xb7, 0xea, 0x45, 0x85, 0x1c, 0x38, 0x49, 0xac, 0x78, 0x6d, 0xc7, 0x3e, 0xa4, 0xa5, 0xff, 0xa0,
+	0xbf, 0xa5, 0xbf, 0xb0, 0x77, 0xd5, 0x39, 0xb6, 0xc1, 0x66, 0x1d, 0xa9, 0x77, 0x9e, 0x79, 0xe6,
+	0x99, 0x19, 0x0f, 0xcf, 0x78, 0x00, 0x79, 0x61, 0x5b, 0x73, 0xe6, 0xce, 0x1f, 0x56, 0xb7, 0xe7,
+	0x9e, 0xef, 0x32, 0x17, 0x15, 0xac, 0xa5, 0xad, 0x58, 0xd0, 0x1a, 0x3b, 0x16, 0xb3, 0x4c, 0xdb,
+	0xfa, 0x93, 0x12, 0xfa, 0xb4, 0xa2, 0x01, 0x43, 0xff, 0x83, 0x9a, 0x6b, 0x2f, 0x2f, 0x2d, 0x67,
+	0x60, 0xf9, 0x1d, 0xe9, 0x54, 0x3a, 0xab, 0x91, 0xad, 0x83, 0xa3, 0x0e, 0xfd, 0x3d, 0x42, 0xf3,
+	0x21, 0xba, 0x71, 0xa0, 0x0e, 0x54, 0x5c, 0x7b, 0x39, 0x73, 0x7d, 0xd6, 0x29, 0x9c, 0x4a, 0x67,
+	0x25, 0x12, 0x9b, 0xca, 0x7b, 0x78, 0xbd, 0x2d, 0xa5, 0xfa, 0xd4, 0x64, 0x54, 0xb5, 0x57, 0x01,
+	0xa3, 0x7e, 0x5c, 0xf7, 0x00, 0x4a, 0x9e, 0xeb, 0xb3, 0xa0, 0x23, 0x9d, 0x16, 0xce, 0xf6, 0x48,
+	0x68, 0x28, 0x32, 0x34, 0xf1, 0x1f, 0x74, 0xb1, 0x62, 0x71, 0x7f, 0x4a, 0x0b, 0xf6, 0xaf, 0x2c,
+	0x27, 0xd9, 0xb2, 0x72, 0x04, 0x07, 0x84, 0x06, 0xcc, 0xf4, 0x59, 0xff, 0x9e, 0x3a, 0x2c, 0x88,
+	0xfd, 0x3f, 0x02, 0xda, 0xf1, 0x7b, 0xf6, 0x1a, 0xbd, 0x06, 0x30, 0xb9, 0x39, 0x72, 0x83, 0xa8,
+	0x5a, 0x8d, 0x24, 0x3c, 0xca, 0x21, 0xb4, 0x35, 0xe6, 0x7a, 0x1a, 0xf5, 0x9f, 0xad, 0x05, 0xdd,
+	0x24, 0x6b, 0x43, 0x2b, 0xed, 0xf6, 0xec, 0xb5, 0xb2, 0x80, 0x96, 0xe1, 0xdd, 0xfb, 0xe6, 0x92,
+	0x6a, 0x8c, 0x7a, 0x1a, 0x33, 0xd9, 0x2a, 0x40, 0xdf, 0x40, 0x31, 0x60, 0xd4, 0x13, 0xc3, 0x6b,
+	0xf6, 0x5a, 0xe7, 0xd6, 0xd2, 0x3e, 0x4f, 0x44, 0x05, 0x44, 0xc0, 0xe8, 0x5b, 0x28, 0x07, 0x82,
+	0x20, 0xe6, 0xd8, 0xec, 0xed, 0x8b, 0xc0, 0x6d, 0x1e, 0x12, 0xc1, 0xbc, 0x21, 0xf5, 0x81, 0x2e,
+	0x1e, 0x7f, 0xa6, 0x7e, 0x60, 0xb9, 0x4e, 0xdc, 0x10, 0x86, 0x56, 0xda, 0xcd, 0x5f, 0xee, 0x02,
+	0xda, 0xe3, 0x20, 0xf2, 0xa8, 0xee, 0x17, 0xcf, 0x64, 0xd6, 0xad, 0x4d, 0x45, 0x2b, 0x55, 0x92,
+	0x05, 0x29, 0xdf, 0xc3, 0xa1, 0x48, 0x33, 0xb0, 0x82, 0x47, 0xcd, 0x33, 0x17, 0x34, 0xf1, 0x83,
+	0xf8, 0x26, 0xb3, 0x5c, 0x41, 0x96, 0x48, 0x68, 0x28, 0xff, 0x48, 0x51, 0x37, 0x89, 0x78, 0x5e,
+	0xf8, 0x13, 0x94, 0xef, 0x4c, 0xcb, 0xa6, 0x4b, 0x31, 0xd1, 0x7a, 0xef, 0xff, 0xe2, 0x6d, 0x32,
+	0x22, 0xcf, 0xaf, 0x44, 0x18, 0x76, 0x98, 0xbf, 0x26, 0x11, 0xa7, 0x8b, 0xa1, 0xc6, 0xa3, 0x8c,
+	0xc0, 0xbc, 0xa7, 0x5c, 0x63, 0xe6, 0xb3, 0x69, 0xd9, 0x66, 0xdc, 0x79, 0x91, 0x6c, 0x1d, 0xa8,
+	0x0b, 0x55, 0x9f, 0x3e, 0xad, 0x2c, 0x9f, 0x2e, 0xc5, 0xe0, 0x8a, 0x64, 0x63, 0x77, 0x7f, 0x83,
+	0x7a, 0x22, 0x3b, 0x92, 0xa1, 0xf0, 0x48, 0xd7, 0x91, 0x88, 0xf9, 0x23, 0xfa, 0x00, 0xa5, 0x67,
+	0xd3, 0x5e, 0x51, 0xc1, 0xac, 0xf7, 0x94, 0x17, 0x9b, 0xdc, 0x74, 0x43, 0x42, 0xc2, 0x4f, 0xf9,
+	0x0f, 0x92, 0xf2, 0x0a, 0x4e, 0x66, 0x3e, 0xf5, 0x4c, 0x9f, 0x72, 0x2d, 0xa7, 0xf5, 0xab, 0x9c,
+	0xc0, 0x71, 0x16, 0xc8, 0x55, 0xf2, 0x04, 0x25, 0xf5, 0x61, 0xe5, 0x3c, 0xa2, 0x23, 0x28, 0xdf,
+	0xae, 0xee, 0xee, 0x68, 0xb8, 0x58, 0x0d, 0x12, 0x59, 0xe8, 0x0d, 0x14, 0xd9, 0xda, 0xa3, 0x29,
+	0x21, 0x08, 0xc6, 0xb9, 0xbe, 0xf6, 0x28, 0x11, 0xa0, 0xf2, 0x1d, 0x14, 0xb9, 0x85, 0xea, 0x50,
+	0x31, 0x26, 0x9f, 0x27, 0xd3, 0x5f, 0x26, 0x72, 0x0e, 0x01, 0x94, 0x35, 0x7d, 0x30, 0x35, 0x74,
+	0x59, 0x8a, 0x9e, 0x31, 0x21, 0x72, 0x5e, 0x79, 0x84, 0xca, 0x0d, 0x0d, 0xc4, 0x38, 0x15, 0x28,
+	0x2d, 0x78, 0x2e, 0x51, 0xb3, 0xde, 0x83, 0x6d, 0xf6, 0x51, 0x8e, 0x84, 0x10, 0xba, 0x48, 0x69,
+	0xb1, 0xde, 0x3b, 0xda, 0x15, 0x6d, 0x28, 0xc9, 0x51, 0x2e, 0x16, 0xe5, 0x25, 0x40, 0x75, 0xe1,
+	0x3a, 0x8c, 0xaf, 0x95, 0xf2, 0x09, 0x64, 0x8d, 0x32, 0xd5, 0x75, 0xee, 0xac, 0xfb, 0x58, 0x3d,
+	0x08, 0x8a, 0x8e, 0xf9, 0x85, 0x46, 0xc3, 0x17, 0xcf, 0x5c, 0x51, 0xdb, 0xe9, 0xd7, 0xa2, 0xc9,
+	0xf2, 0x15, 0x4f, 0xb0, 0xf9, 0xbc, 0xde, 0x82, 0x3c, 0xfc, 0x0f, 0xf9, 0x94, 0xb7, 0xd0, 0x1c,
+	0xa6, 0x98, 0xdb, 0x0a, 0x52, 0xa2, 0xc2, 0xbb, 0xbf, 0xf3, 0xd0, 0x48, 0x2e, 0x20, 0x92, 0xa1,
+	0x11, 0x8d, 0x70, 0xae, 0xe9, 0x78, 0x16, 0xce, 0x51, 0x9d, 0x4e, 0xae, 0xc6, 0x43, 0x59, 0xe2,
+	0xa8, 0xa6, 0xf7, 0x89, 0x3e, 0xef, 0x0f, 0xf1, 0x44, 0xd7, 0xe4, 0x3c, 0xea, 0xc0, 0x81, 0x4a,
+	0x70, 0x5f, 0xc7, 0x73, 0xbd, 0x4f, 0x86, 0x58, 0x9f, 0x47, 0xb1, 0x05, 0xf4, 0x0a, 0x8e, 0xb5,
+	0x91, 0xa1, 0x0f, 0x44, 0xaa, 0xa9, 0x41, 0x54, 0x3c, 0x57, 0xaf, 0x0d, 0x4d, 0xc7, 0x44, 0x2e,
+	0xa2, 0x63, 0x68, 0x8f, 0x27, 0x63, 0x7d, 0x43, 0x8a, 0x80, 0x52, 0x8a, 0xb5, 0x03, 0x96, 0x51,
+	0x0b, 0xf6, 0xd4, 0x11, 0x56, 0x3f, 0xcf, 0x8d, 0xd9, 0x90, 0xf4, 0x07, 0x58, 0xae, 0x20, 0x04,
+	0xcd, 0xc8, 0x98, 0xdf, 0xf4, 0x45, 0x58, 0x15, 0xed, 0x43, 0x5d, 0x9d, 0xce, 0x7e, 0x8d, 0x1d,
+	0x35, 0x74, 0x08, 0xad, 0x38, 0x68, 0x46, 0xc6, 0x37, 0x7d, 0x32, 0xc6, 0x9a, 0x0c, 0xbc, 0xf7,
+	0xf0, 0x6d, 0x76, 0x0a, 0xd5, 0x39, 0x81, 0xe0, 0xf0, 0x4d, 0x0c, 0x82, 0xe7, 0xb3, 0x29, 0xd1,
+	0x35, 0xb9, 0xf1, 0x4e, 0x07, 0x48, 0x7c, 0xcc, 0x78, 0xe9, 0xcd, 0xa8, 0xfa, 0xba, 0xa1, 0xc9,
+	0x39, 0xae, 0xc0, 0x19, 0x9e, 0x0c, 0xc6, 0x13, 0x3e, 0xad, 0x3a, 0x54, 0x88, 0x31, 0x99, 0x70,
+	0x23, 0x8f, 0x1a, 0x50, 0x55, 0xa7, 0x37, 0xb3, 0x6b, 0xac, 0x63, 0xb9, 0xc0, 0x87, 0x7a, 0xd5,
+	0x1f, 0x5f, 0xe3, 0x81, 0x5c, 0xec, 0xfd, 0x55, 0x82, 0xaa, 0x6a, 0x5b, 0xba, 0x3b, 0x5a, 0xdd,
+	0xa2, 0x4b, 0x68, 0x24, 0x3f, 0x5d, 0xa8, 0xb3, 0xdd, 0xc3, 0xf4, 0x47, 0xae, 0x7b, 0x94, 0x81,
+	0x70, 0x89, 0xe4, 0xd0, 0x08, 0x9a, 0xe9, 0xc5, 0x45, 0xdd, 0xcc, 0x6d, 0x0e, 0xf3, 0x74, 0x5e,
+	0xda, 0x74, 0x25, 0x87, 0xde, 0x03, 0x6c, 0x6f, 0x13, 0x0a, 0x2b, 0x7e, 0x75, 0x17, 0xbb, 0x0d,
+	0xe1, 0x8f, 0x96, 0x4a, 0xc9, 0x5d, 0x48, 0x68, 0x06, 0xc7, 0x2f, 0xdc, 0x34, 0xf4, 0x66, 0x27,
+	0x49, 0xd6, 0xc5, 0xcb, 0xc8, 0x78, 0x01, 0x95, 0xe8, 0xda, 0xa1, 0xb6, 0x00, 0xd3, 0xb7, 0x2f,
+	0x83, 0xd1, 0x83, 0x6a, 0x7c, 0x0d, 0xd1, 0x81, 0x40, 0x77, 0x8e, 0x63, 0x06, 0xe7, 0x23, 0xd4,
+	0x36, 0x0b, 0x87, 0x0e, 0xc3, 0xab, 0xb3, 0xb3, 0x6e, 0xdd, 0xf6, 0xae, 0x3b, 0x1c, 0xd5, 0x47,
+	0xa8, 0x0d, 0x77, 0xa8, 0xc3, 0x6c, 0xea, 0x70, 0x97, 0x8a, 0x61, 0x2f, 0x75, 0x8c, 0xd1, 0x89,
+	0x88, 0xcb, 0x3a, 0xdc, 0xdd, 0xe3, 0x2c, 0x28, 0x4c, 0x73, 0x09, 0x8d, 0xe4, 0x19, 0x8e, 0xa4,
+	0x93, 0x71, 0xb0, 0x23, 0xe9, 0x7c, 0x7d, 0xb3, 0x73, 0xb7, 0x65, 0xf1, 0x1f, 0xe8, 0x87, 0x7f,
+	0x03, 0x00, 0x00, 0xff, 0xff, 0x25, 0xb2, 0x9d, 0x5d, 0x17, 0x09, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1083,8 +1128,9 @@ var _ grpc.ClientConn
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion4
 
-// Client API for CliToHub service
-
+// CliToHubClient is the client API for CliToHub service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type CliToHubClient interface {
 	CheckVersion(ctx context.Context, in *CheckVersionRequest, opts ...grpc.CallOption) (*CheckVersionReply, error)
 	CheckDiskSpace(ctx context.Context, in *CheckDiskSpaceRequest, opts ...grpc.CallOption) (*CheckDiskSpaceReply, error)
@@ -1108,7 +1154,7 @@ func NewCliToHubClient(cc *grpc.ClientConn) CliToHubClient {
 
 func (c *cliToHubClient) CheckVersion(ctx context.Context, in *CheckVersionRequest, opts ...grpc.CallOption) (*CheckVersionReply, error) {
 	out := new(CheckVersionReply)
-	err := grpc.Invoke(ctx, "/idl.CliToHub/CheckVersion", in, out, c.cc, opts...)
+	err := c.cc.Invoke(ctx, "/idl.CliToHub/CheckVersion", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1117,7 +1163,7 @@ func (c *cliToHubClient) CheckVersion(ctx context.Context, in *CheckVersionReque
 
 func (c *cliToHubClient) CheckDiskSpace(ctx context.Context, in *CheckDiskSpaceRequest, opts ...grpc.CallOption) (*CheckDiskSpaceReply, error) {
 	out := new(CheckDiskSpaceReply)
-	err := grpc.Invoke(ctx, "/idl.CliToHub/CheckDiskSpace", in, out, c.cc, opts...)
+	err := c.cc.Invoke(ctx, "/idl.CliToHub/CheckDiskSpace", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1125,7 +1171,7 @@ func (c *cliToHubClient) CheckDiskSpace(ctx context.Context, in *CheckDiskSpaceR
 }
 
 func (c *cliToHubClient) Initialize(ctx context.Context, in *InitializeRequest, opts ...grpc.CallOption) (CliToHub_InitializeClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_CliToHub_serviceDesc.Streams[0], c.cc, "/idl.CliToHub/Initialize", opts...)
+	stream, err := c.cc.NewStream(ctx, &_CliToHub_serviceDesc.Streams[0], "/idl.CliToHub/Initialize", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1157,7 +1203,7 @@ func (x *cliToHubInitializeClient) Recv() (*Message, error) {
 }
 
 func (c *cliToHubClient) InitializeCreateCluster(ctx context.Context, in *InitializeCreateClusterRequest, opts ...grpc.CallOption) (CliToHub_InitializeCreateClusterClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_CliToHub_serviceDesc.Streams[1], c.cc, "/idl.CliToHub/InitializeCreateCluster", opts...)
+	stream, err := c.cc.NewStream(ctx, &_CliToHub_serviceDesc.Streams[1], "/idl.CliToHub/InitializeCreateCluster", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1189,7 +1235,7 @@ func (x *cliToHubInitializeCreateClusterClient) Recv() (*Message, error) {
 }
 
 func (c *cliToHubClient) Execute(ctx context.Context, in *ExecuteRequest, opts ...grpc.CallOption) (CliToHub_ExecuteClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_CliToHub_serviceDesc.Streams[2], c.cc, "/idl.CliToHub/Execute", opts...)
+	stream, err := c.cc.NewStream(ctx, &_CliToHub_serviceDesc.Streams[2], "/idl.CliToHub/Execute", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1221,7 +1267,7 @@ func (x *cliToHubExecuteClient) Recv() (*Message, error) {
 }
 
 func (c *cliToHubClient) Finalize(ctx context.Context, in *FinalizeRequest, opts ...grpc.CallOption) (CliToHub_FinalizeClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_CliToHub_serviceDesc.Streams[3], c.cc, "/idl.CliToHub/Finalize", opts...)
+	stream, err := c.cc.NewStream(ctx, &_CliToHub_serviceDesc.Streams[3], "/idl.CliToHub/Finalize", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1254,7 +1300,7 @@ func (x *cliToHubFinalizeClient) Recv() (*Message, error) {
 
 func (c *cliToHubClient) SetConfig(ctx context.Context, in *SetConfigRequest, opts ...grpc.CallOption) (*SetConfigReply, error) {
 	out := new(SetConfigReply)
-	err := grpc.Invoke(ctx, "/idl.CliToHub/SetConfig", in, out, c.cc, opts...)
+	err := c.cc.Invoke(ctx, "/idl.CliToHub/SetConfig", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1263,7 +1309,7 @@ func (c *cliToHubClient) SetConfig(ctx context.Context, in *SetConfigRequest, op
 
 func (c *cliToHubClient) GetConfig(ctx context.Context, in *GetConfigRequest, opts ...grpc.CallOption) (*GetConfigReply, error) {
 	out := new(GetConfigReply)
-	err := grpc.Invoke(ctx, "/idl.CliToHub/GetConfig", in, out, c.cc, opts...)
+	err := c.cc.Invoke(ctx, "/idl.CliToHub/GetConfig", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1272,7 +1318,7 @@ func (c *cliToHubClient) GetConfig(ctx context.Context, in *GetConfigRequest, op
 
 func (c *cliToHubClient) RestartAgents(ctx context.Context, in *RestartAgentsRequest, opts ...grpc.CallOption) (*RestartAgentsReply, error) {
 	out := new(RestartAgentsReply)
-	err := grpc.Invoke(ctx, "/idl.CliToHub/RestartAgents", in, out, c.cc, opts...)
+	err := c.cc.Invoke(ctx, "/idl.CliToHub/RestartAgents", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1281,15 +1327,14 @@ func (c *cliToHubClient) RestartAgents(ctx context.Context, in *RestartAgentsReq
 
 func (c *cliToHubClient) StopServices(ctx context.Context, in *StopServicesRequest, opts ...grpc.CallOption) (*StopServicesReply, error) {
 	out := new(StopServicesReply)
-	err := grpc.Invoke(ctx, "/idl.CliToHub/StopServices", in, out, c.cc, opts...)
+	err := c.cc.Invoke(ctx, "/idl.CliToHub/StopServices", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// Server API for CliToHub service
-
+// CliToHubServer is the server API for CliToHub service.
 type CliToHubServer interface {
 	CheckVersion(context.Context, *CheckVersionRequest) (*CheckVersionReply, error)
 	CheckDiskSpace(context.Context, *CheckDiskSpaceRequest) (*CheckDiskSpaceReply, error)
@@ -1301,6 +1346,41 @@ type CliToHubServer interface {
 	GetConfig(context.Context, *GetConfigRequest) (*GetConfigReply, error)
 	RestartAgents(context.Context, *RestartAgentsRequest) (*RestartAgentsReply, error)
 	StopServices(context.Context, *StopServicesRequest) (*StopServicesReply, error)
+}
+
+// UnimplementedCliToHubServer can be embedded to have forward compatible implementations.
+type UnimplementedCliToHubServer struct {
+}
+
+func (*UnimplementedCliToHubServer) CheckVersion(ctx context.Context, req *CheckVersionRequest) (*CheckVersionReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CheckVersion not implemented")
+}
+func (*UnimplementedCliToHubServer) CheckDiskSpace(ctx context.Context, req *CheckDiskSpaceRequest) (*CheckDiskSpaceReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CheckDiskSpace not implemented")
+}
+func (*UnimplementedCliToHubServer) Initialize(req *InitializeRequest, srv CliToHub_InitializeServer) error {
+	return status.Errorf(codes.Unimplemented, "method Initialize not implemented")
+}
+func (*UnimplementedCliToHubServer) InitializeCreateCluster(req *InitializeCreateClusterRequest, srv CliToHub_InitializeCreateClusterServer) error {
+	return status.Errorf(codes.Unimplemented, "method InitializeCreateCluster not implemented")
+}
+func (*UnimplementedCliToHubServer) Execute(req *ExecuteRequest, srv CliToHub_ExecuteServer) error {
+	return status.Errorf(codes.Unimplemented, "method Execute not implemented")
+}
+func (*UnimplementedCliToHubServer) Finalize(req *FinalizeRequest, srv CliToHub_FinalizeServer) error {
+	return status.Errorf(codes.Unimplemented, "method Finalize not implemented")
+}
+func (*UnimplementedCliToHubServer) SetConfig(ctx context.Context, req *SetConfigRequest) (*SetConfigReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SetConfig not implemented")
+}
+func (*UnimplementedCliToHubServer) GetConfig(ctx context.Context, req *GetConfigRequest) (*GetConfigReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetConfig not implemented")
+}
+func (*UnimplementedCliToHubServer) RestartAgents(ctx context.Context, req *RestartAgentsRequest) (*RestartAgentsReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RestartAgents not implemented")
+}
+func (*UnimplementedCliToHubServer) StopServices(ctx context.Context, req *StopServicesRequest) (*StopServicesReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method StopServices not implemented")
 }
 
 func RegisterCliToHubServer(s *grpc.Server, srv CliToHubServer) {
@@ -1551,76 +1631,4 @@ var _CliToHub_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Metadata: "cli_to_hub.proto",
-}
-
-func init() { proto.RegisterFile("cli_to_hub.proto", fileDescriptor_cli_to_hub_eec94ec24fdc3e31) }
-
-var fileDescriptor_cli_to_hub_eec94ec24fdc3e31 = []byte{
-	// 1043 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x56, 0x6d, 0x6f, 0xe2, 0x46,
-	0x10, 0xc6, 0xbc, 0x33, 0x70, 0x9c, 0x59, 0xf2, 0x42, 0xb8, 0xea, 0x14, 0xf9, 0xda, 0x6b, 0x74,
-	0x55, 0xa3, 0x88, 0x56, 0xd5, 0x5d, 0x75, 0x5f, 0x88, 0xd9, 0x00, 0xba, 0x04, 0xd0, 0xda, 0x6e,
-	0xd5, 0x0f, 0x15, 0x72, 0x60, 0x93, 0x58, 0xf8, 0x6c, 0xc7, 0x5e, 0xd2, 0xd2, 0x7f, 0xd0, 0xdf,
-	0xd2, 0x5f, 0xd8, 0x6f, 0xd5, 0xae, 0x0d, 0xd8, 0x3e, 0x47, 0xea, 0x37, 0xcf, 0x3c, 0xf3, 0xcc,
-	0x8c, 0x87, 0x67, 0x3c, 0x80, 0xbc, 0xb0, 0xad, 0x39, 0x73, 0xe7, 0x0f, 0xeb, 0xdb, 0x73, 0xcf,
-	0x77, 0x99, 0x8b, 0x0a, 0xd6, 0xd2, 0x56, 0x2c, 0x68, 0x8d, 0x1d, 0x8b, 0x59, 0xa6, 0x6d, 0xfd,
-	0x45, 0x09, 0x7d, 0x5c, 0xd3, 0x80, 0xa1, 0xaf, 0xa0, 0xe6, 0xda, 0xcb, 0x4b, 0xcb, 0x19, 0x58,
-	0x7e, 0x47, 0x3a, 0x95, 0xce, 0x6a, 0x64, 0xef, 0xe0, 0xa8, 0x43, 0xff, 0x88, 0xd0, 0x7c, 0x88,
-	0xee, 0x1c, 0xa8, 0x03, 0x15, 0xd7, 0x5e, 0xce, 0x5c, 0x9f, 0x75, 0x0a, 0xa7, 0xd2, 0x59, 0x89,
-	0x6c, 0x4d, 0xe5, 0x14, 0x5e, 0xef, 0x4b, 0xa9, 0x3e, 0x35, 0x19, 0x55, 0xed, 0x75, 0xc0, 0xa8,
-	0x1f, 0xd5, 0x55, 0x64, 0x68, 0xe2, 0x3f, 0xe9, 0x62, 0xcd, 0xb6, 0x9d, 0x28, 0x2d, 0x78, 0x79,
-	0x65, 0x39, 0xf1, 0xe6, 0x94, 0x23, 0x38, 0x20, 0x34, 0x60, 0xa6, 0xcf, 0xfa, 0xf7, 0xd4, 0x61,
-	0xc1, 0xd6, 0xff, 0x23, 0xa0, 0x94, 0xdf, 0xb3, 0x37, 0xe8, 0x35, 0x80, 0xc9, 0xcd, 0x91, 0x1b,
-	0xb0, 0xa0, 0x23, 0x9d, 0x16, 0xce, 0x6a, 0x24, 0xe6, 0x51, 0x0e, 0xa1, 0xad, 0x31, 0xd7, 0xd3,
-	0xa8, 0xff, 0x64, 0x2d, 0xe8, 0x2e, 0x59, 0x1b, 0x5a, 0x49, 0xb7, 0x67, 0x6f, 0x94, 0x05, 0xb4,
-	0x0c, 0xef, 0xde, 0x37, 0x97, 0x54, 0x63, 0xd4, 0xd3, 0x98, 0xc9, 0xd6, 0x01, 0xfa, 0x06, 0x8a,
-	0x01, 0xa3, 0x9e, 0x18, 0x53, 0xb3, 0xd7, 0x3a, 0xb7, 0x96, 0xf6, 0x79, 0x2c, 0x2a, 0x20, 0x02,
-	0x46, 0xdf, 0x42, 0x39, 0x10, 0x04, 0x31, 0xb1, 0x66, 0xef, 0xa5, 0x08, 0xdc, 0xe7, 0x21, 0x11,
-	0xcc, 0x1b, 0x52, 0x1f, 0xe8, 0x62, 0xf5, 0x0b, 0xf5, 0x03, 0xcb, 0x75, 0xb6, 0x0d, 0x61, 0x68,
-	0x25, 0xdd, 0xfc, 0xe5, 0x2e, 0xa0, 0x3d, 0x0e, 0x22, 0x8f, 0xea, 0x7e, 0xf6, 0x4c, 0x66, 0xdd,
-	0xda, 0x54, 0xb4, 0x52, 0x25, 0x59, 0x90, 0xf2, 0x3d, 0x1c, 0x8a, 0x34, 0x03, 0x2b, 0x58, 0x69,
-	0x9e, 0xb9, 0xd8, 0xfd, 0xe4, 0x07, 0x50, 0xf2, 0x4d, 0x66, 0xb9, 0x82, 0x2c, 0x91, 0xd0, 0x50,
-	0xfe, 0x95, 0xa2, 0x6e, 0x62, 0xf1, 0xbc, 0xf0, 0x47, 0x28, 0xdf, 0x99, 0x96, 0x4d, 0x97, 0x62,
-	0xa2, 0xf5, 0xde, 0xd7, 0xe2, 0x6d, 0x32, 0x22, 0xcf, 0xaf, 0x44, 0x18, 0x76, 0x98, 0xbf, 0x21,
-	0x11, 0xa7, 0x8b, 0xa1, 0xc6, 0xa3, 0x8c, 0xc0, 0xbc, 0xa7, 0x5c, 0x4d, 0xe6, 0x93, 0x69, 0xd9,
-	0xe6, 0xb6, 0xf3, 0x22, 0xd9, 0x3b, 0x50, 0x17, 0xaa, 0x3e, 0x7d, 0x5c, 0x5b, 0x3e, 0x5d, 0x8a,
-	0xc1, 0x15, 0xc9, 0xce, 0xee, 0xfe, 0x0e, 0xf5, 0x58, 0x76, 0x24, 0x43, 0x61, 0x45, 0x37, 0x91,
-	0x5c, 0xf9, 0x23, 0x7a, 0x0f, 0xa5, 0x27, 0xd3, 0x5e, 0x53, 0xc1, 0xac, 0xf7, 0x94, 0x67, 0x9b,
-	0xdc, 0x75, 0x43, 0x42, 0xc2, 0xcf, 0xf9, 0xf7, 0x92, 0xf2, 0x0a, 0x4e, 0x66, 0x3e, 0xf5, 0x4c,
-	0x9f, 0x72, 0xd5, 0xa6, 0x94, 0x7a, 0x02, 0xc7, 0x59, 0x20, 0x57, 0xc9, 0x23, 0x94, 0xd4, 0x87,
-	0xb5, 0xb3, 0x42, 0x47, 0x50, 0xbe, 0x5d, 0xdf, 0xdd, 0xd1, 0x70, 0x85, 0x1a, 0x24, 0xb2, 0xd0,
-	0x1b, 0x28, 0xb2, 0x8d, 0x47, 0x13, 0x42, 0x10, 0x8c, 0x73, 0x7d, 0xe3, 0x51, 0x22, 0x40, 0xe5,
-	0x3b, 0x28, 0x72, 0x0b, 0xd5, 0xa1, 0x62, 0x4c, 0x3e, 0x4d, 0xa6, 0xbf, 0x4e, 0xe4, 0x1c, 0x02,
-	0x28, 0x6b, 0xfa, 0x60, 0x6a, 0xe8, 0xb2, 0x14, 0x3d, 0x63, 0x42, 0xe4, 0xbc, 0xb2, 0x82, 0xca,
-	0x0d, 0x0d, 0xc4, 0x38, 0x15, 0x28, 0x2d, 0x78, 0x2e, 0x51, 0xb3, 0xde, 0x83, 0x7d, 0xf6, 0x51,
-	0x8e, 0x84, 0x10, 0xba, 0x48, 0x68, 0xb1, 0xde, 0x3b, 0x4a, 0x8b, 0x36, 0x94, 0xe4, 0x28, 0xb7,
-	0x15, 0xe5, 0x25, 0x40, 0x75, 0xe1, 0x3a, 0x8c, 0xaf, 0x95, 0xf2, 0x11, 0x64, 0x8d, 0x32, 0xd5,
-	0x75, 0xee, 0xac, 0xfb, 0xad, 0x7a, 0x10, 0x14, 0x1d, 0xf3, 0x33, 0x8d, 0x86, 0x2f, 0x9e, 0xb9,
-	0xa2, 0xf6, 0xd3, 0xaf, 0x45, 0x93, 0xe5, 0x2b, 0x1e, 0x63, 0xf3, 0x79, 0xbd, 0x05, 0x79, 0xf8,
-	0x3f, 0xf2, 0x29, 0x6f, 0xa1, 0x39, 0x4c, 0x30, 0xf7, 0x15, 0xa4, 0x58, 0x85, 0x77, 0xff, 0xe4,
-	0xa1, 0x11, 0x5f, 0x40, 0x24, 0x43, 0x23, 0x1a, 0xe1, 0x5c, 0xd3, 0xf1, 0x2c, 0x9c, 0xa3, 0x3a,
-	0x9d, 0x5c, 0x8d, 0x87, 0xb2, 0xc4, 0x51, 0x4d, 0xef, 0x13, 0x7d, 0xde, 0x1f, 0xe2, 0x89, 0xae,
-	0xc9, 0x79, 0xd4, 0x81, 0x03, 0x95, 0xe0, 0xbe, 0x8e, 0xe7, 0x7a, 0x9f, 0x0c, 0xb1, 0x3e, 0x8f,
-	0x62, 0x0b, 0xe8, 0x15, 0x1c, 0x6b, 0x23, 0x43, 0x1f, 0x88, 0x54, 0x53, 0x83, 0xa8, 0x78, 0xae,
-	0x5e, 0x1b, 0x9a, 0x8e, 0x89, 0x5c, 0x44, 0xc7, 0xd0, 0x1e, 0x4f, 0xc6, 0xfa, 0x8e, 0x14, 0x01,
-	0xa5, 0x04, 0x2b, 0x05, 0x96, 0x51, 0x0b, 0x5e, 0xa8, 0x23, 0xac, 0x7e, 0x9a, 0x1b, 0xb3, 0x21,
-	0xe9, 0x0f, 0xb0, 0x5c, 0x41, 0x08, 0x9a, 0x91, 0x31, 0xbf, 0xe9, 0x8b, 0xb0, 0x2a, 0x7a, 0x09,
-	0x75, 0x75, 0x3a, 0xfb, 0x6d, 0xeb, 0xa8, 0xa1, 0x43, 0x68, 0x6d, 0x83, 0x66, 0x64, 0x7c, 0xd3,
-	0x27, 0x63, 0xac, 0xc9, 0xc0, 0x7b, 0x0f, 0xdf, 0x26, 0x55, 0xa8, 0xce, 0x09, 0x04, 0x87, 0x6f,
-	0x62, 0x10, 0x3c, 0x9f, 0x4d, 0x89, 0xae, 0xc9, 0x8d, 0x77, 0x3a, 0x40, 0xec, 0x63, 0xc6, 0x4b,
-	0xef, 0x46, 0xd5, 0xd7, 0x0d, 0x4d, 0xce, 0x71, 0x05, 0xce, 0xf0, 0x64, 0x30, 0x9e, 0xf0, 0x69,
-	0xd5, 0xa1, 0x42, 0x8c, 0xc9, 0x84, 0x1b, 0x79, 0xd4, 0x80, 0xaa, 0x3a, 0xbd, 0x99, 0x5d, 0x63,
-	0x1d, 0xcb, 0x05, 0x3e, 0xd4, 0xab, 0xfe, 0xf8, 0x1a, 0x0f, 0xe4, 0x62, 0xef, 0xef, 0x12, 0x54,
-	0x55, 0xdb, 0xd2, 0xdd, 0xd1, 0xfa, 0x16, 0x5d, 0x42, 0x23, 0xfe, 0xe9, 0x42, 0x9d, 0xfd, 0x1e,
-	0x26, 0x3f, 0x72, 0xdd, 0xa3, 0x0c, 0x84, 0x4b, 0x24, 0x87, 0x46, 0xd0, 0x4c, 0x2e, 0x2e, 0xea,
-	0x66, 0x6e, 0x73, 0x98, 0xa7, 0xf3, 0xdc, 0xa6, 0x2b, 0x39, 0xf4, 0x13, 0xc0, 0xfe, 0x0a, 0xa1,
-	0xb0, 0xe2, 0x17, 0x17, 0xb0, 0xdb, 0x10, 0xfe, 0x68, 0xa9, 0x94, 0xdc, 0x85, 0x84, 0x66, 0x70,
-	0xfc, 0xcc, 0xf5, 0x42, 0x6f, 0x52, 0x49, 0xb2, 0x6e, 0x5b, 0x46, 0xc6, 0x0b, 0xa8, 0x44, 0xd7,
-	0x0e, 0xb5, 0x05, 0x98, 0xbc, 0x7d, 0x19, 0x8c, 0x1e, 0x54, 0xb7, 0xd7, 0x10, 0x1d, 0x08, 0x34,
-	0x75, 0x1c, 0x33, 0x38, 0x1f, 0xa0, 0xb6, 0x5b, 0x38, 0x74, 0x18, 0x5e, 0x9d, 0xd4, 0xba, 0x75,
-	0xdb, 0x69, 0x77, 0x38, 0xaa, 0x0f, 0x50, 0x1b, 0xa6, 0xa8, 0xc3, 0x6c, 0xea, 0x30, 0x4d, 0xc5,
-	0xf0, 0x22, 0x71, 0x8c, 0xd1, 0x89, 0x88, 0xcb, 0x3a, 0xdc, 0xdd, 0xe3, 0x2c, 0x28, 0x4c, 0x73,
-	0x09, 0x8d, 0xf8, 0x19, 0x8e, 0xa4, 0x93, 0x71, 0xb0, 0x23, 0xe9, 0x7c, 0x79, 0xb3, 0x73, 0xb7,
-	0x65, 0xf1, 0x6f, 0xe7, 0x87, 0xff, 0x02, 0x00, 0x00, 0xff, 0xff, 0x52, 0xfc, 0xd1, 0x3f, 0x01,
-	0x09, 0x00, 0x00,
 }

--- a/idl/cli_to_hub.proto
+++ b/idl/cli_to_hub.proto
@@ -20,8 +20,9 @@ message InitializeRequest {
     string newBinDir = 2;
     int32 oldPort = 3;
 }
-message InitializeCreateClusterRequest {}
-
+message InitializeCreateClusterRequest {
+    repeated uint32 ports = 1;
+}
 message ExecuteRequest {}
 message FinalizeRequest {}
 

--- a/idl/hub_to_agent.pb.go
+++ b/idl/hub_to_agent.pb.go
@@ -3,13 +3,14 @@
 
 package idl
 
-import proto "github.com/golang/protobuf/proto"
-import fmt "fmt"
-import math "math"
-
 import (
-	context "golang.org/x/net/context"
+	context "context"
+	fmt "fmt"
+	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -21,14 +22,14 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type UpgradePrimariesRequest struct {
-	OldBinDir            string         `protobuf:"bytes,1,opt,name=OldBinDir" json:"OldBinDir,omitempty"`
-	NewBinDir            string         `protobuf:"bytes,2,opt,name=NewBinDir" json:"NewBinDir,omitempty"`
-	NewVersion           string         `protobuf:"bytes,3,opt,name=NewVersion" json:"NewVersion,omitempty"`
-	DataDirPairs         []*DataDirPair `protobuf:"bytes,4,rep,name=DataDirPairs" json:"DataDirPairs,omitempty"`
-	CheckOnly            bool           `protobuf:"varint,5,opt,name=CheckOnly" json:"CheckOnly,omitempty"`
+	OldBinDir            string         `protobuf:"bytes,1,opt,name=OldBinDir,proto3" json:"OldBinDir,omitempty"`
+	NewBinDir            string         `protobuf:"bytes,2,opt,name=NewBinDir,proto3" json:"NewBinDir,omitempty"`
+	NewVersion           string         `protobuf:"bytes,3,opt,name=NewVersion,proto3" json:"NewVersion,omitempty"`
+	DataDirPairs         []*DataDirPair `protobuf:"bytes,4,rep,name=DataDirPairs,proto3" json:"DataDirPairs,omitempty"`
+	CheckOnly            bool           `protobuf:"varint,5,opt,name=CheckOnly,proto3" json:"CheckOnly,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
 	XXX_unrecognized     []byte         `json:"-"`
 	XXX_sizecache        int32          `json:"-"`
@@ -38,16 +39,17 @@ func (m *UpgradePrimariesRequest) Reset()         { *m = UpgradePrimariesRequest
 func (m *UpgradePrimariesRequest) String() string { return proto.CompactTextString(m) }
 func (*UpgradePrimariesRequest) ProtoMessage()    {}
 func (*UpgradePrimariesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{0}
+	return fileDescriptor_9e73bb06acc917d8, []int{0}
 }
+
 func (m *UpgradePrimariesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UpgradePrimariesRequest.Unmarshal(m, b)
 }
 func (m *UpgradePrimariesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UpgradePrimariesRequest.Marshal(b, m, deterministic)
 }
-func (dst *UpgradePrimariesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UpgradePrimariesRequest.Merge(dst, src)
+func (m *UpgradePrimariesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UpgradePrimariesRequest.Merge(m, src)
 }
 func (m *UpgradePrimariesRequest) XXX_Size() int {
 	return xxx_messageInfo_UpgradePrimariesRequest.Size(m)
@@ -94,11 +96,11 @@ func (m *UpgradePrimariesRequest) GetCheckOnly() bool {
 }
 
 type DataDirPair struct {
-	OldDataDir           string   `protobuf:"bytes,1,opt,name=OldDataDir" json:"OldDataDir,omitempty"`
-	NewDataDir           string   `protobuf:"bytes,2,opt,name=NewDataDir" json:"NewDataDir,omitempty"`
-	OldPort              int32    `protobuf:"varint,3,opt,name=OldPort" json:"OldPort,omitempty"`
-	NewPort              int32    `protobuf:"varint,4,opt,name=NewPort" json:"NewPort,omitempty"`
-	Content              int32    `protobuf:"varint,5,opt,name=Content" json:"Content,omitempty"`
+	OldDataDir           string   `protobuf:"bytes,1,opt,name=OldDataDir,proto3" json:"OldDataDir,omitempty"`
+	NewDataDir           string   `protobuf:"bytes,2,opt,name=NewDataDir,proto3" json:"NewDataDir,omitempty"`
+	OldPort              int32    `protobuf:"varint,3,opt,name=OldPort,proto3" json:"OldPort,omitempty"`
+	NewPort              int32    `protobuf:"varint,4,opt,name=NewPort,proto3" json:"NewPort,omitempty"`
+	Content              int32    `protobuf:"varint,5,opt,name=Content,proto3" json:"Content,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -108,16 +110,17 @@ func (m *DataDirPair) Reset()         { *m = DataDirPair{} }
 func (m *DataDirPair) String() string { return proto.CompactTextString(m) }
 func (*DataDirPair) ProtoMessage()    {}
 func (*DataDirPair) Descriptor() ([]byte, []int) {
-	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{1}
+	return fileDescriptor_9e73bb06acc917d8, []int{1}
 }
+
 func (m *DataDirPair) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DataDirPair.Unmarshal(m, b)
 }
 func (m *DataDirPair) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DataDirPair.Marshal(b, m, deterministic)
 }
-func (dst *DataDirPair) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DataDirPair.Merge(dst, src)
+func (m *DataDirPair) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DataDirPair.Merge(m, src)
 }
 func (m *DataDirPair) XXX_Size() int {
 	return xxx_messageInfo_DataDirPair.Size(m)
@@ -173,16 +176,17 @@ func (m *UpgradePrimariesReply) Reset()         { *m = UpgradePrimariesReply{} }
 func (m *UpgradePrimariesReply) String() string { return proto.CompactTextString(m) }
 func (*UpgradePrimariesReply) ProtoMessage()    {}
 func (*UpgradePrimariesReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{2}
+	return fileDescriptor_9e73bb06acc917d8, []int{2}
 }
+
 func (m *UpgradePrimariesReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UpgradePrimariesReply.Unmarshal(m, b)
 }
 func (m *UpgradePrimariesReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UpgradePrimariesReply.Marshal(b, m, deterministic)
 }
-func (dst *UpgradePrimariesReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UpgradePrimariesReply.Merge(dst, src)
+func (m *UpgradePrimariesReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UpgradePrimariesReply.Merge(m, src)
 }
 func (m *UpgradePrimariesReply) XXX_Size() int {
 	return xxx_messageInfo_UpgradePrimariesReply.Size(m)
@@ -194,7 +198,7 @@ func (m *UpgradePrimariesReply) XXX_DiscardUnknown() {
 var xxx_messageInfo_UpgradePrimariesReply proto.InternalMessageInfo
 
 type CreateSegmentDataDirRequest struct {
-	Datadirs             []string `protobuf:"bytes,1,rep,name=datadirs" json:"datadirs,omitempty"`
+	Datadirs             []string `protobuf:"bytes,1,rep,name=datadirs,proto3" json:"datadirs,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -204,16 +208,17 @@ func (m *CreateSegmentDataDirRequest) Reset()         { *m = CreateSegmentDataDi
 func (m *CreateSegmentDataDirRequest) String() string { return proto.CompactTextString(m) }
 func (*CreateSegmentDataDirRequest) ProtoMessage()    {}
 func (*CreateSegmentDataDirRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{3}
+	return fileDescriptor_9e73bb06acc917d8, []int{3}
 }
+
 func (m *CreateSegmentDataDirRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateSegmentDataDirRequest.Unmarshal(m, b)
 }
 func (m *CreateSegmentDataDirRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CreateSegmentDataDirRequest.Marshal(b, m, deterministic)
 }
-func (dst *CreateSegmentDataDirRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CreateSegmentDataDirRequest.Merge(dst, src)
+func (m *CreateSegmentDataDirRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CreateSegmentDataDirRequest.Merge(m, src)
 }
 func (m *CreateSegmentDataDirRequest) XXX_Size() int {
 	return xxx_messageInfo_CreateSegmentDataDirRequest.Size(m)
@@ -241,16 +246,17 @@ func (m *CreateSegmentDataDirReply) Reset()         { *m = CreateSegmentDataDirR
 func (m *CreateSegmentDataDirReply) String() string { return proto.CompactTextString(m) }
 func (*CreateSegmentDataDirReply) ProtoMessage()    {}
 func (*CreateSegmentDataDirReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{4}
+	return fileDescriptor_9e73bb06acc917d8, []int{4}
 }
+
 func (m *CreateSegmentDataDirReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateSegmentDataDirReply.Unmarshal(m, b)
 }
 func (m *CreateSegmentDataDirReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CreateSegmentDataDirReply.Marshal(b, m, deterministic)
 }
-func (dst *CreateSegmentDataDirReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CreateSegmentDataDirReply.Merge(dst, src)
+func (m *CreateSegmentDataDirReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CreateSegmentDataDirReply.Merge(m, src)
 }
 func (m *CreateSegmentDataDirReply) XXX_Size() int {
 	return xxx_messageInfo_CreateSegmentDataDirReply.Size(m)
@@ -262,8 +268,8 @@ func (m *CreateSegmentDataDirReply) XXX_DiscardUnknown() {
 var xxx_messageInfo_CreateSegmentDataDirReply proto.InternalMessageInfo
 
 type CopyMasterDirRequest struct {
-	MasterDir            string   `protobuf:"bytes,1,opt,name=masterDir" json:"masterDir,omitempty"`
-	Datadirs             []string `protobuf:"bytes,2,rep,name=datadirs" json:"datadirs,omitempty"`
+	MasterDir            string   `protobuf:"bytes,1,opt,name=masterDir,proto3" json:"masterDir,omitempty"`
+	Datadirs             []string `protobuf:"bytes,2,rep,name=datadirs,proto3" json:"datadirs,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -273,16 +279,17 @@ func (m *CopyMasterDirRequest) Reset()         { *m = CopyMasterDirRequest{} }
 func (m *CopyMasterDirRequest) String() string { return proto.CompactTextString(m) }
 func (*CopyMasterDirRequest) ProtoMessage()    {}
 func (*CopyMasterDirRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{5}
+	return fileDescriptor_9e73bb06acc917d8, []int{5}
 }
+
 func (m *CopyMasterDirRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CopyMasterDirRequest.Unmarshal(m, b)
 }
 func (m *CopyMasterDirRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CopyMasterDirRequest.Marshal(b, m, deterministic)
 }
-func (dst *CopyMasterDirRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CopyMasterDirRequest.Merge(dst, src)
+func (m *CopyMasterDirRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CopyMasterDirRequest.Merge(m, src)
 }
 func (m *CopyMasterDirRequest) XXX_Size() int {
 	return xxx_messageInfo_CopyMasterDirRequest.Size(m)
@@ -317,16 +324,17 @@ func (m *CopyMasterDirReply) Reset()         { *m = CopyMasterDirReply{} }
 func (m *CopyMasterDirReply) String() string { return proto.CompactTextString(m) }
 func (*CopyMasterDirReply) ProtoMessage()    {}
 func (*CopyMasterDirReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{6}
+	return fileDescriptor_9e73bb06acc917d8, []int{6}
 }
+
 func (m *CopyMasterDirReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CopyMasterDirReply.Unmarshal(m, b)
 }
 func (m *CopyMasterDirReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CopyMasterDirReply.Marshal(b, m, deterministic)
 }
-func (dst *CopyMasterDirReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CopyMasterDirReply.Merge(dst, src)
+func (m *CopyMasterDirReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CopyMasterDirReply.Merge(m, src)
 }
 func (m *CopyMasterDirReply) XXX_Size() int {
 	return xxx_messageInfo_CopyMasterDirReply.Size(m)
@@ -347,16 +355,17 @@ func (m *StopAgentRequest) Reset()         { *m = StopAgentRequest{} }
 func (m *StopAgentRequest) String() string { return proto.CompactTextString(m) }
 func (*StopAgentRequest) ProtoMessage()    {}
 func (*StopAgentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{7}
+	return fileDescriptor_9e73bb06acc917d8, []int{7}
 }
+
 func (m *StopAgentRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StopAgentRequest.Unmarshal(m, b)
 }
 func (m *StopAgentRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StopAgentRequest.Marshal(b, m, deterministic)
 }
-func (dst *StopAgentRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StopAgentRequest.Merge(dst, src)
+func (m *StopAgentRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StopAgentRequest.Merge(m, src)
 }
 func (m *StopAgentRequest) XXX_Size() int {
 	return xxx_messageInfo_StopAgentRequest.Size(m)
@@ -377,16 +386,17 @@ func (m *StopAgentReply) Reset()         { *m = StopAgentReply{} }
 func (m *StopAgentReply) String() string { return proto.CompactTextString(m) }
 func (*StopAgentReply) ProtoMessage()    {}
 func (*StopAgentReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{8}
+	return fileDescriptor_9e73bb06acc917d8, []int{8}
 }
+
 func (m *StopAgentReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StopAgentReply.Unmarshal(m, b)
 }
 func (m *StopAgentReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StopAgentReply.Marshal(b, m, deterministic)
 }
-func (dst *StopAgentReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StopAgentReply.Merge(dst, src)
+func (m *StopAgentReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StopAgentReply.Merge(m, src)
 }
 func (m *StopAgentReply) XXX_Size() int {
 	return xxx_messageInfo_StopAgentReply.Size(m)
@@ -398,8 +408,8 @@ func (m *StopAgentReply) XXX_DiscardUnknown() {
 var xxx_messageInfo_StopAgentReply proto.InternalMessageInfo
 
 type CheckSegmentDiskSpaceRequest struct {
-	Request              *CheckDiskSpaceRequest `protobuf:"bytes,1,opt,name=request" json:"request,omitempty"`
-	Datadirs             []string               `protobuf:"bytes,2,rep,name=datadirs" json:"datadirs,omitempty"`
+	Request              *CheckDiskSpaceRequest `protobuf:"bytes,1,opt,name=request,proto3" json:"request,omitempty"`
+	Datadirs             []string               `protobuf:"bytes,2,rep,name=datadirs,proto3" json:"datadirs,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}               `json:"-"`
 	XXX_unrecognized     []byte                 `json:"-"`
 	XXX_sizecache        int32                  `json:"-"`
@@ -409,16 +419,17 @@ func (m *CheckSegmentDiskSpaceRequest) Reset()         { *m = CheckSegmentDiskSp
 func (m *CheckSegmentDiskSpaceRequest) String() string { return proto.CompactTextString(m) }
 func (*CheckSegmentDiskSpaceRequest) ProtoMessage()    {}
 func (*CheckSegmentDiskSpaceRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{9}
+	return fileDescriptor_9e73bb06acc917d8, []int{9}
 }
+
 func (m *CheckSegmentDiskSpaceRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CheckSegmentDiskSpaceRequest.Unmarshal(m, b)
 }
 func (m *CheckSegmentDiskSpaceRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CheckSegmentDiskSpaceRequest.Marshal(b, m, deterministic)
 }
-func (dst *CheckSegmentDiskSpaceRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CheckSegmentDiskSpaceRequest.Merge(dst, src)
+func (m *CheckSegmentDiskSpaceRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CheckSegmentDiskSpaceRequest.Merge(m, src)
 }
 func (m *CheckSegmentDiskSpaceRequest) XXX_Size() int {
 	return xxx_messageInfo_CheckSegmentDiskSpaceRequest.Size(m)
@@ -456,6 +467,45 @@ func init() {
 	proto.RegisterType((*CheckSegmentDiskSpaceRequest)(nil), "idl.CheckSegmentDiskSpaceRequest")
 }
 
+func init() { proto.RegisterFile("hub_to_agent.proto", fileDescriptor_9e73bb06acc917d8) }
+
+var fileDescriptor_9e73bb06acc917d8 = []byte{
+	// 517 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x54, 0xc1, 0x72, 0xda, 0x30,
+	0x10, 0xad, 0x21, 0x34, 0x61, 0xe9, 0x64, 0x18, 0x35, 0x19, 0x1c, 0x87, 0xc9, 0x50, 0xf7, 0x50,
+	0x4e, 0x1c, 0x68, 0x2e, 0x39, 0xb6, 0xd0, 0x63, 0x81, 0x31, 0x6d, 0xaf, 0x8c, 0xb0, 0x77, 0x40,
+	0x13, 0x63, 0xb9, 0xb2, 0x3c, 0x94, 0x6f, 0xe9, 0xa7, 0xf4, 0x0b, 0xfa, 0x57, 0x1d, 0xc9, 0x96,
+	0x31, 0xae, 0xc9, 0x8d, 0x7d, 0x6f, 0xf5, 0xde, 0x93, 0x76, 0x31, 0x90, 0x6d, 0xba, 0x5e, 0x49,
+	0xbe, 0xa2, 0x1b, 0x8c, 0xe4, 0x28, 0x16, 0x5c, 0x72, 0xd2, 0x64, 0x41, 0xe8, 0x74, 0xfd, 0x90,
+	0x29, 0x62, 0x9b, 0xae, 0x33, 0xd8, 0xfd, 0x6b, 0x41, 0xef, 0x7b, 0xbc, 0x11, 0x34, 0xc0, 0x85,
+	0x60, 0x3b, 0x2a, 0x18, 0x26, 0x1e, 0xfe, 0x4c, 0x31, 0x91, 0xa4, 0x0f, 0xed, 0x79, 0x18, 0x7c,
+	0x66, 0xd1, 0x94, 0x09, 0xdb, 0x1a, 0x58, 0xc3, 0xb6, 0x77, 0x04, 0x14, 0x3b, 0xc3, 0x7d, 0xce,
+	0x36, 0x32, 0xb6, 0x00, 0xc8, 0x03, 0xc0, 0x0c, 0xf7, 0x3f, 0x50, 0x24, 0x8c, 0x47, 0x76, 0x53,
+	0xd3, 0x25, 0x84, 0x3c, 0xc2, 0x9b, 0x29, 0x95, 0x74, 0xca, 0xc4, 0x82, 0x32, 0x91, 0xd8, 0x17,
+	0x83, 0xe6, 0xb0, 0x33, 0xee, 0x8e, 0x58, 0x10, 0x8e, 0x4a, 0x84, 0x77, 0xd2, 0xa5, 0x3c, 0x27,
+	0x5b, 0xf4, 0x9f, 0xe7, 0x51, 0x78, 0xb0, 0x5b, 0x03, 0x6b, 0x78, 0xe5, 0x1d, 0x01, 0xf7, 0xb7,
+	0x05, 0x9d, 0x52, 0xbb, 0xca, 0x30, 0x0f, 0x83, 0x1c, 0xc9, 0x2f, 0x50, 0x42, 0xf2, 0x8c, 0x86,
+	0x6f, 0x14, 0x19, 0x0d, 0x6f, 0xc3, 0xe5, 0x3c, 0x0c, 0x16, 0x5c, 0x48, 0x7d, 0x81, 0x96, 0x67,
+	0x4a, 0xc5, 0xcc, 0x70, 0xaf, 0x99, 0x8b, 0x8c, 0xc9, 0x4b, 0xc5, 0x4c, 0x78, 0x24, 0x31, 0x92,
+	0x3a, 0x5f, 0xcb, 0x33, 0xa5, 0xdb, 0x83, 0xdb, 0xff, 0x1f, 0x3a, 0x0e, 0x0f, 0xee, 0x13, 0xdc,
+	0x4f, 0x04, 0x52, 0x89, 0x4b, 0xdc, 0xec, 0x30, 0x92, 0xb9, 0xbd, 0x99, 0x82, 0x03, 0x57, 0x01,
+	0x95, 0x34, 0x50, 0xaf, 0x64, 0x0d, 0x9a, 0xc3, 0xb6, 0x57, 0xd4, 0xee, 0x3d, 0xdc, 0xd5, 0x1f,
+	0x55, 0xba, 0x0b, 0xb8, 0x99, 0xf0, 0xf8, 0xf0, 0x95, 0x26, 0x12, 0x45, 0x49, 0xb0, 0x0f, 0xed,
+	0x9d, 0xc1, 0xcc, 0x58, 0x0b, 0xe0, 0xc4, 0xae, 0x51, 0xb1, 0xbb, 0x01, 0x52, 0x51, 0x54, 0x3e,
+	0x04, 0xba, 0x4b, 0xc9, 0xe3, 0x4f, 0x6a, 0xd9, 0x72, 0x0f, 0xb7, 0x0b, 0xd7, 0x25, 0x4c, 0x75,
+	0xc5, 0xd0, 0xd7, 0x93, 0x32, 0x49, 0x59, 0xf2, 0xbc, 0x8c, 0xa9, 0x8f, 0x26, 0xd5, 0x23, 0x5c,
+	0x8a, 0xec, 0xa7, 0xce, 0xd4, 0x19, 0x3b, 0x7a, 0x17, 0xf4, 0x99, 0x6a, 0xb3, 0x67, 0x5a, 0x5f,
+	0x4a, 0x3b, 0xfe, 0xd3, 0x84, 0x96, 0x0e, 0x40, 0xe6, 0x70, 0x7d, 0xaa, 0x43, 0xde, 0x1d, 0xc5,
+	0xcf, 0x04, 0x72, 0xec, 0x5a, 0x7f, 0x75, 0x95, 0x57, 0x84, 0xc2, 0x7b, 0xad, 0xfc, 0xe5, 0x17,
+	0xfa, 0xa9, 0xc4, 0xea, 0x5c, 0x97, 0xe9, 0x7a, 0x29, 0x31, 0x26, 0x7d, 0x2d, 0x71, 0xe6, 0xef,
+	0xe5, 0x38, 0x67, 0xd8, 0xcc, 0x62, 0x0d, 0xfd, 0xba, 0xd1, 0xa2, 0x2f, 0xb9, 0x6a, 0x23, 0x83,
+	0x2c, 0xde, 0xf9, 0xc5, 0x71, 0x1e, 0x5e, 0xe8, 0xc8, 0x3c, 0x56, 0xf0, 0xe1, 0x64, 0x9e, 0x5a,
+	0xfc, 0xf0, 0x8d, 0x17, 0x4f, 0x72, 0xb4, 0xbb, 0xcb, 0xc4, 0x6a, 0xf6, 0xc9, 0xe9, 0xd5, 0x51,
+	0x99, 0xc1, 0x13, 0xb4, 0x8b, 0x35, 0x20, 0xb7, 0xba, 0xaf, 0xba, 0x2a, 0xce, 0xdb, 0x2a, 0xac,
+	0x8f, 0xae, 0x5f, 0xeb, 0xef, 0xd3, 0xc7, 0x7f, 0x01, 0x00, 0x00, 0xff, 0xff, 0x9a, 0x6c, 0x5a,
+	0x21, 0xcc, 0x04, 0x00, 0x00,
+}
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
 var _ grpc.ClientConn
@@ -464,8 +514,9 @@ var _ grpc.ClientConn
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion4
 
-// Client API for Agent service
-
+// AgentClient is the client API for Agent service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type AgentClient interface {
 	CheckDiskSpace(ctx context.Context, in *CheckSegmentDiskSpaceRequest, opts ...grpc.CallOption) (*CheckDiskSpaceReply, error)
 	AgentExecuteUpgradePrimariesSubStep(ctx context.Context, in *UpgradePrimariesRequest, opts ...grpc.CallOption) (*UpgradePrimariesReply, error)
@@ -484,7 +535,7 @@ func NewAgentClient(cc *grpc.ClientConn) AgentClient {
 
 func (c *agentClient) CheckDiskSpace(ctx context.Context, in *CheckSegmentDiskSpaceRequest, opts ...grpc.CallOption) (*CheckDiskSpaceReply, error) {
 	out := new(CheckDiskSpaceReply)
-	err := grpc.Invoke(ctx, "/idl.Agent/CheckDiskSpace", in, out, c.cc, opts...)
+	err := c.cc.Invoke(ctx, "/idl.Agent/CheckDiskSpace", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -493,7 +544,7 @@ func (c *agentClient) CheckDiskSpace(ctx context.Context, in *CheckSegmentDiskSp
 
 func (c *agentClient) AgentExecuteUpgradePrimariesSubStep(ctx context.Context, in *UpgradePrimariesRequest, opts ...grpc.CallOption) (*UpgradePrimariesReply, error) {
 	out := new(UpgradePrimariesReply)
-	err := grpc.Invoke(ctx, "/idl.Agent/AgentExecuteUpgradePrimariesSubStep", in, out, c.cc, opts...)
+	err := c.cc.Invoke(ctx, "/idl.Agent/AgentExecuteUpgradePrimariesSubStep", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -502,7 +553,7 @@ func (c *agentClient) AgentExecuteUpgradePrimariesSubStep(ctx context.Context, i
 
 func (c *agentClient) CreateSegmentDataDirectories(ctx context.Context, in *CreateSegmentDataDirRequest, opts ...grpc.CallOption) (*CreateSegmentDataDirReply, error) {
 	out := new(CreateSegmentDataDirReply)
-	err := grpc.Invoke(ctx, "/idl.Agent/CreateSegmentDataDirectories", in, out, c.cc, opts...)
+	err := c.cc.Invoke(ctx, "/idl.Agent/CreateSegmentDataDirectories", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -511,7 +562,7 @@ func (c *agentClient) CreateSegmentDataDirectories(ctx context.Context, in *Crea
 
 func (c *agentClient) CopyMasterDirectoryToSegmentDirectories(ctx context.Context, in *CopyMasterDirRequest, opts ...grpc.CallOption) (*CopyMasterDirReply, error) {
 	out := new(CopyMasterDirReply)
-	err := grpc.Invoke(ctx, "/idl.Agent/CopyMasterDirectoryToSegmentDirectories", in, out, c.cc, opts...)
+	err := c.cc.Invoke(ctx, "/idl.Agent/CopyMasterDirectoryToSegmentDirectories", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -520,21 +571,40 @@ func (c *agentClient) CopyMasterDirectoryToSegmentDirectories(ctx context.Contex
 
 func (c *agentClient) StopAgent(ctx context.Context, in *StopAgentRequest, opts ...grpc.CallOption) (*StopAgentReply, error) {
 	out := new(StopAgentReply)
-	err := grpc.Invoke(ctx, "/idl.Agent/StopAgent", in, out, c.cc, opts...)
+	err := c.cc.Invoke(ctx, "/idl.Agent/StopAgent", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// Server API for Agent service
-
+// AgentServer is the server API for Agent service.
 type AgentServer interface {
 	CheckDiskSpace(context.Context, *CheckSegmentDiskSpaceRequest) (*CheckDiskSpaceReply, error)
 	AgentExecuteUpgradePrimariesSubStep(context.Context, *UpgradePrimariesRequest) (*UpgradePrimariesReply, error)
 	CreateSegmentDataDirectories(context.Context, *CreateSegmentDataDirRequest) (*CreateSegmentDataDirReply, error)
 	CopyMasterDirectoryToSegmentDirectories(context.Context, *CopyMasterDirRequest) (*CopyMasterDirReply, error)
 	StopAgent(context.Context, *StopAgentRequest) (*StopAgentReply, error)
+}
+
+// UnimplementedAgentServer can be embedded to have forward compatible implementations.
+type UnimplementedAgentServer struct {
+}
+
+func (*UnimplementedAgentServer) CheckDiskSpace(ctx context.Context, req *CheckSegmentDiskSpaceRequest) (*CheckDiskSpaceReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CheckDiskSpace not implemented")
+}
+func (*UnimplementedAgentServer) AgentExecuteUpgradePrimariesSubStep(ctx context.Context, req *UpgradePrimariesRequest) (*UpgradePrimariesReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AgentExecuteUpgradePrimariesSubStep not implemented")
+}
+func (*UnimplementedAgentServer) CreateSegmentDataDirectories(ctx context.Context, req *CreateSegmentDataDirRequest) (*CreateSegmentDataDirReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateSegmentDataDirectories not implemented")
+}
+func (*UnimplementedAgentServer) CopyMasterDirectoryToSegmentDirectories(ctx context.Context, req *CopyMasterDirRequest) (*CopyMasterDirReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CopyMasterDirectoryToSegmentDirectories not implemented")
+}
+func (*UnimplementedAgentServer) StopAgent(ctx context.Context, req *StopAgentRequest) (*StopAgentReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method StopAgent not implemented")
 }
 
 func RegisterAgentServer(s *grpc.Server, srv AgentServer) {
@@ -658,43 +728,4 @@ var _Agent_serviceDesc = grpc.ServiceDesc{
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "hub_to_agent.proto",
-}
-
-func init() { proto.RegisterFile("hub_to_agent.proto", fileDescriptor_hub_to_agent_96c6333f00419581) }
-
-var fileDescriptor_hub_to_agent_96c6333f00419581 = []byte{
-	// 517 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x54, 0xc1, 0x72, 0xda, 0x30,
-	0x10, 0xad, 0x21, 0x34, 0x61, 0xe9, 0x64, 0x18, 0x35, 0x19, 0x1c, 0x87, 0xc9, 0x50, 0xf7, 0x50,
-	0x4e, 0x1c, 0x68, 0x2e, 0x39, 0xb6, 0xd0, 0x63, 0x81, 0x31, 0x6d, 0xaf, 0x8c, 0xb0, 0x77, 0x40,
-	0x13, 0x63, 0xb9, 0xb2, 0x3c, 0x94, 0x6f, 0xe9, 0xa7, 0xf4, 0x0b, 0xfa, 0x57, 0x1d, 0xc9, 0x96,
-	0x31, 0xae, 0xc9, 0x8d, 0x7d, 0x6f, 0xf5, 0xde, 0x93, 0x76, 0x31, 0x90, 0x6d, 0xba, 0x5e, 0x49,
-	0xbe, 0xa2, 0x1b, 0x8c, 0xe4, 0x28, 0x16, 0x5c, 0x72, 0xd2, 0x64, 0x41, 0xe8, 0x74, 0xfd, 0x90,
-	0x29, 0x62, 0x9b, 0xae, 0x33, 0xd8, 0xfd, 0x6b, 0x41, 0xef, 0x7b, 0xbc, 0x11, 0x34, 0xc0, 0x85,
-	0x60, 0x3b, 0x2a, 0x18, 0x26, 0x1e, 0xfe, 0x4c, 0x31, 0x91, 0xa4, 0x0f, 0xed, 0x79, 0x18, 0x7c,
-	0x66, 0xd1, 0x94, 0x09, 0xdb, 0x1a, 0x58, 0xc3, 0xb6, 0x77, 0x04, 0x14, 0x3b, 0xc3, 0x7d, 0xce,
-	0x36, 0x32, 0xb6, 0x00, 0xc8, 0x03, 0xc0, 0x0c, 0xf7, 0x3f, 0x50, 0x24, 0x8c, 0x47, 0x76, 0x53,
-	0xd3, 0x25, 0x84, 0x3c, 0xc2, 0x9b, 0x29, 0x95, 0x74, 0xca, 0xc4, 0x82, 0x32, 0x91, 0xd8, 0x17,
-	0x83, 0xe6, 0xb0, 0x33, 0xee, 0x8e, 0x58, 0x10, 0x8e, 0x4a, 0x84, 0x77, 0xd2, 0xa5, 0x3c, 0x27,
-	0x5b, 0xf4, 0x9f, 0xe7, 0x51, 0x78, 0xb0, 0x5b, 0x03, 0x6b, 0x78, 0xe5, 0x1d, 0x01, 0xf7, 0xb7,
-	0x05, 0x9d, 0x52, 0xbb, 0xca, 0x30, 0x0f, 0x83, 0x1c, 0xc9, 0x2f, 0x50, 0x42, 0xf2, 0x8c, 0x86,
-	0x6f, 0x14, 0x19, 0x0d, 0x6f, 0xc3, 0xe5, 0x3c, 0x0c, 0x16, 0x5c, 0x48, 0x7d, 0x81, 0x96, 0x67,
-	0x4a, 0xc5, 0xcc, 0x70, 0xaf, 0x99, 0x8b, 0x8c, 0xc9, 0x4b, 0xc5, 0x4c, 0x78, 0x24, 0x31, 0x92,
-	0x3a, 0x5f, 0xcb, 0x33, 0xa5, 0xdb, 0x83, 0xdb, 0xff, 0x1f, 0x3a, 0x0e, 0x0f, 0xee, 0x13, 0xdc,
-	0x4f, 0x04, 0x52, 0x89, 0x4b, 0xdc, 0xec, 0x30, 0x92, 0xb9, 0xbd, 0x99, 0x82, 0x03, 0x57, 0x01,
-	0x95, 0x34, 0x50, 0xaf, 0x64, 0x0d, 0x9a, 0xc3, 0xb6, 0x57, 0xd4, 0xee, 0x3d, 0xdc, 0xd5, 0x1f,
-	0x55, 0xba, 0x0b, 0xb8, 0x99, 0xf0, 0xf8, 0xf0, 0x95, 0x26, 0x12, 0x45, 0x49, 0xb0, 0x0f, 0xed,
-	0x9d, 0xc1, 0xcc, 0x58, 0x0b, 0xe0, 0xc4, 0xae, 0x51, 0xb1, 0xbb, 0x01, 0x52, 0x51, 0x54, 0x3e,
-	0x04, 0xba, 0x4b, 0xc9, 0xe3, 0x4f, 0x6a, 0xd9, 0x72, 0x0f, 0xb7, 0x0b, 0xd7, 0x25, 0x4c, 0x75,
-	0xc5, 0xd0, 0xd7, 0x93, 0x32, 0x49, 0x59, 0xf2, 0xbc, 0x8c, 0xa9, 0x8f, 0x26, 0xd5, 0x23, 0x5c,
-	0x8a, 0xec, 0xa7, 0xce, 0xd4, 0x19, 0x3b, 0x7a, 0x17, 0xf4, 0x99, 0x6a, 0xb3, 0x67, 0x5a, 0x5f,
-	0x4a, 0x3b, 0xfe, 0xd3, 0x84, 0x96, 0x0e, 0x40, 0xe6, 0x70, 0x7d, 0xaa, 0x43, 0xde, 0x1d, 0xc5,
-	0xcf, 0x04, 0x72, 0xec, 0x5a, 0x7f, 0x75, 0x95, 0x57, 0x84, 0xc2, 0x7b, 0xad, 0xfc, 0xe5, 0x17,
-	0xfa, 0xa9, 0xc4, 0xea, 0x5c, 0x97, 0xe9, 0x7a, 0x29, 0x31, 0x26, 0x7d, 0x2d, 0x71, 0xe6, 0xef,
-	0xe5, 0x38, 0x67, 0xd8, 0xcc, 0x62, 0x0d, 0xfd, 0xba, 0xd1, 0xa2, 0x2f, 0xb9, 0x6a, 0x23, 0x83,
-	0x2c, 0xde, 0xf9, 0xc5, 0x71, 0x1e, 0x5e, 0xe8, 0xc8, 0x3c, 0x56, 0xf0, 0xe1, 0x64, 0x9e, 0x5a,
-	0xfc, 0xf0, 0x8d, 0x17, 0x4f, 0x72, 0xb4, 0xbb, 0xcb, 0xc4, 0x6a, 0xf6, 0xc9, 0xe9, 0xd5, 0x51,
-	0x99, 0xc1, 0x13, 0xb4, 0x8b, 0x35, 0x20, 0xb7, 0xba, 0xaf, 0xba, 0x2a, 0xce, 0xdb, 0x2a, 0xac,
-	0x8f, 0xae, 0x5f, 0xeb, 0xef, 0xd3, 0xc7, 0x7f, 0x01, 0x00, 0x00, 0xff, 0xff, 0x9a, 0x6c, 0x5a,
-	0x21, 0xcc, 0x04, 0x00, 0x00,
 }

--- a/idl/mock_idl/mock_hub_to_agent.pb.go
+++ b/idl/mock_idl/mock_hub_to_agent.pb.go
@@ -5,9 +5,9 @@
 package mock_idl
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	idl "github.com/greenplum-db/gpupgrade/idl"
-	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 	reflect "reflect"
 )


### PR DESCRIPTION
The --ports flag enables users to choose the ports for initializing the new cluster.  ~Ports are assigned on each host in order of content ID, beginning at the lowest number.~ The lowest port is used for the master, and then remaining ports are assigned on each host in order of content ID, beginning at the second-lowest number. Unneeded ports at the top of the set are ignored, but an error results if the set is too small to handle all segments on a host. If no ports are given, start at 50432 (the pg_upgrade default) and count up, as if the user specified a range of 50432-65535.

If gpinitsystem fails due to a port collision then an error is returned and the user can fix or specify a different set of ports.

Ports can be specified either individually, or as ranges, separated by commas. When specifying a range a dash is used. For example, `--ports 6000,6005-6008` uses a port set <6000,6005,6006,6007,6008> for each host.
