### PR TITLE
StopCluster: make idempotent by handling any starting cluster state

### DIFF
--- a/ci/scripts/upgrade-cluster.bash
+++ b/ci/scripts/upgrade-cluster.bash
@@ -48,6 +48,7 @@ sudo ln -s trampoline pg_ctl
 sudo ln -s trampoline pg_resetxlog
 sudo ln -s trampoline postgres
 
+sudo ln -s trampoline gpstart
 sudo ln -s trampoline gpstop
 
 # GPHOME_NEW might be the same as GPHOME_OLD for same-version upgrades.
@@ -62,6 +63,7 @@ if [ "$GPHOME_NEW" != "$GPHOME_OLD" ]; then
     sudo ln -s trampoline pg_resetxlog
     sudo ln -s trampoline postgres
 
+    sudo ln -s trampoline gpstart
     sudo ln -s trampoline gpstop
 fi
 

--- a/ci/scripts/upgrade-cluster.bash
+++ b/ci/scripts/upgrade-cluster.bash
@@ -76,7 +76,6 @@ sudo ln -s trampoline psql
 sudo ln -s trampoline vacuumdb
 
 sudo ln -s trampoline gpinitsystem
-sudo ln -s trampoline gpstart
 EOF
     done
 }

--- a/hub/start_or_stop_cluster_test.go
+++ b/hub/start_or_stop_cluster_test.go
@@ -1,12 +1,14 @@
 package hub
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"testing"
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
+	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
 	"github.com/greenplum-db/gpupgrade/utils"
