### PR TITLE
Make start agents idempotent

### DIFF
--- a/testutils/port_listener/main.go
+++ b/testutils/port_listener/main.go
@@ -1,0 +1,86 @@
+// The port_listener utility listens on the specified port on all ipv4 and ipv6
+// interfaces. If no ipv6 interface is detected it will not listen on ipv6.
+// Usage:
+//
+//   go run port_listener <port>
+//
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func main() {
+	args := os.Args[1:]
+	if len(args) != 1 {
+		log.Fatalf("usage: %s <port_number>", os.Args[0])
+	}
+
+	port := args[0]
+
+	signals := make(chan os.Signal, 1)
+	done := make(chan bool, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+
+	log := "tcp4"
+
+	go func() {
+		connect("tcp4", port)
+	}()
+
+	if isIpv6Enabled() {
+		log += " and tcp6"
+		go func() {
+			connect("tcp6", port)
+		}()
+	}
+
+	fmt.Printf("listening on %s on port %s...\n", log, port)
+
+	go func() {
+		signal := <-signals
+		fmt.Printf("\nReceived %s. Exiting.", signal)
+		done <- true
+	}()
+
+	<-done
+}
+
+func connect(network string, port string) net.Listener {
+	listener, err := net.Listen(network, ":"+port)
+	if err != nil {
+		log.Fatalf("failed to listen on port %s for %s: %v", port, network, err)
+	}
+
+	_, err = listener.Accept()
+	if err != nil {
+		log.Fatalf("failed to accept on port %s for %s: %v", port, network, err)
+	}
+
+	return listener
+}
+
+func isIpv6Enabled() bool {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		log.Fatalf("failed to determine interface addrs: %v", err)
+	}
+
+	for _, addr := range addrs {
+		ip, _, err := net.ParseCIDR(addr.String())
+		if err != nil {
+			log.Fatalf("failed to parse network address %s: %v", addr.String(), err)
+		}
+
+		if ip.To4() == nil {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
To make the start agents substep idempotent we reuse the RestartAgents implementation. We will need to revisit starting and stopping of the hub and agents as our current implementation has some drawbacks. Namely, we have no way of stopping spurious agents that the hub is not aware of. PID files seems like the way to go.

This introduces a test helper program port_listener/main.go to listen on all ipv4 and ipv6 interfaces on a specific port. If no ipv6 interface is found it will not listen on ipv6. This is useful where our current CI infrastructure does not support ipv6.

We use port_listener/main.go instead of netcat since this guarantees to bind to all interfaces, and keeps the held gRPC connection open during gRPC retries.
