### PR TITLE
agent: retain internal.auto.conf during master copy

### DIFF
--- a/agent/services/copy_master_data_dir.go
+++ b/agent/services/copy_master_data_dir.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"fmt"
 	"os"
-
-	"github.com/greenplum-db/gpupgrade/idl"
-	"github.com/greenplum-db/gpupgrade/utils"
-	"github.com/pkg/errors"
-
 	"path/filepath"
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/pkg/errors"
+
+	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/utils"
 )
 
 func (s *AgentServer) CopyMasterDirectoryToSegmentDirectories(ctx context.Context, in *idl.CopyMasterDirRequest) (*idl.CopyMasterDirReply, error) {
@@ -88,7 +87,12 @@ func copyMasterDirOverSegment(executor cluster.Executor, masterDir string, segDa
 // Put segment config files back, overwriting the master versions
 func restoreSegmentFiles(segDataDir string) error {
 	// Files that differ between the master and the segments, where we want to keep the segment versions
-	filesToPreserve := []string{"postgresql.conf", "pg_hba.conf", "postmaster.opts"}
+	filesToPreserve := []string{
+		"internal.auto.conf",
+		"postgresql.conf",
+		"pg_hba.conf",
+		"postmaster.opts",
+	}
 	backupSegDir := fmt.Sprintf("%s.old", segDataDir)
 	for _, file := range filesToPreserve {
 		err := utils.System.Rename(filepath.Join(backupSegDir, file), filepath.Join(segDataDir, file))

--- a/agent/services/copy_master_data_dir_test.go
+++ b/agent/services/copy_master_data_dir_test.go
@@ -1,17 +1,18 @@
 package services_test
 
 import (
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"github.com/greenplum-db/gpupgrade/idl"
-	"github.com/greenplum-db/gpupgrade/utils"
-
 	"os"
 	"strings"
 
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	"github.com/pkg/errors"
+
 	"github.com/greenplum-db/gpupgrade/agent/services"
+	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/utils"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 )
 
 var _ = Describe("CopyMasterDirectoryToSegmentDirectories", func() {
@@ -70,10 +71,12 @@ var _ = Describe("CopyMasterDirectoryToSegmentDirectories", func() {
 
 		Expect(renamedFiles).To(Equal([]string{
 			"/tmp/dataDir0.old",
+			"/tmp/dataDir0/internal.auto.conf",
 			"/tmp/dataDir0/postgresql.conf",
 			"/tmp/dataDir0/pg_hba.conf",
 			"/tmp/dataDir0/postmaster.opts",
 			"/tmp/dataDir1.old",
+			"/tmp/dataDir1/internal.auto.conf",
 			"/tmp/dataDir1/postgresql.conf",
 			"/tmp/dataDir1/pg_hba.conf",
 			"/tmp/dataDir1/postmaster.opts",


### PR DESCRIPTION
...so that segments' DBIDs are correctly preserved. This fixes problems with mirror attachment after upgrade.