### PR TITLE
CI: reenable installcheck script

### DIFF
--- a/ci/scripts/install-tests.bash
+++ b/ci/scripts/install-tests.bash
@@ -17,20 +17,20 @@ time make_cluster
 
 time chown -R gpadmin:gpadmin go
 
-su gpadmin <<'EOF'
-set -ex
+su gpadmin -c '
+    set -ex
 
-export GOPATH=$PWD/go
-export PATH=$GOPATH/bin:$PATH
-source /usr/local/greenplum-db-devel/greenplum_path.sh
-source gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+    export TERM=linux
+    export GOPATH=$PWD/go
+    export PATH=$GOPATH/bin:$PATH
+    source /usr/local/greenplum-db-devel/greenplum_path.sh
+    source gpdb_src/gpAux/gpdemo/gpdemo-env.sh
 
-cd $GOPATH/src/github.com/greenplum-db/gpupgrade
-make
-make check --keep-going
+    cd $GOPATH/src/github.com/greenplum-db/gpupgrade
+    make
+    make check --keep-going
 
-# Note that installcheck is currently destructive.
-make install
-make installcheck
-EOF
-
+    # Note that installcheck is currently destructive.
+    make install
+    make installcheck
+'

--- a/installcheck.bats
+++ b/installcheck.bats
@@ -26,7 +26,9 @@ teardown() {
     gpupgrade initialize \
               --old-bindir "$GPHOME"/bin \
               --new-bindir "$GPHOME_NEW"/bin \
-              --old-port 15432 3>&-
+              --old-port $PGPORT \
+              --disk-free-ratio=0 \
+              3>&-
 
     gpupgrade execute
     gpupgrade finalize


### PR DESCRIPTION
installcheck isn't currently as useful as it was originally, but the fact that the CI wasn't running it at all is a little bit more disturbing. Switch install-tests from a stdin heredoc, which was being silently consumed by something inside `make check`, to a simple command string. (This has the side effect of reenabling pretty-print for the BATS suite, so we must export a `TERM` setting just like `noinstall-tests` does.)

Now that installcheck is running, fix up the bats script to handle recent-ish changes to gpupgrade and the GPDB environment.