### PR TITLE
tweaks for help text for gpupgrade/initalize/execute/finalize

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -499,7 +499,7 @@ Initialize will carry out the following sub-steps:
  - Create directories
  - Generate upgrade configuration
  - Start gpupgrade hub process
- - Check source cluster configuration
+ - Retrieve source cluster configuration
  - Start gpupgrade agent processes
  - Check disk space
  - Generate target cluster configuration
@@ -508,7 +508,7 @@ Initialize will carry out the following sub-steps:
  - Back up target master
  - Run pg_upgrade checks
 
-Usage: gpupgrade initialize <flags> 
+Usage: gpupgrade initialize <flags>
 
 Required Flags:
 

--- a/cmd/gpupgrade/main.go
+++ b/cmd/gpupgrade/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"runtime/debug"
 
@@ -16,8 +15,6 @@ import (
 func main() {
 	setUpLogging()
 
-	confirmValidCommand()
-
 	root := commands.BuildRootCommand()
 	root.SilenceErrors = true // we'll print these ourselves
 
@@ -26,12 +23,6 @@ func main() {
 		// Use v to print the stack trace of an object errors.
 		fmt.Printf("\n%+v\n", err)
 		os.Exit(1)
-	}
-}
-
-func confirmValidCommand() {
-	if len(os.Args[1:]) < 1 {
-		log.Fatal("Please specify one command of: check, config, initialize, prepare, status, upgrade, or version")
 	}
 }
 

--- a/integrations/commands_test.go
+++ b/integrations/commands_test.go
@@ -1,7 +1,6 @@
 package integrations_test
 
 import (
-	"bytes"
 	"fmt"
 	"os/exec"
 
@@ -18,16 +17,31 @@ var _ = Describe("test gpupgrade help messages", func() {
 		"execute":    commands.ExecuteHelp,
 		"finalize":   commands.FinalizeHelp,
 	}
-	flagList := []string{"-?", "-h", "--help", "help"}
 
+	flagList := []string{"-?", "-h", "--help", "help"}
 	for command, help := range helpMap {
 		for _, flag := range flagList {
-			It(fmt.Sprintf("testing command %s with flag %s", command, flag), func() {
+			command := command
+			flag := flag
+			help := help
+
+			It(fmt.Sprintf("testing command %q with flag %q", command, flag), func() {
 				cmd := exec.Command("gpupgrade", command, flag)
+				if command == "" {
+					cmd = exec.Command("gpupgrade", flag)
+				}
 				output, err := cmd.Output()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(bytes.Compare(output, []byte(help))).To(BeZero())
+				Expect(string(output)).To(Equal(help))
 			})
 		}
 	}
+
+	It("testing command gpupgrade with no arguments", func() {
+		cmd := exec.Command("gpupgrade")
+		output, err := cmd.Output()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(output)).To(Equal(commands.GlobalHelp))
+	})
+
 })

--- a/test/args.bats
+++ b/test/args.bats
@@ -2,13 +2,6 @@
 
 load helpers
 
-@test "gpupgrade outputs help text when no params are given" {
-    run gpupgrade
-
-    [ "$status" -eq 1 ]
-    [[ "$output" = *"Please specify one command of: check, config, initialize, prepare, status, upgrade, or version"* ]]
-}
-
 @test "gpupgrade subcommands fail when passed insufficient arguments" {
     run gpupgrade initialize
     [ "$status" -eq 1 ]


### PR DESCRIPTION
This follow up to commit 12a1c9cd4bbdb1ee08b15212b43bc23b9de7454c
("Update help text for gpupgrade/initalize/execute/finalize")
tweaks the help output for "gpupgrade initialize" and outputs the
help message when "gpupgrade" is run without any additional
arguments.

Co-authored-by: Jacob Champion <pchampion@pivotal.io>