### PR TITLE
Pass the request object instead of individual parameters

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -62,13 +62,12 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b7388e8388cea56e5fd6b604eecfe56f5d02c0f41c49ad5a853da39b6dc197a0"
+  digest = "1:8c2e9bb4264b0993ec59e55b2cd79c05545572d684586d3e9b227a83f1756dff"
   name = "github.com/greenplum-db/gp-common-go-libs"
   packages = [
     "cluster",
     "dbconn",
     "gplog",
-    "iohelper",
     "operating",
     "testhelper",
   ]
@@ -395,8 +394,6 @@
     "github.com/greenplum-db/gp-common-go-libs/cluster",
     "github.com/greenplum-db/gp-common-go-libs/dbconn",
     "github.com/greenplum-db/gp-common-go-libs/gplog",
-    "github.com/greenplum-db/gp-common-go-libs/iohelper",
-    "github.com/greenplum-db/gp-common-go-libs/operating",
     "github.com/greenplum-db/gp-common-go-libs/testhelper",
     "github.com/hashicorp/go-multierror",
     "github.com/lib/pq",

--- a/agent/upgrade_primaries_test.go
+++ b/agent/upgrade_primaries_test.go
@@ -81,7 +81,14 @@ func TestUpgradePrimary(t *testing.T) {
 		execCommand = exectest.NewCommand(FailedMain)
 		defer func() { execCommand = nil }()
 
-		err := UpgradePrimary("/old/bin", "/new/bin", pairs, tempDir, true, false)
+		request := &idl.UpgradePrimariesRequest{
+			OldBinDir:    "/old/bin",
+			NewBinDir:    "/new/bin",
+			DataDirPairs: pairs,
+			CheckOnly:    true,
+			UseLinkMode:  false,
+		}
+		err := UpgradePrimary(tempDir, request)
 		if err == nil {
 			t.Fatal("UpgradeSegments() returned no error")
 		}
@@ -100,7 +107,13 @@ func TestUpgradePrimary(t *testing.T) {
 		execCommand = exectest.NewCommand(FailedMain)
 		defer func() { execCommand = nil }()
 
-		err := UpgradePrimary("/old/bin", "/new/bin", pairs, tempDir, false, false)
+		request := &idl.UpgradePrimariesRequest{
+			OldBinDir:    "/old/bin",
+			NewBinDir:    "/new/bin",
+			DataDirPairs: pairs,
+			CheckOnly:    false,
+			UseLinkMode:  false}
+		err := UpgradePrimary(tempDir, request)
 		if err == nil {
 			t.Fatal("UpgradeSegments() returned no error")
 		}

--- a/cli/commanders/steps.go
+++ b/cli/commanders/steps.go
@@ -38,14 +38,7 @@ var indicators = map[idl.Status]string{
 	idl.Status_FAILED:   "[FAILED]",
 }
 
-func Initialize(client idl.CliToHubClient, oldBinDir, newBinDir string, oldPort int, linkMode bool, verbose bool) (err error) {
-
-	request := &idl.InitializeRequest{
-		OldBinDir:   oldBinDir,
-		NewBinDir:   newBinDir,
-		OldPort:     int32(oldPort),
-		UseLinkMode: linkMode,
-	}
+func Initialize(client idl.CliToHubClient, request *idl.InitializeRequest, verbose bool) (err error) {
 
 	stream, err := client.Initialize(context.Background(), request)
 	if err != nil {

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -290,7 +290,13 @@ This step can be reverted.
 
 			client := connectToHub()
 
-			err = commanders.Initialize(client, oldBinDir, newBinDir, oldPort, linkMode, verbose)
+			request := &idl.InitializeRequest{
+				OldBinDir:   oldBinDir,
+				NewBinDir:   newBinDir,
+				OldPort:     int32(oldPort),
+				UseLinkMode: linkMode,
+			}
+			err = commanders.Initialize(client, request, verbose)
 			if err != nil {
 				return errors.Wrap(err, "initializing hub")
 			}

--- a/idl/cli_to_hub.pb.go
+++ b/idl/cli_to_hub.pb.go
@@ -3,12 +3,15 @@
 
 package idl
 
-import proto "github.com/golang/protobuf/proto"
-import fmt "fmt"
-import math "math"
-
 import (
+	fmt "fmt"
+
+	proto "github.com/golang/protobuf/proto"
+
+	math "math"
+
 	context "golang.org/x/net/context"
+
 	grpc "google.golang.org/grpc"
 )
 


### PR DESCRIPTION
As the number of parameters are increased in the initialize command,
instead of adding every parameter the request object should be passed.
This is more scalable and little modification is required for every new
parameter addition