### PR TITLE
Introduce a new package to run, track status, and skip substeps

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -53,6 +53,14 @@
   version = "v1.3.2"
 
 [[projects]]
+  digest = "1:c3388642e07731a240e14f4bc7207df59cfcc009447c657b9de87fec072d07e3"
+  name = "github.com/google/renameio"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f0e32980c006571efd537032e5f9cd8c1a92819e"
+  version = "v0.1.0"
+
+[[projects]]
   branch = "master"
   digest = "1:b7388e8388cea56e5fd6b604eecfe56f5d02c0f41c49ad5a853da39b6dc197a0"
   name = "github.com/greenplum-db/gp-common-go-libs"
@@ -383,6 +391,7 @@
     "github.com/golang/mock/mockgen",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/protoc-gen-go",
+    "github.com/google/renameio",
     "github.com/greenplum-db/gp-common-go-libs/cluster",
     "github.com/greenplum-db/gp-common-go-libs/dbconn",
     "github.com/greenplum-db/gp-common-go-libs/gplog",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -101,3 +101,7 @@ required = [
 [[constraint]]
   branch = "master"
   name = "golang.org/x/xerrors"
+
+[[constraint]]
+  name = "github.com/google/renameio"
+  version = "0.1.0"

--- a/hub/substeps.go
+++ b/hub/substeps.go
@@ -81,6 +81,7 @@ type messageSender interface {
 	Send(*idl.Message) error // matches gRPC streaming Send()
 }
 
+// TODO: remove; this is part of step.Step now
 func sendStatus(stream messageSender, step idl.UpgradeSteps, status idl.StepStatus) {
 	// A stream is not guaranteed to remain connected during execution, so
 	// errors are explicitly ignored.
@@ -156,6 +157,16 @@ func (m *multiplexedStream) Stdout() io.Writer {
 
 func (m *multiplexedStream) Stderr() io.Writer {
 	return m.stderr
+}
+
+// Close closes the stream's io.Writer if that writer also provides a Close
+// method (i.e. it also implements io.WriteCloser). If not, Close is a no-op.
+func (m *multiplexedStream) Close() error {
+	if closer, ok := m.writer.(io.WriteCloser); ok {
+		return closer.Close()
+	}
+
+	return nil
 }
 
 type streamWriter struct {

--- a/hub/substeps_new.go
+++ b/hub/substeps_new.go
@@ -1,0 +1,63 @@
+package hub
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"golang.org/x/xerrors"
+
+	"github.com/greenplum-db/gpupgrade/step"
+)
+
+func BeginStep(stateDir string, name string, sender messageSender) (*step.Step, error) {
+	path := filepath.Join(stateDir, fmt.Sprintf("%s.log", name))
+	log, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		return nil, xerrors.Errorf(`step "%s": %w`, name, err)
+	}
+
+	_, err = fmt.Fprintf(log, "\n%s in progress.\n", strings.Title(name))
+	if err != nil {
+		log.Close()
+		return nil, xerrors.Errorf(`logging step "%s": %w`, name, err)
+	}
+
+	statusPath, err := getStatusFile(stateDir)
+	if err != nil {
+		return nil, xerrors.Errorf("step %q: %w", name, err)
+	}
+
+	streams := newMultiplexedStream(sender, log)
+	return step.New(name, sender, step.NewFileStore(statusPath), streams), nil
+}
+
+// Returns path to status file, and if one does not exist it creates an empty
+// JSON file.
+func getStatusFile(stateDir string) (path string, err error) {
+	path = filepath.Join(stateDir, "status.json")
+
+	f, err := os.OpenFile(path, os.O_EXCL|os.O_CREATE|os.O_WRONLY, 0600)
+	if os.IsExist(err) {
+		return path, nil
+	}
+	if err != nil {
+		return "", err
+	}
+
+	defer func() {
+		if cErr := f.Close(); cErr != nil {
+			err = multierror.Append(err, cErr).ErrorOrNil()
+		}
+	}()
+
+	// MarshallJSON requires a well-formed JSON file
+	_, err = f.WriteString("{}")
+	if err != nil {
+		return "", err
+	}
+
+	return path, nil
+}

--- a/hub/substeps_new_test.go
+++ b/hub/substeps_new_test.go
@@ -1,0 +1,66 @@
+package hub
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStatusFile(t *testing.T) {
+	stateDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.RemoveAll(stateDir); err != nil {
+			t.Errorf("removing temp directory: %v", err)
+		}
+	}()
+
+	path := filepath.Join(stateDir, "status.json")
+
+	t.Run("creates status file if it does not exist", func(t *testing.T) {
+		_, err := os.Open(path)
+		if !os.IsNotExist(err) {
+			t.Errorf("returned error %#v want ErrNotExist", err)
+		}
+
+		statusFile, err := getStatusFile(stateDir)
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
+
+		actual, err := ioutil.ReadFile(statusFile)
+		if err != nil {
+			t.Fatalf("ReadFile(%q) returned error %#v", statusFile, err)
+		}
+
+		expected := "{}"
+		if string(actual) != expected {
+			t.Errorf("read %v want %v", string(actual), expected)
+		}
+	})
+
+	t.Run("does not create status file if it already exists", func(t *testing.T) {
+		expected := "1234"
+		err := ioutil.WriteFile(path, []byte(expected), 0600)
+		if err != nil {
+			t.Fatalf("unexpected error %v", err)
+		}
+
+		statusFile, err := getStatusFile(stateDir)
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
+
+		actual, err := ioutil.ReadFile(statusFile)
+		if err != nil {
+			t.Errorf("ReadFile(%q) returned error %#v", statusFile, err)
+		}
+
+		if string(actual) != expected {
+			t.Errorf("read %v want %v", string(actual), expected)
+		}
+	})
+}

--- a/idl/cli_to_hub.proto
+++ b/idl/cli_to_hub.proto
@@ -34,11 +34,13 @@ message RestartAgentsReply {
 message StopServicesRequest {}
 message StopServicesReply {}
 
+// TODO: rename to SubstepStatus
 message UpgradeStepStatus {
     UpgradeSteps step = 1;
     StepStatus status = 2;
 }
 
+// TODO: rename to Substep
 enum UpgradeSteps {
     UNKNOWN_STEP = 0; // http://androiddevblog.com/protocol-buffers-pitfall-adding-enum-values/
     CONFIG = 1;
@@ -55,9 +57,10 @@ enum UpgradeSteps {
     RECONFIGURE_PORTS = 12;
 }
 
+// TODO: rename to Status
 enum StepStatus {
     UNKNOWN_STATUS = 0; // http://androiddevblog.com/protocol-buffers-pitfall-adding-enum-values/
-    PENDING = 1;
+    PENDING = 1; // TODO remove
     RUNNING = 2;
     COMPLETE = 3;
     FAILED = 4;

--- a/idl/sender.go
+++ b/idl/sender.go
@@ -1,0 +1,7 @@
+package idl
+
+// MessageSender is an interface common to all gRPC streaming server
+// implementations that allows the sending of a Message struct.
+type MessageSender interface {
+	Send(*Message) error // matches gRPC streaming Send()
+}

--- a/step/file_store.go
+++ b/step/file_store.go
@@ -1,0 +1,115 @@
+package step
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/google/renameio"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/greenplum-db/gpupgrade/idl"
+)
+
+// FileStore implements step.Store by providing persistent storage on disk.
+type FileStore struct {
+	path string
+}
+
+func NewFileStore(path string) *FileStore {
+	return &FileStore{path}
+}
+
+// PrettyStatus exists only to write a string description of idl.StepStatus to
+// the JSON representation, instead of an integer.
+type PrettyStatus struct {
+	idl.StepStatus
+}
+
+func (p PrettyStatus) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}
+
+func (p *PrettyStatus) UnmarshalText(buf []byte) error {
+	name := string(buf)
+
+	val, ok := idl.StepStatus_value[name]
+	if !ok {
+		return fmt.Errorf("unknown substep name %q", name)
+	}
+
+	p.StepStatus = idl.StepStatus(val)
+	return nil
+}
+
+func (f *FileStore) load() (map[string]idl.StepStatus, error) {
+	data, err := ioutil.ReadFile(f.path)
+	if err != nil {
+		return nil, err
+	}
+
+	var prettySubsteps map[string]PrettyStatus
+	err = json.Unmarshal(data, &prettySubsteps)
+	if err != nil {
+		return nil, err
+	}
+
+	substeps := make(map[string]idl.StepStatus)
+	for k, v := range prettySubsteps {
+		substeps[k] = v.StepStatus
+	}
+	return substeps, nil
+}
+
+func (f *FileStore) Read(substep idl.UpgradeSteps) (idl.StepStatus, error) {
+	steps, err := f.load()
+	if err != nil {
+		return idl.StepStatus_UNKNOWN_STATUS, err
+	}
+
+	status, ok := steps[substep.String()]
+	if !ok {
+		return idl.StepStatus_UNKNOWN_STATUS, nil
+	}
+
+	return status, nil
+}
+
+// Write atomically updates the status file.
+// Load the latest values from the filesystem, rather than storing
+// in-memory on a struct to avoid having two sources of truth.
+func (f *FileStore) Write(substep idl.UpgradeSteps, status idl.StepStatus) (err error) {
+	steps, err := f.load()
+	if err != nil {
+		return err
+	}
+
+	prettySteps := make(map[string]PrettyStatus)
+	for k, v := range steps {
+		prettySteps[k] = PrettyStatus{v}
+	}
+	prettySteps[substep.String()] = PrettyStatus{status}
+
+	data, err := json.MarshalIndent(prettySteps, "", "  ") // pretty print JSON
+	if err != nil {
+		return err
+	}
+
+	// Use renameio to ensure atomicity when writing the status file.
+	t, err := renameio.TempFile("", f.path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cErr := t.Cleanup(); cErr != nil {
+			err = multierror.Append(err, cErr).ErrorOrNil()
+		}
+	}()
+
+	_, err = t.Write(data)
+	if err != nil {
+		return err
+	}
+
+	return t.CloseAtomicallyReplace()
+}

--- a/step/file_store_test.go
+++ b/step/file_store_test.go
@@ -1,0 +1,100 @@
+package step_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/step"
+)
+
+func TestFileStore(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Errorf("removing temp directory: %v", err)
+		}
+	}()
+
+	path := filepath.Join(tmpDir, "status.json")
+	fs := step.NewFileStore(path)
+
+	t.Run("bubbles up any read failures", func(t *testing.T) {
+		_, err := fs.Read(idl.UpgradeSteps_CHECK_UPGRADE)
+
+		if !os.IsNotExist(err) {
+			t.Errorf("returned error %#v, want ErrNotExist", err)
+		}
+	})
+
+	err = ioutil.WriteFile(path, []byte("{}"), 0600)
+	if err != nil {
+		t.Fatalf("writing initial status file: %v", err)
+	}
+
+	t.Run("reads the same status that was written", func(t *testing.T) {
+		substep := idl.UpgradeSteps_CHECK_UPGRADE
+		expected := idl.StepStatus_COMPLETE
+
+		err := fs.Write(substep, expected)
+		if err != nil {
+			t.Fatalf("Write() returned error %#v", err)
+		}
+
+		status, err := fs.Read(substep)
+		if err != nil {
+			t.Errorf("Read() returned error %#v", err)
+		}
+		if status != expected {
+			t.Errorf("read %v, want %v", status, expected)
+		}
+	})
+
+	t.Run("returns unknown status if substep has not been written", func(t *testing.T) {
+		err = ioutil.WriteFile(path, []byte("{}"), 0600)
+		if err != nil {
+			t.Fatalf("clearing status file: %v", err)
+		}
+
+		status, err := fs.Read(idl.UpgradeSteps_INIT_TARGET_CLUSTER)
+		if err != nil {
+			t.Errorf("Read() returned error %#v", err)
+		}
+
+		expected := idl.StepStatus_UNKNOWN_STATUS
+		if status != expected {
+			t.Errorf("read %v, want %v", status, expected)
+		}
+	})
+
+	t.Run("uses human-readable serialization", func(t *testing.T) {
+		substep := idl.UpgradeSteps_INIT_TARGET_CLUSTER
+		status := idl.StepStatus_FAILED
+		if err := fs.Write(substep, status); err != nil {
+			t.Fatalf("Write(): %+v", err)
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			t.Fatalf("opening file: %+v", err)
+		}
+		defer f.Close()
+
+		dec := json.NewDecoder(f)
+		raw := make(map[string]string)
+		if err := dec.Decode(&raw); err != nil {
+			t.Fatalf("decoding statuses: %+v", err)
+		}
+
+		key := substep.String()
+		if raw[key] != status.String() {
+			t.Errorf("status[%q] = %q, want %q", key, raw[key], status.String())
+		}
+	})
+}

