### PR TITLE
Cluster: add mirrors concept

### DIFF
--- a/hub/check_disk_space_test.go
+++ b/hub/check_disk_space_test.go
@@ -46,11 +46,9 @@ func TestCheckDiskSpace(t *testing.T) {
 	}
 
 	t.Run("reports no failures with enough space", func(t *testing.T) {
-		c = &utils.Cluster{
-			Cluster: cluster.NewCluster([]cluster.SegConfig{
-				{ContentID: -1, Hostname: "mdw", DataDir: "/data/master"},
-			}),
-		}
+		c = MustCreateCluster(t, []cluster.SegConfig{
+			{ContentID: -1, Hostname: "mdw", DataDir: "/data/master", Role: "p"},
+		})
 		req = &idl.CheckDiskSpaceRequest{Ratio: 0.25}
 		// leave agents empty
 
@@ -58,11 +56,9 @@ func TestCheckDiskSpace(t *testing.T) {
 	})
 
 	t.Run("reports disk failures for the master host", func(t *testing.T) {
-		c = &utils.Cluster{
-			Cluster: cluster.NewCluster([]cluster.SegConfig{
-				{ContentID: -1, Hostname: "mdw", DataDir: "/data/master"},
-			}),
-		}
+		c = MustCreateCluster(t, []cluster.SegConfig{
+			{ContentID: -1, Hostname: "mdw", DataDir: "/data/master", Role: "p"},
+		})
 		req = &idl.CheckDiskSpaceRequest{Ratio: 0.75}
 		// leave agents empty
 
@@ -78,14 +74,12 @@ func TestCheckDiskSpace(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		c = &utils.Cluster{
-			Cluster: cluster.NewCluster([]cluster.SegConfig{
-				{ContentID: -1, Hostname: "mdw", DataDir: "/data/master"},
-				{ContentID: 0, Hostname: "sdw1", DataDir: "/data/primary"},
-				{ContentID: 1, Hostname: "sdw2", DataDir: "/data/primary"},
-				{ContentID: 2, Hostname: "sdw2", DataDir: "/data/primary2"},
-			}),
-		}
+		c = MustCreateCluster(t, []cluster.SegConfig{
+			{ContentID: -1, Hostname: "mdw", DataDir: "/data/master", Role: "p"},
+			{ContentID: 0, Hostname: "sdw1", DataDir: "/data/primary", Role: "p"},
+			{ContentID: 1, Hostname: "sdw2", DataDir: "/data/primary", Role: "p"},
+			{ContentID: 2, Hostname: "sdw2", DataDir: "/data/primary2", Role: "p"},
+		})
 		req = &idl.CheckDiskSpaceRequest{Ratio: 0.25}
 
 		// The usage descriptor returned by each mock agent. All we care is that
@@ -130,12 +124,10 @@ func TestCheckDiskSpace(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		c = &utils.Cluster{
-			Cluster: cluster.NewCluster([]cluster.SegConfig{
-				{ContentID: -1, Hostname: "mdw", DataDir: "/data/master"},
-				{ContentID: 0, Hostname: "sdw1", DataDir: "/data/primary"},
-			}),
-		}
+		c = MustCreateCluster(t, []cluster.SegConfig{
+			{ContentID: -1, Hostname: "mdw", DataDir: "/data/master", Role: "p"},
+			{ContentID: 0, Hostname: "sdw1", DataDir: "/data/primary", Role: "p"},
+		})
 		d.err = errors.New("master disk check is broken")
 		// we don't care what req is for this case
 

--- a/hub/common_test.go
+++ b/hub/common_test.go
@@ -3,8 +3,11 @@ package hub
 import (
 	"io"
 	"io/ioutil"
+	"testing"
 
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
+	"github.com/greenplum-db/gpupgrade/utils"
+	"github.com/greenplum-db/gpupgrade/utils/cluster"
 )
 
 // Set it to nil so we don't accidentally execute a command for real during tests
@@ -49,4 +52,17 @@ type failingWriter struct {
 
 func (f *failingWriter) Write(_ []byte) (int, error) {
 	return 0, f.err
+}
+
+// MustCreateCluster creates a utils.Cluster and calls t.Fatalf() if there is
+// any error.
+func MustCreateCluster(t *testing.T, segs []cluster.SegConfig) *utils.Cluster {
+	t.Helper()
+
+	cluster, err := cluster.NewCluster(segs)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	return &utils.Cluster{Cluster: cluster}
 }

--- a/hub/finalize.go
+++ b/hub/finalize.go
@@ -59,7 +59,7 @@ func ClonePortsFromCluster(db *sql.DB, src *cluster.Cluster) (err error) {
 	}
 
 	for _, content := range src.ContentIDs {
-		port := src.Segments[content].Port
+		port := src.Primaries[content].Port
 		res, err := tx.Exec("UPDATE gp_segment_configuration SET port = $1 WHERE content = $2",
 			port, content)
 		if err != nil {
@@ -169,7 +169,7 @@ func sanityCheckContentIDs(tx *sql.Tx, src *cluster.Cluster) error {
 		return xerrors.Errorf("iterating over segment configuration: %w", err)
 	}
 
-	if !contentsMatch(src.Segments, contents) {
+	if !contentsMatch(src.Primaries, contents) {
 		return newContentMismatchError(src.ContentIDs, contents)
 	}
 

--- a/hub/init_target_cluster.go
+++ b/hub/init_target_cluster.go
@@ -165,7 +165,7 @@ func WriteSegmentArray(config []string, source *utils.Cluster, ports []uint32) (
 		if content == -1 {
 			continue
 		}
-		segment := source.Segments[content]
+		segment := source.Primaries[content]
 		segmentsByHost[segment.Hostname] = append(segmentsByHost[segment.Hostname], segment)
 	}
 
@@ -205,7 +205,7 @@ func WriteSegmentArray(config []string, source *utils.Cluster, ports []uint32) (
 		}
 	}
 
-	master, ok := source.Segments[-1]
+	master, ok := source.Primaries[-1]
 	if !ok {
 		return nil, 0, errors.New("old cluster contains no master segment")
 	}

--- a/hub/start_or_stop_cluster_test.go
+++ b/hub/start_or_stop_cluster_test.go
@@ -5,8 +5,6 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/greenplum-db/gp-common-go-libs/dbconn"
-
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
 	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/greenplum-db/gpupgrade/utils/cluster"
@@ -34,13 +32,11 @@ func init() {
 func TestStartOrStopCluster(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	var source *utils.Cluster
-	cluster := cluster.NewCluster([]cluster.SegConfig{cluster.SegConfig{ContentID: -1, DbID: 1, Port: 15432, Hostname: "localhost", DataDir: "basedir/seg-1"}})
-	source = &utils.Cluster{
-		Cluster: cluster,
-		BinDir:  "/source/bindir",
-		Version: dbconn.GPDBVersion{},
-	}
+	source := MustCreateCluster(t, []cluster.SegConfig{
+		{ContentID: -1, DbID: 1, Port: 15432, Hostname: "localhost", DataDir: "basedir/seg-1", Role: "p"},
+	})
+	source.BinDir = "/source/bindir"
+
 	utils.System.RemoveAll = func(s string) error { return nil }
 	utils.System.MkdirAll = func(s string, perm os.FileMode) error { return nil }
 

--- a/hub/upgrade_master_test.go
+++ b/hub/upgrade_master_test.go
@@ -86,19 +86,10 @@ func init() {
 }
 
 func TestUpgradeMaster(t *testing.T) {
-	source := &utils.Cluster{
-		BinDir: "/old/bin",
-		Cluster: &cluster.Cluster{
-			ContentIDs: []int{-1},
-			Segments: map[int]cluster.SegConfig{
-				-1: cluster.SegConfig{
-					Port:    5432,
-					DataDir: "/data/old",
-					DbID:    1,
-				},
-			},
-		},
-	}
+	source := MustCreateCluster(t, []cluster.SegConfig{
+		{ContentID: -1, Port: 5432, DataDir: "/data/old", DbID: 1, Role: "p"},
+	})
+	source.BinDir = "/old/bin"
 
 	t.Run("masterSegmentFromCluster() creates a correct upgrade segment", func(t *testing.T) {
 		seg := masterSegmentFromCluster(source)
@@ -122,19 +113,10 @@ func TestUpgradeMaster(t *testing.T) {
 	// output streams are hooked up correctly, then defer to the acceptance
 	// tests for full end-to-end verification.
 
-	target := &utils.Cluster{
-		BinDir: "/new/bin",
-		Cluster: &cluster.Cluster{
-			ContentIDs: []int{-1},
-			Segments: map[int]cluster.SegConfig{
-				-1: cluster.SegConfig{
-					Port:    5433,
-					DataDir: "/data/new",
-					DbID:    2,
-				},
-			},
-		},
-	}
+	target := MustCreateCluster(t, []cluster.SegConfig{
+		{ContentID: -1, Port: 5433, DataDir: "/data/new", DbID: 2, Role: "p"},
+	})
+	target.BinDir = "/new/bin"
 
 	// We need a real temporary directory to change to. Replace MkdirAll() so
 	// that we can make sure the directory is the correct one.

--- a/hub/upgrade_primaries.go
+++ b/hub/upgrade_primaries.go
@@ -70,8 +70,8 @@ func (s *Server) GetDataDirPairs() (map[string][]*idl.DataDirPair, error) {
 		if contentID == -1 {
 			continue
 		}
-		sourceSeg := s.Source.Segments[contentID]
-		targetSeg := s.Target.Segments[contentID]
+		sourceSeg := s.Source.Primaries[contentID]
+		targetSeg := s.Target.Primaries[contentID]
 		if sourceSeg.Hostname != targetSeg.Hostname {
 			return nil, fmt.Errorf("hostnames do not match between old and new cluster with content ID %d. Found old cluster hostname: '%s', and new cluster hostname: '%s'", contentID, sourceSeg.Hostname, targetSeg.Hostname)
 		}

--- a/hub/upgrade_primaries_test.go
+++ b/hub/upgrade_primaries_test.go
@@ -15,23 +15,22 @@ import (
 
 var _ = Describe("GetDataDirPairs", func() {
 	It("returns an error if new config does not contain all the same content as the old config", func() {
-		target.Cluster = &cluster.Cluster{
-			ContentIDs: []int{0},
-			Segments: map[int]cluster.SegConfig{
-				0: newSegment(0, "localhost", "new/datadir1", 11),
-			},
-		}
+		var err error
+		target.Cluster, err = cluster.NewCluster([]cluster.SegConfig{
+			{ContentID: 0, Hostname: "localhost", DataDir: "new/datadir1", Port: 11, Role: "p"},
+		})
+		Expect(err).NotTo(HaveOccurred())
 
-		_, err := testHub.GetDataDirPairs()
+		_, err = testHub.GetDataDirPairs()
 
 		Expect(err).To(HaveOccurred())
 		Expect(mockAgent.NumberOfCalls()).To(Equal(0))
 	})
 
 	It("returns an error if the content matches, but the hostname does not", func() {
-		differentSeg := target.Segments[0]
+		differentSeg := target.Primaries[0]
 		differentSeg.Hostname = "localhost2"
-		target.Segments[0] = differentSeg
+		target.Primaries[0] = differentSeg
 
 		_, err := testHub.GetDataDirPairs()
 
@@ -42,24 +41,24 @@ var _ = Describe("GetDataDirPairs", func() {
 
 var _ = Describe("UpgradePrimaries", func() {
 	It("returns nil error, and agent receives only expected segmentConfig values", func() {
-		seg1 := target.Segments[0]
+		seg1 := target.Primaries[0]
 		seg1.DataDir = filepath.Join(dir, "seg1_upgrade")
 		seg1.Port = 27432
-		target.Segments[0] = seg1
+		target.Primaries[0] = seg1
 
-		seg2 := target.Segments[1]
+		seg2 := target.Primaries[1]
 		seg2.DataDir = filepath.Join(dir, "seg2_upgrade")
 		seg2.Port = 27433
 
 		// Set up both segments to be on the same host (but still distinct from
 		// the master host).
 		seg2.Hostname = seg1.Hostname
-		target.Segments[1] = seg2
+		target.Primaries[1] = seg2
 
 		// Source hostnames must match the target.
-		sourceSeg2 := source.Segments[1]
+		sourceSeg2 := source.Primaries[1]
 		sourceSeg2.Hostname = seg2.Hostname
-		source.Segments[1] = sourceSeg2
+		source.Primaries[1] = sourceSeg2
 
 		agentConns, _ := testHub.AgentConns()
 		dataDirPairMap, _ := testHub.GetDataDirPairs()
@@ -102,12 +101,3 @@ var _ = Describe("UpgradePrimaries", func() {
 		Expect(mockAgent.NumberOfCalls()).To(Equal(2))
 	})
 })
-
-func newSegment(content int, hostname, dataDir string, port int) cluster.SegConfig {
-	return cluster.SegConfig{
-		ContentID: content,
-		Hostname:  hostname,
-		DataDir:   dataDir,
-		Port:      port,
-	}
-}

--- a/testutils/sql.go
+++ b/testutils/sql.go
@@ -1,6 +1,8 @@
 package testutils
 
 import (
+	"fmt"
+
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
@@ -14,9 +16,9 @@ import (
 // When changing this implementation, make sure you change MockCluster() to
 // match!
 func MockSegmentConfiguration() *sqlmock.Rows {
-	rows := sqlmock.NewRows([]string{"dbid", "contentid", "port", "hostname", "datadir"})
-	rows.AddRow(1, -1, 15432, "mdw", "/data/master/gpseg-1")
-	rows.AddRow(2, 0, 25432, "sdw1", "/data/primary/gpseg0")
+	rows := sqlmock.NewRows([]string{"dbid", "contentid", "port", "hostname", "datadir", "role"})
+	rows.AddRow(1, -1, 15432, "mdw", "/data/master/gpseg-1", "p")
+	rows.AddRow(2, 0, 25432, "sdw1", "/data/primary/gpseg0", "p")
 
 	return rows
 }
@@ -26,13 +28,16 @@ func MockSegmentConfiguration() *sqlmock.Rows {
 // When changing this implementation, make sure you change
 // MockSegmentConfiguration() to match!
 func MockCluster() *cluster.Cluster {
-	return &cluster.Cluster{
-		ContentIDs: []int{-1, 0},
-		Segments: map[int]cluster.SegConfig{
-			-1: {DbID: 1, ContentID: -1, Port: 15432, Hostname: "mdw", DataDir: "/data/master/gpseg-1"},
-			0:  {DbID: 2, ContentID: 0, Port: 25432, Hostname: "sdw1", DataDir: "/data/primary/gpseg0"},
-		},
+	c, err := cluster.NewCluster([]cluster.SegConfig{
+		{DbID: 1, ContentID: -1, Port: 15432, Hostname: "mdw", DataDir: "/data/master/gpseg-1", Role: "p"},
+		{DbID: 2, ContentID: 0, Port: 25432, Hostname: "sdw1", DataDir: "/data/primary/gpseg0", Role: "p"},
+	})
+
+	if err != nil {
+		panic(fmt.Sprintf("unexpected error %+v", err))
 	}
+
+	return c
 }
 
 // CreateMockDBConn is just like testhelper.CreateAndConnectMockDB(), but it

--- a/testutils/test_utils.go
+++ b/testutils/test_utils.go
@@ -55,7 +55,7 @@ func Check(msg string, e error) {
 func CreateMultinodeSampleCluster(baseDir string) *cluster.Cluster {
 	return &cluster.Cluster{
 		ContentIDs: []int{-1, 0, 1},
-		Segments: map[int]cluster.SegConfig{
+		Primaries: map[int]cluster.SegConfig{
 			-1: cluster.SegConfig{ContentID: -1, DbID: 1, Port: 15432, Hostname: "localhost", DataDir: baseDir + "/seg-1"},
 			0:  cluster.SegConfig{ContentID: 0, DbID: 2, Port: 25432, Hostname: "host1", DataDir: baseDir + "/seg1"},
 			1:  cluster.SegConfig{ContentID: 1, DbID: 3, Port: 25433, Hostname: "host2", DataDir: baseDir + "/seg2"},
@@ -66,7 +66,7 @@ func CreateMultinodeSampleCluster(baseDir string) *cluster.Cluster {
 func CreateSampleCluster(contentID int, port int, hostname string, datadir string) *cluster.Cluster {
 	return &cluster.Cluster{
 		ContentIDs: []int{contentID},
-		Segments: map[int]cluster.SegConfig{
+		Primaries: map[int]cluster.SegConfig{
 			contentID: cluster.SegConfig{ContentID: contentID, Port: port, Hostname: hostname, DataDir: datadir},
 		},
 	}
@@ -81,15 +81,6 @@ func CreateMultinodeSampleClusterPair(baseDir string) (*utils.Cluster, *utils.Cl
 func CreateSampleClusterPair() (*utils.Cluster, *utils.Cluster) {
 	sourceCluster := CreateSampleCluster(-1, 25437, "hostone", "/source/datadir")
 	targetCluster := CreateSampleCluster(-1, 35437, "hosttwo", "/target/datadir")
-	return assembleClusters("/tmp", sourceCluster, targetCluster)
-}
-
-func InitClusterPairFromDB() (*utils.Cluster, *utils.Cluster) {
-	conn := dbconn.NewDBConnFromEnvironment("postgres")
-	conn.MustConnect(1)
-	segConfig := cluster.MustGetSegmentConfiguration(conn)
-	sourceCluster := cluster.NewCluster(segConfig)
-	targetCluster := cluster.NewCluster(segConfig)
 	return assembleClusters("/tmp", sourceCluster, targetCluster)
 }
 

--- a/utils/cluster/cluster_test.go
+++ b/utils/cluster/cluster_test.go
@@ -8,55 +8,151 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/utils/cluster"
 )
 
 func TestCluster(t *testing.T) {
-	segments := map[int]cluster.SegConfig{
-		-1: cluster.SegConfig{DbID: 1, ContentID: -1, Port: 5432, Hostname: "localhost", DataDir: "/data/gpseg-1"},
-		0:  cluster.SegConfig{DbID: 2, ContentID: 0, Port: 20000, Hostname: "localhost", DataDir: "/data/gpseg0"},
-		2:  cluster.SegConfig{DbID: 4, ContentID: 2, Port: 20002, Hostname: "localhost", DataDir: "/data/gpseg2"},
-		3:  cluster.SegConfig{DbID: 5, ContentID: 3, Port: 20003, Hostname: "remotehost2", DataDir: "/data/gpseg3"},
+	primaries := map[int]cluster.SegConfig{
+		-1: {DbID: 1, ContentID: -1, Port: 5432, Hostname: "localhost", DataDir: "/data/gpseg-1"},
+		0:  {DbID: 2, ContentID: 0, Port: 20000, Hostname: "localhost", DataDir: "/data/gpseg0"},
+		2:  {DbID: 4, ContentID: 2, Port: 20002, Hostname: "localhost", DataDir: "/data/gpseg2"},
+		3:  {DbID: 5, ContentID: 3, Port: 20003, Hostname: "remotehost2", DataDir: "/data/gpseg3"},
 	}
-	master := segments[-1]
+	for content, seg := range primaries {
+		seg.Role = cluster.PrimaryRole
+		primaries[content] = seg
+	}
+
+	mirrors := map[int]cluster.SegConfig{
+		-1: {DbID: 8, ContentID: -1, Port: 5433, Hostname: "localhost", DataDir: "/mirror/gpseg-1"},
+		0:  {DbID: 3, ContentID: 0, Port: 20001, Hostname: "localhost", DataDir: "/mirror/gpseg0"},
+		2:  {DbID: 6, ContentID: 2, Port: 20004, Hostname: "localhost", DataDir: "/mirror/gpseg2"},
+		3:  {DbID: 7, ContentID: 3, Port: 20005, Hostname: "remotehost2", DataDir: "/mirror/gpseg3"},
+	}
+	for content, seg := range mirrors {
+		seg.Role = cluster.MirrorRole
+		mirrors[content] = seg
+	}
+
+	master := primaries[-1]
+	standby := mirrors[-1]
 
 	cases := []struct {
-		name     string
-		segments []cluster.SegConfig
+		name      string
+		primaries []cluster.SegConfig
+		mirrors   []cluster.SegConfig
 	}{
-		{"single-host, single-segment", []cluster.SegConfig{master, segments[0]}},
-		{"single-host, multi-segment", []cluster.SegConfig{master, segments[0], segments[2]}},
-		{"multi-host, multi-segment", []cluster.SegConfig{master, segments[0], segments[3]}},
+		{"mirrorless single-host, single-segment", []cluster.SegConfig{master, primaries[0]}, nil},
+		{"mirrorless single-host, multi-segment", []cluster.SegConfig{master, primaries[0], primaries[2]}, nil},
+		{"mirrorless multi-host, multi-segment", []cluster.SegConfig{master, primaries[0], primaries[3]}, nil},
+		{"single-host, single-segment",
+			[]cluster.SegConfig{master, primaries[0]},
+			[]cluster.SegConfig{mirrors[0]},
+		},
+		{"single-host, multi-segment",
+			[]cluster.SegConfig{master, primaries[0], primaries[2]},
+			[]cluster.SegConfig{mirrors[0], mirrors[2]},
+		},
+		{"multi-host, multi-segment",
+			[]cluster.SegConfig{master, primaries[0], primaries[3]},
+			[]cluster.SegConfig{mirrors[0], mirrors[3]},
+		},
+		{"multi-host, multi-segment with standby",
+			[]cluster.SegConfig{master, primaries[0], primaries[3]},
+			[]cluster.SegConfig{standby, mirrors[0], mirrors[3]},
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%s cluster", c.name), func(t *testing.T) {
-			cluster := cluster.NewCluster(c.segments)
+			segments := append(c.primaries, c.mirrors...)
+
+			cluster, err := cluster.NewCluster(segments)
+			if err != nil {
+				t.Fatalf("returned error %+v", err)
+			}
 
 			actualContents := cluster.GetContentList()
 
 			var expectedContents []int
-			for _, seg := range c.segments {
-				expectedContents = append(expectedContents, seg.ContentID)
+			for _, p := range c.primaries {
+				expectedContents = append(expectedContents, p.ContentID)
 			}
 
 			if !reflect.DeepEqual(actualContents, expectedContents) {
-				t.Errorf("had contents %v, want %v", actualContents, expectedContents)
+				t.Errorf("GetContentList() = %v, want %v", actualContents, expectedContents)
 			}
 
-			for _, expected := range c.segments {
+			for _, expected := range c.primaries {
 				content := expected.ContentID
 
-				actual := cluster.Segments[content]
+				actual := cluster.Primaries[content]
 				if actual != expected {
-					t.Errorf("had segment[%d] = %+v, want %+v", content, actual, expected)
+					t.Errorf("Primaries[%d] = %+v, want %+v", content, actual, expected)
 				}
 
-				actualHost := cluster.GetHostForContent(content)
-				if actualHost != expected.Hostname {
-					t.Errorf("had hostname[%d] = %q, want %q", content, actualHost, expected.Hostname)
+				host := cluster.GetHostForContent(content)
+				if host != expected.Hostname {
+					t.Errorf("GetHostForContent(%d) = %q, want %q", content, host, expected.Hostname)
 				}
+
+				port := cluster.GetPortForContent(content)
+				if port != expected.Port {
+					t.Errorf("GetPortForContent(%d) = %d, want %d", content, port, expected.Port)
+				}
+
+				dbid := cluster.GetDbidForContent(content)
+				if dbid != expected.DbID {
+					t.Errorf("GetDbidForContent(%d) = %d, want %d", content, dbid, expected.DbID)
+				}
+
+				datadir := cluster.GetDirForContent(content)
+				if datadir != expected.DataDir {
+					t.Errorf("GetDirForContent(%d) = %q, want %q", content, datadir, expected.DataDir)
+				}
+			}
+
+			for _, expected := range c.mirrors {
+				content := expected.ContentID
+
+				actual := cluster.Mirrors[content]
+				if actual != expected {
+					t.Errorf("Mirrors[%d] = %+v, want %+v", content, actual, expected)
+				}
+			}
+		})
+	}
+
+	errCases := []struct {
+		name     string
+		segments []cluster.SegConfig
+	}{
+		{"bad role", []cluster.SegConfig{
+			{Role: "x"},
+		}},
+		{"mirror without primary", []cluster.SegConfig{
+			{ContentID: 0, Role: "p"},
+			{ContentID: 1, Role: "m"},
+		}},
+		{"duplicated primary contents", []cluster.SegConfig{
+			{ContentID: 0, Role: "p"},
+			{ContentID: 0, Role: "p"},
+		}},
+		{"duplicated mirror contents", []cluster.SegConfig{
+			{ContentID: 0, Role: "p"},
+			{ContentID: 0, Role: "m"},
+			{ContentID: 0, Role: "m"},
+		}},
+	}
+
+	for _, c := range errCases {
+		t.Run(fmt.Sprintf("doesn't allow %s", c.name), func(t *testing.T) {
+			_, err := cluster.NewCluster(c.segments)
+
+			if !xerrors.Is(err, cluster.ErrInvalidSegments) {
+				t.Errorf("returned error %#v, want %#v", err, cluster.ErrInvalidSegments)
 			}
 		})
 	}

--- a/utils/cluster_test.go
+++ b/utils/cluster_test.go
@@ -56,22 +56,22 @@ var _ = Describe("Cluster", func() {
 		It("maps all hosts to segment configurations", func() {
 			segments, err := expectedCluster.SegmentsOn("host1")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(segments).To(Equal([]cluster.SegConfig{expectedCluster.Segments[0]}))
+			Expect(segments).To(Equal([]cluster.SegConfig{expectedCluster.Primaries[0]}))
 
 			segments, err = expectedCluster.SegmentsOn("host2")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(segments).To(Equal([]cluster.SegConfig{expectedCluster.Segments[1]}))
+			Expect(segments).To(Equal([]cluster.SegConfig{expectedCluster.Primaries[1]}))
 
 			segments, err = expectedCluster.SegmentsOn("localhost")
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("groups all segments by hostname", func() {
-			seg1 := expectedCluster.Segments[1]
+			seg1 := expectedCluster.Primaries[1]
 			seg1.Hostname = "host1"
-			expectedCluster.Segments[1] = seg1
+			expectedCluster.Primaries[1] = seg1
 
-			expected := []cluster.SegConfig{expectedCluster.Segments[0], expectedCluster.Segments[1]}
+			expected := []cluster.SegConfig{expectedCluster.Primaries[0], expectedCluster.Primaries[1]}
 			segments, err := expectedCluster.SegmentsOn("host1")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(segments).To(ConsistOf(expected))


### PR DESCRIPTION
Support mirrors in our `Cluster` structs:
- `Cluster.Mirrors` maps content IDs to mirror configurations.
- `Cluster.Segments` is now `Cluster.Primaries`.
- `SegConfig` has a required `Role` member (set to either `"p"` or `"m"`).
- The master and standby are treated as a special-case primary and mirror, respectively.

Per-commit review is encouraged. Roadmap:
- migrate `cluster` tests from Ginkgo to table-driven Go style
- make the change to the `Cluster` API
- make the downstream changes necessary to consume the new API