### PR TITLE
make first two substeps of Initialize idempotent 

### DIFF
--- a/cli/commanders/initialize.go
+++ b/cli/commanders/initialize.go
@@ -89,7 +89,7 @@ func StartHub() (err error) {
 		return err
 	}
 	if running {
-		gplog.Debug("gpupgrade hub already running...")
+		gplog.Debug("gpupgrade hub already running...skipping.")
 		return nil
 	}
 

--- a/cli/commanders/initialize.go
+++ b/cli/commanders/initialize.go
@@ -19,23 +19,31 @@ import (
 var execCommandHubStart = exec.Command
 var execCommandHubCount = exec.Command
 
-// we create the state directory in the cli to ensure that at most one gpupgrade is occuring
+// we create the state directory in the cli to ensure that at most one gpupgrade is occurring
 // at the same time.
-func CreateStateDirAndClusterConfigs(sourceBinDir, targetBinDir string) (err error) {
-	s := Substep("Creating directories...")
+func CreateStateDir() (err error) {
+	s := Substep("Creating state directory...")
 	defer s.Finish(&err)
 
 	stateDir := utils.GetStateDir()
 	err = os.Mkdir(stateDir, 0700)
 	if os.IsExist(err) {
-		return fmt.Errorf("gpupgrade state dir (%s) already exists. Did you already run gpupgrade initialize?", stateDir)
-	} else if err != nil {
+		gplog.Debug("State directory %s already present...skipping", stateDir)
+		return nil
+	}
+	if err != nil {
+		gplog.Debug("State directory %s could not be created.", stateDir)
 		return err
 	}
 
-	// Create empty clusters in source and target so that gpupgrade hub can
-	// start without having replaced them with current values.
-	// TODO: implement a slicker scheme to allow this.
+	return nil
+}
+
+func CreateInitialClusterConfigs(sourceBinDir, targetBinDir string) (err error) {
+	s := Substep("Creating initial cluster config files...")
+	defer s.Finish(&err)
+
+	stateDir := utils.GetStateDir()
 	emptyCluster := cluster.NewCluster([]cluster.SegConfig{})
 
 	source := &utils.Cluster{
@@ -43,16 +51,26 @@ func CreateStateDirAndClusterConfigs(sourceBinDir, targetBinDir string) (err err
 		BinDir:     path.Clean(sourceBinDir),
 		ConfigPath: filepath.Join(stateDir, utils.SOURCE_CONFIG_FILENAME),
 	}
-	err = source.Commit()
-	if err != nil {
-		return errors.Wrap(err, "Unable to save empty source cluster configuration")
-	}
 
 	target := &utils.Cluster{
 		Cluster:    emptyCluster,
 		BinDir:     path.Clean(targetBinDir),
 		ConfigPath: filepath.Join(stateDir, utils.TARGET_CONFIG_FILENAME),
 	}
+
+	if source.Load() == nil && target.Load() == nil {
+		gplog.Debug("Initial cluster config files(%s or %s) already present...skipping.", source.ConfigPath, target.ConfigPath)
+		return nil
+	}
+
+	// Create empty clusters in source and target so that gpupgrade hub can
+	// start without having replaced them with current values.
+	// TODO: implement a slicker scheme to allow this.
+	err = source.Commit()
+	if err != nil {
+		return errors.Wrap(err, "Unable to save empty source cluster configuration")
+	}
+
 	err = target.Commit()
 	if err != nil {
 		return errors.Wrap(err, "Unable to save empty target cluster configuration")
@@ -64,6 +82,16 @@ func CreateStateDirAndClusterConfigs(sourceBinDir, targetBinDir string) (err err
 func StartHub() (err error) {
 	s := Substep("Starting hub...")
 	defer s.Finish(&err)
+
+	running, err := IsHubRunning()
+	if err != nil {
+		gplog.Error("failed to determine if hub already running")
+		return err
+	}
+	if running {
+		gplog.Debug("gpupgrade hub already running...")
+		return nil
+	}
 
 	cmd := execCommandHubStart("gpupgrade", "hub", "--daemonize")
 	stdout, cmdErr := cmd.Output()

--- a/cli/commanders/initialize_test.go
+++ b/cli/commanders/initialize_test.go
@@ -67,7 +67,7 @@ func teardown() {
 	execCommandHubCount = exec.Command
 }
 
-func TestNoHubIsAlreadyRunning(t *testing.T) {
+func TestIsHubRunning_ReturnsFalseWhenNotRunning(t *testing.T) {
 	setup(t)
 	defer teardown()
 
@@ -77,7 +77,7 @@ func TestNoHubIsAlreadyRunning(t *testing.T) {
 	g.Expect(running).To(BeFalse())
 }
 
-func TestHubIsAlreadyRunning(t *testing.T) {
+func TestIsHubRunning_ReturnsTrueWhenRunning(t *testing.T) {
 	setup(t)
 	defer teardown()
 
@@ -87,7 +87,7 @@ func TestHubIsAlreadyRunning(t *testing.T) {
 	g.Expect(running).To(BeTrue())
 }
 
-func TestHowManyHubsRunningFails(t *testing.T) {
+func TestIsHubRunning_ErrorsWhenCheckFails(t *testing.T) {
 	setup(t)
 	defer teardown()
 
@@ -97,19 +97,41 @@ func TestHowManyHubsRunningFails(t *testing.T) {
 	g.Expect(err).ToNot(BeNil())
 }
 
-func TestWeCanStartHub(t *testing.T) {
+func TestStartHub_Succeeds(t *testing.T) {
 	setup(t)
 	defer teardown()
 
+	execCommandHubCount = exectest.NewCommand(IsHubRunning_False)
 	execCommandHubStart = exectest.NewCommand(GpupgradeHub_good_Main)
 	err := StartHub()
 	g.Expect(err).To(BeNil())
 }
 
-func TestStartHubFails(t *testing.T) {
+func TestStartHub_FailsToStartWhenHubIsRunningErrors(t *testing.T) {
 	setup(t)
 	defer teardown()
 
+	execCommandHubCount = exectest.NewCommand(IsHubRunning_Error)
+	execCommandHubStart = exectest.NewCommand(GpupgradeHub_good_Main) // should not hit this, but fail it we do
+	err := StartHub()
+	g.Expect(err).ToNot(BeNil())
+}
+
+func TestStartHub_ReturnsWhenHubIsRunning(t *testing.T) {
+	setup(t)
+	defer teardown()
+
+	execCommandHubCount = exectest.NewCommand(IsHubRunning_True)
+	execCommandHubStart = exectest.NewCommand(GpupgradeHub_bad_Main) // should not hit this, but fail if we do
+	err := StartHub()
+	g.Expect(err).To(BeNil())
+}
+
+func TestStartHub_FailsWhenStartingTheHubErrors(t *testing.T) {
+	setup(t)
+	defer teardown()
+
+	execCommandHubCount = exectest.NewCommand(IsHubRunning_False)
 	execCommandHubStart = exectest.NewCommand(GpupgradeHub_bad_Main)
 	err := StartHub()
 	g.Expect(err).ToNot(BeNil())

--- a/cli/commanders/initialize_test.go
+++ b/cli/commanders/initialize_test.go
@@ -2,9 +2,14 @@ package commanders
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"reflect"
 	"testing"
+
+	"github.com/greenplum-db/gpupgrade/utils"
 
 	. "github.com/onsi/gomega"
 
@@ -108,4 +113,143 @@ func TestStartHubFails(t *testing.T) {
 	execCommandHubStart = exectest.NewCommand(GpupgradeHub_bad_Main)
 	err := StartHub()
 	g.Expect(err).ToNot(BeNil())
+}
+
+func TestCreateStateDir(t *testing.T) {
+	home, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatalf("failed creating temp dir %#v", err)
+	}
+
+	oldStateDir, isSet := os.LookupEnv("GPUGRADE_HOME")
+	defer func() {
+		if isSet {
+			os.Setenv("GPUPGRADE_HOME", oldStateDir)
+		}
+	}()
+
+	stateDir := filepath.Join(home, ".gpupgrade")
+	err = os.Setenv("GPUPGRADE_HOME", stateDir)
+	if err != nil {
+		t.Fatalf("failed to set GPUPGRADE_HOME %#v", err)
+	}
+
+	t.Run("test idempotence", func(t *testing.T) {
+		var infoOld os.FileInfo
+
+		{ // creates state directory if none exist or fails
+			if _, err = os.Stat(stateDir); err == nil {
+				t.Errorf("stateDir exists")
+			}
+
+			err = CreateStateDir()
+			if err != nil {
+				t.Fatalf("unexpected error %#v", err)
+			}
+
+			if infoOld, err = os.Stat(home); err != nil {
+				t.Errorf("unexpected error %#v", err)
+			}
+		}
+
+		{ // creating state directory is idempotent
+			err = CreateStateDir()
+			if err != nil {
+				t.Fatalf("unexpected error %#v", err)
+			}
+
+			var infoNew os.FileInfo
+			if infoNew, err = os.Stat(home); err != nil {
+				t.Errorf("unexpected error %#v", err)
+			}
+
+			if !reflect.DeepEqual(infoOld, infoNew) {
+				t.Error("want fileInfo before to match fileInfo new")
+			}
+		}
+
+		{ //  creating state directory succeeds on multiple runs
+			err = CreateStateDir()
+			if err != nil {
+				t.Fatalf("unexpected error %#v", err)
+			}
+		}
+	})
+}
+
+func TestCreateInitialClusterConfigs(t *testing.T) {
+	home, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatalf("failed creating temp dir %#v", err)
+	}
+
+	oldStateDir, isSet := os.LookupEnv("GPUGRADE_HOME")
+	defer func() {
+		if isSet {
+			os.Setenv("GPUPGRADE_HOME", oldStateDir)
+		}
+	}()
+	stateDir := filepath.Join(home, ".gpupgrade")
+	err = os.Setenv("GPUPGRADE_HOME", stateDir)
+	if err != nil {
+		t.Fatalf("failed to set GPUPGRADE_HOME %#v", err)
+	}
+
+	if _, err := os.Stat(stateDir); err == nil {
+		t.Errorf("stateDir exists")
+	}
+	err = CreateStateDir()
+	if err != nil {
+		t.Fatalf("failed to create state dir %#v", err)
+	}
+
+	oldBinDir := "old/dir/bin"
+	newBinDir := "new/dir/bin"
+	var sourceOld, targetOld os.FileInfo
+
+	t.Run("test idempotence", func(t *testing.T) {
+
+		{ // creates initial cluster config files if none exist or fails"
+			err = CreateInitialClusterConfigs(oldBinDir, newBinDir)
+			if err != nil {
+				t.Fatalf("unexpected error %#v", err)
+			}
+
+			if sourceOld, err = os.Stat(filepath.Join(stateDir, utils.SOURCE_CONFIG_FILENAME)); err != nil {
+				t.Errorf("unexpected error %#v", err)
+			}
+			if targetOld, err = os.Stat(filepath.Join(stateDir, utils.TARGET_CONFIG_FILENAME)); err != nil {
+				t.Errorf("unexpected error %#v", err)
+			}
+		}
+
+		{ // creating cluster config files is idempotent
+			err = CreateInitialClusterConfigs(oldBinDir, newBinDir)
+			if err != nil {
+				t.Fatalf("unexpected error %#v", err)
+			}
+
+			var sourceNew, targetNew os.FileInfo
+			if sourceNew, err = os.Stat(filepath.Join(stateDir, utils.SOURCE_CONFIG_FILENAME)); err != nil {
+				t.Errorf("got unexpected error %#v", err)
+			}
+			if targetNew, err = os.Stat(filepath.Join(stateDir, utils.TARGET_CONFIG_FILENAME)); err != nil {
+				t.Errorf("got unexpected error %#v", err)
+			}
+
+			if sourceOld.ModTime() != sourceNew.ModTime() {
+				t.Errorf("want %#v got %#v", sourceOld.ModTime(), sourceNew.ModTime())
+			}
+			if targetOld.ModTime() != targetNew.ModTime() {
+				t.Errorf("want %#v got %#v", targetOld.ModTime(), targetNew.ModTime())
+			}
+		}
+
+		{ // creating cluster config files succeeds on multiple runs
+			err = CreateInitialClusterConfigs(oldBinDir, newBinDir)
+			if err != nil {
+				t.Fatalf("unexpected error %#v", err)
+			}
+		}
+	})
 }

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -272,9 +272,14 @@ This step can be reverted.
 			fmt.Println("Initialization in progress.")
 			fmt.Println()
 
-			err = commanders.CreateStateDirAndClusterConfigs(oldBinDir, newBinDir)
+			err = commanders.CreateStateDir()
 			if err != nil {
-				return errors.Wrap(err, "tried to create state directory")
+				return errors.Wrap(err, "creating state directory")
+			}
+
+			err = commanders.CreateInitialClusterConfigs(oldBinDir, newBinDir)
+			if err != nil {
+				return errors.Wrap(err, "creating initial cluster configs")
 			}
 
 			running, err := commanders.IsHubRunning()

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -282,16 +282,6 @@ This step can be reverted.
 				return errors.Wrap(err, "creating initial cluster configs")
 			}
 
-			running, err := commanders.IsHubRunning()
-			if err != nil {
-				gplog.Error("failed to determine if hub already running")
-				return err
-			}
-			if running {
-				gplog.Error("gpupgrade hub process already running")
-				return errors.New("gpupgrade hub process already running")
-			}
-
 			err = commanders.StartHub()
 			if err != nil {
 				return errors.Wrap(err, "starting hub")

--- a/integrations/hub_test.go
+++ b/integrations/hub_test.go
@@ -23,7 +23,9 @@ var _ = Describe("gpupgrade hub", func() {
 	})
 
 	It("does not daemonize unless explicitly told to", func() {
-		err := commanders.CreateStateDirAndClusterConfigs("", "")
+		err := commanders.CreateStateDir()
+		Expect(err).ToNot(HaveOccurred())
+		err = commanders.CreateInitialClusterConfigs("", "")
 		Expect(err).ToNot(HaveOccurred())
 
 		cmd := exec.Command("gpupgrade", "hub")


### PR DESCRIPTION
In preparation for skipping completed substeps and continuing when an error occurred, we make the first two substeps of Initialize idempotent.  In addition, we split the first substep into two substeps: creating the state directory and creating the initial cluster config files.

Note that these substeps are run in the cli(vs. the hub), so they do not use the checklist manager.

Note that there are two commits but, due to inadvertent rebasing issues, some of the code that should be in the second commit are actually in the first(namely, the startHub substep IsHubRunning being included in the first commit). 