### PR TITLE
Move CLI commands back into the cli package

### DIFF
--- a/cli/commanders/initialize.go
+++ b/cli/commanders/initialize.go
@@ -6,9 +6,10 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/greenplum-db/gpupgrade/hub"
+
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 
-	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/utils"
 )
 

--- a/cli/commanders/initialize_test.go
+++ b/cli/commanders/initialize_test.go
@@ -9,10 +9,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/greenplum-db/gpupgrade/hub"
-
 	. "github.com/onsi/gomega"
 
+	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
 )
 

--- a/cli/commands/agent.go
+++ b/cli/commands/agent.go
@@ -1,16 +1,18 @@
-package agent
+package commands
 
 import (
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/spf13/cobra"
 
+	"github.com/greenplum-db/gpupgrade/agent"
+
 	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/greenplum-db/gpupgrade/utils/daemon"
 	"github.com/greenplum-db/gpupgrade/utils/log"
 )
 
-func Command() *cobra.Command {
+func Agent() *cobra.Command {
 	var logdir, statedir string
 	var shouldDaemonize bool
 
@@ -24,12 +26,12 @@ func Command() *cobra.Command {
 			gplog.InitializeLogging("gpupgrade agent", logdir)
 			defer log.WritePanics()
 
-			conf := Config{
+			conf := agent.Config{
 				Port:     6416,
 				StateDir: statedir,
 			}
 
-			agentServer := NewServer(&cluster.GPDBExecutor{}, conf)
+			agentServer := agent.NewServer(&cluster.GPDBExecutor{}, conf)
 			if shouldDaemonize {
 				agentServer.MakeDaemon()
 			}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -44,9 +44,7 @@ import (
 	"google.golang.org/grpc/codes"
 	grpcStatus "google.golang.org/grpc/status"
 
-	"github.com/greenplum-db/gpupgrade/agent"
 	"github.com/greenplum-db/gpupgrade/cli/commanders"
-	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
 )
@@ -62,8 +60,8 @@ func BuildRootCommand() *cobra.Command {
 	root.AddCommand(finalize)
 	root.AddCommand(restartServices)
 	root.AddCommand(killServices)
-	root.AddCommand(hub.Command())
-	root.AddCommand(agent.Command())
+	root.AddCommand(Agent())
+	root.AddCommand(Hub())
 
 	subConfigSet := createConfigSetSubcommand()
 	subConfigShow := createConfigShowSubcommand()

--- a/cli/commands/hub.go
+++ b/cli/commands/hub.go
@@ -1,4 +1,4 @@
-package hub
+package commands
 
 import (
 	"fmt"
@@ -11,17 +11,16 @@ import (
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 
+	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/greenplum-db/gpupgrade/utils/daemon"
 	"github.com/greenplum-db/gpupgrade/utils/log"
 )
 
-const ConfigFileName = "config.json"
-
 // This directory to have the implementation code for the gRPC server to serve
 // Minimal CLI command parsing to embrace that booting this binary to run the hub might have some flags like a log dir
 
-func Command() *cobra.Command {
+func Hub() *cobra.Command {
 	var logdir string
 	var shouldDaemonize bool
 
@@ -50,19 +49,19 @@ func Command() *cobra.Command {
 			//
 			// they're not defined in the configuration (as happens
 			// pre-initialize), we still need good defaults.
-			conf := &Config{
+			conf := &hub.Config{
 				Port:        7527,
 				AgentPort:   6416,
 				UseLinkMode: false,
 			}
 
-			path := filepath.Join(stateDir, ConfigFileName)
+			path := filepath.Join(stateDir, hub.ConfigFileName)
 			err = loadConfig(conf, path)
 			if err != nil {
 				return err
 			}
 
-			h := New(conf, grpc.DialContext, stateDir)
+			h := hub.New(conf, grpc.DialContext, stateDir)
 
 			if shouldDaemonize {
 				h.MakeDaemon()
@@ -84,7 +83,7 @@ func Command() *cobra.Command {
 	return cmd
 }
 
-func loadConfig(conf *Config, path string) error {
+func loadConfig(conf *hub.Config, path string) error {
 	file, err := os.Open(path)
 	if err != nil {
 		return xerrors.Errorf("opening configuration file: %w", err)

--- a/hub/config.go
+++ b/hub/config.go
@@ -10,6 +10,8 @@ import (
 	"golang.org/x/net/context"
 )
 
+const ConfigFileName = "config.json"
+
 func (h *Hub) SetConfig(ctx context.Context, in *idl.SetConfigRequest) (*idl.SetConfigReply, error) {
 	switch in.Name {
 	case "old-bindir":


### PR DESCRIPTION
Most of the code in Command()s (now HubCommand() and AgentCommand()) are cli related. Only the construction and calling of the Agent and Hub objects are specific to their subdomains.

Some of the logic around config files can probably be pushed back down into hub.