### PR TITLE
finalize: refactor port logic and init target cluster

### DIFF
--- a/hub/finalize.go
+++ b/hub/finalize.go
@@ -36,7 +36,7 @@ func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeSe
 			}
 
 			return UpgradeStandby(greenplumRunner, StandbyConfig{
-				Port:          s.TargetPorts.Standby,
+				Port:          s.TargetInitializeConfig.Standby.Port,
 				Hostname:      s.Source.StandbyHostname(),
 				DataDirectory: s.Source.StandbyDataDirectory() + "_upgrade",
 			})

--- a/hub/server.go
+++ b/hub/server.go
@@ -352,6 +352,12 @@ func (s *Server) closeAgentConns() {
 	}
 }
 
+type InitializeConfig struct {
+	Standby    utils.SegConfig
+	Master	   utils.SegConfig
+	Primaries  []utils.SegConfig
+}
+
 // Config contains all the information that will be persisted to/loaded from
 // from disk during calls to Save() and Load().
 type Config struct {
@@ -360,17 +366,11 @@ type Config struct {
 
 	// TargetPorts is the list of temporary ports to be used for the target
 	// cluster. It's assigned during initial configuration.
-	TargetPorts PortAssignments
+	TargetInitializeConfig InitializeConfig
 
 	Port        int
 	AgentPort   int
 	UseLinkMode bool
-}
-
-type PortAssignments struct {
-	Master    int
-	Standby   int
-	Primaries []int
 }
 
 func (c *Config) Load(r io.Reader) error {

--- a/hub/server_internal_test.go
+++ b/hub/server_internal_test.go
@@ -6,13 +6,15 @@ import (
 	"testing"
 
 	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/utils"
 )
 
 func TestConfig(t *testing.T) {
 	// "stream" refers to the io.Writer/Reader interfaces.
 	t.Run("saves itself to the provided stream", func(t *testing.T) {
 		source, target := testutils.CreateMultinodeSampleClusterPair("/tmp")
-		original := &Config{source, target, PortAssignments{15432, 15432, []int{25432}}, 12345, 54321, false}
+		targetInitializeConfig := InitializeConfig{Master: utils.SegConfig{Hostname: "mdw"}}
+		original := &Config{source, target, targetInitializeConfig, 12345, 54321, false}
 
 		buf := new(bytes.Buffer)
 		err := original.Save(buf)

--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Hub", func() {
 		agentA, mockDialer, hubToAgentPort = mock_agent.NewMockAgentServer()
 		source, target = testutils.CreateMultinodeSampleClusterPair("/tmp")
 		useLinkMode = false
-		conf = &hub.Config{source, target, hub.PortAssignments{50432, 50432, []int{50433}}, cliToHubPort, hubToAgentPort, useLinkMode}
+		conf = &hub.Config{source, target, hub.InitializeConfig{}, cliToHubPort, hubToAgentPort, useLinkMode}
 	})
 
 	AfterEach(func() {
@@ -189,7 +189,7 @@ var _ = Describe("Hub", func() {
 func TestHubSaveConfig(t *testing.T) {
 	source, target := testutils.CreateMultinodeSampleClusterPair("/tmp")
 	useLinkMode := false
-	conf := &hub.Config{source, target, hub.PortAssignments{50432, 50432, []int{50433}}, 12345, 54321, useLinkMode}
+	conf := &hub.Config{source, target, hub.InitializeConfig{}, 12345, 54321, useLinkMode}
 
 	h := hub.New(conf, nil, "")
 

--- a/hub/services_suite_test.go
+++ b/hub/services_suite_test.go
@@ -61,7 +61,7 @@ var _ = BeforeEach(func() {
 	mockAgent, dialer, port = mock_agent.NewMockAgentServer()
 	client = mock_idl.NewMockAgentClient(ctrl)
 	useLinkMode = false
-	conf := &hub.Config{source, target, hub.PortAssignments{50432, 50432, []int{50433}}, 0, port, useLinkMode}
+	conf := &hub.Config{source, target, hub.InitializeConfig{}, 0, port, useLinkMode}
 	testHub = hub.New(conf, dialer, dir)
 })
 

--- a/hub/upgrade_primaries_test.go
+++ b/hub/upgrade_primaries_test.go
@@ -177,7 +177,7 @@ func TestGetDataDirPairs(t *testing.T) {
 			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: utils.PrimaryRole, PreferredRole: utils.PrimaryRole},
 		})
 
-		conf := &hub.Config{source, target, hub.PortAssignments{50432, 50432, []int{50433}}, 0, port, useLinkMode}
+		conf := &hub.Config{source, target, hub.InitializeConfig{}, 0, port, useLinkMode}
 		server := hub.New(conf, nil, "")
 
 		_, err := server.GetDataDirPairs()
@@ -199,7 +199,7 @@ func TestGetDataDirPairs(t *testing.T) {
 			{ContentID: 2, DbID: 3, Hostname: "mdw", DataDir: "/data/dbfast2/seg2", Role: utils.PrimaryRole, PreferredRole: utils.PrimaryRole},
 		})
 
-		conf := &hub.Config{source, target, hub.PortAssignments{50432, 50432, []int{50433}}, 0, port, useLinkMode}
+		conf := &hub.Config{source, target, hub.InitializeConfig{}, 0, port, useLinkMode}
 		server := hub.New(conf, nil, "")
 
 		_, err := server.GetDataDirPairs()
@@ -221,7 +221,7 @@ func TestGetDataDirPairs(t *testing.T) {
 			{ContentID: 1, DbID: 3, Hostname: "localhost", DataDir: "/data/dbfast2/seg2", Role: utils.PrimaryRole, PreferredRole: utils.PrimaryRole},
 		})
 
-		conf := &hub.Config{source, target, hub.PortAssignments{50432, 50432, []int{50433}}, 0, port, useLinkMode}
+		conf := &hub.Config{source, target, hub.InitializeConfig{}, 0, port, useLinkMode}
 		server := hub.New(conf, nil, "")
 
 		_, err := server.GetDataDirPairs()

--- a/testutils/insert_target_config/main.go
+++ b/testutils/insert_target_config/main.go
@@ -45,6 +45,7 @@ func main() {
 	// populate the contents of target cluster to config
 	conn := dbconn.NewDBConnFromEnvironment("postgres")
 	config.Target, err = utils.ClusterFromDB(conn, binDir)
+	config.TargetInitializeConfig, err = hub.AssignDatadirsAndPorts(config.Source, []int{})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Introduce a new object called InitializeConfig. It is used to store
configuration for creating segments on the target cluster. We create a master,
standby and primaries based on the contents of this struct, and it is also
saved to the disk in config.json.

This refactor is done in preparation for finalize: upgrade mirrors https://github.com/greenplum-db/gpupgrade/pull/236