@@ -14,9 +16,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func StartClusterCmd()        {}
-func StopClusterCmd()         {}
-func IsPostmasterRunningCmd() {}
 func IsPostmasterRunningCmd_Errors() {
 	os.Stderr.WriteString("exit status 2")
 	os.Exit(2)
@@ -24,9 +23,6 @@ func IsPostmasterRunningCmd_Errors() {
 
 func init() {
 	exectest.RegisterMains(
-		StartClusterCmd,
-		StopClusterCmd,
-		IsPostmasterRunningCmd,
 		IsPostmasterRunningCmd_Errors,
 	)
 }
@@ -35,7 +31,13 @@ func TestStartOrStopCluster(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	var source *utils.Cluster
-	cluster := cluster.NewCluster([]cluster.SegConfig{cluster.SegConfig{ContentID: -1, DbID: 1, Port: 15432, Hostname: "localhost", DataDir: "basedir/seg-1"}})
+	cluster := cluster.NewCluster([]cluster.SegConfig{{
+		ContentID: -1,
+		DbID:      1,
+		Port:      15432,
+		Hostname:  "localhost",
+		DataDir:   "basedir/seg-1",
+	}})
 	source = &utils.Cluster{
 		Cluster: cluster,
 		BinDir:  "/source/bindir",
@@ -53,7 +55,7 @@ func TestStartOrStopCluster(t *testing.T) {
 	}()
 
 	t.Run("isPostmasterRunning succeeds", func(t *testing.T) {
-		isPostmasterRunningCmd = exectest.NewCommandWithVerifier(IsPostmasterRunningCmd,
+		isPostmasterRunningCmd = exectest.NewCommandWithVerifier(Success,
 			func(path string, args ...string) {
 				g.Expect(path).To(Equal("bash"))
 				g.Expect(args).To(Equal([]string{"-c", "pgrep -F basedir/seg-1/postmaster.pid"}))
@@ -70,40 +72,106 @@ func TestStartOrStopCluster(t *testing.T) {
 		g.Expect(err).To(HaveOccurred())
 	})
 
-	t.Run("stopCluster successfully shuts down cluster", func(t *testing.T) {
-		isPostmasterRunningCmd = exectest.NewCommandWithVerifier(IsPostmasterRunningCmd,
-			func(path string, args ...string) {
-				g.Expect(path).To(Equal("bash"))
-				g.Expect(args).To(Equal([]string{"-c", "pgrep -F basedir/seg-1/postmaster.pid"}))
-			})
+	t.Run("stopCluster", func(t *testing.T) {
+		setup := func(t *testing.T) {
+			// XXX The cost-to-benefit ratio of this verification is very high.
+			// It pins a lot of behavior that we don't care about.
 
-		startStopClusterCmd = exectest.NewCommandWithVerifier(StopClusterCmd,
-			func(path string, args ...string) {
-				g.Expect(path).To(Equal("bash"))
-				g.Expect(args).To(Equal([]string{"-c", "source /source/bindir/../greenplum_path.sh " +
-					"&& /source/bindir/gpstop -a -d basedir/seg-1"}))
-			})
+			verify := func(t *testing.T, path string, args []string, expected string) {
+				t.Helper()
 
-		err := StopCluster(DevNull, source)
-		g.Expect(err).ToNot(HaveOccurred())
-	})
+				if path != "bash" {
+					t.Errorf("executable was %q, want %q", path, "bash")
+				}
 
-	t.Run("stopCluster detects that cluster is already shutdown", func(t *testing.T) {
-		isPostmasterRunningCmd = exectest.NewCommand(IsPostmasterRunningCmd_Errors)
+				if len(args) != 2 {
+					t.Errorf("expected two arguments to %q, got %q", path, args)
+					return
+				}
 
-		var skippedStopClusterCommand = true
-		startStopClusterCmd = exectest.NewCommandWithVerifier(IsPostmasterRunningCmd,
-			func(path string, args ...string) {
-				skippedStopClusterCommand = false
-			})
+				if args[0] != "-c" {
+					t.Errorf("first argument to %q must be -c; got %q", path, args[0])
+				}
 
-		err := StopCluster(DevNull, source)
-		g.Expect(err).To(HaveOccurred())
-		g.Expect(skippedStopClusterCommand).To(Equal(true))
+				expected = fmt.Sprintf("source /source/bindir/../greenplum_path.sh && %s", expected)
+				if args[1] != expected {
+					t.Errorf("bash command was %q, want %q", args[1], expected)
+				}
+			}
+
+			pgCtlCmd = exectest.NewCommandWithVerifier(Success,
+				func(path string, args ...string) {
+					expected := "/source/bindir/pg_ctl stop -m fast -w -D basedir/seg-1"
+					verify(t, path, args, expected)
+				})
+
+			gpstartCmd = exectest.NewCommandWithVerifier(Success,
+				func(path string, args ...string) {
+					expected := "/source/bindir/gpstart -a -d basedir/seg-1"
+					verify(t, path, args, expected)
+				})
+
+			gpstopCmd = exectest.NewCommandWithVerifier(Success,
+				func(path string, args ...string) {
+					expected := "/source/bindir/gpstop -a -f -d basedir/seg-1"
+					verify(t, path, args, expected)
+				})
+		}
+
+		teardown := func() {
+			pgCtlCmd = nil
+			gpstartCmd = nil
+			gpstopCmd = nil
+		}
+
+		t.Run("runs expected command sequence", func(t *testing.T) {
+			setup(t)
+			defer teardown()
+
+			if err := StopCluster(DevNull, source); err != nil {
+				t.Errorf("StopCluster() returned error %+v", err)
+			}
+		})
+
+		t.Run("does not fail if pg_ctl stop fails", func(t *testing.T) {
+			setup(t)
+			defer teardown()
+
+			pgCtlCmd = exectest.NewCommand(Failure)
+			if err := StopCluster(DevNull, source); err != nil {
+				t.Errorf("StopCluster() returned error %+v", err)
+			}
+		})
+
+		t.Run("fails if gpstart fails", func(t *testing.T) {
+			setup(t)
+			defer teardown()
+
+			gpstartCmd = exectest.NewCommand(Failure)
+			err := StopCluster(DevNull, source)
+
+			var actual *exec.ExitError
+			if !xerrors.As(err, &actual) {
+				t.Fatalf("StopCluster() returned %#v, want type %T", err, actual)
+			}
+		})
+
+		t.Run("fails if gpstop fails", func(t *testing.T) {
+			setup(t)
+			defer teardown()
+
+			gpstopCmd = exectest.NewCommand(Failure)
+			err := StopCluster(DevNull, source)
+
+			var actual *exec.ExitError
+			if !xerrors.As(err, &actual) {
+				t.Fatalf("StopCluster() returned %#v, want type %T", err, actual)
+			}
+		})
 	})
 
 	t.Run("startCluster successfully starts up cluster", func(t *testing.T) {
-		startStopClusterCmd = exectest.NewCommandWithVerifier(StartClusterCmd,
+		startStopClusterCmd = exectest.NewCommandWithVerifier(Success,
 			func(path string, args ...string) {
 				g.Expect(path).To(Equal("bash"))
 				g.Expect(args).To(Equal([]string{"-c", "source /source/bindir/../greenplum_path.sh " +

--- a/hub/start_or_stop_cluster_test.go
+++ b/hub/start_or_stop_cluster_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"reflect"
 	"testing"
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
@@ -21,9 +22,35 @@ func IsPostmasterRunningCmd_Errors() {
 	os.Exit(2)
 }
 
+// FailIfEnvVarsExist is an exectest.Main implementation that exits non-zero if
+// any environment variables are received.
+func FailIfEnvVarsExist() {
+	if env := os.Environ(); len(env) != 0 {
+		fmt.Fprintf(os.Stderr, "unexpected environment variables: %q\n", env)
+		os.Exit(1)
+	}
+}
+
+const clusterMDD = "basedir/seg-1" // used by CheckMasterDataDirectoryEnvVar below
+
+// CheckMasterDataDirectoryEnvVar is an exectest.Main implementation that exits
+// non-zero if the MASTER_DATA_DIRECTORY environment variable is not set to the
+// value of clusterMDD.
+func CheckMasterDataDirectoryEnvVar() {
+	expected := []string{fmt.Sprintf("MASTER_DATA_DIRECTORY=%s", clusterMDD)}
+
+	if env := os.Environ(); !reflect.DeepEqual(env, expected) {
+		fmt.Fprintf(os.Stderr, "incorrect environment variables: %q\n", env)
+		fmt.Fprintf(os.Stderr, "want %q\n", expected)
+		os.Exit(1)
+	}
+}
+
 func init() {
 	exectest.RegisterMains(
 		IsPostmasterRunningCmd_Errors,
+		FailIfEnvVarsExist,
+		CheckMasterDataDirectoryEnvVar,
 	)
 }
 
@@ -36,12 +63,12 @@ func TestStartOrStopCluster(t *testing.T) {
 		DbID:      1,
 		Port:      15432,
 		Hostname:  "localhost",
-		DataDir:   "basedir/seg-1",
+		DataDir:   clusterMDD,
 	}})
 	source = &utils.Cluster{
 		Cluster: cluster,
 		BinDir:  "/source/bindir",
-		Version: dbconn.GPDBVersion{},
+		Version: dbconn.NewVersion("6.0.0"),
 	}
 	utils.System.RemoveAll = func(s string) error { return nil }
 	utils.System.MkdirAll = func(s string, perm os.FileMode) error { return nil }
@@ -73,7 +100,7 @@ func TestStartOrStopCluster(t *testing.T) {
 	})
 
 	t.Run("stopCluster", func(t *testing.T) {
-		setup := func(t *testing.T) {
+		setup := func(t *testing.T, main exectest.Main) {
 			// XXX The cost-to-benefit ratio of this verification is very high.
 			// It pins a lot of behavior that we don't care about.
 
@@ -99,19 +126,19 @@ func TestStartOrStopCluster(t *testing.T) {
 				}
 			}
 
-			pgCtlCmd = exectest.NewCommandWithVerifier(Success,
+			pgCtlCmd = exectest.NewCommandWithVerifier(main,
 				func(path string, args ...string) {
 					expected := "/source/bindir/pg_ctl stop -m fast -w -D basedir/seg-1"
 					verify(t, path, args, expected)
 				})
 
-			gpstartCmd = exectest.NewCommandWithVerifier(Success,
+			gpstartCmd = exectest.NewCommandWithVerifier(main,
 				func(path string, args ...string) {
 					expected := "/source/bindir/gpstart -a -d basedir/seg-1"
 					verify(t, path, args, expected)
 				})
 
-			gpstopCmd = exectest.NewCommandWithVerifier(Success,
+			gpstopCmd = exectest.NewCommandWithVerifier(main,
 				func(path string, args ...string) {
 					expected := "/source/bindir/gpstop -a -f -d basedir/seg-1"
 					verify(t, path, args, expected)
@@ -125,7 +152,7 @@ func TestStartOrStopCluster(t *testing.T) {
 		}
 
 		t.Run("runs expected command sequence", func(t *testing.T) {
-			setup(t)
+			setup(t, Success)
 			defer teardown()
 
 			if err := StopCluster(DevNull, source); err != nil {
@@ -134,7 +161,7 @@ func TestStartOrStopCluster(t *testing.T) {
 		})
 
 		t.Run("does not fail if pg_ctl stop fails", func(t *testing.T) {
-			setup(t)
+			setup(t, Success)
 			defer teardown()
 
 			pgCtlCmd = exectest.NewCommand(Failure)
@@ -144,7 +171,7 @@ func TestStartOrStopCluster(t *testing.T) {
 		})
 
 		t.Run("fails if gpstart fails", func(t *testing.T) {
-			setup(t)
+			setup(t, Success)
 			defer teardown()
 
 			gpstartCmd = exectest.NewCommand(Failure)
@@ -157,7 +184,7 @@ func TestStartOrStopCluster(t *testing.T) {
 		})
 
 		t.Run("fails if gpstop fails", func(t *testing.T) {
-			setup(t)
+			setup(t, Success)
 			defer teardown()
 
 			gpstopCmd = exectest.NewCommand(Failure)
@@ -166,6 +193,37 @@ func TestStartOrStopCluster(t *testing.T) {
 			var actual *exec.ExitError
 			if !xerrors.As(err, &actual) {
 				t.Fatalf("StopCluster() returned %#v, want type %T", err, actual)
+			}
+		})
+
+		t.Run("does not leak environment variables to subprocesses", func(t *testing.T) {
+			setup(t, FailIfEnvVarsExist)
+			defer teardown()
+
+			// Save stderr for debugging.
+			streams := new(bufferedStreams)
+
+			if err := StopCluster(streams, source); err != nil {
+				t.Errorf("StopCluster() returned error %+v", err)
+				t.Logf("subprocess stderr:\n%s", streams.stderr.String())
+			}
+		})
+
+		t.Run("sets MASTER_DATA_DIRECTORY envvar for 5X clusters", func(t *testing.T) {
+			setup(t, CheckMasterDataDirectoryEnvVar)
+			defer teardown()
+
+			// Make a 5X cluster.
+			cluster := new(utils.Cluster)
+			*cluster = *source
+			cluster.Version = dbconn.NewVersion("5.14.1")
+
+			// Save stderr for debugging.
+			streams := new(bufferedStreams)
+
+			if err := StopCluster(streams, cluster); err != nil {
+				t.Errorf("StopCluster() returned error %+v", err)
+				t.Logf("subprocess stderr:\n%s", streams.stderr.String())
 			}
 		})
 	})

--- a/hub/start_or_stop_cluster_test.go
+++ b/hub/start_or_stop_cluster_test.go
@@ -93,7 +93,7 @@ func TestStartOrStopCluster(t *testing.T) {
 					t.Errorf("first argument to %q must be -c; got %q", path, args[0])
 				}
 
-				expected = fmt.Sprintf("source /source/bindir/../greenplum_path.sh && %s", expected)
+				expected = fmt.Sprintf("source /source/greenplum_path.sh && %s", expected)
 				if args[1] != expected {
 					t.Errorf("bash command was %q, want %q", args[1], expected)
 				}

--- a/hub/upgrade_master_test.go
+++ b/hub/upgrade_master_test.go
@@ -19,7 +19,9 @@ import (
 	"github.com/greenplum-db/gpupgrade/utils"
 )
 
+// TODO: move to the exectest package; these are widely used
 func Success() {}
+func Failure() { os.Exit(1) }
 
 const StreamingMainStdout = "expected\nstdout\n"
 const StreamingMainStderr = "process\nstderr\n"
@@ -50,6 +52,7 @@ func BlindlyWritingMain() {
 func init() {
 	exectest.RegisterMains(
 		Success,
+		Failure,
 		StreamingMain,
 		BlindlyWritingMain,
 	)


### PR DESCRIPTION
This substep now runs through these steps on each call, regardless of the current state of the cluster:
1) pg_ctl stop the master
2) gpstart the cluster, putting it in a known good state
3) gpstop the cluster

We tested this via manually injecting a fault using the debugger.