### PR TITLE
disk.CheckUsage: fix floating-point math

### DIFF
--- a/cli/commanders/checks.go
+++ b/cli/commanders/checks.go
@@ -14,7 +14,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/utils/disk"
 )
 
-func RunPreChecks(client idl.CliToHubClient, ratio float32) error {
+func RunPreChecks(client idl.CliToHubClient, ratio float64) error {
 	//TODO: when do we check this?  It requires the source cluster to be up.
 	//err := CheckVersion(client)
 	//if err != nil {
@@ -115,7 +115,7 @@ func (t tableRows) Swap(i, j int) {
 	t[i], t[j] = t[j], t[i]
 }
 
-func CheckDiskSpace(client idl.CliToHubClient, ratio float32) (err error) {
+func CheckDiskSpace(client idl.CliToHubClient, ratio float64) (err error) {
 	s := Substep("Checking disk space...")
 	defer s.Finish(&err)
 

--- a/cli/commanders/checks_test.go
+++ b/cli/commanders/checks_test.go
@@ -163,7 +163,7 @@ func TestDiskSpaceCheck(t *testing.T) {
 
 			// exact value doesn't matter; we simply verify that it's passed
 			// through to gRPC as-is
-			ratio := float32(0.5)
+			ratio := float64(0.5)
 
 			client := mock_idl.NewMockCliToHubClient(ctrl)
 			client.EXPECT().CheckDiskSpace(

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -233,7 +233,7 @@ var version = &cobra.Command{
 func initialize() *cobra.Command {
 	var oldBinDir, newBinDir string
 	var oldPort int
-	var diskFreeRatio float32
+	var diskFreeRatio float64
 	var stopBeforeClusterCreation bool
 	var verbose bool
 
@@ -321,7 +321,7 @@ If you would like to return the cluster to its original state, run
 	subInit.MarkPersistentFlagRequired("old-port")
 	subInit.PersistentFlags().BoolVar(&stopBeforeClusterCreation, "stop-before-cluster-creation", false, "only run up to pre-init")
 	subInit.PersistentFlags().MarkHidden("stop-before-cluster-creation")
-	subInit.PersistentFlags().Float32Var(&diskFreeRatio, "disk-free-ratio", 0.60, "percentage of disk space that must be available (from 0.0 - 1.0)")
+	subInit.PersistentFlags().Float64Var(&diskFreeRatio, "disk-free-ratio", 0.60, "percentage of disk space that must be available (from 0.0 - 1.0)")
 	subInit.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "print the output stream from all substeps")
 
 	return subInit

--- a/hub/services/check_disk_space_test.go
+++ b/hub/services/check_disk_space_test.go
@@ -11,6 +11,7 @@ import (
 	sigar "github.com/cloudfoundry/gosigar"
 	"github.com/golang/mock/gomock"
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	multierror "github.com/hashicorp/go-multierror"
 	"golang.org/x/sys/unix"
 	"golang.org/x/xerrors"
@@ -27,6 +28,8 @@ func TestCheckDiskSpace(t *testing.T) {
 	var agents []*Connection
 	var req *idl.CheckDiskSpaceRequest
 	ctx := context.Background()
+
+	testhelper.SetupTestLogger()
 
 	// This helper performs the boring test work. Set the above variables as
 	// part of your more interesting test setup.

--- a/idl/cli_to_hub.pb.go
+++ b/idl/cli_to_hub.pb.go
@@ -3,14 +3,13 @@
 
 package idl
 
+import proto "github.com/golang/protobuf/proto"
+import fmt "fmt"
+import math "math"
+
 import (
-	context "context"
-	fmt "fmt"
-	proto "github.com/golang/protobuf/proto"
+	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
-	codes "google.golang.org/grpc/codes"
-	status "google.golang.org/grpc/status"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -22,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 type UpgradeSteps int32
 
@@ -57,7 +56,6 @@ var UpgradeSteps_name = map[int32]string{
 	11: "START_TARGET_CLUSTER",
 	12: "RECONFIGURE_PORTS",
 }
-
 var UpgradeSteps_value = map[string]int32{
 	"UNKNOWN_STEP":            0,
 	"CONFIG":                  1,
@@ -77,9 +75,8 @@ var UpgradeSteps_value = map[string]int32{
 func (x UpgradeSteps) String() string {
 	return proto.EnumName(UpgradeSteps_name, int32(x))
 }
-
 func (UpgradeSteps) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{0}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{0}
 }
 
 type StepStatus int32
@@ -99,7 +96,6 @@ var StepStatus_name = map[int32]string{
 	3: "COMPLETE",
 	4: "FAILED",
 }
-
 var StepStatus_value = map[string]int32{
 	"UNKNOWN_STATUS": 0,
 	"PENDING":        1,
@@ -111,9 +107,8 @@ var StepStatus_value = map[string]int32{
 func (x StepStatus) String() string {
 	return proto.EnumName(StepStatus_name, int32(x))
 }
-
 func (StepStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{1}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{1}
 }
 
 type Chunk_Type int32
@@ -129,7 +124,6 @@ var Chunk_Type_name = map[int32]string{
 	1: "STDOUT",
 	2: "STDERR",
 }
-
 var Chunk_Type_value = map[string]int32{
 	"UNKNOWN": 0,
 	"STDOUT":  1,
@@ -139,15 +133,14 @@ var Chunk_Type_value = map[string]int32{
 func (x Chunk_Type) String() string {
 	return proto.EnumName(Chunk_Type_name, int32(x))
 }
-
 func (Chunk_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{15, 0}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{15, 0}
 }
 
 type InitializeRequest struct {
-	OldBinDir            string   `protobuf:"bytes,1,opt,name=oldBinDir,proto3" json:"oldBinDir,omitempty"`
-	NewBinDir            string   `protobuf:"bytes,2,opt,name=newBinDir,proto3" json:"newBinDir,omitempty"`
-	OldPort              int32    `protobuf:"varint,3,opt,name=oldPort,proto3" json:"oldPort,omitempty"`
+	OldBinDir            string   `protobuf:"bytes,1,opt,name=oldBinDir" json:"oldBinDir,omitempty"`
+	NewBinDir            string   `protobuf:"bytes,2,opt,name=newBinDir" json:"newBinDir,omitempty"`
+	OldPort              int32    `protobuf:"varint,3,opt,name=oldPort" json:"oldPort,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -157,17 +150,16 @@ func (m *InitializeRequest) Reset()         { *m = InitializeRequest{} }
 func (m *InitializeRequest) String() string { return proto.CompactTextString(m) }
 func (*InitializeRequest) ProtoMessage()    {}
 func (*InitializeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{0}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{0}
 }
-
 func (m *InitializeRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_InitializeRequest.Unmarshal(m, b)
 }
 func (m *InitializeRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_InitializeRequest.Marshal(b, m, deterministic)
 }
-func (m *InitializeRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_InitializeRequest.Merge(m, src)
+func (dst *InitializeRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_InitializeRequest.Merge(dst, src)
 }
 func (m *InitializeRequest) XXX_Size() int {
 	return xxx_messageInfo_InitializeRequest.Size(m)
@@ -209,17 +201,16 @@ func (m *InitializeCreateClusterRequest) Reset()         { *m = InitializeCreate
 func (m *InitializeCreateClusterRequest) String() string { return proto.CompactTextString(m) }
 func (*InitializeCreateClusterRequest) ProtoMessage()    {}
 func (*InitializeCreateClusterRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{1}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{1}
 }
-
 func (m *InitializeCreateClusterRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_InitializeCreateClusterRequest.Unmarshal(m, b)
 }
 func (m *InitializeCreateClusterRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_InitializeCreateClusterRequest.Marshal(b, m, deterministic)
 }
-func (m *InitializeCreateClusterRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_InitializeCreateClusterRequest.Merge(m, src)
+func (dst *InitializeCreateClusterRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_InitializeCreateClusterRequest.Merge(dst, src)
 }
 func (m *InitializeCreateClusterRequest) XXX_Size() int {
 	return xxx_messageInfo_InitializeCreateClusterRequest.Size(m)
@@ -240,17 +231,16 @@ func (m *ExecuteRequest) Reset()         { *m = ExecuteRequest{} }
 func (m *ExecuteRequest) String() string { return proto.CompactTextString(m) }
 func (*ExecuteRequest) ProtoMessage()    {}
 func (*ExecuteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{2}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{2}
 }
-
 func (m *ExecuteRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ExecuteRequest.Unmarshal(m, b)
 }
 func (m *ExecuteRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ExecuteRequest.Marshal(b, m, deterministic)
 }
-func (m *ExecuteRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ExecuteRequest.Merge(m, src)
+func (dst *ExecuteRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ExecuteRequest.Merge(dst, src)
 }
 func (m *ExecuteRequest) XXX_Size() int {
 	return xxx_messageInfo_ExecuteRequest.Size(m)
@@ -271,17 +261,16 @@ func (m *FinalizeRequest) Reset()         { *m = FinalizeRequest{} }
 func (m *FinalizeRequest) String() string { return proto.CompactTextString(m) }
 func (*FinalizeRequest) ProtoMessage()    {}
 func (*FinalizeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{3}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{3}
 }
-
 func (m *FinalizeRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FinalizeRequest.Unmarshal(m, b)
 }
 func (m *FinalizeRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FinalizeRequest.Marshal(b, m, deterministic)
 }
-func (m *FinalizeRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FinalizeRequest.Merge(m, src)
+func (dst *FinalizeRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FinalizeRequest.Merge(dst, src)
 }
 func (m *FinalizeRequest) XXX_Size() int {
 	return xxx_messageInfo_FinalizeRequest.Size(m)
@@ -302,17 +291,16 @@ func (m *RestartAgentsRequest) Reset()         { *m = RestartAgentsRequest{} }
 func (m *RestartAgentsRequest) String() string { return proto.CompactTextString(m) }
 func (*RestartAgentsRequest) ProtoMessage()    {}
 func (*RestartAgentsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{4}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{4}
 }
-
 func (m *RestartAgentsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RestartAgentsRequest.Unmarshal(m, b)
 }
 func (m *RestartAgentsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RestartAgentsRequest.Marshal(b, m, deterministic)
 }
-func (m *RestartAgentsRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RestartAgentsRequest.Merge(m, src)
+func (dst *RestartAgentsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RestartAgentsRequest.Merge(dst, src)
 }
 func (m *RestartAgentsRequest) XXX_Size() int {
 	return xxx_messageInfo_RestartAgentsRequest.Size(m)
@@ -324,7 +312,7 @@ func (m *RestartAgentsRequest) XXX_DiscardUnknown() {
 var xxx_messageInfo_RestartAgentsRequest proto.InternalMessageInfo
 
 type RestartAgentsReply struct {
-	AgentHosts           []string `protobuf:"bytes,1,rep,name=agentHosts,proto3" json:"agentHosts,omitempty"`
+	AgentHosts           []string `protobuf:"bytes,1,rep,name=agentHosts" json:"agentHosts,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -334,17 +322,16 @@ func (m *RestartAgentsReply) Reset()         { *m = RestartAgentsReply{} }
 func (m *RestartAgentsReply) String() string { return proto.CompactTextString(m) }
 func (*RestartAgentsReply) ProtoMessage()    {}
 func (*RestartAgentsReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{5}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{5}
 }
-
 func (m *RestartAgentsReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RestartAgentsReply.Unmarshal(m, b)
 }
 func (m *RestartAgentsReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_RestartAgentsReply.Marshal(b, m, deterministic)
 }
-func (m *RestartAgentsReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RestartAgentsReply.Merge(m, src)
+func (dst *RestartAgentsReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RestartAgentsReply.Merge(dst, src)
 }
 func (m *RestartAgentsReply) XXX_Size() int {
 	return xxx_messageInfo_RestartAgentsReply.Size(m)
@@ -372,17 +359,16 @@ func (m *StopServicesRequest) Reset()         { *m = StopServicesRequest{} }
 func (m *StopServicesRequest) String() string { return proto.CompactTextString(m) }
 func (*StopServicesRequest) ProtoMessage()    {}
 func (*StopServicesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{6}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{6}
 }
-
 func (m *StopServicesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StopServicesRequest.Unmarshal(m, b)
 }
 func (m *StopServicesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StopServicesRequest.Marshal(b, m, deterministic)
 }
-func (m *StopServicesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StopServicesRequest.Merge(m, src)
+func (dst *StopServicesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StopServicesRequest.Merge(dst, src)
 }
 func (m *StopServicesRequest) XXX_Size() int {
 	return xxx_messageInfo_StopServicesRequest.Size(m)
@@ -403,17 +389,16 @@ func (m *StopServicesReply) Reset()         { *m = StopServicesReply{} }
 func (m *StopServicesReply) String() string { return proto.CompactTextString(m) }
 func (*StopServicesReply) ProtoMessage()    {}
 func (*StopServicesReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{7}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{7}
 }
-
 func (m *StopServicesReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StopServicesReply.Unmarshal(m, b)
 }
 func (m *StopServicesReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StopServicesReply.Marshal(b, m, deterministic)
 }
-func (m *StopServicesReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StopServicesReply.Merge(m, src)
+func (dst *StopServicesReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StopServicesReply.Merge(dst, src)
 }
 func (m *StopServicesReply) XXX_Size() int {
 	return xxx_messageInfo_StopServicesReply.Size(m)
@@ -425,8 +410,8 @@ func (m *StopServicesReply) XXX_DiscardUnknown() {
 var xxx_messageInfo_StopServicesReply proto.InternalMessageInfo
 
 type UpgradeStepStatus struct {
-	Step                 UpgradeSteps `protobuf:"varint,1,opt,name=step,proto3,enum=idl.UpgradeSteps" json:"step,omitempty"`
-	Status               StepStatus   `protobuf:"varint,2,opt,name=status,proto3,enum=idl.StepStatus" json:"status,omitempty"`
+	Step                 UpgradeSteps `protobuf:"varint,1,opt,name=step,enum=idl.UpgradeSteps" json:"step,omitempty"`
+	Status               StepStatus   `protobuf:"varint,2,opt,name=status,enum=idl.StepStatus" json:"status,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
 	XXX_unrecognized     []byte       `json:"-"`
 	XXX_sizecache        int32        `json:"-"`
@@ -436,17 +421,16 @@ func (m *UpgradeStepStatus) Reset()         { *m = UpgradeStepStatus{} }
 func (m *UpgradeStepStatus) String() string { return proto.CompactTextString(m) }
 func (*UpgradeStepStatus) ProtoMessage()    {}
 func (*UpgradeStepStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{8}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{8}
 }
-
 func (m *UpgradeStepStatus) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UpgradeStepStatus.Unmarshal(m, b)
 }
 func (m *UpgradeStepStatus) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UpgradeStepStatus.Marshal(b, m, deterministic)
 }
-func (m *UpgradeStepStatus) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UpgradeStepStatus.Merge(m, src)
+func (dst *UpgradeStepStatus) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UpgradeStepStatus.Merge(dst, src)
 }
 func (m *UpgradeStepStatus) XXX_Size() int {
 	return xxx_messageInfo_UpgradeStepStatus.Size(m)
@@ -481,17 +465,16 @@ func (m *CheckVersionRequest) Reset()         { *m = CheckVersionRequest{} }
 func (m *CheckVersionRequest) String() string { return proto.CompactTextString(m) }
 func (*CheckVersionRequest) ProtoMessage()    {}
 func (*CheckVersionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{9}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{9}
 }
-
 func (m *CheckVersionRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CheckVersionRequest.Unmarshal(m, b)
 }
 func (m *CheckVersionRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CheckVersionRequest.Marshal(b, m, deterministic)
 }
-func (m *CheckVersionRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CheckVersionRequest.Merge(m, src)
+func (dst *CheckVersionRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CheckVersionRequest.Merge(dst, src)
 }
 func (m *CheckVersionRequest) XXX_Size() int {
 	return xxx_messageInfo_CheckVersionRequest.Size(m)
@@ -503,7 +486,7 @@ func (m *CheckVersionRequest) XXX_DiscardUnknown() {
 var xxx_messageInfo_CheckVersionRequest proto.InternalMessageInfo
 
 type CheckVersionReply struct {
-	IsVersionCompatible  bool     `protobuf:"varint,1,opt,name=IsVersionCompatible,proto3" json:"IsVersionCompatible,omitempty"`
+	IsVersionCompatible  bool     `protobuf:"varint,1,opt,name=IsVersionCompatible" json:"IsVersionCompatible,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -513,17 +496,16 @@ func (m *CheckVersionReply) Reset()         { *m = CheckVersionReply{} }
 func (m *CheckVersionReply) String() string { return proto.CompactTextString(m) }
 func (*CheckVersionReply) ProtoMessage()    {}
 func (*CheckVersionReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{10}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{10}
 }
-
 func (m *CheckVersionReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CheckVersionReply.Unmarshal(m, b)
 }
 func (m *CheckVersionReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CheckVersionReply.Marshal(b, m, deterministic)
 }
-func (m *CheckVersionReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CheckVersionReply.Merge(m, src)
+func (dst *CheckVersionReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CheckVersionReply.Merge(dst, src)
 }
 func (m *CheckVersionReply) XXX_Size() int {
 	return xxx_messageInfo_CheckVersionReply.Size(m)
@@ -542,7 +524,7 @@ func (m *CheckVersionReply) GetIsVersionCompatible() bool {
 }
 
 type CheckDiskSpaceRequest struct {
-	Ratio                float32  `protobuf:"fixed32,1,opt,name=ratio,proto3" json:"ratio,omitempty"`
+	Ratio                float64  `protobuf:"fixed64,1,opt,name=ratio" json:"ratio,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -552,17 +534,16 @@ func (m *CheckDiskSpaceRequest) Reset()         { *m = CheckDiskSpaceRequest{} }
 func (m *CheckDiskSpaceRequest) String() string { return proto.CompactTextString(m) }
 func (*CheckDiskSpaceRequest) ProtoMessage()    {}
 func (*CheckDiskSpaceRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{11}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{11}
 }
-
 func (m *CheckDiskSpaceRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CheckDiskSpaceRequest.Unmarshal(m, b)
 }
 func (m *CheckDiskSpaceRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CheckDiskSpaceRequest.Marshal(b, m, deterministic)
 }
-func (m *CheckDiskSpaceRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CheckDiskSpaceRequest.Merge(m, src)
+func (dst *CheckDiskSpaceRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CheckDiskSpaceRequest.Merge(dst, src)
 }
 func (m *CheckDiskSpaceRequest) XXX_Size() int {
 	return xxx_messageInfo_CheckDiskSpaceRequest.Size(m)
@@ -573,7 +554,7 @@ func (m *CheckDiskSpaceRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_CheckDiskSpaceRequest proto.InternalMessageInfo
 
-func (m *CheckDiskSpaceRequest) GetRatio() float32 {
+func (m *CheckDiskSpaceRequest) GetRatio() float64 {
 	if m != nil {
 		return m.Ratio
 	}
@@ -581,7 +562,7 @@ func (m *CheckDiskSpaceRequest) GetRatio() float32 {
 }
 
 type CheckDiskSpaceReply struct {
-	Failed               map[string]*CheckDiskSpaceReply_DiskUsage `protobuf:"bytes,1,rep,name=failed,proto3" json:"failed,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	Failed               map[string]*CheckDiskSpaceReply_DiskUsage `protobuf:"bytes,1,rep,name=failed" json:"failed,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	XXX_NoUnkeyedLiteral struct{}                                  `json:"-"`
 	XXX_unrecognized     []byte                                    `json:"-"`
 	XXX_sizecache        int32                                     `json:"-"`
@@ -591,17 +572,16 @@ func (m *CheckDiskSpaceReply) Reset()         { *m = CheckDiskSpaceReply{} }
 func (m *CheckDiskSpaceReply) String() string { return proto.CompactTextString(m) }
 func (*CheckDiskSpaceReply) ProtoMessage()    {}
 func (*CheckDiskSpaceReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{12}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{12}
 }
-
 func (m *CheckDiskSpaceReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CheckDiskSpaceReply.Unmarshal(m, b)
 }
 func (m *CheckDiskSpaceReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CheckDiskSpaceReply.Marshal(b, m, deterministic)
 }
-func (m *CheckDiskSpaceReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CheckDiskSpaceReply.Merge(m, src)
+func (dst *CheckDiskSpaceReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CheckDiskSpaceReply.Merge(dst, src)
 }
 func (m *CheckDiskSpaceReply) XXX_Size() int {
 	return xxx_messageInfo_CheckDiskSpaceReply.Size(m)
@@ -620,8 +600,8 @@ func (m *CheckDiskSpaceReply) GetFailed() map[string]*CheckDiskSpaceReply_DiskUs
 }
 
 type CheckDiskSpaceReply_DiskUsage struct {
-	Available            uint64   `protobuf:"varint,1,opt,name=available,proto3" json:"available,omitempty"`
-	Required             uint64   `protobuf:"varint,2,opt,name=required,proto3" json:"required,omitempty"`
+	Available            uint64   `protobuf:"varint,1,opt,name=available" json:"available,omitempty"`
+	Required             uint64   `protobuf:"varint,2,opt,name=required" json:"required,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -631,17 +611,16 @@ func (m *CheckDiskSpaceReply_DiskUsage) Reset()         { *m = CheckDiskSpaceRep
 func (m *CheckDiskSpaceReply_DiskUsage) String() string { return proto.CompactTextString(m) }
 func (*CheckDiskSpaceReply_DiskUsage) ProtoMessage()    {}
 func (*CheckDiskSpaceReply_DiskUsage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{12, 0}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{12, 0}
 }
-
 func (m *CheckDiskSpaceReply_DiskUsage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CheckDiskSpaceReply_DiskUsage.Unmarshal(m, b)
 }
 func (m *CheckDiskSpaceReply_DiskUsage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CheckDiskSpaceReply_DiskUsage.Marshal(b, m, deterministic)
 }
-func (m *CheckDiskSpaceReply_DiskUsage) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CheckDiskSpaceReply_DiskUsage.Merge(m, src)
+func (dst *CheckDiskSpaceReply_DiskUsage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CheckDiskSpaceReply_DiskUsage.Merge(dst, src)
 }
 func (m *CheckDiskSpaceReply_DiskUsage) XXX_Size() int {
 	return xxx_messageInfo_CheckDiskSpaceReply_DiskUsage.Size(m)
@@ -676,17 +655,16 @@ func (m *PrepareInitClusterRequest) Reset()         { *m = PrepareInitClusterReq
 func (m *PrepareInitClusterRequest) String() string { return proto.CompactTextString(m) }
 func (*PrepareInitClusterRequest) ProtoMessage()    {}
 func (*PrepareInitClusterRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{13}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{13}
 }
-
 func (m *PrepareInitClusterRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PrepareInitClusterRequest.Unmarshal(m, b)
 }
 func (m *PrepareInitClusterRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_PrepareInitClusterRequest.Marshal(b, m, deterministic)
 }
-func (m *PrepareInitClusterRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_PrepareInitClusterRequest.Merge(m, src)
+func (dst *PrepareInitClusterRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PrepareInitClusterRequest.Merge(dst, src)
 }
 func (m *PrepareInitClusterRequest) XXX_Size() int {
 	return xxx_messageInfo_PrepareInitClusterRequest.Size(m)
@@ -707,17 +685,16 @@ func (m *PrepareInitClusterReply) Reset()         { *m = PrepareInitClusterReply
 func (m *PrepareInitClusterReply) String() string { return proto.CompactTextString(m) }
 func (*PrepareInitClusterReply) ProtoMessage()    {}
 func (*PrepareInitClusterReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{14}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{14}
 }
-
 func (m *PrepareInitClusterReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PrepareInitClusterReply.Unmarshal(m, b)
 }
 func (m *PrepareInitClusterReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_PrepareInitClusterReply.Marshal(b, m, deterministic)
 }
-func (m *PrepareInitClusterReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_PrepareInitClusterReply.Merge(m, src)
+func (dst *PrepareInitClusterReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PrepareInitClusterReply.Merge(dst, src)
 }
 func (m *PrepareInitClusterReply) XXX_Size() int {
 	return xxx_messageInfo_PrepareInitClusterReply.Size(m)
@@ -730,7 +707,7 @@ var xxx_messageInfo_PrepareInitClusterReply proto.InternalMessageInfo
 
 type Chunk struct {
 	Buffer               []byte     `protobuf:"bytes,1,opt,name=buffer,proto3" json:"buffer,omitempty"`
-	Type                 Chunk_Type `protobuf:"varint,2,opt,name=type,proto3,enum=idl.Chunk_Type" json:"type,omitempty"`
+	Type                 Chunk_Type `protobuf:"varint,2,opt,name=type,enum=idl.Chunk_Type" json:"type,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}   `json:"-"`
 	XXX_unrecognized     []byte     `json:"-"`
 	XXX_sizecache        int32      `json:"-"`
@@ -740,17 +717,16 @@ func (m *Chunk) Reset()         { *m = Chunk{} }
 func (m *Chunk) String() string { return proto.CompactTextString(m) }
 func (*Chunk) ProtoMessage()    {}
 func (*Chunk) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{15}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{15}
 }
-
 func (m *Chunk) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Chunk.Unmarshal(m, b)
 }
 func (m *Chunk) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Chunk.Marshal(b, m, deterministic)
 }
-func (m *Chunk) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Chunk.Merge(m, src)
+func (dst *Chunk) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Chunk.Merge(dst, src)
 }
 func (m *Chunk) XXX_Size() int {
 	return xxx_messageInfo_Chunk.Size(m)
@@ -789,17 +765,16 @@ func (m *Message) Reset()         { *m = Message{} }
 func (m *Message) String() string { return proto.CompactTextString(m) }
 func (*Message) ProtoMessage()    {}
 func (*Message) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{16}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{16}
 }
-
 func (m *Message) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Message.Unmarshal(m, b)
 }
 func (m *Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Message.Marshal(b, m, deterministic)
 }
-func (m *Message) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Message.Merge(m, src)
+func (dst *Message) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Message.Merge(dst, src)
 }
 func (m *Message) XXX_Size() int {
 	return xxx_messageInfo_Message.Size(m)
@@ -815,15 +790,13 @@ type isMessage_Contents interface {
 }
 
 type Message_Chunk struct {
-	Chunk *Chunk `protobuf:"bytes,1,opt,name=chunk,proto3,oneof"`
+	Chunk *Chunk `protobuf:"bytes,1,opt,name=chunk,oneof"`
 }
-
 type Message_Status struct {
-	Status *UpgradeStepStatus `protobuf:"bytes,2,opt,name=status,proto3,oneof"`
+	Status *UpgradeStepStatus `protobuf:"bytes,2,opt,name=status,oneof"`
 }
 
-func (*Message_Chunk) isMessage_Contents() {}
-
+func (*Message_Chunk) isMessage_Contents()  {}
 func (*Message_Status) isMessage_Contents() {}
 
 func (m *Message) GetContents() isMessage_Contents {
@@ -847,17 +820,83 @@ func (m *Message) GetStatus() *UpgradeStepStatus {
 	return nil
 }
 
-// XXX_OneofWrappers is for the internal use of the proto package.
-func (*Message) XXX_OneofWrappers() []interface{} {
-	return []interface{}{
+// XXX_OneofFuncs is for the internal use of the proto package.
+func (*Message) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
+	return _Message_OneofMarshaler, _Message_OneofUnmarshaler, _Message_OneofSizer, []interface{}{
 		(*Message_Chunk)(nil),
 		(*Message_Status)(nil),
 	}
 }
 
+func _Message_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
+	m := msg.(*Message)
+	// contents
+	switch x := m.Contents.(type) {
+	case *Message_Chunk:
+		b.EncodeVarint(1<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Chunk); err != nil {
+			return err
+		}
+	case *Message_Status:
+		b.EncodeVarint(2<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.Status); err != nil {
+			return err
+		}
+	case nil:
+	default:
+		return fmt.Errorf("Message.Contents has unexpected type %T", x)
+	}
+	return nil
+}
+
+func _Message_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
+	m := msg.(*Message)
+	switch tag {
+	case 1: // contents.chunk
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(Chunk)
+		err := b.DecodeMessage(msg)
+		m.Contents = &Message_Chunk{msg}
+		return true, err
+	case 2: // contents.status
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(UpgradeStepStatus)
+		err := b.DecodeMessage(msg)
+		m.Contents = &Message_Status{msg}
+		return true, err
+	default:
+		return false, nil
+	}
+}
+
+func _Message_OneofSizer(msg proto.Message) (n int) {
+	m := msg.(*Message)
+	// contents
+	switch x := m.Contents.(type) {
+	case *Message_Chunk:
+		s := proto.Size(x.Chunk)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_Status:
+		s := proto.Size(x.Status)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case nil:
+	default:
+		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
+	}
+	return n
+}
+
 type SetConfigRequest struct {
-	Name                 string   `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Value                string   `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	Name                 string   `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
+	Value                string   `protobuf:"bytes,2,opt,name=value" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -867,17 +906,16 @@ func (m *SetConfigRequest) Reset()         { *m = SetConfigRequest{} }
 func (m *SetConfigRequest) String() string { return proto.CompactTextString(m) }
 func (*SetConfigRequest) ProtoMessage()    {}
 func (*SetConfigRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{17}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{17}
 }
-
 func (m *SetConfigRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SetConfigRequest.Unmarshal(m, b)
 }
 func (m *SetConfigRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SetConfigRequest.Marshal(b, m, deterministic)
 }
-func (m *SetConfigRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SetConfigRequest.Merge(m, src)
+func (dst *SetConfigRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SetConfigRequest.Merge(dst, src)
 }
 func (m *SetConfigRequest) XXX_Size() int {
 	return xxx_messageInfo_SetConfigRequest.Size(m)
@@ -912,17 +950,16 @@ func (m *SetConfigReply) Reset()         { *m = SetConfigReply{} }
 func (m *SetConfigReply) String() string { return proto.CompactTextString(m) }
 func (*SetConfigReply) ProtoMessage()    {}
 func (*SetConfigReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{18}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{18}
 }
-
 func (m *SetConfigReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SetConfigReply.Unmarshal(m, b)
 }
 func (m *SetConfigReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SetConfigReply.Marshal(b, m, deterministic)
 }
-func (m *SetConfigReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SetConfigReply.Merge(m, src)
+func (dst *SetConfigReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SetConfigReply.Merge(dst, src)
 }
 func (m *SetConfigReply) XXX_Size() int {
 	return xxx_messageInfo_SetConfigReply.Size(m)
@@ -934,7 +971,7 @@ func (m *SetConfigReply) XXX_DiscardUnknown() {
 var xxx_messageInfo_SetConfigReply proto.InternalMessageInfo
 
 type GetConfigRequest struct {
-	Name                 string   `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Name                 string   `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -944,17 +981,16 @@ func (m *GetConfigRequest) Reset()         { *m = GetConfigRequest{} }
 func (m *GetConfigRequest) String() string { return proto.CompactTextString(m) }
 func (*GetConfigRequest) ProtoMessage()    {}
 func (*GetConfigRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{19}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{19}
 }
-
 func (m *GetConfigRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetConfigRequest.Unmarshal(m, b)
 }
 func (m *GetConfigRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GetConfigRequest.Marshal(b, m, deterministic)
 }
-func (m *GetConfigRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetConfigRequest.Merge(m, src)
+func (dst *GetConfigRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetConfigRequest.Merge(dst, src)
 }
 func (m *GetConfigRequest) XXX_Size() int {
 	return xxx_messageInfo_GetConfigRequest.Size(m)
@@ -973,7 +1009,7 @@ func (m *GetConfigRequest) GetName() string {
 }
 
 type GetConfigReply struct {
-	Value                string   `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"`
+	Value                string   `protobuf:"bytes,1,opt,name=value" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -983,17 +1019,16 @@ func (m *GetConfigReply) Reset()         { *m = GetConfigReply{} }
 func (m *GetConfigReply) String() string { return proto.CompactTextString(m) }
 func (*GetConfigReply) ProtoMessage()    {}
 func (*GetConfigReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_631e66a01873be02, []int{20}
+	return fileDescriptor_cli_to_hub_eec94ec24fdc3e31, []int{20}
 }
-
 func (m *GetConfigReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetConfigReply.Unmarshal(m, b)
 }
 func (m *GetConfigReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GetConfigReply.Marshal(b, m, deterministic)
 }
-func (m *GetConfigReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetConfigReply.Merge(m, src)
+func (dst *GetConfigReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetConfigReply.Merge(dst, src)
 }
 func (m *GetConfigReply) XXX_Size() int {
 	return xxx_messageInfo_GetConfigReply.Size(m)
@@ -1012,9 +1047,6 @@ func (m *GetConfigReply) GetValue() string {
 }
 
 func init() {
-	proto.RegisterEnum("idl.UpgradeSteps", UpgradeSteps_name, UpgradeSteps_value)
-	proto.RegisterEnum("idl.StepStatus", StepStatus_name, StepStatus_value)
-	proto.RegisterEnum("idl.Chunk_Type", Chunk_Type_name, Chunk_Type_value)
 	proto.RegisterType((*InitializeRequest)(nil), "idl.InitializeRequest")
 	proto.RegisterType((*InitializeCreateClusterRequest)(nil), "idl.InitializeCreateClusterRequest")
 	proto.RegisterType((*ExecuteRequest)(nil), "idl.ExecuteRequest")
@@ -1038,78 +1070,9 @@ func init() {
 	proto.RegisterType((*SetConfigReply)(nil), "idl.SetConfigReply")
 	proto.RegisterType((*GetConfigRequest)(nil), "idl.GetConfigRequest")
 	proto.RegisterType((*GetConfigReply)(nil), "idl.GetConfigReply")
-}
-
-func init() { proto.RegisterFile("cli_to_hub.proto", fileDescriptor_631e66a01873be02) }
-
-var fileDescriptor_631e66a01873be02 = []byte{
-	// 1043 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x56, 0x6d, 0x6f, 0xe2, 0x46,
-	0x10, 0xe6, 0xfd, 0x65, 0xe0, 0x38, 0xb3, 0xe4, 0x85, 0x70, 0xd5, 0x29, 0xf2, 0xb5, 0xd7, 0xe8,
-	0xaa, 0x46, 0x11, 0xad, 0xaa, 0xbb, 0xea, 0xbe, 0x10, 0xb3, 0x01, 0x74, 0x09, 0xa0, 0xb5, 0xdd,
-	0xaa, 0x1f, 0x2a, 0xe4, 0xc0, 0x26, 0x59, 0xe1, 0xb3, 0x1d, 0x7b, 0x49, 0x4b, 0xff, 0x41, 0x7f,
-	0x4b, 0x7f, 0x61, 0xbf, 0x55, 0xbb, 0x36, 0x60, 0x7c, 0x8e, 0xd4, 0x6f, 0x9e, 0x79, 0xe6, 0x99,
-	0x19, 0x0f, 0xcf, 0x78, 0x00, 0x65, 0x6e, 0xb3, 0x19, 0x77, 0x67, 0x0f, 0xab, 0xdb, 0x73, 0xcf,
-	0x77, 0xb9, 0x8b, 0xf2, 0x6c, 0x61, 0xab, 0x0c, 0x9a, 0x23, 0x87, 0x71, 0x66, 0xd9, 0xec, 0x2f,
-	0x4a, 0xe8, 0xe3, 0x8a, 0x06, 0x1c, 0x7d, 0x05, 0x55, 0xd7, 0x5e, 0x5c, 0x32, 0xa7, 0xcf, 0xfc,
-	0x76, 0xf6, 0x34, 0x7b, 0x56, 0x25, 0x3b, 0x87, 0x40, 0x1d, 0xfa, 0x47, 0x84, 0xe6, 0x42, 0x74,
-	0xeb, 0x40, 0x6d, 0x28, 0xbb, 0xf6, 0x62, 0xea, 0xfa, 0xbc, 0x9d, 0x3f, 0xcd, 0x9e, 0x15, 0xc9,
-	0xc6, 0x54, 0x4f, 0xe1, 0xf5, 0xae, 0x94, 0xe6, 0x53, 0x8b, 0x53, 0xcd, 0x5e, 0x05, 0x9c, 0xfa,
-	0x51, 0x5d, 0x55, 0x81, 0x06, 0xfe, 0x93, 0xce, 0x57, 0x7c, 0xd3, 0x89, 0xda, 0x84, 0x97, 0x57,
-	0xcc, 0x89, 0x37, 0xa7, 0x1e, 0xc1, 0x01, 0xa1, 0x01, 0xb7, 0x7c, 0xde, 0xbb, 0xa7, 0x0e, 0x0f,
-	0x36, 0xfe, 0x1f, 0x01, 0x25, 0xfc, 0x9e, 0xbd, 0x46, 0xaf, 0x01, 0x2c, 0x61, 0x0e, 0xdd, 0x80,
-	0x07, 0xed, 0xec, 0x69, 0xfe, 0xac, 0x4a, 0x62, 0x1e, 0xf5, 0x10, 0x5a, 0x3a, 0x77, 0x3d, 0x9d,
-	0xfa, 0x4f, 0x6c, 0x4e, 0xb7, 0xc9, 0x5a, 0xd0, 0xdc, 0x77, 0x7b, 0xf6, 0x5a, 0x9d, 0x43, 0xd3,
-	0xf4, 0xee, 0x7d, 0x6b, 0x41, 0x75, 0x4e, 0x3d, 0x9d, 0x5b, 0x7c, 0x15, 0xa0, 0x6f, 0xa0, 0x10,
-	0x70, 0xea, 0xc9, 0x31, 0x35, 0xba, 0xcd, 0x73, 0xb6, 0xb0, 0xcf, 0x63, 0x51, 0x01, 0x91, 0x30,
-	0xfa, 0x16, 0x4a, 0x81, 0x24, 0xc8, 0x89, 0x35, 0xba, 0x2f, 0x65, 0xe0, 0x2e, 0x0f, 0x89, 0x60,
-	0xd1, 0x90, 0xf6, 0x40, 0xe7, 0xcb, 0x5f, 0xa8, 0x1f, 0x30, 0xd7, 0xd9, 0x34, 0x84, 0xa1, 0xb9,
-	0xef, 0x16, 0x2f, 0x77, 0x01, 0xad, 0x51, 0x10, 0x79, 0x34, 0xf7, 0xb3, 0x67, 0x71, 0x76, 0x6b,
-	0x53, 0xd9, 0x4a, 0x85, 0xa4, 0x41, 0xea, 0xf7, 0x70, 0x28, 0xd3, 0xf4, 0x59, 0xb0, 0xd4, 0x3d,
-	0x6b, 0xbe, 0xfd, 0xc9, 0x0f, 0xa0, 0xe8, 0x5b, 0x9c, 0xb9, 0x92, 0x9c, 0x23, 0xa1, 0xa1, 0xfe,
-	0x9b, 0x8d, 0xba, 0x89, 0xc5, 0x8b, 0xc2, 0x1f, 0xa1, 0x74, 0x67, 0x31, 0x9b, 0x2e, 0xe4, 0x44,
-	0x6b, 0xdd, 0xaf, 0xe5, 0xdb, 0xa4, 0x44, 0x9e, 0x5f, 0xc9, 0x30, 0xec, 0x70, 0x7f, 0x4d, 0x22,
-	0x4e, 0x07, 0x43, 0x55, 0x44, 0x99, 0x81, 0x75, 0x4f, 0x85, 0x9a, 0xac, 0x27, 0x8b, 0xd9, 0xd6,
-	0xa6, 0xf3, 0x02, 0xd9, 0x39, 0x50, 0x07, 0x2a, 0x3e, 0x7d, 0x5c, 0x31, 0x9f, 0x2e, 0xe4, 0xe0,
-	0x0a, 0x64, 0x6b, 0x77, 0x7e, 0x87, 0x5a, 0x2c, 0x3b, 0x52, 0x20, 0xbf, 0xa4, 0xeb, 0x48, 0xae,
-	0xe2, 0x11, 0xbd, 0x87, 0xe2, 0x93, 0x65, 0xaf, 0xa8, 0x64, 0xd6, 0xba, 0xea, 0xb3, 0x4d, 0x6e,
-	0xbb, 0x21, 0x21, 0xe1, 0xe7, 0xdc, 0xfb, 0xac, 0xfa, 0x0a, 0x4e, 0xa6, 0x3e, 0xf5, 0x2c, 0x9f,
-	0x0a, 0xd5, 0x26, 0x94, 0x7a, 0x02, 0xc7, 0x69, 0xa0, 0x50, 0xc9, 0x23, 0x14, 0xb5, 0x87, 0x95,
-	0xb3, 0x44, 0x47, 0x50, 0xba, 0x5d, 0xdd, 0xdd, 0xd1, 0x70, 0x85, 0xea, 0x24, 0xb2, 0xd0, 0x1b,
-	0x28, 0xf0, 0xb5, 0x47, 0xf7, 0x84, 0x20, 0x19, 0xe7, 0xc6, 0xda, 0xa3, 0x44, 0x82, 0xea, 0x77,
-	0x50, 0x10, 0x16, 0xaa, 0x41, 0xd9, 0x1c, 0x7f, 0x1a, 0x4f, 0x7e, 0x1d, 0x2b, 0x19, 0x04, 0x50,
-	0xd2, 0x8d, 0xfe, 0xc4, 0x34, 0x94, 0x6c, 0xf4, 0x8c, 0x09, 0x51, 0x72, 0xea, 0x12, 0xca, 0x37,
-	0x34, 0x90, 0xe3, 0x54, 0xa1, 0x38, 0x17, 0xb9, 0x64, 0xcd, 0x5a, 0x17, 0x76, 0xd9, 0x87, 0x19,
-	0x12, 0x42, 0xe8, 0x62, 0x4f, 0x8b, 0xb5, 0xee, 0x51, 0x52, 0xb4, 0xa1, 0x24, 0x87, 0x99, 0x8d,
-	0x28, 0x2f, 0x01, 0x2a, 0x73, 0xd7, 0xe1, 0x62, 0xad, 0xd4, 0x8f, 0xa0, 0xe8, 0x94, 0x6b, 0xae,
-	0x73, 0xc7, 0xee, 0x37, 0xea, 0x41, 0x50, 0x70, 0xac, 0xcf, 0x34, 0x1a, 0xbe, 0x7c, 0x16, 0x8a,
-	0xda, 0x4d, 0xbf, 0x1a, 0x4d, 0x56, 0xac, 0x78, 0x8c, 0x2d, 0xe6, 0xf5, 0x16, 0x94, 0xc1, 0xff,
-	0xc8, 0xa7, 0xbe, 0x85, 0xc6, 0x60, 0x8f, 0xb9, 0xab, 0x90, 0x8d, 0x55, 0x78, 0xf7, 0x4f, 0x0e,
-	0xea, 0xf1, 0x05, 0x44, 0x0a, 0xd4, 0xa3, 0x11, 0xce, 0x74, 0x03, 0x4f, 0xc3, 0x39, 0x6a, 0x93,
-	0xf1, 0xd5, 0x68, 0xa0, 0x64, 0x05, 0xaa, 0x1b, 0x3d, 0x62, 0xcc, 0x7a, 0x03, 0x3c, 0x36, 0x74,
-	0x25, 0x87, 0xda, 0x70, 0xa0, 0x11, 0xdc, 0x33, 0xf0, 0xcc, 0xe8, 0x91, 0x01, 0x36, 0x66, 0x51,
-	0x6c, 0x1e, 0xbd, 0x82, 0x63, 0x7d, 0x68, 0x1a, 0x7d, 0x99, 0x6a, 0x62, 0x12, 0x0d, 0xcf, 0xb4,
-	0x6b, 0x53, 0x37, 0x30, 0x51, 0x0a, 0xe8, 0x18, 0x5a, 0xa3, 0xf1, 0xc8, 0xd8, 0x92, 0x22, 0xa0,
-	0xb8, 0xc7, 0x4a, 0x80, 0x25, 0xd4, 0x84, 0x17, 0xda, 0x10, 0x6b, 0x9f, 0x66, 0xe6, 0x74, 0x40,
-	0x7a, 0x7d, 0xac, 0x94, 0x11, 0x82, 0x46, 0x64, 0xcc, 0x6e, 0x7a, 0x32, 0xac, 0x82, 0x5e, 0x42,
-	0x4d, 0x9b, 0x4c, 0x7f, 0xdb, 0x38, 0xaa, 0xe8, 0x10, 0x9a, 0x9b, 0xa0, 0x29, 0x19, 0xdd, 0xf4,
-	0xc8, 0x08, 0xeb, 0x0a, 0x88, 0xde, 0xc3, 0xb7, 0x49, 0x14, 0xaa, 0x09, 0x02, 0xc1, 0xe1, 0x9b,
-	0x98, 0x04, 0xcf, 0xa6, 0x13, 0x62, 0xe8, 0x4a, 0xfd, 0x9d, 0x01, 0x10, 0xfb, 0x98, 0x89, 0xd2,
-	0xdb, 0x51, 0xf5, 0x0c, 0x53, 0x57, 0x32, 0x42, 0x81, 0x53, 0x3c, 0xee, 0x8f, 0xc6, 0x62, 0x5a,
-	0x35, 0x28, 0x13, 0x73, 0x3c, 0x16, 0x46, 0x0e, 0xd5, 0xa1, 0xa2, 0x4d, 0x6e, 0xa6, 0xd7, 0xd8,
-	0xc0, 0x4a, 0x5e, 0x0c, 0xf5, 0xaa, 0x37, 0xba, 0xc6, 0x7d, 0xa5, 0xd0, 0xfd, 0xbb, 0x08, 0x15,
-	0xcd, 0x66, 0x86, 0x3b, 0x5c, 0xdd, 0xa2, 0x4b, 0xa8, 0xc7, 0x3f, 0x5d, 0xa8, 0xbd, 0xdb, 0xc3,
-	0xfd, 0x8f, 0x5c, 0xe7, 0x28, 0x05, 0x11, 0x12, 0xc9, 0xa0, 0x21, 0x34, 0xf6, 0x17, 0x17, 0x75,
-	0x52, 0xb7, 0x39, 0xcc, 0xd3, 0x7e, 0x6e, 0xd3, 0xd5, 0x0c, 0xfa, 0x09, 0x60, 0x77, 0x85, 0x50,
-	0x58, 0xf1, 0x8b, 0x0b, 0xd8, 0xa9, 0x4b, 0x7f, 0xb4, 0x54, 0x6a, 0xe6, 0x22, 0x8b, 0xa6, 0x70,
-	0xfc, 0xcc, 0xf5, 0x42, 0x6f, 0x12, 0x49, 0xd2, 0x6e, 0x5b, 0x4a, 0xc6, 0x0b, 0x28, 0x47, 0xd7,
-	0x0e, 0xb5, 0x24, 0xb8, 0x7f, 0xfb, 0x52, 0x18, 0x5d, 0xa8, 0x6c, 0xae, 0x21, 0x3a, 0x90, 0x68,
-	0xe2, 0x38, 0xa6, 0x70, 0x3e, 0x40, 0x75, 0xbb, 0x70, 0xe8, 0x30, 0xbc, 0x3a, 0x89, 0x75, 0xeb,
-	0xb4, 0x92, 0xee, 0x70, 0x54, 0x1f, 0xa0, 0x3a, 0x48, 0x50, 0x07, 0xe9, 0xd4, 0x41, 0x92, 0x8a,
-	0xe1, 0xc5, 0xde, 0x31, 0x46, 0x27, 0x32, 0x2e, 0xed, 0x70, 0x77, 0x8e, 0xd3, 0xa0, 0x30, 0xcd,
-	0x25, 0xd4, 0xe3, 0x67, 0x38, 0x92, 0x4e, 0xca, 0xc1, 0x8e, 0xa4, 0xf3, 0xe5, 0xcd, 0xce, 0xdc,
-	0x96, 0xe4, 0xbf, 0x9d, 0x1f, 0xfe, 0x0b, 0x00, 0x00, 0xff, 0xff, 0xcb, 0x83, 0xa0, 0x2b, 0x01,
-	0x09, 0x00, 0x00,
+	proto.RegisterEnum("idl.UpgradeSteps", UpgradeSteps_name, UpgradeSteps_value)
+	proto.RegisterEnum("idl.StepStatus", StepStatus_name, StepStatus_value)
+	proto.RegisterEnum("idl.Chunk_Type", Chunk_Type_name, Chunk_Type_value)
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1120,9 +1083,8 @@ var _ grpc.ClientConn
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion4
 
-// CliToHubClient is the client API for CliToHub service.
-//
-// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+// Client API for CliToHub service
+
 type CliToHubClient interface {
 	CheckVersion(ctx context.Context, in *CheckVersionRequest, opts ...grpc.CallOption) (*CheckVersionReply, error)
 	CheckDiskSpace(ctx context.Context, in *CheckDiskSpaceRequest, opts ...grpc.CallOption) (*CheckDiskSpaceReply, error)
@@ -1146,7 +1108,7 @@ func NewCliToHubClient(cc *grpc.ClientConn) CliToHubClient {
 
 func (c *cliToHubClient) CheckVersion(ctx context.Context, in *CheckVersionRequest, opts ...grpc.CallOption) (*CheckVersionReply, error) {
 	out := new(CheckVersionReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/CheckVersion", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/CheckVersion", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1155,7 +1117,7 @@ func (c *cliToHubClient) CheckVersion(ctx context.Context, in *CheckVersionReque
 
 func (c *cliToHubClient) CheckDiskSpace(ctx context.Context, in *CheckDiskSpaceRequest, opts ...grpc.CallOption) (*CheckDiskSpaceReply, error) {
 	out := new(CheckDiskSpaceReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/CheckDiskSpace", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/CheckDiskSpace", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1163,7 +1125,7 @@ func (c *cliToHubClient) CheckDiskSpace(ctx context.Context, in *CheckDiskSpaceR
 }
 
 func (c *cliToHubClient) Initialize(ctx context.Context, in *InitializeRequest, opts ...grpc.CallOption) (CliToHub_InitializeClient, error) {
-	stream, err := c.cc.NewStream(ctx, &_CliToHub_serviceDesc.Streams[0], "/idl.CliToHub/Initialize", opts...)
+	stream, err := grpc.NewClientStream(ctx, &_CliToHub_serviceDesc.Streams[0], c.cc, "/idl.CliToHub/Initialize", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1195,7 +1157,7 @@ func (x *cliToHubInitializeClient) Recv() (*Message, error) {
 }
 
 func (c *cliToHubClient) InitializeCreateCluster(ctx context.Context, in *InitializeCreateClusterRequest, opts ...grpc.CallOption) (CliToHub_InitializeCreateClusterClient, error) {
-	stream, err := c.cc.NewStream(ctx, &_CliToHub_serviceDesc.Streams[1], "/idl.CliToHub/InitializeCreateCluster", opts...)
+	stream, err := grpc.NewClientStream(ctx, &_CliToHub_serviceDesc.Streams[1], c.cc, "/idl.CliToHub/InitializeCreateCluster", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1227,7 +1189,7 @@ func (x *cliToHubInitializeCreateClusterClient) Recv() (*Message, error) {
 }
 
 func (c *cliToHubClient) Execute(ctx context.Context, in *ExecuteRequest, opts ...grpc.CallOption) (CliToHub_ExecuteClient, error) {
-	stream, err := c.cc.NewStream(ctx, &_CliToHub_serviceDesc.Streams[2], "/idl.CliToHub/Execute", opts...)
+	stream, err := grpc.NewClientStream(ctx, &_CliToHub_serviceDesc.Streams[2], c.cc, "/idl.CliToHub/Execute", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1259,7 +1221,7 @@ func (x *cliToHubExecuteClient) Recv() (*Message, error) {
 }
 
 func (c *cliToHubClient) Finalize(ctx context.Context, in *FinalizeRequest, opts ...grpc.CallOption) (CliToHub_FinalizeClient, error) {
-	stream, err := c.cc.NewStream(ctx, &_CliToHub_serviceDesc.Streams[3], "/idl.CliToHub/Finalize", opts...)
+	stream, err := grpc.NewClientStream(ctx, &_CliToHub_serviceDesc.Streams[3], c.cc, "/idl.CliToHub/Finalize", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1292,7 +1254,7 @@ func (x *cliToHubFinalizeClient) Recv() (*Message, error) {
 
 func (c *cliToHubClient) SetConfig(ctx context.Context, in *SetConfigRequest, opts ...grpc.CallOption) (*SetConfigReply, error) {
 	out := new(SetConfigReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/SetConfig", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/SetConfig", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1301,7 +1263,7 @@ func (c *cliToHubClient) SetConfig(ctx context.Context, in *SetConfigRequest, op
 
 func (c *cliToHubClient) GetConfig(ctx context.Context, in *GetConfigRequest, opts ...grpc.CallOption) (*GetConfigReply, error) {
 	out := new(GetConfigReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/GetConfig", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/GetConfig", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1310,7 +1272,7 @@ func (c *cliToHubClient) GetConfig(ctx context.Context, in *GetConfigRequest, op
 
 func (c *cliToHubClient) RestartAgents(ctx context.Context, in *RestartAgentsRequest, opts ...grpc.CallOption) (*RestartAgentsReply, error) {
 	out := new(RestartAgentsReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/RestartAgents", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/RestartAgents", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1319,14 +1281,15 @@ func (c *cliToHubClient) RestartAgents(ctx context.Context, in *RestartAgentsReq
 
 func (c *cliToHubClient) StopServices(ctx context.Context, in *StopServicesRequest, opts ...grpc.CallOption) (*StopServicesReply, error) {
 	out := new(StopServicesReply)
-	err := c.cc.Invoke(ctx, "/idl.CliToHub/StopServices", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.CliToHub/StopServices", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// CliToHubServer is the server API for CliToHub service.
+// Server API for CliToHub service
+
 type CliToHubServer interface {
 	CheckVersion(context.Context, *CheckVersionRequest) (*CheckVersionReply, error)
 	CheckDiskSpace(context.Context, *CheckDiskSpaceRequest) (*CheckDiskSpaceReply, error)
@@ -1338,41 +1301,6 @@ type CliToHubServer interface {
 	GetConfig(context.Context, *GetConfigRequest) (*GetConfigReply, error)
 	RestartAgents(context.Context, *RestartAgentsRequest) (*RestartAgentsReply, error)
 	StopServices(context.Context, *StopServicesRequest) (*StopServicesReply, error)
-}
-
-// UnimplementedCliToHubServer can be embedded to have forward compatible implementations.
-type UnimplementedCliToHubServer struct {
-}
-
-func (*UnimplementedCliToHubServer) CheckVersion(ctx context.Context, req *CheckVersionRequest) (*CheckVersionReply, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method CheckVersion not implemented")
-}
-func (*UnimplementedCliToHubServer) CheckDiskSpace(ctx context.Context, req *CheckDiskSpaceRequest) (*CheckDiskSpaceReply, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method CheckDiskSpace not implemented")
-}
-func (*UnimplementedCliToHubServer) Initialize(req *InitializeRequest, srv CliToHub_InitializeServer) error {
-	return status.Errorf(codes.Unimplemented, "method Initialize not implemented")
-}
-func (*UnimplementedCliToHubServer) InitializeCreateCluster(req *InitializeCreateClusterRequest, srv CliToHub_InitializeCreateClusterServer) error {
-	return status.Errorf(codes.Unimplemented, "method InitializeCreateCluster not implemented")
-}
-func (*UnimplementedCliToHubServer) Execute(req *ExecuteRequest, srv CliToHub_ExecuteServer) error {
-	return status.Errorf(codes.Unimplemented, "method Execute not implemented")
-}
-func (*UnimplementedCliToHubServer) Finalize(req *FinalizeRequest, srv CliToHub_FinalizeServer) error {
-	return status.Errorf(codes.Unimplemented, "method Finalize not implemented")
-}
-func (*UnimplementedCliToHubServer) SetConfig(ctx context.Context, req *SetConfigRequest) (*SetConfigReply, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method SetConfig not implemented")
-}
-func (*UnimplementedCliToHubServer) GetConfig(ctx context.Context, req *GetConfigRequest) (*GetConfigReply, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method GetConfig not implemented")
-}
-func (*UnimplementedCliToHubServer) RestartAgents(ctx context.Context, req *RestartAgentsRequest) (*RestartAgentsReply, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method RestartAgents not implemented")
-}
-func (*UnimplementedCliToHubServer) StopServices(ctx context.Context, req *StopServicesRequest) (*StopServicesReply, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method StopServices not implemented")
 }
 
 func RegisterCliToHubServer(s *grpc.Server, srv CliToHubServer) {
@@ -1623,4 +1551,76 @@ var _CliToHub_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Metadata: "cli_to_hub.proto",
+}
+
+func init() { proto.RegisterFile("cli_to_hub.proto", fileDescriptor_cli_to_hub_eec94ec24fdc3e31) }
+
+var fileDescriptor_cli_to_hub_eec94ec24fdc3e31 = []byte{
+	// 1043 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x56, 0x6d, 0x6f, 0xe2, 0x46,
+	0x10, 0xc6, 0xbc, 0x33, 0x70, 0x9c, 0x59, 0xf2, 0x42, 0xb8, 0xea, 0x14, 0xf9, 0xda, 0x6b, 0x74,
+	0x55, 0xa3, 0x88, 0x56, 0xd5, 0x5d, 0x75, 0x5f, 0x88, 0xd9, 0x00, 0xba, 0x04, 0xd0, 0xda, 0x6e,
+	0xd5, 0x0f, 0x15, 0x72, 0x60, 0x93, 0x58, 0xf8, 0x6c, 0xc7, 0x5e, 0xd2, 0xd2, 0x7f, 0xd0, 0xdf,
+	0xd2, 0x5f, 0xd8, 0x6f, 0xd5, 0xae, 0x0d, 0xd8, 0x3e, 0x47, 0xea, 0x37, 0xcf, 0x3c, 0xf3, 0xcc,
+	0x8c, 0x87, 0x67, 0x3c, 0x80, 0xbc, 0xb0, 0xad, 0x39, 0x73, 0xe7, 0x0f, 0xeb, 0xdb, 0x73, 0xcf,
+	0x77, 0x99, 0x8b, 0x0a, 0xd6, 0xd2, 0x56, 0x2c, 0x68, 0x8d, 0x1d, 0x8b, 0x59, 0xa6, 0x6d, 0xfd,
+	0x45, 0x09, 0x7d, 0x5c, 0xd3, 0x80, 0xa1, 0xaf, 0xa0, 0xe6, 0xda, 0xcb, 0x4b, 0xcb, 0x19, 0x58,
+	0x7e, 0x47, 0x3a, 0x95, 0xce, 0x6a, 0x64, 0xef, 0xe0, 0xa8, 0x43, 0xff, 0x88, 0xd0, 0x7c, 0x88,
+	0xee, 0x1c, 0xa8, 0x03, 0x15, 0xd7, 0x5e, 0xce, 0x5c, 0x9f, 0x75, 0x0a, 0xa7, 0xd2, 0x59, 0x89,
+	0x6c, 0x4d, 0xe5, 0x14, 0x5e, 0xef, 0x4b, 0xa9, 0x3e, 0x35, 0x19, 0x55, 0xed, 0x75, 0xc0, 0xa8,
+	0x1f, 0xd5, 0x55, 0x64, 0x68, 0xe2, 0x3f, 0xe9, 0x62, 0xcd, 0xb6, 0x9d, 0x28, 0x2d, 0x78, 0x79,
+	0x65, 0x39, 0xf1, 0xe6, 0x94, 0x23, 0x38, 0x20, 0x34, 0x60, 0xa6, 0xcf, 0xfa, 0xf7, 0xd4, 0x61,
+	0xc1, 0xd6, 0xff, 0x23, 0xa0, 0x94, 0xdf, 0xb3, 0x37, 0xe8, 0x35, 0x80, 0xc9, 0xcd, 0x91, 0x1b,
+	0xb0, 0xa0, 0x23, 0x9d, 0x16, 0xce, 0x6a, 0x24, 0xe6, 0x51, 0x0e, 0xa1, 0xad, 0x31, 0xd7, 0xd3,
+	0xa8, 0xff, 0x64, 0x2d, 0xe8, 0x2e, 0x59, 0x1b, 0x5a, 0x49, 0xb7, 0x67, 0x6f, 0x94, 0x05, 0xb4,
+	0x0c, 0xef, 0xde, 0x37, 0x97, 0x54, 0x63, 0xd4, 0xd3, 0x98, 0xc9, 0xd6, 0x01, 0xfa, 0x06, 0x8a,
+	0x01, 0xa3, 0x9e, 0x18, 0x53, 0xb3, 0xd7, 0x3a, 0xb7, 0x96, 0xf6, 0x79, 0x2c, 0x2a, 0x20, 0x02,
+	0x46, 0xdf, 0x42, 0x39, 0x10, 0x04, 0x31, 0xb1, 0x66, 0xef, 0xa5, 0x08, 0xdc, 0xe7, 0x21, 0x11,
+	0xcc, 0x1b, 0x52, 0x1f, 0xe8, 0x62, 0xf5, 0x0b, 0xf5, 0x03, 0xcb, 0x75, 0xb6, 0x0d, 0x61, 0x68,
+	0x25, 0xdd, 0xfc, 0xe5, 0x2e, 0xa0, 0x3d, 0x0e, 0x22, 0x8f, 0xea, 0x7e, 0xf6, 0x4c, 0x66, 0xdd,
+	0xda, 0x54, 0xb4, 0x52, 0x25, 0x59, 0x90, 0xf2, 0x3d, 0x1c, 0x8a, 0x34, 0x03, 0x2b, 0x58, 0x69,
+	0x9e, 0xb9, 0xd8, 0xfd, 0xe4, 0x07, 0x50, 0xf2, 0x4d, 0x66, 0xb9, 0x82, 0x2c, 0x91, 0xd0, 0x50,
+	0xfe, 0x95, 0xa2, 0x6e, 0x62, 0xf1, 0xbc, 0xf0, 0x47, 0x28, 0xdf, 0x99, 0x96, 0x4d, 0x97, 0x62,
+	0xa2, 0xf5, 0xde, 0xd7, 0xe2, 0x6d, 0x32, 0x22, 0xcf, 0xaf, 0x44, 0x18, 0x76, 0x98, 0xbf, 0x21,
+	0x11, 0xa7, 0x8b, 0xa1, 0xc6, 0xa3, 0x8c, 0xc0, 0xbc, 0xa7, 0x5c, 0x4d, 0xe6, 0x93, 0x69, 0xd9,
+	0xe6, 0xb6, 0xf3, 0x22, 0xd9, 0x3b, 0x50, 0x17, 0xaa, 0x3e, 0x7d, 0x5c, 0x5b, 0x3e, 0x5d, 0x8a,
+	0xc1, 0x15, 0xc9, 0xce, 0xee, 0xfe, 0x0e, 0xf5, 0x58, 0x76, 0x24, 0x43, 0x61, 0x45, 0x37, 0x91,
+	0x5c, 0xf9, 0x23, 0x7a, 0x0f, 0xa5, 0x27, 0xd3, 0x5e, 0x53, 0xc1, 0xac, 0xf7, 0x94, 0x67, 0x9b,
+	0xdc, 0x75, 0x43, 0x42, 0xc2, 0xcf, 0xf9, 0xf7, 0x92, 0xf2, 0x0a, 0x4e, 0x66, 0x3e, 0xf5, 0x4c,
+	0x9f, 0x72, 0xd5, 0xa6, 0x94, 0x7a, 0x02, 0xc7, 0x59, 0x20, 0x57, 0xc9, 0x23, 0x94, 0xd4, 0x87,
+	0xb5, 0xb3, 0x42, 0x47, 0x50, 0xbe, 0x5d, 0xdf, 0xdd, 0xd1, 0x70, 0x85, 0x1a, 0x24, 0xb2, 0xd0,
+	0x1b, 0x28, 0xb2, 0x8d, 0x47, 0x13, 0x42, 0x10, 0x8c, 0x73, 0x7d, 0xe3, 0x51, 0x22, 0x40, 0xe5,
+	0x3b, 0x28, 0x72, 0x0b, 0xd5, 0xa1, 0x62, 0x4c, 0x3e, 0x4d, 0xa6, 0xbf, 0x4e, 0xe4, 0x1c, 0x02,
+	0x28, 0x6b, 0xfa, 0x60, 0x6a, 0xe8, 0xb2, 0x14, 0x3d, 0x63, 0x42, 0xe4, 0xbc, 0xb2, 0x82, 0xca,
+	0x0d, 0x0d, 0xc4, 0x38, 0x15, 0x28, 0x2d, 0x78, 0x2e, 0x51, 0xb3, 0xde, 0x83, 0x7d, 0xf6, 0x51,
+	0x8e, 0x84, 0x10, 0xba, 0x48, 0x68, 0xb1, 0xde, 0x3b, 0x4a, 0x8b, 0x36, 0x94, 0xe4, 0x28, 0xb7,
+	0x15, 0xe5, 0x25, 0x40, 0x75, 0xe1, 0x3a, 0x8c, 0xaf, 0x95, 0xf2, 0x11, 0x64, 0x8d, 0x32, 0xd5,
+	0x75, 0xee, 0xac, 0xfb, 0xad, 0x7a, 0x10, 0x14, 0x1d, 0xf3, 0x33, 0x8d, 0x86, 0x2f, 0x9e, 0xb9,
+	0xa2, 0xf6, 0xd3, 0xaf, 0x45, 0x93, 0xe5, 0x2b, 0x1e, 0x63, 0xf3, 0x79, 0xbd, 0x05, 0x79, 0xf8,
+	0x3f, 0xf2, 0x29, 0x6f, 0xa1, 0x39, 0x4c, 0x30, 0xf7, 0x15, 0xa4, 0x58, 0x85, 0x77, 0xff, 0xe4,
+	0xa1, 0x11, 0x5f, 0x40, 0x24, 0x43, 0x23, 0x1a, 0xe1, 0x5c, 0xd3, 0xf1, 0x2c, 0x9c, 0xa3, 0x3a,
+	0x9d, 0x5c, 0x8d, 0x87, 0xb2, 0xc4, 0x51, 0x4d, 0xef, 0x13, 0x7d, 0xde, 0x1f, 0xe2, 0x89, 0xae,
+	0xc9, 0x79, 0xd4, 0x81, 0x03, 0x95, 0xe0, 0xbe, 0x8e, 0xe7, 0x7a, 0x9f, 0x0c, 0xb1, 0x3e, 0x8f,
+	0x62, 0x0b, 0xe8, 0x15, 0x1c, 0x6b, 0x23, 0x43, 0x1f, 0x88, 0x54, 0x53, 0x83, 0xa8, 0x78, 0xae,
+	0x5e, 0x1b, 0x9a, 0x8e, 0x89, 0x5c, 0x44, 0xc7, 0xd0, 0x1e, 0x4f, 0xc6, 0xfa, 0x8e, 0x14, 0x01,
+	0xa5, 0x04, 0x2b, 0x05, 0x96, 0x51, 0x0b, 0x5e, 0xa8, 0x23, 0xac, 0x7e, 0x9a, 0x1b, 0xb3, 0x21,
+	0xe9, 0x0f, 0xb0, 0x5c, 0x41, 0x08, 0x9a, 0x91, 0x31, 0xbf, 0xe9, 0x8b, 0xb0, 0x2a, 0x7a, 0x09,
+	0x75, 0x75, 0x3a, 0xfb, 0x6d, 0xeb, 0xa8, 0xa1, 0x43, 0x68, 0x6d, 0x83, 0x66, 0x64, 0x7c, 0xd3,
+	0x27, 0x63, 0xac, 0xc9, 0xc0, 0x7b, 0x0f, 0xdf, 0x26, 0x55, 0xa8, 0xce, 0x09, 0x04, 0x87, 0x6f,
+	0x62, 0x10, 0x3c, 0x9f, 0x4d, 0x89, 0xae, 0xc9, 0x8d, 0x77, 0x3a, 0x40, 0xec, 0x63, 0xc6, 0x4b,
+	0xef, 0x46, 0xd5, 0xd7, 0x0d, 0x4d, 0xce, 0x71, 0x05, 0xce, 0xf0, 0x64, 0x30, 0x9e, 0xf0, 0x69,
+	0xd5, 0xa1, 0x42, 0x8c, 0xc9, 0x84, 0x1b, 0x79, 0xd4, 0x80, 0xaa, 0x3a, 0xbd, 0x99, 0x5d, 0x63,
+	0x1d, 0xcb, 0x05, 0x3e, 0xd4, 0xab, 0xfe, 0xf8, 0x1a, 0x0f, 0xe4, 0x62, 0xef, 0xef, 0x12, 0x54,
+	0x55, 0xdb, 0xd2, 0xdd, 0xd1, 0xfa, 0x16, 0x5d, 0x42, 0x23, 0xfe, 0xe9, 0x42, 0x9d, 0xfd, 0x1e,
+	0x26, 0x3f, 0x72, 0xdd, 0xa3, 0x0c, 0x84, 0x4b, 0x24, 0x87, 0x46, 0xd0, 0x4c, 0x2e, 0x2e, 0xea,
+	0x66, 0x6e, 0x73, 0x98, 0xa7, 0xf3, 0xdc, 0xa6, 0x2b, 0x39, 0xf4, 0x13, 0xc0, 0xfe, 0x0a, 0xa1,
+	0xb0, 0xe2, 0x17, 0x17, 0xb0, 0xdb, 0x10, 0xfe, 0x68, 0xa9, 0x94, 0xdc, 0x85, 0x84, 0x66, 0x70,
+	0xfc, 0xcc, 0xf5, 0x42, 0x6f, 0x52, 0x49, 0xb2, 0x6e, 0x5b, 0x46, 0xc6, 0x0b, 0xa8, 0x44, 0xd7,
+	0x0e, 0xb5, 0x05, 0x98, 0xbc, 0x7d, 0x19, 0x8c, 0x1e, 0x54, 0xb7, 0xd7, 0x10, 0x1d, 0x08, 0x34,
+	0x75, 0x1c, 0x33, 0x38, 0x1f, 0xa0, 0xb6, 0x5b, 0x38, 0x74, 0x18, 0x5e, 0x9d, 0xd4, 0xba, 0x75,
+	0xdb, 0x69, 0x77, 0x38, 0xaa, 0x0f, 0x50, 0x1b, 0xa6, 0xa8, 0xc3, 0x6c, 0xea, 0x30, 0x4d, 0xc5,
+	0xf0, 0x22, 0x71, 0x8c, 0xd1, 0x89, 0x88, 0xcb, 0x3a, 0xdc, 0xdd, 0xe3, 0x2c, 0x28, 0x4c, 0x73,
+	0x09, 0x8d, 0xf8, 0x19, 0x8e, 0xa4, 0x93, 0x71, 0xb0, 0x23, 0xe9, 0x7c, 0x79, 0xb3, 0x73, 0xb7,
+	0x65, 0xf1, 0x6f, 0xe7, 0x87, 0xff, 0x02, 0x00, 0x00, 0xff, 0xff, 0x52, 0xfc, 0xd1, 0x3f, 0x01,
+	0x09, 0x00, 0x00,
 }

--- a/idl/cli_to_hub.proto
+++ b/idl/cli_to_hub.proto
@@ -69,7 +69,7 @@ message CheckVersionReply {
 }
 
 message CheckDiskSpaceRequest {
-	float ratio = 1;
+  double ratio = 1;
 }
 
 message CheckDiskSpaceReply {

--- a/idl/hub_to_agent.pb.go
+++ b/idl/hub_to_agent.pb.go
@@ -3,14 +3,13 @@
 
 package idl
 
+import proto "github.com/golang/protobuf/proto"
+import fmt "fmt"
+import math "math"
+
 import (
-	context "context"
-	fmt "fmt"
-	proto "github.com/golang/protobuf/proto"
+	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
-	codes "google.golang.org/grpc/codes"
-	status "google.golang.org/grpc/status"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -22,14 +21,14 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 type UpgradePrimariesRequest struct {
-	OldBinDir            string         `protobuf:"bytes,1,opt,name=OldBinDir,proto3" json:"OldBinDir,omitempty"`
-	NewBinDir            string         `protobuf:"bytes,2,opt,name=NewBinDir,proto3" json:"NewBinDir,omitempty"`
-	NewVersion           string         `protobuf:"bytes,3,opt,name=NewVersion,proto3" json:"NewVersion,omitempty"`
-	DataDirPairs         []*DataDirPair `protobuf:"bytes,4,rep,name=DataDirPairs,proto3" json:"DataDirPairs,omitempty"`
-	CheckOnly            bool           `protobuf:"varint,5,opt,name=CheckOnly,proto3" json:"CheckOnly,omitempty"`
+	OldBinDir            string         `protobuf:"bytes,1,opt,name=OldBinDir" json:"OldBinDir,omitempty"`
+	NewBinDir            string         `protobuf:"bytes,2,opt,name=NewBinDir" json:"NewBinDir,omitempty"`
+	NewVersion           string         `protobuf:"bytes,3,opt,name=NewVersion" json:"NewVersion,omitempty"`
+	DataDirPairs         []*DataDirPair `protobuf:"bytes,4,rep,name=DataDirPairs" json:"DataDirPairs,omitempty"`
+	CheckOnly            bool           `protobuf:"varint,5,opt,name=CheckOnly" json:"CheckOnly,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
 	XXX_unrecognized     []byte         `json:"-"`
 	XXX_sizecache        int32          `json:"-"`
@@ -39,17 +38,16 @@ func (m *UpgradePrimariesRequest) Reset()         { *m = UpgradePrimariesRequest
 func (m *UpgradePrimariesRequest) String() string { return proto.CompactTextString(m) }
 func (*UpgradePrimariesRequest) ProtoMessage()    {}
 func (*UpgradePrimariesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9e73bb06acc917d8, []int{0}
+	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{0}
 }
-
 func (m *UpgradePrimariesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UpgradePrimariesRequest.Unmarshal(m, b)
 }
 func (m *UpgradePrimariesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UpgradePrimariesRequest.Marshal(b, m, deterministic)
 }
-func (m *UpgradePrimariesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UpgradePrimariesRequest.Merge(m, src)
+func (dst *UpgradePrimariesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UpgradePrimariesRequest.Merge(dst, src)
 }
 func (m *UpgradePrimariesRequest) XXX_Size() int {
 	return xxx_messageInfo_UpgradePrimariesRequest.Size(m)
@@ -96,11 +94,11 @@ func (m *UpgradePrimariesRequest) GetCheckOnly() bool {
 }
 
 type DataDirPair struct {
-	OldDataDir           string   `protobuf:"bytes,1,opt,name=OldDataDir,proto3" json:"OldDataDir,omitempty"`
-	NewDataDir           string   `protobuf:"bytes,2,opt,name=NewDataDir,proto3" json:"NewDataDir,omitempty"`
-	OldPort              int32    `protobuf:"varint,3,opt,name=OldPort,proto3" json:"OldPort,omitempty"`
-	NewPort              int32    `protobuf:"varint,4,opt,name=NewPort,proto3" json:"NewPort,omitempty"`
-	Content              int32    `protobuf:"varint,5,opt,name=Content,proto3" json:"Content,omitempty"`
+	OldDataDir           string   `protobuf:"bytes,1,opt,name=OldDataDir" json:"OldDataDir,omitempty"`
+	NewDataDir           string   `protobuf:"bytes,2,opt,name=NewDataDir" json:"NewDataDir,omitempty"`
+	OldPort              int32    `protobuf:"varint,3,opt,name=OldPort" json:"OldPort,omitempty"`
+	NewPort              int32    `protobuf:"varint,4,opt,name=NewPort" json:"NewPort,omitempty"`
+	Content              int32    `protobuf:"varint,5,opt,name=Content" json:"Content,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -110,17 +108,16 @@ func (m *DataDirPair) Reset()         { *m = DataDirPair{} }
 func (m *DataDirPair) String() string { return proto.CompactTextString(m) }
 func (*DataDirPair) ProtoMessage()    {}
 func (*DataDirPair) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9e73bb06acc917d8, []int{1}
+	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{1}
 }
-
 func (m *DataDirPair) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DataDirPair.Unmarshal(m, b)
 }
 func (m *DataDirPair) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DataDirPair.Marshal(b, m, deterministic)
 }
-func (m *DataDirPair) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DataDirPair.Merge(m, src)
+func (dst *DataDirPair) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DataDirPair.Merge(dst, src)
 }
 func (m *DataDirPair) XXX_Size() int {
 	return xxx_messageInfo_DataDirPair.Size(m)
@@ -176,17 +173,16 @@ func (m *UpgradePrimariesReply) Reset()         { *m = UpgradePrimariesReply{} }
 func (m *UpgradePrimariesReply) String() string { return proto.CompactTextString(m) }
 func (*UpgradePrimariesReply) ProtoMessage()    {}
 func (*UpgradePrimariesReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9e73bb06acc917d8, []int{2}
+	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{2}
 }
-
 func (m *UpgradePrimariesReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UpgradePrimariesReply.Unmarshal(m, b)
 }
 func (m *UpgradePrimariesReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_UpgradePrimariesReply.Marshal(b, m, deterministic)
 }
-func (m *UpgradePrimariesReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UpgradePrimariesReply.Merge(m, src)
+func (dst *UpgradePrimariesReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UpgradePrimariesReply.Merge(dst, src)
 }
 func (m *UpgradePrimariesReply) XXX_Size() int {
 	return xxx_messageInfo_UpgradePrimariesReply.Size(m)
@@ -198,7 +194,7 @@ func (m *UpgradePrimariesReply) XXX_DiscardUnknown() {
 var xxx_messageInfo_UpgradePrimariesReply proto.InternalMessageInfo
 
 type CreateSegmentDataDirRequest struct {
-	Datadirs             []string `protobuf:"bytes,1,rep,name=datadirs,proto3" json:"datadirs,omitempty"`
+	Datadirs             []string `protobuf:"bytes,1,rep,name=datadirs" json:"datadirs,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -208,17 +204,16 @@ func (m *CreateSegmentDataDirRequest) Reset()         { *m = CreateSegmentDataDi
 func (m *CreateSegmentDataDirRequest) String() string { return proto.CompactTextString(m) }
 func (*CreateSegmentDataDirRequest) ProtoMessage()    {}
 func (*CreateSegmentDataDirRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9e73bb06acc917d8, []int{3}
+	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{3}
 }
-
 func (m *CreateSegmentDataDirRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateSegmentDataDirRequest.Unmarshal(m, b)
 }
 func (m *CreateSegmentDataDirRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CreateSegmentDataDirRequest.Marshal(b, m, deterministic)
 }
-func (m *CreateSegmentDataDirRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CreateSegmentDataDirRequest.Merge(m, src)
+func (dst *CreateSegmentDataDirRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CreateSegmentDataDirRequest.Merge(dst, src)
 }
 func (m *CreateSegmentDataDirRequest) XXX_Size() int {
 	return xxx_messageInfo_CreateSegmentDataDirRequest.Size(m)
@@ -246,17 +241,16 @@ func (m *CreateSegmentDataDirReply) Reset()         { *m = CreateSegmentDataDirR
 func (m *CreateSegmentDataDirReply) String() string { return proto.CompactTextString(m) }
 func (*CreateSegmentDataDirReply) ProtoMessage()    {}
 func (*CreateSegmentDataDirReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9e73bb06acc917d8, []int{4}
+	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{4}
 }
-
 func (m *CreateSegmentDataDirReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateSegmentDataDirReply.Unmarshal(m, b)
 }
 func (m *CreateSegmentDataDirReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CreateSegmentDataDirReply.Marshal(b, m, deterministic)
 }
-func (m *CreateSegmentDataDirReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CreateSegmentDataDirReply.Merge(m, src)
+func (dst *CreateSegmentDataDirReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CreateSegmentDataDirReply.Merge(dst, src)
 }
 func (m *CreateSegmentDataDirReply) XXX_Size() int {
 	return xxx_messageInfo_CreateSegmentDataDirReply.Size(m)
@@ -268,8 +262,8 @@ func (m *CreateSegmentDataDirReply) XXX_DiscardUnknown() {
 var xxx_messageInfo_CreateSegmentDataDirReply proto.InternalMessageInfo
 
 type CopyMasterDirRequest struct {
-	MasterDir            string   `protobuf:"bytes,1,opt,name=masterDir,proto3" json:"masterDir,omitempty"`
-	Datadirs             []string `protobuf:"bytes,2,rep,name=datadirs,proto3" json:"datadirs,omitempty"`
+	MasterDir            string   `protobuf:"bytes,1,opt,name=masterDir" json:"masterDir,omitempty"`
+	Datadirs             []string `protobuf:"bytes,2,rep,name=datadirs" json:"datadirs,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -279,17 +273,16 @@ func (m *CopyMasterDirRequest) Reset()         { *m = CopyMasterDirRequest{} }
 func (m *CopyMasterDirRequest) String() string { return proto.CompactTextString(m) }
 func (*CopyMasterDirRequest) ProtoMessage()    {}
 func (*CopyMasterDirRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9e73bb06acc917d8, []int{5}
+	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{5}
 }
-
 func (m *CopyMasterDirRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CopyMasterDirRequest.Unmarshal(m, b)
 }
 func (m *CopyMasterDirRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CopyMasterDirRequest.Marshal(b, m, deterministic)
 }
-func (m *CopyMasterDirRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CopyMasterDirRequest.Merge(m, src)
+func (dst *CopyMasterDirRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CopyMasterDirRequest.Merge(dst, src)
 }
 func (m *CopyMasterDirRequest) XXX_Size() int {
 	return xxx_messageInfo_CopyMasterDirRequest.Size(m)
@@ -324,17 +317,16 @@ func (m *CopyMasterDirReply) Reset()         { *m = CopyMasterDirReply{} }
 func (m *CopyMasterDirReply) String() string { return proto.CompactTextString(m) }
 func (*CopyMasterDirReply) ProtoMessage()    {}
 func (*CopyMasterDirReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9e73bb06acc917d8, []int{6}
+	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{6}
 }
-
 func (m *CopyMasterDirReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CopyMasterDirReply.Unmarshal(m, b)
 }
 func (m *CopyMasterDirReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CopyMasterDirReply.Marshal(b, m, deterministic)
 }
-func (m *CopyMasterDirReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CopyMasterDirReply.Merge(m, src)
+func (dst *CopyMasterDirReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CopyMasterDirReply.Merge(dst, src)
 }
 func (m *CopyMasterDirReply) XXX_Size() int {
 	return xxx_messageInfo_CopyMasterDirReply.Size(m)
@@ -355,17 +347,16 @@ func (m *StopAgentRequest) Reset()         { *m = StopAgentRequest{} }
 func (m *StopAgentRequest) String() string { return proto.CompactTextString(m) }
 func (*StopAgentRequest) ProtoMessage()    {}
 func (*StopAgentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9e73bb06acc917d8, []int{7}
+	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{7}
 }
-
 func (m *StopAgentRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StopAgentRequest.Unmarshal(m, b)
 }
 func (m *StopAgentRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StopAgentRequest.Marshal(b, m, deterministic)
 }
-func (m *StopAgentRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StopAgentRequest.Merge(m, src)
+func (dst *StopAgentRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StopAgentRequest.Merge(dst, src)
 }
 func (m *StopAgentRequest) XXX_Size() int {
 	return xxx_messageInfo_StopAgentRequest.Size(m)
@@ -386,17 +377,16 @@ func (m *StopAgentReply) Reset()         { *m = StopAgentReply{} }
 func (m *StopAgentReply) String() string { return proto.CompactTextString(m) }
 func (*StopAgentReply) ProtoMessage()    {}
 func (*StopAgentReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9e73bb06acc917d8, []int{8}
+	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{8}
 }
-
 func (m *StopAgentReply) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StopAgentReply.Unmarshal(m, b)
 }
 func (m *StopAgentReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StopAgentReply.Marshal(b, m, deterministic)
 }
-func (m *StopAgentReply) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StopAgentReply.Merge(m, src)
+func (dst *StopAgentReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StopAgentReply.Merge(dst, src)
 }
 func (m *StopAgentReply) XXX_Size() int {
 	return xxx_messageInfo_StopAgentReply.Size(m)
@@ -408,8 +398,8 @@ func (m *StopAgentReply) XXX_DiscardUnknown() {
 var xxx_messageInfo_StopAgentReply proto.InternalMessageInfo
 
 type CheckSegmentDiskSpaceRequest struct {
-	Request              *CheckDiskSpaceRequest `protobuf:"bytes,1,opt,name=request,proto3" json:"request,omitempty"`
-	Datadirs             []string               `protobuf:"bytes,2,rep,name=datadirs,proto3" json:"datadirs,omitempty"`
+	Request              *CheckDiskSpaceRequest `protobuf:"bytes,1,opt,name=request" json:"request,omitempty"`
+	Datadirs             []string               `protobuf:"bytes,2,rep,name=datadirs" json:"datadirs,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}               `json:"-"`
 	XXX_unrecognized     []byte                 `json:"-"`
 	XXX_sizecache        int32                  `json:"-"`
@@ -419,17 +409,16 @@ func (m *CheckSegmentDiskSpaceRequest) Reset()         { *m = CheckSegmentDiskSp
 func (m *CheckSegmentDiskSpaceRequest) String() string { return proto.CompactTextString(m) }
 func (*CheckSegmentDiskSpaceRequest) ProtoMessage()    {}
 func (*CheckSegmentDiskSpaceRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9e73bb06acc917d8, []int{9}
+	return fileDescriptor_hub_to_agent_96c6333f00419581, []int{9}
 }
-
 func (m *CheckSegmentDiskSpaceRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CheckSegmentDiskSpaceRequest.Unmarshal(m, b)
 }
 func (m *CheckSegmentDiskSpaceRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CheckSegmentDiskSpaceRequest.Marshal(b, m, deterministic)
 }
-func (m *CheckSegmentDiskSpaceRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CheckSegmentDiskSpaceRequest.Merge(m, src)
+func (dst *CheckSegmentDiskSpaceRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CheckSegmentDiskSpaceRequest.Merge(dst, src)
 }
 func (m *CheckSegmentDiskSpaceRequest) XXX_Size() int {
 	return xxx_messageInfo_CheckSegmentDiskSpaceRequest.Size(m)
@@ -467,45 +456,6 @@ func init() {
 	proto.RegisterType((*CheckSegmentDiskSpaceRequest)(nil), "idl.CheckSegmentDiskSpaceRequest")
 }
 
-func init() { proto.RegisterFile("hub_to_agent.proto", fileDescriptor_9e73bb06acc917d8) }
-
-var fileDescriptor_9e73bb06acc917d8 = []byte{
-	// 517 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x54, 0xc1, 0x72, 0xda, 0x30,
-	0x10, 0xad, 0x21, 0x34, 0x61, 0xe9, 0x64, 0x18, 0x35, 0x19, 0x1c, 0x87, 0xc9, 0x50, 0xf7, 0x50,
-	0x4e, 0x1c, 0x68, 0x2e, 0x39, 0xb6, 0xd0, 0x63, 0x81, 0x31, 0x6d, 0xaf, 0x8c, 0xb0, 0x77, 0x40,
-	0x13, 0x63, 0xb9, 0xb2, 0x3c, 0x94, 0x6f, 0xe9, 0xa7, 0xf4, 0x0b, 0xfa, 0x57, 0x1d, 0xc9, 0x96,
-	0x31, 0xae, 0xc9, 0x8d, 0x7d, 0x6f, 0xf5, 0xde, 0x93, 0x76, 0x31, 0x90, 0x6d, 0xba, 0x5e, 0x49,
-	0xbe, 0xa2, 0x1b, 0x8c, 0xe4, 0x28, 0x16, 0x5c, 0x72, 0xd2, 0x64, 0x41, 0xe8, 0x74, 0xfd, 0x90,
-	0x29, 0x62, 0x9b, 0xae, 0x33, 0xd8, 0xfd, 0x6b, 0x41, 0xef, 0x7b, 0xbc, 0x11, 0x34, 0xc0, 0x85,
-	0x60, 0x3b, 0x2a, 0x18, 0x26, 0x1e, 0xfe, 0x4c, 0x31, 0x91, 0xa4, 0x0f, 0xed, 0x79, 0x18, 0x7c,
-	0x66, 0xd1, 0x94, 0x09, 0xdb, 0x1a, 0x58, 0xc3, 0xb6, 0x77, 0x04, 0x14, 0x3b, 0xc3, 0x7d, 0xce,
-	0x36, 0x32, 0xb6, 0x00, 0xc8, 0x03, 0xc0, 0x0c, 0xf7, 0x3f, 0x50, 0x24, 0x8c, 0x47, 0x76, 0x53,
-	0xd3, 0x25, 0x84, 0x3c, 0xc2, 0x9b, 0x29, 0x95, 0x74, 0xca, 0xc4, 0x82, 0x32, 0x91, 0xd8, 0x17,
-	0x83, 0xe6, 0xb0, 0x33, 0xee, 0x8e, 0x58, 0x10, 0x8e, 0x4a, 0x84, 0x77, 0xd2, 0xa5, 0x3c, 0x27,
-	0x5b, 0xf4, 0x9f, 0xe7, 0x51, 0x78, 0xb0, 0x5b, 0x03, 0x6b, 0x78, 0xe5, 0x1d, 0x01, 0xf7, 0xb7,
-	0x05, 0x9d, 0x52, 0xbb, 0xca, 0x30, 0x0f, 0x83, 0x1c, 0xc9, 0x2f, 0x50, 0x42, 0xf2, 0x8c, 0x86,
-	0x6f, 0x14, 0x19, 0x0d, 0x6f, 0xc3, 0xe5, 0x3c, 0x0c, 0x16, 0x5c, 0x48, 0x7d, 0x81, 0x96, 0x67,
-	0x4a, 0xc5, 0xcc, 0x70, 0xaf, 0x99, 0x8b, 0x8c, 0xc9, 0x4b, 0xc5, 0x4c, 0x78, 0x24, 0x31, 0x92,
-	0x3a, 0x5f, 0xcb, 0x33, 0xa5, 0xdb, 0x83, 0xdb, 0xff, 0x1f, 0x3a, 0x0e, 0x0f, 0xee, 0x13, 0xdc,
-	0x4f, 0x04, 0x52, 0x89, 0x4b, 0xdc, 0xec, 0x30, 0x92, 0xb9, 0xbd, 0x99, 0x82, 0x03, 0x57, 0x01,
-	0x95, 0x34, 0x50, 0xaf, 0x64, 0x0d, 0x9a, 0xc3, 0xb6, 0x57, 0xd4, 0xee, 0x3d, 0xdc, 0xd5, 0x1f,
-	0x55, 0xba, 0x0b, 0xb8, 0x99, 0xf0, 0xf8, 0xf0, 0x95, 0x26, 0x12, 0x45, 0x49, 0xb0, 0x0f, 0xed,
-	0x9d, 0xc1, 0xcc, 0x58, 0x0b, 0xe0, 0xc4, 0xae, 0x51, 0xb1, 0xbb, 0x01, 0x52, 0x51, 0x54, 0x3e,
-	0x04, 0xba, 0x4b, 0xc9, 0xe3, 0x4f, 0x6a, 0xd9, 0x72, 0x0f, 0xb7, 0x0b, 0xd7, 0x25, 0x4c, 0x75,
-	0xc5, 0xd0, 0xd7, 0x93, 0x32, 0x49, 0x59, 0xf2, 0xbc, 0x8c, 0xa9, 0x8f, 0x26, 0xd5, 0x23, 0x5c,
-	0x8a, 0xec, 0xa7, 0xce, 0xd4, 0x19, 0x3b, 0x7a, 0x17, 0xf4, 0x99, 0x6a, 0xb3, 0x67, 0x5a, 0x5f,
-	0x4a, 0x3b, 0xfe, 0xd3, 0x84, 0x96, 0x0e, 0x40, 0xe6, 0x70, 0x7d, 0xaa, 0x43, 0xde, 0x1d, 0xc5,
-	0xcf, 0x04, 0x72, 0xec, 0x5a, 0x7f, 0x75, 0x95, 0x57, 0x84, 0xc2, 0x7b, 0xad, 0xfc, 0xe5, 0x17,
-	0xfa, 0xa9, 0xc4, 0xea, 0x5c, 0x97, 0xe9, 0x7a, 0x29, 0x31, 0x26, 0x7d, 0x2d, 0x71, 0xe6, 0xef,
-	0xe5, 0x38, 0x67, 0xd8, 0xcc, 0x62, 0x0d, 0xfd, 0xba, 0xd1, 0xa2, 0x2f, 0xb9, 0x6a, 0x23, 0x83,
-	0x2c, 0xde, 0xf9, 0xc5, 0x71, 0x1e, 0x5e, 0xe8, 0xc8, 0x3c, 0x56, 0xf0, 0xe1, 0x64, 0x9e, 0x5a,
-	0xfc, 0xf0, 0x8d, 0x17, 0x4f, 0x72, 0xb4, 0xbb, 0xcb, 0xc4, 0x6a, 0xf6, 0xc9, 0xe9, 0xd5, 0x51,
-	0x99, 0xc1, 0x13, 0xb4, 0x8b, 0x35, 0x20, 0xb7, 0xba, 0xaf, 0xba, 0x2a, 0xce, 0xdb, 0x2a, 0xac,
-	0x8f, 0xae, 0x5f, 0xeb, 0xef, 0xd3, 0xc7, 0x7f, 0x01, 0x00, 0x00, 0xff, 0xff, 0x9a, 0x6c, 0x5a,
-	0x21, 0xcc, 0x04, 0x00, 0x00,
-}
-
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
 var _ grpc.ClientConn
@@ -514,9 +464,8 @@ var _ grpc.ClientConn
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion4
 
-// AgentClient is the client API for Agent service.
-//
-// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+// Client API for Agent service
+
 type AgentClient interface {
 	CheckDiskSpace(ctx context.Context, in *CheckSegmentDiskSpaceRequest, opts ...grpc.CallOption) (*CheckDiskSpaceReply, error)
 	AgentExecuteUpgradePrimariesSubStep(ctx context.Context, in *UpgradePrimariesRequest, opts ...grpc.CallOption) (*UpgradePrimariesReply, error)
@@ -535,7 +484,7 @@ func NewAgentClient(cc *grpc.ClientConn) AgentClient {
 
 func (c *agentClient) CheckDiskSpace(ctx context.Context, in *CheckSegmentDiskSpaceRequest, opts ...grpc.CallOption) (*CheckDiskSpaceReply, error) {
 	out := new(CheckDiskSpaceReply)
-	err := c.cc.Invoke(ctx, "/idl.Agent/CheckDiskSpace", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.Agent/CheckDiskSpace", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -544,7 +493,7 @@ func (c *agentClient) CheckDiskSpace(ctx context.Context, in *CheckSegmentDiskSp
 
 func (c *agentClient) AgentExecuteUpgradePrimariesSubStep(ctx context.Context, in *UpgradePrimariesRequest, opts ...grpc.CallOption) (*UpgradePrimariesReply, error) {
 	out := new(UpgradePrimariesReply)
-	err := c.cc.Invoke(ctx, "/idl.Agent/AgentExecuteUpgradePrimariesSubStep", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.Agent/AgentExecuteUpgradePrimariesSubStep", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -553,7 +502,7 @@ func (c *agentClient) AgentExecuteUpgradePrimariesSubStep(ctx context.Context, i
 
 func (c *agentClient) CreateSegmentDataDirectories(ctx context.Context, in *CreateSegmentDataDirRequest, opts ...grpc.CallOption) (*CreateSegmentDataDirReply, error) {
 	out := new(CreateSegmentDataDirReply)
-	err := c.cc.Invoke(ctx, "/idl.Agent/CreateSegmentDataDirectories", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.Agent/CreateSegmentDataDirectories", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -562,7 +511,7 @@ func (c *agentClient) CreateSegmentDataDirectories(ctx context.Context, in *Crea
 
 func (c *agentClient) CopyMasterDirectoryToSegmentDirectories(ctx context.Context, in *CopyMasterDirRequest, opts ...grpc.CallOption) (*CopyMasterDirReply, error) {
 	out := new(CopyMasterDirReply)
-	err := c.cc.Invoke(ctx, "/idl.Agent/CopyMasterDirectoryToSegmentDirectories", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.Agent/CopyMasterDirectoryToSegmentDirectories", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -571,40 +520,21 @@ func (c *agentClient) CopyMasterDirectoryToSegmentDirectories(ctx context.Contex
 
 func (c *agentClient) StopAgent(ctx context.Context, in *StopAgentRequest, opts ...grpc.CallOption) (*StopAgentReply, error) {
 	out := new(StopAgentReply)
-	err := c.cc.Invoke(ctx, "/idl.Agent/StopAgent", in, out, opts...)
+	err := grpc.Invoke(ctx, "/idl.Agent/StopAgent", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// AgentServer is the server API for Agent service.
+// Server API for Agent service
+
 type AgentServer interface {
 	CheckDiskSpace(context.Context, *CheckSegmentDiskSpaceRequest) (*CheckDiskSpaceReply, error)
 	AgentExecuteUpgradePrimariesSubStep(context.Context, *UpgradePrimariesRequest) (*UpgradePrimariesReply, error)
 	CreateSegmentDataDirectories(context.Context, *CreateSegmentDataDirRequest) (*CreateSegmentDataDirReply, error)
 	CopyMasterDirectoryToSegmentDirectories(context.Context, *CopyMasterDirRequest) (*CopyMasterDirReply, error)
 	StopAgent(context.Context, *StopAgentRequest) (*StopAgentReply, error)
-}
-
-// UnimplementedAgentServer can be embedded to have forward compatible implementations.
-type UnimplementedAgentServer struct {
-}
-
-func (*UnimplementedAgentServer) CheckDiskSpace(ctx context.Context, req *CheckSegmentDiskSpaceRequest) (*CheckDiskSpaceReply, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method CheckDiskSpace not implemented")
-}
-func (*UnimplementedAgentServer) AgentExecuteUpgradePrimariesSubStep(ctx context.Context, req *UpgradePrimariesRequest) (*UpgradePrimariesReply, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method AgentExecuteUpgradePrimariesSubStep not implemented")
-}
-func (*UnimplementedAgentServer) CreateSegmentDataDirectories(ctx context.Context, req *CreateSegmentDataDirRequest) (*CreateSegmentDataDirReply, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method CreateSegmentDataDirectories not implemented")
-}
-func (*UnimplementedAgentServer) CopyMasterDirectoryToSegmentDirectories(ctx context.Context, req *CopyMasterDirRequest) (*CopyMasterDirReply, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method CopyMasterDirectoryToSegmentDirectories not implemented")
-}
-func (*UnimplementedAgentServer) StopAgent(ctx context.Context, req *StopAgentRequest) (*StopAgentReply, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method StopAgent not implemented")
 }
 
 func RegisterAgentServer(s *grpc.Server, srv AgentServer) {
@@ -728,4 +658,43 @@ var _Agent_serviceDesc = grpc.ServiceDesc{
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "hub_to_agent.proto",
+}
+
+func init() { proto.RegisterFile("hub_to_agent.proto", fileDescriptor_hub_to_agent_96c6333f00419581) }
+
+var fileDescriptor_hub_to_agent_96c6333f00419581 = []byte{
+	// 517 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x54, 0xc1, 0x72, 0xda, 0x30,
+	0x10, 0xad, 0x21, 0x34, 0x61, 0xe9, 0x64, 0x18, 0x35, 0x19, 0x1c, 0x87, 0xc9, 0x50, 0xf7, 0x50,
+	0x4e, 0x1c, 0x68, 0x2e, 0x39, 0xb6, 0xd0, 0x63, 0x81, 0x31, 0x6d, 0xaf, 0x8c, 0xb0, 0x77, 0x40,
+	0x13, 0x63, 0xb9, 0xb2, 0x3c, 0x94, 0x6f, 0xe9, 0xa7, 0xf4, 0x0b, 0xfa, 0x57, 0x1d, 0xc9, 0x96,
+	0x31, 0xae, 0xc9, 0x8d, 0x7d, 0x6f, 0xf5, 0xde, 0x93, 0x76, 0x31, 0x90, 0x6d, 0xba, 0x5e, 0x49,
+	0xbe, 0xa2, 0x1b, 0x8c, 0xe4, 0x28, 0x16, 0x5c, 0x72, 0xd2, 0x64, 0x41, 0xe8, 0x74, 0xfd, 0x90,
+	0x29, 0x62, 0x9b, 0xae, 0x33, 0xd8, 0xfd, 0x6b, 0x41, 0xef, 0x7b, 0xbc, 0x11, 0x34, 0xc0, 0x85,
+	0x60, 0x3b, 0x2a, 0x18, 0x26, 0x1e, 0xfe, 0x4c, 0x31, 0x91, 0xa4, 0x0f, 0xed, 0x79, 0x18, 0x7c,
+	0x66, 0xd1, 0x94, 0x09, 0xdb, 0x1a, 0x58, 0xc3, 0xb6, 0x77, 0x04, 0x14, 0x3b, 0xc3, 0x7d, 0xce,
+	0x36, 0x32, 0xb6, 0x00, 0xc8, 0x03, 0xc0, 0x0c, 0xf7, 0x3f, 0x50, 0x24, 0x8c, 0x47, 0x76, 0x53,
+	0xd3, 0x25, 0x84, 0x3c, 0xc2, 0x9b, 0x29, 0x95, 0x74, 0xca, 0xc4, 0x82, 0x32, 0x91, 0xd8, 0x17,
+	0x83, 0xe6, 0xb0, 0x33, 0xee, 0x8e, 0x58, 0x10, 0x8e, 0x4a, 0x84, 0x77, 0xd2, 0xa5, 0x3c, 0x27,
+	0x5b, 0xf4, 0x9f, 0xe7, 0x51, 0x78, 0xb0, 0x5b, 0x03, 0x6b, 0x78, 0xe5, 0x1d, 0x01, 0xf7, 0xb7,
+	0x05, 0x9d, 0x52, 0xbb, 0xca, 0x30, 0x0f, 0x83, 0x1c, 0xc9, 0x2f, 0x50, 0x42, 0xf2, 0x8c, 0x86,
+	0x6f, 0x14, 0x19, 0x0d, 0x6f, 0xc3, 0xe5, 0x3c, 0x0c, 0x16, 0x5c, 0x48, 0x7d, 0x81, 0x96, 0x67,
+	0x4a, 0xc5, 0xcc, 0x70, 0xaf, 0x99, 0x8b, 0x8c, 0xc9, 0x4b, 0xc5, 0x4c, 0x78, 0x24, 0x31, 0x92,
+	0x3a, 0x5f, 0xcb, 0x33, 0xa5, 0xdb, 0x83, 0xdb, 0xff, 0x1f, 0x3a, 0x0e, 0x0f, 0xee, 0x13, 0xdc,
+	0x4f, 0x04, 0x52, 0x89, 0x4b, 0xdc, 0xec, 0x30, 0x92, 0xb9, 0xbd, 0x99, 0x82, 0x03, 0x57, 0x01,
+	0x95, 0x34, 0x50, 0xaf, 0x64, 0x0d, 0x9a, 0xc3, 0xb6, 0x57, 0xd4, 0xee, 0x3d, 0xdc, 0xd5, 0x1f,
+	0x55, 0xba, 0x0b, 0xb8, 0x99, 0xf0, 0xf8, 0xf0, 0x95, 0x26, 0x12, 0x45, 0x49, 0xb0, 0x0f, 0xed,
+	0x9d, 0xc1, 0xcc, 0x58, 0x0b, 0xe0, 0xc4, 0xae, 0x51, 0xb1, 0xbb, 0x01, 0x52, 0x51, 0x54, 0x3e,
+	0x04, 0xba, 0x4b, 0xc9, 0xe3, 0x4f, 0x6a, 0xd9, 0x72, 0x0f, 0xb7, 0x0b, 0xd7, 0x25, 0x4c, 0x75,
+	0xc5, 0xd0, 0xd7, 0x93, 0x32, 0x49, 0x59, 0xf2, 0xbc, 0x8c, 0xa9, 0x8f, 0x26, 0xd5, 0x23, 0x5c,
+	0x8a, 0xec, 0xa7, 0xce, 0xd4, 0x19, 0x3b, 0x7a, 0x17, 0xf4, 0x99, 0x6a, 0xb3, 0x67, 0x5a, 0x5f,
+	0x4a, 0x3b, 0xfe, 0xd3, 0x84, 0x96, 0x0e, 0x40, 0xe6, 0x70, 0x7d, 0xaa, 0x43, 0xde, 0x1d, 0xc5,
+	0xcf, 0x04, 0x72, 0xec, 0x5a, 0x7f, 0x75, 0x95, 0x57, 0x84, 0xc2, 0x7b, 0xad, 0xfc, 0xe5, 0x17,
+	0xfa, 0xa9, 0xc4, 0xea, 0x5c, 0x97, 0xe9, 0x7a, 0x29, 0x31, 0x26, 0x7d, 0x2d, 0x71, 0xe6, 0xef,
+	0xe5, 0x38, 0x67, 0xd8, 0xcc, 0x62, 0x0d, 0xfd, 0xba, 0xd1, 0xa2, 0x2f, 0xb9, 0x6a, 0x23, 0x83,
+	0x2c, 0xde, 0xf9, 0xc5, 0x71, 0x1e, 0x5e, 0xe8, 0xc8, 0x3c, 0x56, 0xf0, 0xe1, 0x64, 0x9e, 0x5a,
+	0xfc, 0xf0, 0x8d, 0x17, 0x4f, 0x72, 0xb4, 0xbb, 0xcb, 0xc4, 0x6a, 0xf6, 0xc9, 0xe9, 0xd5, 0x51,
+	0x99, 0xc1, 0x13, 0xb4, 0x8b, 0x35, 0x20, 0xb7, 0xba, 0xaf, 0xba, 0x2a, 0xce, 0xdb, 0x2a, 0xac,
+	0x8f, 0xae, 0x5f, 0xeb, 0xef, 0xd3, 0xc7, 0x7f, 0x01, 0x00, 0x00, 0xff, 0xff, 0x9a, 0x6c, 0x5a,
+	0x21, 0xcc, 0x04, 0x00, 0x00,
 }

--- a/idl/mock_idl/mock_hub_to_agent.pb.go
+++ b/idl/mock_idl/mock_hub_to_agent.pb.go
@@ -5,9 +5,9 @@
 package mock_idl
 
 import (
-	context "context"
 	gomock "github.com/golang/mock/gomock"
 	idl "github.com/greenplum-db/gpupgrade/idl"
+	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 	reflect "reflect"
 )


### PR DESCRIPTION
Due to accumulated representation errors, `CheckUsage()` might report failures in cases where the available space was in fact greater than the required space, leading to very confusing terminal output.

For example: the default free space ratio of 0.6 cannot be exactly represented in IEEE-754 floating point. The CLI parsed this as a `float32`, which was then converted to a `float64` inside the hub and agents, with a value very slightly greater than 0.6. If a disk failed the check, we would calculate the required disk space a second time, using a method that was subtly different from our original check. The combined discrepancies led to a less-than-sane result.

Two-part fix:
- calculate required disk space only once, and use integer comparison to determine whether the check succeeds or fails, to prevent failure reports where avail > required
- use `float64` from the beginning, during command-line parsing, to avoid exacerbating representational error later down the line

To assist with any future debugging, `gplog.Debug()` output has been added during disk space checks.