### PR TITLE
Add --delete flag to rsync for master data directory command

### DIFF
--- a/hub/upgrade_master.go
+++ b/hub/upgrade_master.go
@@ -66,7 +66,7 @@ func masterSegmentFromCluster(cluster *utils.Cluster) *upgrade.Segment {
 
 func RsyncMasterDataDir(stream step.OutStreams, sourceDir, targetDir string) error {
 	sourceDirRsync := filepath.Clean(sourceDir) + string(os.PathSeparator)
-	cmd := execCommandRsync("rsync", "--archive", "--exclude=pg_log/*", sourceDirRsync, targetDir)
+	cmd := execCommandRsync("rsync", "--archive", "--delete", "--exclude=pg_log/*", sourceDirRsync, targetDir)
 
 	cmd.Stdout = stream.Stdout()
 	cmd.Stderr = stream.Stderr()

--- a/test/execute.bats
+++ b/test/execute.bats
@@ -130,7 +130,16 @@ reset_master_and_primary_pg_control_files() {
     # ensure that initialize created a backup and upgrade master refreshed the
     # target master data directory with the backup.
     rm -rf "${datadir}"/qddir_upgrade/demoDataDir-1/*
+    
+    # create an extra file to ensure that its deleted during rsync as we pass
+    # --delete flag
+    mkdir "${datadir}"/qddir_upgrade/demoDataDir-1/base_extra    
+    touch "${datadir}"/qddir_upgrade/demoDataDir-1/base_extra/1101
     gpupgrade execute --verbose
+    
+    # check that the extraneous files are deleted
+    [ ! -d "${datadir}"/qddir_upgrade/demoDataDir-1/base_extra ]
+
     TEARDOWN_FUNCTIONS+=( reset_master_and_primary_pg_control_files )
 
 }


### PR DESCRIPTION
Ideally in the PR: https://github.com/greenplum-db/gpupgrade/pull/195, the --delete flag should have been included. Adding this via this separate PR.

If there are extraneous files in the target directory they should be deleted with rsync. For instance, when upgrade process to copy is in progress and it fails, re-run of the upgrade should delete all the extra files which might exist or were left behind with the last failed step.