### PR TITLE
gpupgrade link-mode: pg_upgrade --check on master needs --link

### DIFF
--- a/hub/check_upgrade_test.go
+++ b/hub/check_upgrade_test.go
@@ -1,0 +1,131 @@
+package hub
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"google.golang.org/grpc"
+
+	"github.com/greenplum-db/gpupgrade/utils"
+)
+
+type upgraderMock struct {
+	s *Server
+}
+
+func (u upgraderMock) UpgradeMaster(args UpgradeMasterArgs) error {
+	return UpgradeMasterMock(args, u.s)
+}
+
+func (u upgraderMock) UpgradePrimaries(args UpgradePrimaryArgs) error {
+	return UpgradePrimariesMock(args, u.s)
+}
+
+type agentConnSourceMock struct {
+	conns []*Connection
+}
+
+func (a agentConnSourceMock) GetAgents(s *Server) ([]*Connection, error) {
+	return a.conns, nil
+}
+
+var agentsSource = agentConnSourceMock{[]*Connection{&Connection{Conn: nil, Hostname: "bengie"}}}
+
+func setUpgrader(updated UpgradeChecker) {
+	upgrader = updated
+}
+func resetUpgrader() {
+	upgrader = upgradeChecker{}
+}
+
+func setAgentProvider(agents AgentConnProvider) {
+	agentProvider = agents
+}
+func resetAgentProvider() {
+	agentProvider = agentConnProvider{}
+}
+
+func TestMasterIsCheckedLinkModeTrue(t *testing.T) {
+	setAgentProvider(agentsSource)
+	defer resetAgentProvider()
+
+	sourceCluster := MustCreateCluster(t, []utils.SegConfig{
+		{ContentID: -1, DbID: 1, Port: 15432, Hostname: "localhost", DataDir: "/data/qddir/seg-1", Role: "p", PreferredRole: "p"},
+		{ContentID: 0, DbID: 2, Port: 25432, Hostname: "host1", DataDir: "/data/dbfast1/seg1", Role: "p", PreferredRole: "p"},
+		{ContentID: 1, DbID: 3, Port: 25433, Hostname: "host2", DataDir: "/data/dbfast2/seg2", Role: "p", PreferredRole: "p"},
+	})
+	targetCluster := MustCreateCluster(t, []utils.SegConfig{
+		{ContentID: -1, DbID: 1, Port: 15432, Hostname: "localhost", DataDir: "/data/qddir/seg-1", Role: "p", PreferredRole: "p"},
+		{ContentID: 0, DbID: 2, Port: 25432, Hostname: "host1", DataDir: "/data/dbfast1/seg1", Role: "p", PreferredRole: "p"},
+		{ContentID: 1, DbID: 3, Port: 25433, Hostname: "host2", DataDir: "/data/dbfast2/seg2", Role: "p", PreferredRole: "p"},
+	})
+	var stateDirExpected = "/some/state/dir"
+
+	for _, linkMode := range []bool{true, false} {
+		t.Run(fmt.Sprintf("check upgrade correctly passes useLinkMode is %v", linkMode), func(t *testing.T) {
+			conf := &Config{
+				Source:      sourceCluster,
+				Target:      targetCluster,
+				UseLinkMode: linkMode,
+			}
+			s := New(conf, grpc.DialContext, stateDirExpected)
+			testUpgraderMock := upgraderMock{s}
+
+			setUpgrader(testUpgraderMock)
+			defer resetUpgrader()
+
+			err := s.CheckUpgrade(nil)
+			if err != nil {
+				t.Errorf("got error: %+v", err) // yes, '%+v'; '%#v' prints opaque multierror
+			}
+		})
+	}
+}
+
+func UpgradeMasterMock(result UpgradeMasterArgs, expected *Server) error {
+	if !reflect.DeepEqual(result.Source, expected.Source) {
+		return errors.New(fmt.Sprintf("got %#v, expected %#v", result.Source, expected.Source))
+	}
+	if !reflect.DeepEqual(result.Target, expected.Target) {
+		return errors.New(fmt.Sprintf("got %#v, expected %#v", result.Target, expected.Target))
+	}
+	if result.StateDir != expected.StateDir {
+		return errors.New(fmt.Sprintf("got %#v expected %#v", result.StateDir, expected.StateDir))
+	}
+	// does not seem worth testing stream right now
+	if result.CheckOnly != true {
+		return errors.New(fmt.Sprintf("got %#v expected %#v", result.CheckOnly, true))
+	}
+	if result.UseLinkMode != expected.UseLinkMode {
+		return errors.New(fmt.Sprintf("got %#v expected %#v", result.UseLinkMode, expected.UseLinkMode))
+	}
+	return nil
+}
+
+func UpgradePrimariesMock(result UpgradePrimaryArgs, expected *Server) error {
+	if result.CheckOnly != true {
+		return errors.New(fmt.Sprintf("got %#v expected %#v", result.CheckOnly, true))
+	}
+	if result.MasterBackupDir != "" {
+		return errors.New(fmt.Sprintf("got %#v expected %#v", result.MasterBackupDir, ""))
+	}
+	if !reflect.DeepEqual(result.AgentConns, agentsSource.conns) {
+		return errors.New(fmt.Sprintf("got %#v expected %#v", result.AgentConns, agentsSource.conns))
+	}
+	expectedDataDirs, _ := expected.GetDataDirPairs()
+	if !reflect.DeepEqual(result.DataDirPairMap, expectedDataDirs) {
+		return errors.New(fmt.Sprintf("got %#v expected %#v", result.DataDirPairMap, expectedDataDirs))
+	}
+	if !reflect.DeepEqual(result.Source, expected.Source) {
+		return errors.New(fmt.Sprintf("got %#v, expected %#v", result.Source, expected.Source))
+	}
+	if !reflect.DeepEqual(result.Target, expected.Target) {
+		return errors.New(fmt.Sprintf("got %#v, expected %#v", result.Target, expected.Target))
+	}
+	if result.UseLinkMode != expected.UseLinkMode {
+		return errors.New(fmt.Sprintf("got %#v expected %#v", result.UseLinkMode, expected.UseLinkMode))
+	}
+	return nil
+}

