### PR TITLE
CI: filter/patch to fix the 5-to-6 pipeline diff

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -328,10 +328,10 @@ jobs:
       params:
         GPHOME_OLD: /usr/local/greenplum-db-old
         GPHOME_NEW: /usr/local/greenplum-db-new
+        FILTER_DIFF: 1
   ensure:
     <<: *set_failed
   on_success:
     <<: *ccp_destroy
-# todo: uncomment this once compare_dumps() is fixed
-#  on_failure:
-#    <<: *slack_alert
+  on_failure:
+    <<: *slack_alert

--- a/ci/scripts/filter/acceptable_diff
+++ b/ci/scripts/filter/acceptable_diff
@@ -1,0 +1,16 @@
+--- old.sql	2019-11-19 16:15:52.000000000 -0700
++++ /dev/fd/63	2019-11-19 18:02:03.000000000 -0700
+@@ -131,10 +132,11 @@
+ SET xmloption = content;
+ SET client_min_messages = warning;
+ 
+-SET default_tablespace = '';
+-
+ SET default_with_oids = false;
+ 
++
++SET default_tablespace = '';
++
+ --
+ -- Name: test_table; Type: TABLE; Schema: public; Owner: gpadmin; Tablespace: 
+ --

--- a/ci/scripts/filter/filter.go
+++ b/ci/scripts/filter/filter.go
@@ -1,0 +1,119 @@
+/*
+	The filter command massages the post-upgrade SQL dump by removing known
+	differences. It does this with two sets of rules -- lines and blocks.
+
+	- Line rules are regular expressions that will cause any matching lines to
+	be removed immediately.
+
+	- Block rules are regular expressions that cause any matching lines, and any
+	preceding comments or blank lines, to be removed.
+
+	The main complication here comes from the block rules, which require us to
+	use a lookahead buffer.
+
+	filter reads from stdin and writes to stdout. Usage:
+
+		filter < new.sql > new-filtered.sql
+
+	Error handling is basic: any failures result in a log.Fatal() call.
+*/
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var lineRegexes []*regexp.Regexp
+var blockRegexes []*regexp.Regexp
+
+func init() {
+	// linePatterns remove exactly what is matched, on a line-by-line basis.
+	linePatterns := []string{
+		"ALTER DATABASE .+ SET gp_use_legacy_hashops TO 'on';",
+	}
+
+	// blockPatterns remove lines that match, AND any comments or whitespace
+	// immediately preceding them.
+	blockPatterns := []string{
+		"CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;",
+		"COMMENT ON EXTENSION plpgsql IS",
+		"COMMENT ON DATABASE postgres IS",
+	}
+
+	for _, pattern := range linePatterns {
+		lineRegexes = append(lineRegexes, regexp.MustCompile(pattern))
+	}
+	for _, pattern := range blockPatterns {
+		blockRegexes = append(blockRegexes, regexp.MustCompile(pattern))
+	}
+}
+
+func write(out io.Writer, lines ...string) {
+	for _, line := range lines {
+		_, err := fmt.Fprintln(out, line)
+		if err != nil {
+			log.Fatalf("writing output: %+v", err)
+		}
+	}
+}
+
+func Filter(in io.Reader, out io.Writer) {
+	scanner := bufio.NewScanner(in)
+
+	var buf []string // lines buffered for look-ahead
+
+nextline:
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// First filter on a line-by-line basis.
+		for _, r := range lineRegexes {
+			if r.MatchString(line) {
+				continue nextline
+			}
+		}
+
+		if strings.HasPrefix(line, "--") || len(line) == 0 {
+			// A comment or an empty line. We only want to output this section
+			// if the SQL it's attached to isn't filtered.
+			buf = append(buf, line)
+			continue nextline
+		}
+
+		for _, r := range blockRegexes {
+			if r.MatchString(line) {
+				// Discard this line and any buffered comment block.
+				buf = buf[:0]
+				continue nextline
+			}
+		}
+
+		// We want to keep this line. Flush and empty our buffer first.
+		if len(buf) > 0 {
+			write(out, buf...)
+			buf = buf[:0]
+		}
+
+		write(out, line)
+	}
+
+	if scanner.Err() != nil {
+		log.Fatalf("scanning stdin: %+v", scanner.Err())
+	}
+
+	// Flush and empty our buffer.
+	if len(buf) > 0 {
+		write(out, buf...)
+		buf = buf[:0]
+	}
+}
+
+func main() {
+	Filter(os.Stdin, os.Stdout)
+}

