### PR TITLE
Add an .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.go]
+indent_style = tab
+indent_size = 4
+
+[*.{bash,bats,sh}]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+[ci/**.yml]
+indent_style = space
+indent_size = 2
+
+[*.proto]
+# https://developers.google.com/protocol-buffers/docs/style
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
...so that hopefully GitHub will display our PRs correctly. Also, possibly, some editors will stop doing annoying things, like leaving off newlines at EOF.