### PR TITLE
hub accepts a --state-directory flag

### DIFF
--- a/cli/commanders/initialize_test.go
+++ b/cli/commanders/initialize_test.go
@@ -103,7 +103,7 @@ func TestStartHub_Succeeds(t *testing.T) {
 
 	execCommandHubCount = exectest.NewCommand(IsHubRunning_False)
 	execCommandHubStart = exectest.NewCommand(GpupgradeHub_good_Main)
-	err := StartHub()
+	err := StartHub("")
 	g.Expect(err).To(BeNil())
 }
 
@@ -113,7 +113,7 @@ func TestStartHub_FailsToStartWhenHubIsRunningErrors(t *testing.T) {
 
 	execCommandHubCount = exectest.NewCommand(IsHubRunning_Error)
 	execCommandHubStart = exectest.NewCommand(GpupgradeHub_good_Main) // should not hit this, but fail it we do
-	err := StartHub()
+	err := StartHub("")
 	g.Expect(err).ToNot(BeNil())
 }
 
@@ -123,7 +123,7 @@ func TestStartHub_ReturnsWhenHubIsRunning(t *testing.T) {
 
 	execCommandHubCount = exectest.NewCommand(IsHubRunning_True)
 	execCommandHubStart = exectest.NewCommand(GpupgradeHub_bad_Main) // should not hit this, but fail if we do
-	err := StartHub()
+	err := StartHub("")
 	g.Expect(err).To(BeNil())
 }
 
@@ -133,7 +133,7 @@ func TestStartHub_FailsWhenStartingTheHubErrors(t *testing.T) {
 
 	execCommandHubCount = exectest.NewCommand(IsHubRunning_False)
 	execCommandHubStart = exectest.NewCommand(GpupgradeHub_bad_Main)
-	err := StartHub()
+	err := StartHub("")
 	g.Expect(err).ToNot(BeNil())
 }
 
@@ -164,9 +164,12 @@ func TestCreateStateDir(t *testing.T) {
 				t.Errorf("stateDir exists")
 			}
 
-			err = CreateStateDir()
+			result, err := CreateStateDir()
 			if err != nil {
 				t.Fatalf("unexpected error %#v", err)
+			}
+			if result != stateDir {
+				t.Errorf("expected %q got %q", stateDir, result)
 			}
 
 			if infoOld, err = os.Stat(home); err != nil {
@@ -175,9 +178,12 @@ func TestCreateStateDir(t *testing.T) {
 		}
 
 		{ // creating state directory is idempotent
-			err = CreateStateDir()
+			result, err := CreateStateDir()
 			if err != nil {
 				t.Fatalf("unexpected error %#v", err)
+			}
+			if result != stateDir {
+				t.Errorf("expected %q got %q", stateDir, result)
 			}
 
 			var infoNew os.FileInfo
@@ -191,9 +197,12 @@ func TestCreateStateDir(t *testing.T) {
 		}
 
 		{ //  creating state directory succeeds on multiple runs
-			err = CreateStateDir()
+			result, err := CreateStateDir()
 			if err != nil {
 				t.Fatalf("unexpected error %#v", err)
+			}
+			if result != stateDir {
+				t.Errorf("expected %q got %q", stateDir, result)
 			}
 		}
 	})
