### PR TITLE
initialize: add basic test for substep idempotence

### DIFF
--- a/cli/bash/bash-completion.sh
+++ b/cli/bash/bash-completion.sh
@@ -260,6 +260,8 @@ _gpupgrade_config_show()
 
     flags+=("--new-bindir")
     local_nonpersistent_flags+=("--new-bindir")
+    flags+=("--new-datadir")
+    local_nonpersistent_flags+=("--new-datadir")
     flags+=("--old-bindir")
     local_nonpersistent_flags+=("--old-bindir")
 

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -214,6 +214,7 @@ func createConfigShowSubcommand() *cobra.Command {
 
 	subShow.Flags().Bool("old-bindir", false, "show install directory for old gpdb version")
 	subShow.Flags().Bool("new-bindir", false, "show install directory for new gpdb version")
+	subShow.Flags().Bool("new-datadir", false, "show temporary data directory for new gpdb cluster")
 
 	return subShow
 }

--- a/hub/config.go
+++ b/hub/config.go
@@ -38,6 +38,8 @@ func (h *Hub) GetConfig(ctx context.Context, in *idl.GetConfigRequest) (*idl.Get
 		resp.Value = h.Source.BinDir
 	case "new-bindir":
 		resp.Value = h.Target.BinDir
+	case "new-datadir":
+		resp.Value = h.Target.MasterDataDir()
 	default:
 		return nil, status.Errorf(codes.NotFound, "%s is not a valid configuration key", in.Name)
 	}

