### PR TITLE
move SHUTDOWN_SOURCE_CLUSTER from initialize to execute

### DIFF
--- a/hub/execute.go
+++ b/hub/execute.go
@@ -26,6 +26,10 @@ func (h *Hub) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_ExecuteSe
 		}
 	}()
 
+	s.Run(idl.Substep_SHUTDOWN_SOURCE_CLUSTER, func(stream step.OutStreams) error {
+		return StopCluster(stream, h.Source)
+	})
+
 	s.Run(idl.Substep_UPGRADE_MASTER, func(streams step.OutStreams) error {
 		stateDir := h.StateDir
 		return UpgradeMaster(h.Source, h.Target, stateDir, streams, false, h.UseLinkMode)

--- a/hub/initialize.go
+++ b/hub/initialize.go
@@ -80,10 +80,6 @@ func (h *Hub) InitializeCreateCluster(in *idl.InitializeCreateClusterRequest, st
 		return err
 	})
 
-	s.Run(idl.Substep_SHUTDOWN_SOURCE_CLUSTER, func(stream step.OutStreams) error {
-		return StopCluster(stream, h.Source)
-	})
-
 	s.Run(idl.Substep_INIT_TARGET_CLUSTER, func(stream step.OutStreams) error {
 		return h.CreateTargetCluster(stream, h.Config.TargetMasterPort)
 	})

--- a/test/execute.bats
+++ b/test/execute.bats
@@ -32,7 +32,7 @@ teardown() {
         $FUNCTION
     done
 
-    gpstart -a
+    start_source_cluster
 }
 
 ensure_hardlinks_for_relfilenode_on_master_and_segments() {
@@ -141,5 +141,4 @@ reset_master_and_primary_pg_control_files() {
     [ ! -d "${datadir}"/qddir_upgrade/demoDataDir-1/base_extra ]
 
     TEARDOWN_FUNCTIONS+=( reset_master_and_primary_pg_control_files )
-
 }

--- a/test/finalize.bats
+++ b/test/finalize.bats
@@ -38,7 +38,7 @@ teardown() {
         rm -rf "$STATE_DIR/demoDataDir*"
         rm -r "$STATE_DIR"
 
-        gpstart -a
+        start_source_cluster
     fi
 }
 

--- a/test/gpinitsystem.bats
+++ b/test/gpinitsystem.bats
@@ -25,8 +25,6 @@ teardown() {
     if [ -n "$NEW_CLUSTER" ]; then
         delete_cluster $NEW_CLUSTER
     fi
-
-    gpstart -a
 }
 
 @test "initialize runs gpinitsystem based on the source cluster" {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -26,6 +26,11 @@ skip_if_no_gpdb() {
     [ -n "${PGPORT}" ] || skip "this test requires an active GPDB cluster (set PGPORT)"
 }
 
+# start_source_cluster() ensures that database is up before returning
+start_source_cluster() {
+    "${GPHOME}"/bin/pg_isready -q || "${GPHOME}"/bin/gpstart -a
+}
+
 # Calls gpdeletesystem on the cluster pointed to by the given master data
 # directory.
 delete_cluster() {

--- a/test/initialize.bats
+++ b/test/initialize.bats
@@ -50,7 +50,6 @@ teardown_target_cluster() {
 }
 
 setup_check_upgrade_to_fail() {
-    gpstart -a
     $PSQL -d postgres -p $PGPORT -c "CREATE TABLE test_pg_upgrade(a int) DISTRIBUTED BY (a) PARTITION BY RANGE (a)(start (1) end(4) every(1));"
     $PSQL -d postgres -p $PGPORT -c "CREATE UNIQUE INDEX fomo ON test_pg_upgrade (a);"
 }
@@ -269,4 +268,11 @@ wait_for_port_change() {
     # Other substeps are skipped when marked completed in the state dir,
     # for check_upgrade, we always run it.
     [ "$status" -eq 1 ] || fail "$output"
+}
+
+@test "the source cluster is running at the end of initialize" {
+    set_target_cluster_var_for_teardown
+    TEARDOWN_FUNCTIONS+=( teardown_target_cluster )
+
+    pg_isready -q || fail "expected source cluster to be available"
 }

--- a/test/pg_upgrade.bats
+++ b/test/pg_upgrade.bats
@@ -31,7 +31,7 @@ teardown() {
         delete_cluster $NEW_CLUSTER
     fi
 
-    gpstart -a
+    start_source_cluster
 
     $PSQL -d postgres -p $PGPORT -c "DROP TABLE IF EXISTS test_pg_upgrade CASCADE;"
 }
@@ -69,9 +69,7 @@ setup_newmasterdir() {
     grep "Checking for indexes on partitioned tables                  fatal" "$GPUPGRADE_HOME"/initialize.log
 
     # revert added index
-    gpstart -a
     $PSQL -d postgres -p $PGPORT -c "DROP TABLE test_pg_upgrade CASCADE;"
-    gpstop -a
 
     KEEP_STATE_DIR=0
 }


### PR DESCRIPTION
The source cluster should be up after initialize completes, as
the user may want to run initialize well in advance of execute.
Hence, the source cluster would still be used in production after
initialize completes.

Tests have been updated to reflect this change.