--- a/hub/execute.go
+++ b/hub/execute.go
@@ -39,7 +39,14 @@ func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_Execut
 
 	st.Run(idl.Substep_UPGRADE_MASTER, func(streams step.OutStreams) error {
 		stateDir := s.StateDir
-		return UpgradeMaster(s.Source, s.Target, stateDir, streams, false, s.UseLinkMode)
+		return UpgradeMaster(UpgradeMasterArgs{
+			Source:      s.Source,
+			Target:      s.Target,
+			StateDir:    stateDir,
+			Stream:      streams,
+			CheckOnly:   false,
+			UseLinkMode: s.UseLinkMode,
+		})
 	})
 
 	st.Run(idl.Substep_COPY_MASTER, func(streams step.OutStreams) error {
@@ -59,7 +66,15 @@ func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_Execut
 			return errors.Wrap(err, "failed to get old and new primary data directories")
 		}
 
-		return UpgradePrimaries(false, upgradedMasterBackupDir, agentConns, dataDirPair, s.Source, s.Target, s.UseLinkMode)
+		return UpgradePrimaries(UpgradePrimaryArgs{
+			CheckOnly:       false,
+			MasterBackupDir: upgradedMasterBackupDir,
+			AgentConns:      agentConns,
+			DataDirPairMap:  dataDirPair,
+			Source:          s.Source,
+			Target:          s.Target,
+			UseLinkMode:     s.UseLinkMode,
+		})
 	})
 
 	st.Run(idl.Substep_START_TARGET_CLUSTER, func(streams step.OutStreams) error {

--- a/hub/upgrade_master_test.go
+++ b/hub/upgrade_master_test.go
@@ -148,7 +148,14 @@ func TestUpgradeMaster(t *testing.T) {
 		SetRsyncExecCommand(exectest.NewCommand(Success))
 		defer ResetRsyncExecCommand()
 
-		err := UpgradeMaster(source, target, tempDir, DevNull, false, false)
+		err := UpgradeMaster(UpgradeMasterArgs{
+			Source:      source,
+			Target:      target,
+			StateDir:    tempDir,
+			Stream:      DevNull,
+			CheckOnly:   false,
+			UseLinkMode: false,
+		})
 		if err != nil {
 			t.Errorf("returned error %+v", err)
 		}
@@ -168,7 +175,14 @@ func TestUpgradeMaster(t *testing.T) {
 
 		stream := new(bufferedStreams)
 
-		err := UpgradeMaster(source, target, tempDir, stream, false, false)
+		err := UpgradeMaster(UpgradeMasterArgs{
+			Source:      source,
+			Target:      target,
+			StateDir:    tempDir,
+			Stream:      stream,
+			CheckOnly:   false,
+			UseLinkMode: false,
+		})
 		if err != nil {
 			t.Errorf("returned error %+v", err)
 		}
@@ -193,7 +207,14 @@ func TestUpgradeMaster(t *testing.T) {
 		defer ResetRsyncExecCommand()
 
 		expectedErr := errors.New("write failed!")
-		err := UpgradeMaster(source, target, tempDir, failingStreams{expectedErr}, false, false)
+		err := UpgradeMaster(UpgradeMasterArgs{
+			Source:      source,
+			Target:      target,
+			StateDir:    tempDir,
+			Stream:      failingStreams{expectedErr},
+			CheckOnly:   false,
+			UseLinkMode: false,
+		})
 		if !xerrors.Is(err, expectedErr) {
 			t.Errorf("returned error %+v, want %+v", err, expectedErr)
 		}
@@ -208,7 +229,14 @@ func TestUpgradeMaster(t *testing.T) {
 
 		stream := new(bufferedStreams)
 
-		err := UpgradeMaster(source, target, tempDir, stream, false, false)
+		err := UpgradeMaster(UpgradeMasterArgs{
+			Source:      source,
+			Target:      target,
+			StateDir:    tempDir,
+			Stream:      stream,
+			CheckOnly:   false,
+			UseLinkMode: false,
+		})
 		if err == nil {
 			t.Errorf("expected error, returned nil")
 		}

--- a/hub/upgrade_primaries_test.go
+++ b/hub/upgrade_primaries_test.go
@@ -91,7 +91,15 @@ func TestUpgradePrimaries(t *testing.T) {
 			{nil, client2, "sdw2", nil},
 		}
 
-		err := hub.UpgradePrimaries(false, "", agentConns, pairs, source, target, false)
+		err := hub.UpgradePrimaries(hub.UpgradePrimaryArgs{
+			CheckOnly:       false,
+			MasterBackupDir: "",
+			AgentConns:      agentConns,
+			DataDirPairMap:  pairs,
+			Source:          source,
+			Target:          target,
+			UseLinkMode:     false,
+		})
 		if err != nil {
 			t.Errorf("got unexpected error: %+v", err)
 		}
@@ -135,7 +143,15 @@ func TestUpgradePrimaries(t *testing.T) {
 			{nil, failedClient, "sdw2", nil},
 		}
 
-		err := hub.UpgradePrimaries(false, "", agentConns, pairs, source, target, false)
+		err := hub.UpgradePrimaries(hub.UpgradePrimaryArgs{
+			CheckOnly:       false,
+			MasterBackupDir: "",
+			AgentConns:      agentConns,
+			DataDirPairMap:  pairs,
+			Source:          source,
+			Target:          target,
+			UseLinkMode:     false,
+		})
 		if err == nil {
 			t.Fatal("expected error got nil")
 		}


### PR DESCRIPTION
The original PR adding link mode
(https://github.com/greenplum-db/gpupgrade/pull/177) did not throw the
--link mode flag for link-mode of gpupgrade.  However, according to the
documentation(https://www.postgresql.org/docs/9.4/pgupgrade.html), this
is necessary to enable link-mode specific tests.

Testing has been added.  The tests make sure that CheckUpgrade() passes
the correct arguments to the upgrade functions.

This commit also fixes a bug in CheckUpgrade() where it would
potentially deadlock filling up the error chan.  The previous code did
not fail fast, so could end up adding more than the 1 error into the
channel allocated to it.

I also collected the UpgradeMaster and UpgradePrimaries args(many) into an argument struct to make the code more readable.

This repeats the closed PR #214 but with tests added.