--- a/test/config.bats
+++ b/test/config.bats
@@ -62,7 +62,8 @@ teardown() {
     run gpupgrade config show
     [ "$status" -eq 0 ]
     [ "${lines[0]}" = "new-bindir - /my/new/bin/dir" ]
-    [ "${lines[1]}" = "old-bindir - /my/old/bin/dir" ]
+    [ "${lines[1]}" = "new-datadir - " ] # This isn't populated until cluster creation, but it's still displayed here
+    [ "${lines[2]}" = "old-bindir - /my/old/bin/dir" ]
 }
 
 @test "multiple configuration values can be set at once" {
@@ -71,5 +72,5 @@ teardown() {
     run gpupgrade config show
     [ "$status" -eq 0 ]
     [ "${lines[0]}" = "new-bindir - /my/new/bin/dir" ]
-    [ "${lines[1]}" = "old-bindir - /my/old/bin/dir" ]
+    [ "${lines[2]}" = "old-bindir - /my/old/bin/dir" ]
 }

--- a/test/execute.bats
+++ b/test/execute.bats
@@ -98,8 +98,7 @@ reset_master_and_primary_pg_control_files() {
         --disk-free-ratio 0 \
         --verbose
 
-    local datadir=$(dirname $(dirname "${MASTER_DATA_DIRECTORY}"))
-    NEW_CLUSTER="${datadir}/qddir_upgrade/demoDataDir-1"
+    NEW_CLUSTER="$(gpupgrade config show --new-datadir)"
 
     gpupgrade execute --verbose
     TEARDOWN_FUNCTIONS+=( reset_master_and_primary_pg_control_files )
@@ -121,24 +120,24 @@ reset_master_and_primary_pg_control_files() {
         --disk-free-ratio 0 \
         --verbose
 
-    local datadir=$(dirname $(dirname "${MASTER_DATA_DIRECTORY}"))
-    NEW_CLUSTER="${datadir}/qddir_upgrade/demoDataDir-1"
+    local datadir="$(gpupgrade config show --new-datadir)"
+    NEW_CLUSTER="${datadir}"
 
     # Initialize creates a backup of the target master data dir, during execute
     # upgrade master steps refreshes the content of the target master data dir
     # with the existing backup. Remove the target master data directory to
     # ensure that initialize created a backup and upgrade master refreshed the
     # target master data directory with the backup.
-    rm -rf "${datadir}"/qddir_upgrade/demoDataDir-1/*
+    rm -rf "${datadir}"/*
     
     # create an extra file to ensure that its deleted during rsync as we pass
     # --delete flag
-    mkdir "${datadir}"/qddir_upgrade/demoDataDir-1/base_extra    
-    touch "${datadir}"/qddir_upgrade/demoDataDir-1/base_extra/1101
+    mkdir "${datadir}"/base_extra
+    touch "${datadir}"/base_extra/1101
     gpupgrade execute --verbose
     
     # check that the extraneous files are deleted
-    [ ! -d "${datadir}"/qddir_upgrade/demoDataDir-1/base_extra ]
+    [ ! -d "${datadir}"/base_extra ]
 
     TEARDOWN_FUNCTIONS+=( reset_master_and_primary_pg_control_files )
 }

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -62,18 +62,6 @@ delete_target_datadirs() {
     rm -rf "${datadir}"/*_upgrade
 }
 
-# Takes an old datadir and echoes the expected new datadir path.
-upgrade_datadir() {
-    local base="$(basename $1)"
-    local dir="$(dirname $1)_upgrade"
-
-    # Sanity check.
-    [ -n "$base" ]
-    [ -n "$dir" ]
-
-    echo "$dir/$base"
-}
-
 # require_gnu_stat tries to find a GNU stat program. If one is found, it will be
 # assigned to the STAT global variable; otherwise the current test is skipped.
 require_gnu_stat() {

--- a/test/initialize.bats
+++ b/test/initialize.bats
@@ -41,8 +41,7 @@ teardown() {
 }
 
 set_target_cluster_var_for_teardown() {
-    local newmasterdir="$(upgrade_datadir $MASTER_DATA_DIRECTORY)"
-    TARGET_CLUSTER="${newmasterdir}"
+    TARGET_CLUSTER="$(gpupgrade config show --new-datadir)"
 }
 
 teardown_target_cluster() {
@@ -247,14 +246,14 @@ wait_for_port_change() {
 }
 
 @test "the check_upgrade substep always runs" {
-    set_target_cluster_var_for_teardown
-    TEARDOWN_FUNCTIONS+=( teardown_target_cluster )
-
     gpupgrade initialize \
         --old-bindir="$GPHOME/bin" \
         --new-bindir="$GPHOME/bin" \
         --old-port="${PGPORT}" \
         --disk-free-ratio 0 3>&-
+
+    set_target_cluster_var_for_teardown
+    TEARDOWN_FUNCTIONS+=( teardown_target_cluster )
 
     setup_check_upgrade_to_fail
     TEARDOWN_FUNCTIONS+=( teardown_check_upgrade_failure )

--- a/test/initialize.bats
+++ b/test/initialize.bats
@@ -174,27 +174,6 @@ outputContains() {
     done
 }
 
-# TODO: Remove this test once PR #179 is merged.
-@test "start agents idempotent" {
-    run gpupgrade initialize \
-        --old-bindir="$GPHOME/bin" \
-        --new-bindir="$GPHOME/bin" \
-        --old-port="${PGPORT}" \
-        --disk-free-ratio 0 \
-        --stop-before-cluster-creation 3>&-
-    [ "$status" -eq 0 ] || fail "failed to initialize: $output"
-
-    sed  -i -e 's/"START_AGENTS": "COMPLETE"/"START_AGENTS": "FAILED"/g' "$GPUPGRADE_HOME/status.json"
-
-    run gpupgrade initialize \
-        --old-bindir="$GPHOME/bin" \
-        --new-bindir="$GPHOME/bin" \
-        --old-port="${PGPORT}" \
-        --disk-free-ratio 0 \
-        --stop-before-cluster-creation 3>&-
-    [ "$status" -eq 0 ] || fail "failed to initialize: $output"
-}
-
 wait_for_port_change() {
     local port=$1
     local ret=$2
@@ -274,4 +253,29 @@ wait_for_port_change() {
     TEARDOWN_FUNCTIONS+=( teardown_target_cluster )
 
     pg_isready -q || fail "expected source cluster to be available"
+}
+
+# This is a very simple way to flush out the most obvious idempotence bugs. It
+# replicates what would happen if every substep failed/crashed right after
+# completing its work but before completion was signalled back to the hub.
+@test "all substeps can be re-run after completion" {
+    # Force a target cluster to be created (setup's initialize stops before that
+    # happens).
+    gpupgrade initialize \
+        --old-bindir="$GPHOME/bin" \
+        --new-bindir="$GPHOME/bin" \
+        --old-port="${PGPORT}"\
+        --disk-free-ratio 0 3>&-
+
+    set_target_cluster_var_for_teardown
+    TEARDOWN_FUNCTIONS+=( teardown_target_cluster )
+
+    # Mark every substep in the status file as failed. Then re-initialize.
+    sed -i.bak -e 's/"COMPLETE"/"FAILED"/g' "$GPUPGRADE_HOME/status.json"
+
+    gpupgrade initialize \
+        --old-bindir="$GPHOME/bin" \
+        --new-bindir="$GPHOME/bin" \
+        --old-port="${PGPORT}"\
+        --disk-free-ratio 0 3>&-
 }


### PR DESCRIPTION
This (draft) PR tests a very basic property of each `initialize` substep: if a substep completes its work and then crashes immediately after, can it be restarted and still succeed? To do this, we manually mark every completed substep as `FAILED` in the status file and re-run. It doesn't work yet, unsurprisingly, as several substeps don't have this property yet.

The first two commits are prefactors that made writing/debugging the new test easier.