### PR TITLE
RFC: exectest improvements

### DIFF
--- a/agent/services/execute_upgrade_primaries_sub_step_test.go
+++ b/agent/services/execute_upgrade_primaries_sub_step_test.go
@@ -17,9 +17,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// Does nothing.
-func EmptyMain() {}
-
 // Prints the environment, one variable per line, in NAME=VALUE format.
 func EnvironmentMain() {
 	for _, e := range os.Environ() {
@@ -27,15 +24,9 @@ func EnvironmentMain() {
 	}
 }
 
-func FailedMain() {
-	os.Exit(1)
-}
-
 func init() {
 	exectest.RegisterMains(
-		EmptyMain,
 		EnvironmentMain,
-		FailedMain,
 	)
 }
 
@@ -70,7 +61,7 @@ var _ = Describe("UpgradeSegments", func() {
 	})
 
 	It("calls pg_upgrade with the expected options with no check", func() {
-		execCommand = exectest.NewCommandWithVerifier(EmptyMain,
+		execCommand = exectest.NewCommandWithVerifier(exectest.Success,
 			func(path string, args ...string) {
 				// pg_upgrade should be run from the target installation.
 				expectedPath := filepath.Join(targetBinDir, "pg_upgrade")
@@ -108,7 +99,7 @@ var _ = Describe("UpgradeSegments", func() {
 	})
 
 	It("calls pg_upgrade with the expected options with check", func() {
-		execCommand = exectest.NewCommandWithVerifier(EmptyMain,
+		execCommand = exectest.NewCommandWithVerifier(exectest.Success,
 			func(path string, args ...string) {
 				// pg_upgrade should be run from the target installation.
 				expectedPath := filepath.Join(targetBinDir, "pg_upgrade")
@@ -148,7 +139,7 @@ var _ = Describe("UpgradeSegments", func() {
 	})
 
 	It("when pg_upgrade --check fails it returns an error", func() {
-		execCommand = exectest.NewCommand(FailedMain)
+		execCommand = exectest.NewCommand(exectest.Failure)
 
 		err := UpgradeSegments("/old/bin", "/new/bin", segments, "/tmp", true)
 		Expect(err).To(HaveOccurred())
@@ -157,7 +148,7 @@ var _ = Describe("UpgradeSegments", func() {
 	})
 
 	It("when pg_upgrade with no check fails it returns an error", func() {
-		execCommand = exectest.NewCommand(FailedMain)
+		execCommand = exectest.NewCommand(exectest.Failure)
 
 		err := UpgradeSegments("/old/bin", "/new/bin", segments, "/tmp", false)
 		Expect(err).To(HaveOccurred())

--- a/hub/services/execute_test.go
+++ b/hub/services/execute_test.go
@@ -91,10 +91,6 @@ func TestStreaming(t *testing.T) {
 	var pair clusterPair   // the unit under test
 	var log *gbytes.Buffer // contains gplog output
 
-	// Disable exec.Command. This way, if a test forgets to mock it out, we
-	// crash the test instead of executing code on a dev system.
-	execCommand = nil
-
 	// Store gplog output.
 	_, _, log = testhelper.SetupTestLogger()
 
@@ -160,7 +156,8 @@ func TestStreaming(t *testing.T) {
 				return nil
 			})
 
-		execCommand = exectest.NewCommand(StreamingMain)
+		SetExecCommand(exectest.NewCommand(StreamingMain))
+		defer ResetExecCommand()
 
 		err := pair.ConvertMaster(mockStream, ioutil.Discard, "", false)
 		g.Expect(err).NotTo(HaveOccurred())
@@ -179,7 +176,8 @@ func TestStreaming(t *testing.T) {
 			AnyTimes()
 
 		// Write ten bytes each to stdout/err.
-		execCommand = exectest.NewCommand(TenByteMain)
+		SetExecCommand(exectest.NewCommand(TenByteMain))
+		defer ResetExecCommand()
 
 		var buf bytes.Buffer
 		err := pair.ConvertMaster(mockStream, &buf, "", false)
@@ -215,7 +213,8 @@ func TestStreaming(t *testing.T) {
 			AnyTimes()
 
 		// Don't fail in the subprocess even when the stdout stream is closed.
-		execCommand = exectest.NewCommand(BlindlyWritingMain)
+		SetExecCommand(exectest.NewCommand(BlindlyWritingMain))
+		defer ResetExecCommand()
 
 		expectedErr := errors.New("write failed!")
 		err := pair.ConvertMaster(mockStream, NewFailingWriter(expectedErr), "", false)
@@ -235,7 +234,8 @@ func TestStreaming(t *testing.T) {
 			Times(1) // we expect only one failed attempt to Send
 
 		// Write ten bytes each to stdout/err.
-		execCommand = exectest.NewCommand(TenByteMain)
+		SetExecCommand(exectest.NewCommand(TenByteMain))
+		defer ResetExecCommand()
 
 		var buf bytes.Buffer
 		err := pair.ConvertMaster(mockStream, &buf, "", false)

--- a/hub/services/execute_upgrade_master_sub_step_test.go
+++ b/hub/services/execute_upgrade_master_sub_step_test.go
@@ -45,10 +45,6 @@ func init() {
 func TestUpgradeMaster(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	// Disable exec.Command. This way, if a test forgets to mock it out, we
-	// crash the test instead of executing code on a dev system.
-	execCommand = nil
-
 	// Initialize the sample cluster pair.
 	pair := clusterPair{
 		Source: &utils.Cluster{
@@ -87,7 +83,8 @@ func TestUpgradeMaster(t *testing.T) {
 			AnyTimes()
 
 		// Print the working directory of the command.
-		execCommand = exectest.NewCommand(WorkingDirectoryMain)
+		SetExecCommand(exectest.NewCommand(WorkingDirectoryMain))
+		defer ResetExecCommand()
 
 		// NOTE: avoid testing paths that might be symlinks, such as /tmp, as
 		// the "actual" working directory might look different to the
@@ -118,7 +115,8 @@ func TestUpgradeMaster(t *testing.T) {
 		}()
 
 		// Echo the environment to stdout.
-		execCommand = exectest.NewCommand(EnvironmentMain)
+		SetExecCommand(exectest.NewCommand(EnvironmentMain))
+		defer ResetExecCommand()
 
 		var buf bytes.Buffer
 		err := pair.ConvertMaster(mockStream, &buf, "", false)

--- a/hub/services/hub_start_services_test.go
+++ b/hub/services/hub_start_services_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"log"
 	"net"
-	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -21,21 +20,6 @@ import (
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
 )
-
-func gpupgrade_agent() {
-}
-
-func gpupgrade_agent_Errors() {
-	os.Stderr.WriteString("could not find state-directory")
-	os.Exit(1)
-}
-
-func init() {
-	exectest.RegisterMains(
-		gpupgrade_agent,
-		gpupgrade_agent_Errors,
-	)
-}
 
 func TestRestartAgent(t *testing.T) {
 	testhelper.SetupTestLogger()
@@ -55,7 +39,7 @@ func TestRestartAgent(t *testing.T) {
 	stateDir := "/not/existent/directory"
 	ctx := context.Background()
 
-	services.SetExecCommand(exectest.NewCommand(gpupgrade_agent))
+	services.SetExecCommand(exectest.NewCommand(exectest.Success))
 	defer services.ResetExecCommand()
 
 	t.Run("does not start running agents", func(t *testing.T) {
@@ -98,7 +82,7 @@ func TestRestartAgent(t *testing.T) {
 	})
 
 	t.Run("returns an error when gpupgrade_agent fails", func(t *testing.T) {
-		services.SetExecCommand(exectest.NewCommand(gpupgrade_agent_Errors))
+		services.SetExecCommand(exectest.NewCommand(exectest.Failure))
 
 		// we fail all connections here so that RestartAgents will run the
 		//  (error producing) gpupgrade_agent_Errors

--- a/hub/services/init_target_cluster_sub_step_test.go
+++ b/hub/services/init_target_cluster_sub_step_test.go
@@ -24,20 +24,6 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
-func gpinitsystem() {}
-
-func gpinitsystem_Exits1() {
-	os.Stdout.WriteString("[WARN]:-Master open file limit is 256 should be >= 65535")
-	os.Exit(1)
-}
-
-func init() {
-	exectest.RegisterMains(
-		gpinitsystem,
-		gpinitsystem_Exits1,
-	)
-}
-
 func TestCreateInitialInitsystemConfig(t *testing.T) {
 	testhelper.SetupTestLogger() // initialize gplog
 
@@ -229,12 +215,12 @@ func TestRunInitsystemForTargetCluster(t *testing.T) {
 		AnyTimes()
 
 	cluster6X := &utils.Cluster{
-		BinDir: "/target/bin",
+		BinDir:  "/target/bin",
 		Version: dbconn.NewVersion("6.0.0"),
 	}
 
 	cluster7X := &utils.Cluster{
-		BinDir: "/target/bin",
+		BinDir:  "/target/bin",
 		Version: dbconn.NewVersion("7.0.0"),
 	}
 
@@ -246,7 +232,7 @@ func TestRunInitsystemForTargetCluster(t *testing.T) {
 	}()
 
 	t.Run("does not use --ignore-warnings when upgrading to GPDB7 or higher", func(t *testing.T) {
-		execCommand = exectest.NewCommandWithVerifier(gpinitsystem,
+		execCommand = exectest.NewCommandWithVerifier(exectest.Success,
 			func(path string, args ...string) {
 				if path != "bash" {
 					t.Errorf("executed %q, want bash", path)
@@ -267,7 +253,7 @@ func TestRunInitsystemForTargetCluster(t *testing.T) {
 	})
 
 	t.Run("only uses --ignore-warnings when upgrading to GPDB6", func(t *testing.T) {
-		execCommand = exectest.NewCommandWithVerifier(gpinitsystem,
+		execCommand = exectest.NewCommandWithVerifier(exectest.Success,
 			func(path string, args ...string) {
 				if path != "bash" {
 					t.Errorf("executed %q, want bash", path)
@@ -288,7 +274,7 @@ func TestRunInitsystemForTargetCluster(t *testing.T) {
 	})
 
 	t.Run("should use executables in the source's bindir even if bindir has a trailing slash", func(t *testing.T) {
-		execCommand = exectest.NewCommandWithVerifier(gpinitsystem,
+		execCommand = exectest.NewCommandWithVerifier(exectest.Success,
 			func(path string, args ...string) {
 				if path != "bash" {
 					t.Errorf("executed %q, want bash", path)
@@ -310,7 +296,7 @@ func TestRunInitsystemForTargetCluster(t *testing.T) {
 	})
 
 	t.Run("returns an error when gpinitsystem fails with --ignore-warnings when upgrading to GPDB6", func(t *testing.T) {
-		execCommand = exectest.NewCommand(gpinitsystem_Exits1)
+		execCommand = exectest.NewCommand(exectest.Failure)
 
 		var buf bytes.Buffer
 		err := RunInitsystemForTargetCluster(mockStream, &buf, cluster6X, gpinitsystemConfigPath)
@@ -326,7 +312,7 @@ func TestRunInitsystemForTargetCluster(t *testing.T) {
 	})
 
 	t.Run("returns an error when gpinitsystem errors when upgrading to GPDB7 or higher", func(t *testing.T) {
-		execCommand = exectest.NewCommand(gpinitsystem_Exits1)
+		execCommand = exectest.NewCommand(exectest.Failure)
 
 		var buf bytes.Buffer
 		err := RunInitsystemForTargetCluster(mockStream, &buf, cluster7X, gpinitsystemConfigPath)

--- a/hub/services/start_or_stop_cluster_sub_step.go
+++ b/hub/services/start_or_stop_cluster_sub_step.go
@@ -3,14 +3,11 @@ package services
 import (
 	"fmt"
 	"io"
-	"os/exec"
+
+	"github.com/pkg/errors"
 
 	"github.com/greenplum-db/gpupgrade/utils"
-	"github.com/pkg/errors"
 )
-
-var isPostmasterRunningCmd = exec.Command
-var startStopClusterCmd = exec.Command
 
 func (h *Hub) ShutdownCluster(stream messageSender, log io.Writer, isSource bool) error {
 	if isSource {
@@ -50,7 +47,7 @@ func startStopCluster(stream messageSender, log io.Writer, cluster *utils.Cluste
 		}
 	}
 
-	cmd := startStopClusterCmd("bash", "-c",
+	cmd := execCommand("bash", "-c",
 		fmt.Sprintf("source %[1]s/../greenplum_path.sh && %[1]s/%[2]s -a -d %[3]s",
 			cluster.BinDir,
 			cmdName,
@@ -63,7 +60,7 @@ func startStopCluster(stream messageSender, log io.Writer, cluster *utils.Cluste
 }
 
 func IsPostmasterRunning(stream messageSender, log io.Writer, cluster *utils.Cluster) error {
-	cmd := isPostmasterRunningCmd("bash", "-c",
+	cmd := execCommand("bash", "-c",
 		fmt.Sprintf("pgrep -F %s/postmaster.pid",
 			cluster.MasterDataDir(),
 		))

--- a/testutils/exectest/command_internal_test.go
+++ b/testutils/exectest/command_internal_test.go
@@ -1,0 +1,7 @@
+package exectest
+
+// SetRunCalled allows tests to change the value of the internal runCalled flag.
+// (See the tests for why this is useful.)
+func SetRunCalled(called bool) {
+	runCalled = called
+}

--- a/testutils/exectest/command_test.go
+++ b/testutils/exectest/command_test.go
@@ -1,4 +1,4 @@
-package exectest
+package exectest_test
 
 import (
 	"fmt"
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"reflect"
 	"testing"
+
+	. "github.com/greenplum-db/gpupgrade/testutils/exectest"
 )
 
 const successfulStdout = "stdout for SuccessfulMain"
@@ -79,13 +81,13 @@ func TestNewCommand(t *testing.T) {
 	t.Run("panics if not called from Run()", func(t *testing.T) {
 		// We're obviously being called from Run() inside this test, so fake the
 		// situation by unsetting the flag that tracks it.
-		runCalled = false
+		SetRunCalled(false)
 
 		defer func() {
 			if r := recover(); r == nil {
 				t.Errorf("did not panic")
 			}
-			runCalled = true // reset the flag
+			SetRunCalled(true) // reset the flag
 		}()
 
 		NewCommand(SuccessfulMain)

--- a/testutils/exectest/mains.go
+++ b/testutils/exectest/mains.go
@@ -1,0 +1,19 @@
+package exectest
+
+import "os"
+
+// These are built-in Main implementations that seem to be common/useful to many
+// tests.
+
+// Success is a Main implementation that exits with a zero exit code.
+func Success() {}
+
+// Failure is a Main implementation that exits with an exit code of 1.
+func Failure() { os.Exit(1) }
+
+func init() {
+	RegisterMains(
+		Success,
+		Failure,
+	)
+}

--- a/testutils/exectest/mains_test.go
+++ b/testutils/exectest/mains_test.go
@@ -1,0 +1,41 @@
+package exectest_test
+
+import (
+	"os/exec"
+	"testing"
+
+	"golang.org/x/xerrors"
+
+	. "github.com/greenplum-db/gpupgrade/testutils/exectest"
+)
+
+func TestBuiltinMains(t *testing.T) {
+	t.Run("Success()", func(t *testing.T) {
+		success := NewCommand(Success)("/unused/path")
+		err := success.Run()
+		if err != nil {
+			t.Errorf("exited with error %v", err)
+
+			var exitErr *exec.ExitError
+			if xerrors.As(err, &exitErr) {
+				t.Logf("subprocess stderr follows:\n%s", string(exitErr.Stderr))
+			}
+		}
+	})
+
+	t.Run("Failure()", func(t *testing.T) {
+		failure := NewCommand(Failure)("/unused/path")
+		err := failure.Run()
+		if err == nil {
+			t.Fatal("exited without an error")
+		}
+
+		var exitErr *exec.ExitError
+		if !xerrors.As(err, &exitErr) {
+			t.Fatalf("unexpected error %#v", err)
+		}
+		if exitErr.ExitCode() != 1 {
+			t.Errorf("exit code %d want %d", exitErr.ExitCode(), 1)
+		}
+	})
+}


### PR DESCRIPTION
This is a WIP. What I'm trying to do is get rid of some of the more annoying duplications: the proliferation of empty "success" and "failure" functions, and the introduction of additional `execCommand` injection points (`startStopCmd`, `isPostmasterRunningCmd`, etc.).