### PR TITLE
Experiment with golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,21 @@ installcheck:
 		@echo "# FIXME: Make, if run in parallel, hangs after test completes."
 		./installcheck.bats
 
+# To lint, you must install golangci-lint via one of the supported methods
+# listed at
+#
+#     https://github.com/golangci/golangci-lint#install
+#
+# DO NOT add the linter to the project dependencies in Gopkg.toml, as much as
+# you may want to streamline this installation process, because
+# 1. `go get` is an explicitly unsupported installation method for this utility,
+#    much like it is for gpupgrade itself, and
+# 2. adding it as a project dependency opens up the possibility of accidentally
+#    vendoring GPL'd code.
+.PHONY: lint
+lint:
+	golangci-lint run
+
 clean:
 		# Build artifacts
 		rm -f gpupgrade

--- a/ci/parser/pipeline-template.yml
+++ b/ci/parser/pipeline-template.yml
@@ -171,6 +171,15 @@ jobs:
   on_failure:
     <<: *slack_alert
 
+- name: lint
+  plan:
+  - get: gpupgrade_src
+    trigger: true
+  - task: lint
+    file: gpupgrade_src/ci/tasks/lint.yml
+  on_failure:
+    <<: *slack_alert
+
 - name: noinstall-tests
   plan:
   - in_parallel:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -172,6 +172,15 @@ jobs:
   on_failure:
     <<: *slack_alert
 
+- name: lint
+  plan:
+  - get: gpupgrade_src
+    trigger: true
+  - task: lint
+    file: gpupgrade_src/ci/tasks/lint.yml
+  on_failure:
+    <<: *slack_alert
+
 - name: noinstall-tests
   plan:
   - in_parallel:
@@ -341,3 +350,4 @@ jobs:
     <<: *ccp_destroy
   on_failure:
     <<: *slack_alert
+

--- a/ci/tasks/lint.yml
+++ b/ci/tasks/lint.yml
@@ -1,0 +1,23 @@
+PLATFORM: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: golangci/golangci-lint
+    tag: 'latest'
+
+inputs:
+- name: gpupgrade_src
+  path: ../../../go/src/github.com/greenplum-db/gpupgrade
+
+run:
+  path: bash
+  args:
+  - -c
+  - |
+    set -ex
+
+    cd $GOPATH/src/github.com/greenplum-db/gpupgrade
+    make depend # to pull in dependencies for analysis
+
+    golangci-lint run


### PR DESCRIPTION
Because `golangci/golangci-lint` provides its own Docker image, this is pretty easy to slot into Concourse. [Here's some example output in a failed job](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:dev:lint/jobs/lint/builds/3), for absolutely no effort put into linter configuration.

Obviously we wouldn't merge this without first fixing the issues, but what do we think?