### PR TITLE
Add verbose flag to finalize

### DIFF
--- a/cli/bash/bash-completion.sh
+++ b/cli/bash/bash-completion.sh
@@ -320,6 +320,9 @@ _gpupgrade_finalize()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--verbose")
+    flags+=("-v")
+    local_nonpersistent_flags+=("--verbose")
 
     must_have_one_flag=()
     must_have_one_noun=()

--- a/cli/commanders/steps.go
+++ b/cli/commanders/steps.go
@@ -108,7 +108,7 @@ If you would like to return the cluster to its original state, run
 	return nil
 }
 
-func Finalize(client idl.CliToHubClient) error {
+func Finalize(client idl.CliToHubClient, verbose bool) error {
 	fmt.Println()
 	fmt.Println("Finalize in progress.")
 	fmt.Println()
@@ -119,7 +119,7 @@ func Finalize(client idl.CliToHubClient) error {
 		return err
 	}
 
-	err = UILoop(stream, false)
+	err = UILoop(stream, verbose)
 	if err != nil {
 		return xerrors.Errorf("Finalize: %w", err)
 	}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -56,7 +56,7 @@ func BuildRootCommand() *cobra.Command {
 	root.AddCommand(config, version)
 	root.AddCommand(initialize())
 	root.AddCommand(execute())
-	root.AddCommand(finalize)
+	root.AddCommand(finalize())
 	root.AddCommand(restartServices)
 	root.AddCommand(killServices)
 	root.AddCommand(Agent())
@@ -364,21 +364,29 @@ This step can be reverted.
 	return cmd
 }
 
-var finalize = &cobra.Command{
-	Use:   "finalize",
-	Short: "finalizes the cluster after upgrade execution",
-	Long: `
+func finalize() *cobra.Command {
+	var verbose bool
+
+	cmd := &cobra.Command{
+		Use:   "finalize",
+		Short: "finalizes the cluster after upgrade execution",
+		Long: `
 Updates the port of the new cluster.
 This step can not be reverted.
 `,
-	Run: func(cmd *cobra.Command, args []string) {
-		client := connectToHub()
-		err := commanders.Finalize(client)
-		if err != nil {
-			gplog.Error(err.Error())
-			os.Exit(1)
-		}
-	},
+		Run: func(cmd *cobra.Command, args []string) {
+			client := connectToHub()
+			err := commanders.Finalize(client, verbose)
+			if err != nil {
+				gplog.Error(err.Error())
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "print the output stream from all substeps")
+
+	return cmd
 }
 
 func parsePorts(val string) ([]uint32, error) {


### PR DESCRIPTION
stream out output of subcommands using --verbose in finalize

```
  gpupgrade finalize [flags]

Flags:
  -h, --help      help for finalize
  -v, --verbose   print the output stream from all substeps



14:23 $ gpupgrade finalize --verbose

Finalize in progress.


Starting FINALIZE_UPGRADE_STANDBY...

Upgrading standby...                                               [IN PROGRESS]
20200221:14:23:53:014156 gpinitstandby:bhuvi:bhuvneshchaudhary-[ERROR]:-Request made to remove warm master standby, but no standby located.
20200221:14:23:53:014156 gpinitstandby:bhuvi:bhuvneshchaudhary-[ERROR]:-Error removing standby master: no standby configured
20200221:14:23:53:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Validating environment and parameters for standby initialization...
20200221:14:23:54:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Checking for data directory /Users/bhuvneshchaudhary/workspace/gpdb/gpAux/gpdemo/datadirs/standby_upgrade on bhuvi.attlocal.net
20200221:14:23:54:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:------------------------------------------------------
20200221:14:23:54:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Greenplum standby master initialization parameters
20200221:14:23:54:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:------------------------------------------------------
20200221:14:23:54:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Greenplum master hostname               = bhuvi.attlocal.net
20200221:14:23:54:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Greenplum master data directory         = /Users/bhuvneshchaudhary/workspace/gpdb/gpAux/gpdemo/datadirs/qddir_upgrade/demoDataDir-1
20200221:14:23:54:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Greenplum master port                   = 50432
20200221:14:23:54:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Greenplum standby master hostname       = bhuvi.attlocal.net
20200221:14:23:54:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Greenplum standby master port           = 50433
20200221:14:23:54:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Greenplum standby master data directory = /Users/bhuvneshchaudhary/workspace/gpdb/gpAux/gpdemo/datadirs/standby_upgrade
20200221:14:23:54:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Greenplum update system catalog         = On
20200221:14:23:54:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Syncing Greenplum Database extensions to standby
20200221:14:23:54:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-The packages on bhuvi.attlocal.net are consistent.
20200221:14:23:54:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Adding standby master to catalog...
20200221:14:23:54:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Database catalog updated successfully.
20200221:14:23:54:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Updating pg_hba.conf file...
20200221:14:23:55:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-pg_hba.conf files updated successfully.
20200221:14:23:56:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Starting standby master
20200221:14:23:56:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Checking if standby master is running on host: bhuvi.attlocal.net  in directory: /Users/bhuvneshchaudhary/workspace/gpdb/gpAux/gpdemo/datadirs/standby_upgrade
20200221:14:23:57:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Cleaning up pg_hba.conf backup files...
20200221:14:23:58:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Backup files of pg_hba.conf cleaned up successfully.
20200221:14:23:58:014161 gpinitstandby:bhuvi:bhuvneshchaudhary-[INFO]:-Successfully created standby master on bhuvi.attlocal.net
Upgrading standby...                                               [COMPLETE]

Starting FINALIZE_SHUTDOWN_TARGET_CLUSTER...

Stopping new cluster                                               [IN PROGRESS]
14099
20200221:14:23:58:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Starting gpstop with args: -a -d /Users/bhuvneshchaudhary/workspace/gpdb/gpAux/gpdemo/datadirs/qddir_upgrade/demoDataDir-1
20200221:14:23:58:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Gathering information and validating the environment...
20200221:14:23:58:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Obtaining Greenplum Master catalog information
20200221:14:23:58:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Obtaining Segment details from master...
20200221:14:23:58:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.3.0+dev.82.gae9dd076f9 build dev'
20200221:14:23:58:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Commencing Master instance shutdown with mode='smart'
20200221:14:23:58:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Master segment instance directory=/Users/bhuvneshchaudhary/workspace/gpdb/gpAux/gpdemo/datadirs/qddir_upgrade/demoDataDir-1
20200221:14:23:58:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Stopping master segment and waiting for user connections to finish ...
server shutting down
20200221:14:23:59:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Attempting forceful termination of any leftover master process
20200221:14:23:59:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Terminating processes for segment /Users/bhuvneshchaudhary/workspace/gpdb/gpAux/gpdemo/datadirs/qddir_upgrade/demoDataDir-1
20200221:14:23:59:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Stopping master standby host bhuvi.attlocal.net mode=fast
20200221:14:24:00:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Successfully shutdown standby process on bhuvi.attlocal.net
20200221:14:24:00:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Targeting dbid [2] for shutdown
20200221:14:24:00:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Commencing parallel segment instance shutdown, please wait...
20200221:14:24:00:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-0.00% of jobs completed
20200221:14:24:00:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-100.00% of jobs completed
20200221:14:24:00:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-----------------------------------------------------
20200221:14:24:00:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-   Segments stopped successfully      = 1
20200221:14:24:00:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-   Segments with errors during stop   = 0
20200221:14:24:00:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-----------------------------------------------------
20200221:14:24:00:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Successfully shutdown 1 of 1 segment instances
20200221:14:24:00:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Database successfully shutdown with no errors reported
20200221:14:24:00:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Cleaning up leftover gpmmon process
20200221:14:24:00:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-No leftover gpmmon process found
20200221:14:24:00:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Cleaning up leftover gpsmon processes
20200221:14:24:00:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-No leftover gpsmon processes on some hosts. not attempting forceful termination on these hosts
20200221:14:24:00:014309 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Cleaning up leftover shared memory
Stopping new cluster                                               [COMPLETE]

Starting FINALIZE_START_TARGET_MASTER...

Starting new master...                                             [IN PROGRESS]
20200221:14:24:01:014392 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Starting gpstart with args: -m -a -d /Users/bhuvneshchaudhary/workspace/gpdb/gpAux/gpdemo/datadirs/qddir_upgrade/demoDataDir-1
20200221:14:24:01:014392 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Gathering information and validating the environment...
20200221:14:24:01:014392 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Greenplum Binary Version: 'postgres (Greenplum Database) 6.3.0+dev.82.gae9dd076f9 build dev'
20200221:14:24:01:014392 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Greenplum Catalog Version: '301908232'
20200221:14:24:01:014392 gpstart:bhuvi:bhuvneshchaudhary-[WARNING]:-****************************************************************************
20200221:14:24:01:014392 gpstart:bhuvi:bhuvneshchaudhary-[WARNING]:-Master-only start requested. Disruptive action if standby master configured.
20200221:14:24:01:014392 gpstart:bhuvi:bhuvneshchaudhary-[WARNING]:-This is advisable only under the direct supervision of Greenplum support.
20200221:14:24:01:014392 gpstart:bhuvi:bhuvneshchaudhary-[WARNING]:-This mode of operation is not supported in a production environment and
20200221:14:24:01:014392 gpstart:bhuvi:bhuvneshchaudhary-[WARNING]:-may lead to a split-brain condition and possible unrecoverable data loss.
20200221:14:24:01:014392 gpstart:bhuvi:bhuvneshchaudhary-[WARNING]:-****************************************************************************
20200221:14:24:01:014392 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Starting Master instance in admin mode
20200221:14:24:01:014392 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Obtaining Greenplum Master catalog information
20200221:14:24:01:014392 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Obtaining Segment details from master...
20200221:14:24:01:014392 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Setting new master era
20200221:14:24:01:014392 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Master Started...
Starting new master...                                             [COMPLETE]

Starting FINALIZE_UPDATE_CATALOG_WITH_PORT...

Updating new master with port information...                       [IN PROGRESS]
Updating new master with port information...                       [COMPLETE]

Starting FINALIZE_SHUTDOWN_TARGET_MASTER...

Stopping new master...                                             [IN PROGRESS]
14400
20200221:14:24:02:014414 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Starting gpstop with args: -m -a -d /Users/bhuvneshchaudhary/workspace/gpdb/gpAux/gpdemo/datadirs/qddir_upgrade/demoDataDir-1
20200221:14:24:02:014414 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Gathering information and validating the environment...
20200221:14:24:02:014414 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Obtaining Greenplum Master catalog information
20200221:14:24:02:014414 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Obtaining Segment details from master...
20200221:14:24:02:014414 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.3.0+dev.82.gae9dd076f9 build dev'
20200221:14:24:02:014414 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Commencing Master instance shutdown with mode='smart'
20200221:14:24:02:014414 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Master segment instance directory=/Users/bhuvneshchaudhary/workspace/gpdb/gpAux/gpdemo/datadirs/qddir_upgrade/demoDataDir-1
20200221:14:24:02:014414 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Stopping master segment and waiting for user connections to finish ...
server shutting down
20200221:14:24:03:014414 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Attempting forceful termination of any leftover master process
20200221:14:24:03:014414 gpstop:bhuvi:bhuvneshchaudhary-[INFO]:-Terminating processes for segment /Users/bhuvneshchaudhary/workspace/gpdb/gpAux/gpdemo/datadirs/qddir_upgrade/demoDataDir-1
Stopping new master...                                             [COMPLETE]

Starting FINALIZE_UPDATE_POSTGRESQL_CONF...

Updating master postgreql.conf...                                  [IN PROGRESS]
Updating master postgreql.conf...                                  [COMPLETE]

Starting FINALIZE_START_TARGET_CLUSTER...

Starting new cluster...                                            [IN PROGRESS]
20200221:14:24:03:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Starting gpstart with args: -a -d /Users/bhuvneshchaudhary/workspace/gpdb/gpAux/gpdemo/datadirs/qddir_upgrade/demoDataDir-1
20200221:14:24:03:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Gathering information and validating the environment...
20200221:14:24:03:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Greenplum Binary Version: 'postgres (Greenplum Database) 6.3.0+dev.82.gae9dd076f9 build dev'
20200221:14:24:03:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Greenplum Catalog Version: '301908232'
20200221:14:24:03:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Starting Master instance in admin mode
20200221:14:24:03:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Obtaining Greenplum Master catalog information
20200221:14:24:03:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Obtaining Segment details from master...
20200221:14:24:03:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Setting new master era
20200221:14:24:03:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Master Started...
20200221:14:24:04:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Shutting down master
20200221:14:24:04:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Commencing parallel segment instance startup, please wait...
.
20200221:14:24:05:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Process results...
20200221:14:24:05:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-----------------------------------------------------
20200221:14:24:05:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-   Successful segment starts                                            = 1
20200221:14:24:05:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-   Failed segment starts                                                = 0
20200221:14:24:05:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-   Skipped segment starts (segments are marked down in configuration)   = 0
20200221:14:24:05:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-----------------------------------------------------
20200221:14:24:05:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Successfully started 1 of 1 segment instances
20200221:14:24:05:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-----------------------------------------------------
20200221:14:24:05:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Starting Master instance bhuvi.attlocal.net directory /Users/bhuvneshchaudhary/workspace/gpdb/gpAux/gpdemo/datadirs/qddir_upgrade/demoDataDir-1
20200221:14:24:06:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Command pg_ctl reports Master bhuvi.attlocal.net instance active
20200221:14:24:06:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Connecting to dbname='template1' connect_timeout=15
20200221:14:24:06:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Starting standby master
20200221:14:24:06:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Checking if standby master is running on host: bhuvi.attlocal.net  in directory: /Users/bhuvneshchaudhary/workspace/gpdb/gpAux/gpdemo/datadirs/standby_upgrade
20200221:14:24:06:014431 gpstart:bhuvi:bhuvneshchaudhary-[INFO]:-Database successfully started
Starting new cluster...                                            [COMPLETE]

The cluster is now upgraded and is ready to be used.
````