@@ -220,9 +229,12 @@ func TestCreateInitialClusterConfigs(t *testing.T) {
 	if _, err := os.Stat(stateDir); err == nil {
 		t.Errorf("stateDir exists")
 	}
-	err = CreateStateDir()
+	result, err := CreateStateDir()
 	if err != nil {
 		t.Fatalf("failed to create state dir %#v", err)
+	}
+	if result != stateDir {
+		t.Errorf("expected %q got %q", stateDir, result)
 	}
 
 	var sourceOld os.FileInfo
@@ -230,7 +242,7 @@ func TestCreateInitialClusterConfigs(t *testing.T) {
 	t.Run("test idempotence", func(t *testing.T) {
 
 		{ // creates initial cluster config files if none exist or fails"
-			err = CreateInitialClusterConfigs()
+			err = CreateInitialClusterConfigs(stateDir)
 			if err != nil {
 				t.Fatalf("unexpected error %#v", err)
 			}
@@ -241,7 +253,7 @@ func TestCreateInitialClusterConfigs(t *testing.T) {
 		}
 
 		{ // creating cluster config files is idempotent
-			err = CreateInitialClusterConfigs()
+			err = CreateInitialClusterConfigs(stateDir)
 			if err != nil {
 				t.Fatalf("unexpected error %#v", err)
 			}
@@ -257,7 +269,7 @@ func TestCreateInitialClusterConfigs(t *testing.T) {
 		}
 
 		{ // creating cluster config files succeeds on multiple runs
-			err = CreateInitialClusterConfigs()
+			err = CreateInitialClusterConfigs(stateDir)
 			if err != nil {
 				t.Fatalf("unexpected error %#v", err)
 			}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -273,17 +273,17 @@ This step can be reverted.
 			fmt.Println("Initialization in progress.")
 			fmt.Println()
 
-			err = commanders.CreateStateDir()
+			stateDir, err := commanders.CreateStateDir()
 			if err != nil {
 				return errors.Wrap(err, "creating state directory")
 			}
 
-			err = commanders.CreateInitialClusterConfigs()
+			err = commanders.CreateInitialClusterConfigs(stateDir)
 			if err != nil {
 				return errors.Wrap(err, "creating initial cluster configs")
 			}
 
-			err = commanders.StartHub()
+			err = commanders.StartHub(stateDir)
 			if err != nil {
 				return errors.Wrap(err, "starting hub")
 			}
@@ -429,7 +429,7 @@ var restartServices = &cobra.Command{
 		}
 
 		if !running {
-			err = commanders.StartHub()
+			err = commanders.StartHub(utils.GetStateDir())
 			if err != nil {
 				return err
 			}

--- a/hub/commands.go
+++ b/hub/commands.go
@@ -24,7 +24,7 @@ const ConfigFileName = "config.json"
 // Minimal CLI command parsing to embrace that booting this binary to run the hub might have some flags like a log dir
 
 func Command() *cobra.Command {
-	var logdir string
+	var logdir, stateDir string
 	var shouldDaemonize bool
 
 	var cmd = &cobra.Command{
@@ -38,7 +38,6 @@ func Command() *cobra.Command {
 			debug.SetTraceback("all")
 			defer log.WritePanics()
 
-			stateDir := utils.GetStateDir()
 			finfo, err := os.Stat(stateDir)
 			if os.IsNotExist(err) {
 				return fmt.Errorf("gpupgrade state dir (%s) does not exist. Did you run gpupgrade initialize?", stateDir)
@@ -101,6 +100,7 @@ func Command() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVar(&logdir, "log-directory", "", "gpupgrade hub log directory")
+	cmd.Flags().StringVar(&stateDir, "state-directory", utils.GetStateDir(), "Agent state directory")
 
 	daemon.MakeDaemonizable(cmd, &shouldDaemonize)
 

--- a/integrations/hub_test.go
+++ b/integrations/hub_test.go
@@ -23,12 +23,12 @@ var _ = Describe("gpupgrade hub", func() {
 	})
 
 	It("does not daemonize unless explicitly told to", func() {
-		err := commanders.CreateStateDir()
+		stateDir, err := commanders.CreateStateDir()
 		Expect(err).ToNot(HaveOccurred())
-		err = commanders.CreateInitialClusterConfigs()
+		err = commanders.CreateInitialClusterConfigs(stateDir)
 		Expect(err).ToNot(HaveOccurred())
 
-		cmd := exec.Command("gpupgrade", "hub")
+		cmd := exec.Command("gpupgrade", "hub", "--state-directory", stateDir)
 		done := make(chan error, 1)
 
 		go func() {


### PR DESCRIPTION
For a given cluster upgrade, the CLI and Hub must agree on the
state directory used as the CLI and Hub are both required to run
on the master host.  Currently, we also want to Hub and Agent
state directory to match, even though the segment hosts need not
coincide with the master host.

To keep this consistent, we have the CLI pass its state directory
to the Hub via this new command flag.  The Hub alread does the same
thing with each agent.