--- a/ci/scripts/filter/filter_test.go
+++ b/ci/scripts/filter/filter_test.go
@@ -1,0 +1,117 @@
+package main_test
+
+import (
+	"bytes"
+	"testing"
+
+	main "github.com/greenplum-db/gpupgrade/ci/scripts/filter"
+)
+
+func TestFilter(t *testing.T) {
+	t.Run("it writes stdin to stdout when nothing is filtered", func(t *testing.T) {
+		var in, out bytes.Buffer
+
+		expected := "hello\n"
+		in.WriteString(expected)
+
+		main.Filter(&in, &out)
+		if out.String() != expected {
+			t.Errorf("wrote %q want %q", out.String(), expected)
+		}
+	})
+
+	t.Run("filters out legacy hashops settings", func(t *testing.T) {
+		var in, out bytes.Buffer
+
+		in.WriteString(`
+GRANT ALL ON DATABASE template1 TO gpadmin;
+GRANT CONNECT ON DATABASE template1 TO PUBLIC;
+ALTER DATABASE template1 SET gp_use_legacy_hashops TO 'on';
+SET allow_system_table_mods = true;
+CREATE DATABASE test WITH TEMPLATE = template0 OWNER = gpadmin;
+RESET allow_system_table_mods;
+ALTER DATABASE test SET gp_use_legacy_hashops TO 'on';
+`)
+
+		main.Filter(&in, &out)
+
+		expected := `
+GRANT ALL ON DATABASE template1 TO gpadmin;
+GRANT CONNECT ON DATABASE template1 TO PUBLIC;
+SET allow_system_table_mods = true;
+CREATE DATABASE test WITH TEMPLATE = template0 OWNER = gpadmin;
+RESET allow_system_table_mods;
+`
+		if out.String() != expected {
+			t.Errorf("wrote %q want %q", out.String(), expected)
+			t.Logf("actual (expanded): %s", out.String())
+			t.Logf("expected (expanded): %s", expected)
+		}
+	})
+
+	t.Run("filters out empty and commented lines attached to filtered SQL", func(t *testing.T) {
+		var in, out bytes.Buffer
+
+		in.WriteString(`
+GRANT ALL ON DATABASE template1 TO gpadmin;
+
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner:
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+RESET allow_system_table_mods;
+`)
+
+		main.Filter(&in, &out)
+
+		expected := `
+GRANT ALL ON DATABASE template1 TO gpadmin;
+
+
+RESET allow_system_table_mods;
+`
+		if out.String() != expected {
+			t.Errorf("wrote %q want %q", out.String(), expected)
+			t.Logf("actual (expanded): %s", out.String())
+			t.Logf("expected (expanded): %s", expected)
+		}
+	})
+
+	t.Run("keeps trailing comment blocks", func(t *testing.T) {
+		var in, out bytes.Buffer
+
+		in.WriteString(`
+
+--
+-- Greenplum Database database dump complete
+--
+
+--
+-- PostgreSQL database cluster dump complete
+--
+
+`)
+
+		main.Filter(&in, &out)
+
+		expected := `
+
+--
+-- Greenplum Database database dump complete
+--
+
+--
+-- PostgreSQL database cluster dump complete
+--
+
+`
+		if out.String() != expected {
+			t.Errorf("wrote %q want %q", out.String(), expected)
+			t.Logf("actual (expanded): %s", out.String())
+			t.Logf("expected (expanded): %s", expected)
+		}
+	})
+}

--- a/ci/tasks/upgrade-cluster.yml
+++ b/ci/tasks/upgrade-cluster.yml
@@ -16,3 +16,6 @@ inputs:
 
 run:
   path: go/src/github.com/greenplum-db/gpupgrade/ci/scripts/upgrade-cluster.bash
+
+params:
+  FILTER_DIFF: 0


### PR DESCRIPTION
_The first patch in this set is just a prefactor to make things easier, so make sure to review per-commit._

Unfortunately, there are some diffs in the output of pg_dumpall after an upgrade from 5X to 6X, and we're probably not going to be able to change them:

- The plpgsql extension is installed by default in 6, which leads to a group of related SQL additions.
- The postgres database now has an attached comment due to a change in behavior in the 6X initdb.
- All databases will be dumped with `gp_use_legacy_hashops = 'on'` in the 6X cluster, but there has been a product decision not to dump the same setting for a 5X cluster.

To mask these changes, implement a two-step process. First use a filter executable to remove any changes that can be handled with a simple sed-like streaming approach. This still leaves diffs that are hard to handle with a stream parser, so patch out those with a record of the "acceptable diffs" before performing the final comparison.