--- a/step/step.go
+++ b/step/step.go
@@ -1,0 +1,128 @@
+package step
+
+import (
+	"fmt"
+	"io"
+
+	multierror "github.com/hashicorp/go-multierror"
+	"golang.org/x/xerrors"
+
+	"github.com/greenplum-db/gpupgrade/idl"
+)
+
+type Step struct {
+	name    string
+	sender  idl.MessageSender // sends substep status messages
+	store   Store             // persistent substep status storage
+	streams OutStreamsCloser  // writes substep stdout/err
+	err     error
+}
+
+type Store interface {
+	Read(idl.UpgradeSteps) (idl.StepStatus, error)
+	Write(idl.UpgradeSteps, idl.StepStatus) error
+}
+
+type OutStreams interface {
+	Stdout() io.Writer
+	Stderr() io.Writer
+}
+
+type OutStreamsCloser interface {
+	OutStreams
+	Close() error
+}
+
+func New(name string, sender idl.MessageSender, store Store, streams OutStreamsCloser) *Step {
+	return &Step{
+		name:    name,
+		sender:  sender,
+		store:   store,
+		streams: streams,
+	}
+}
+
+func (s *Step) Finish() error {
+	if err := s.streams.Close(); err != nil {
+		return xerrors.Errorf(`step "%s": %w`, s.name, err)
+	}
+
+	return nil
+}
+
+func (s *Step) Err() error {
+	return s.err
+}
+
+func (s *Step) Run(substep idl.UpgradeSteps, f func(OutStreams) error) {
+	var err error
+	defer func() {
+		if err != nil {
+			s.err = xerrors.Errorf(`substep "%s": %w`, s.name, err)
+		}
+	}()
+
+	if s.err != nil {
+		return
+	}
+
+	status, err := s.store.Read(substep)
+	if err != nil {
+		return
+	}
+
+	if status == idl.StepStatus_RUNNING {
+		// TODO: Finalize error wording and recommended action
+		err = fmt.Errorf("Found previous substep %s was running. Manual intervention needed to cleanup. Please contact support.", substep)
+		s.sendStatus(substep, idl.StepStatus_FAILED)
+		return
+	}
+
+	// Only re-run subteps that have failed or pending
+	if status == idl.StepStatus_COMPLETE {
+		// Only send the status back to the UI; don't re-persist to the store
+		s.sendStatus(substep, idl.StepStatus_COMPLETE)
+		return
+	}
+
+	_, err = fmt.Fprintf(s.streams.Stdout(), "\nStarting %s...\n\n", substep)
+	if err != nil {
+		return
+	}
+
+	err = s.write(substep, idl.StepStatus_RUNNING)
+	if err != nil {
+		return
+	}
+
+	err = f(s.streams)
+	if err != nil {
+		if werr := s.write(substep, idl.StepStatus_FAILED); werr != nil {
+			err = multierror.Append(err, werr).ErrorOrNil()
+		}
+		return
+	}
+
+	err = s.write(substep, idl.StepStatus_COMPLETE)
+}
+
+func (s *Step) write(substep idl.UpgradeSteps, status idl.StepStatus) error {
+	err := s.store.Write(substep, status)
+	if err != nil {
+		return err
+	}
+
+	s.sendStatus(substep, status)
+	return nil
+}
+
+func (s *Step) sendStatus(substep idl.UpgradeSteps, status idl.StepStatus) {
+	// A stream is not guaranteed to remain connected during execution, so
+	// errors are explicitly ignored.
+	_ = s.sender.Send(&idl.Message{
+		Contents: &idl.Message_Status{&idl.UpgradeStepStatus{
+			Step:   substep,
+			Status: status,
+		}},
+	})
+}

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -1,0 +1,240 @@
+package step_test
+
+import (
+	"errors"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"golang.org/x/xerrors"
+
+	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
+	"github.com/greenplum-db/gpupgrade/step"
+)
+
+func TestStepRun(t *testing.T) {
+	t.Run("marks a successful substep run as complete", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		server := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
+		server.EXPECT().
+			Send(&idl.Message{Contents: &idl.Message_Status{&idl.UpgradeStepStatus{
+				Step:   idl.UpgradeSteps_CONFIG,
+				Status: idl.StepStatus_RUNNING,
+			}}})
+		server.EXPECT().
+			Send(&idl.Message{Contents: &idl.Message_Status{&idl.UpgradeStepStatus{
+				Step:   idl.UpgradeSteps_CONFIG,
+				Status: idl.StepStatus_COMPLETE,
+			}}})
+
+		s := step.New("Initialize", server, &TestStore{}, DevNull)
+
+		var called bool
+		s.Run(idl.UpgradeSteps_CONFIG, func(streams step.OutStreams) error {
+			called = true
+			return nil
+		})
+
+		if !called {
+			t.Error("expected substep to be called")
+		}
+	})
+
+	t.Run("marks a failed substep run as failed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		server := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
+		server.EXPECT().
+			Send(&idl.Message{Contents: &idl.Message_Status{&idl.UpgradeStepStatus{
+				Step:   idl.UpgradeSteps_CONFIG,
+				Status: idl.StepStatus_RUNNING,
+			}}})
+		server.EXPECT().
+			Send(&idl.Message{Contents: &idl.Message_Status{&idl.UpgradeStepStatus{
+				Step:   idl.UpgradeSteps_CONFIG,
+				Status: idl.StepStatus_FAILED,
+			}}})
+
+		s := step.New("Initialize", server, &TestStore{}, DevNull)
+
+		var called bool
+		s.Run(idl.UpgradeSteps_CONFIG, func(streams step.OutStreams) error {
+			called = true
+			return errors.New("oops")
+		})
+
+		if !called {
+			t.Error("expected substep to be called")
+		}
+	})
+
+	t.Run("returns an error when MarkInProgress fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		server := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
+
+		failingStore := &TestStore{WriteErr: errors.New("oops")}
+		s := step.New("Initialize", server, failingStore, DevNull)
+
+		var called bool
+		s.Run(idl.UpgradeSteps_CHECK_UPGRADE, func(streams step.OutStreams) error {
+			called = true
+			return nil
+		})
+
+		if !xerrors.Is(s.Err(), failingStore.WriteErr) {
+			t.Errorf("returned error %#v want %#v", s.Err(), failingStore.WriteErr)
+		}
+
+		if called {
+			t.Error("expected substep to not be called")
+		}
+	})
+
+	t.Run("skips completed substeps", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		server := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
+		server.EXPECT().
+			Send(&idl.Message{Contents: &idl.Message_Status{&idl.UpgradeStepStatus{
+				Step:   idl.UpgradeSteps_CHECK_UPGRADE,
+				Status: idl.StepStatus_COMPLETE,
+			}}})
+
+		store := &TestStore{Status: idl.StepStatus_COMPLETE}
+		s := step.New("Initialize", server, store, DevNull)
+
+		var called bool
+		s.Run(idl.UpgradeSteps_CHECK_UPGRADE, func(streams step.OutStreams) error {
+			called = true
+			return nil
+		})
+
+		if called {
+			t.Error("expected substep to be skipped")
+		}
+	})
+
+	t.Run("on failure skips subsequent substeps", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		server := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
+		server.EXPECT().Send(gomock.Any()).AnyTimes()
+
+		s := step.New("Initialize", server, &TestStore{}, DevNull)
+
+		expected := errors.New("oops")
+		s.Run(idl.UpgradeSteps_CONFIG, func(streams step.OutStreams) error {
+			return expected
+		})
+
+		var called bool
+		s.Run(idl.UpgradeSteps_START_AGENTS, func(streams step.OutStreams) error {
+			called = true
+			return nil
+		})
+
+		if called {
+			t.Error("expected substep to be skipped")
+		}
+
+		if !xerrors.Is(s.Err(), expected) {
+			t.Errorf("got error %#v, want %#v", s.Err(), expected)
+		}
+	})
+
+	t.Run("for a substep that was running mark it as failed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		server := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
+		server.EXPECT().Send(gomock.Any()).AnyTimes()
+
+		store := &TestStore{Status: idl.StepStatus_RUNNING}
+		s := step.New("Initialize", server, store, DevNull)
+
+		var called bool
+		s.Run(idl.UpgradeSteps_CONFIG, func(streams step.OutStreams) error {
+			called = true
+			return nil
+		})
+
+		if called {
+			t.Error("expected substep to not be called")
+		}
+
+		if s.Err() == nil {
+			t.Error("got nil want err")
+		}
+	})
+}
+
+func TestStepFinish(t *testing.T) {
+	t.Run("closes the output streams", func(t *testing.T) {
+		streams := &devNull{}
+		s := step.New("Initialize", nil, nil, streams)
+
+		err := s.Finish()
+		if err != nil {
+			t.Errorf("unexpected error %#v", err)
+		}
+
+		if !streams.Closed {
+			t.Errorf("stream was not closed")
+		}
+	})
+
+	t.Run("returns an error when failing to close the output streams", func(t *testing.T) {
+		expected := errors.New("oops")
+		streams := &devNull{CloseErr: expected}
+		s := step.New("Initialize", nil, nil, streams)
+
+		err := s.Finish()
+		if !xerrors.Is(err, expected) {
+			t.Errorf("got error %#v, want %#v", err, expected)
+		}
+	})
+}
+
+type TestStore struct {
+	Status   idl.StepStatus
+	WriteErr error
+}
+
+func (t *TestStore) Read(substep idl.UpgradeSteps) (idl.StepStatus, error) {
+	return t.Status, nil
+}
+
+func (t *TestStore) Write(substep idl.UpgradeSteps, status idl.StepStatus) (err error) {
+	return t.WriteErr
+}
+
+// DevNull implements step.OutStreamsCloser as a no-op. It also tracks calls to
+// Close().
+var DevNull = &devNull{}
+
+type devNull struct {
+	Closed   bool
+	CloseErr error
+}
+
+func (devNull) Stdout() io.Writer {
+	return ioutil.Discard
+}
+
+func (devNull) Stderr() io.Writer {
+	return ioutil.Discard
+}
+
+func (d *devNull) Close() error {
+	d.Closed = true
+	return d.CloseErr
+}


### PR DESCRIPTION
We implement a new scheme to run all substeps. This allows us to skip completed substeps when re-running a step after an error. This eliminates existing boilerplate code to fail a step if one substep fails. This includes a mechanism to durably store substep status to disk.  We use a JSON file that is written atomically to disk, and all retrievals of substep status read directly from the disk. 

This PR maintains the current checklist manager and substep tracking mechanism as well as its use by Execute and Finalize.  This allows us to port substeps one at a time over to this new mechanism without breaking existing code.

We initially wanted to refactor the existing checklist manager, but decided to simply rewrite it due to the difficulty in maintaining that existing code.  Some issues we ran into:

- Having two sources of truth for the suSstep status leads to subtle bugs 
  - the in-memory representation on the hub
  - what is on disk. 
- Having a separate checklist containing a stateReader and stateWriter for each individual substep rather than one single reader & writer. 
 - Having to define all the steps upon initialization rather keeping the reader & writer generic. This also allows us to have a single source of truth-the code order of substeps.


This is a draft PR to gather feedback as we continue flushing out unit tests. Once this pattern and mechanism to track substep status is in place the work to make all steps idempotent can be done in parallel.
