### PR TITLE
Enforce xerrors.Errorf as a preference.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,10 @@ format:
 
 # check runs all tests against the locally built gpupgrade binaries. Use -k to
 # continue after failures.
-check: check-ginkgo check-bats
+check: check-code-style check-ginkgo check-bats
 check-ginkgo check-bats: export PATH := $(CURDIR):$(PATH)
+check-code-style:
+	bats -t scripts/enforce-code-style.bats
 
 GINKGO_ARGS := -keepGoing -randomizeSuites -randomizeAllSpecs
 check-ginkgo:

--- a/agent/upgrade_primary.go
+++ b/agent/upgrade_primary.go
@@ -1,7 +1,7 @@
 package agent
 
 import (
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/upgrade"
@@ -11,7 +11,7 @@ func upgradeSegment(segment Segment, request *idl.UpgradePrimariesRequest, host 
 	err := restoreBackup(request, segment)
 
 	if err != nil {
-		return errors.Wrapf(err, "failed to restore master data directory backup on host %s for content id %d: %s",
+		return xerrors.Errorf("failed to restore master data directory backup on host %s for content id %d: %w",
 			host, segment.Content, err)
 	}
 
@@ -22,7 +22,7 @@ func upgradeSegment(segment Segment, request *idl.UpgradePrimariesRequest, host 
 		if request.CheckOnly {
 			failedAction = "check"
 		}
-		return errors.Wrapf(err, "failed to %s primary on host %s with content %d", failedAction, host, segment.Content)
+		return xerrors.Errorf("failed to %s primary on host %s with content %d: %w", failedAction, host, segment.Content, err)
 	}
 
 	return nil

--- a/cli/commanders/checks.go
+++ b/cli/commanders/checks.go
@@ -18,7 +18,7 @@ func RunPreChecks(client idl.CliToHubClient, ratio float64) error {
 	//TODO: when do we check this?  It requires the source cluster to be up.
 	//err := CheckVersion(client)
 	//if err != nil {
-	//	return errors.Wrap(err, "checking version compatibility")
+	//    return err
 	//}
 
 	return CheckDiskSpace(client, ratio)
@@ -30,7 +30,7 @@ func CheckVersion(client idl.CliToHubClient) (err error) {
 
 	resp, err := client.CheckVersion(context.Background(), &idl.CheckVersionRequest{})
 	if err != nil {
-		return errors.Wrap(err, "gRPC call to hub failed")
+		return xerrors.Errorf("gRPC call to hub failed: %w", err)
 	}
 	if !resp.IsVersionCompatible {
 		return errors.New("Version Compatibility Check Failed")

--- a/cli/commanders/steps.go
+++ b/cli/commanders/steps.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/pkg/errors"
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
@@ -52,7 +51,7 @@ var indicators = map[idl.Status]string{
 func Initialize(client idl.CliToHubClient, request *idl.InitializeRequest, verbose bool) (err error) {
 	stream, err := client.Initialize(context.Background(), request)
 	if err != nil {
-		return errors.Wrap(err, "initializing hub")
+		return xerrors.Errorf("initializing hub: %w", err)
 	}
 
 	err = UILoop(stream, verbose)
@@ -68,7 +67,7 @@ func InitializeCreateCluster(client idl.CliToHubClient, verbose bool) (err error
 		&idl.InitializeCreateClusterRequest{},
 	)
 	if err != nil {
-		return errors.Wrap(err, "initializing hub2")
+		return xerrors.Errorf("initializing hub2: %w", err)
 	}
 
 	err = UILoop(stream, verbose)

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -270,17 +270,17 @@ func initialize() *cobra.Command {
 
 			err = commanders.CreateStateDir()
 			if err != nil {
-				return errors.Wrap(err, "creating state directory")
+				return xerrors.Errorf("creating state directory: %w", err)
 			}
 
 			err = commanders.CreateInitialClusterConfigs()
 			if err != nil {
-				return errors.Wrap(err, "creating initial cluster configs")
+				return xerrors.Errorf("creating initial cluster configs: %w", err)
 			}
 
 			err = commanders.StartHub()
 			if err != nil {
-				return errors.Wrap(err, "starting hub")
+				return xerrors.Errorf("starting hub: %w", err)
 			}
 
 			client := connectToHub()
@@ -294,7 +294,7 @@ func initialize() *cobra.Command {
 			}
 			err = commanders.Initialize(client, request, verbose)
 			if err != nil {
-				return errors.Wrap(err, "initializing hub")
+				return xerrors.Errorf("initializing hub: %w", err)
 			}
 
 			err = commanders.RunPreChecks(client, diskFreeRatio)
@@ -308,7 +308,7 @@ func initialize() *cobra.Command {
 
 			err = commanders.InitializeCreateCluster(client, verbose)
 			if err != nil {
-				return errors.Wrap(err, "initializing cluster")
+				return xerrors.Errorf("initializing cluster: %w", err)
 			}
 
 			fmt.Println(`

--- a/hub/check_upgrade.go
+++ b/hub/check_upgrade.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/step"
 )
@@ -60,13 +60,13 @@ func (s *Server) CheckUpgrade(stream step.OutStreams) error {
 
 		conns, connsErr := agentProvider.GetAgents(s)
 		if connsErr != nil {
-			checkErrs <- errors.Wrap(connsErr, "failed to connect to gpupgrade agents")
+			checkErrs <- xerrors.Errorf("failed to connect to gpupgrade agents: %w", connsErr)
 			return
 		}
 
 		dataDirPairMap, dataDirPairsErr := s.GetDataDirPairs()
 		if dataDirPairsErr != nil {
-			checkErrs <- errors.Wrap(dataDirPairsErr, "failed to get old and new primary data directories")
+			checkErrs <- xerrors.Errorf("failed to get old and new primary data directories: %w", dataDirPairsErr)
 			return
 		}
 

--- a/hub/execute.go
+++ b/hub/execute.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
@@ -64,13 +63,13 @@ func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_Execut
 		agentConns, err := s.AgentConns()
 
 		if err != nil {
-			return errors.Wrap(err, "failed to connect to gpupgrade agent")
+			return xerrors.Errorf("failed to connect to gpupgrade agent: %w", err)
 		}
 
 		dataDirPair, err := s.GetDataDirPairs()
 
 		if err != nil {
-			return errors.Wrap(err, "failed to get old and new primary data directories")
+			return xerrors.Errorf("failed to get old and new primary data directories: %w", err)
 		}
 
 		return UpgradePrimaries(UpgradePrimaryArgs{

--- a/hub/fill_cluster_configs.go
+++ b/hub/fill_cluster_configs.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/db"
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -25,7 +26,7 @@ func (s *Server) FillClusterConfigsSubStep(config *Config, conn *sql.DB, _ step.
 	dbconn := db.NewDBConn("localhost", int(request.SourcePort), "template1")
 	source, err := utils.ClusterFromDB(dbconn, request.SourceBinDir)
 	if err != nil {
-		return errors.Wrap(err, "could not retrieve source configuration")
+		return xerrors.Errorf("could not retrieve source configuration: %w", err)
 	}
 
 	config.Source = source

--- a/hub/server.go
+++ b/hub/server.go
@@ -87,7 +87,7 @@ func (s *Server) MakeDaemon() {
 func (s *Server) Start() error {
 	lis, err := net.Listen("tcp", ":"+strconv.Itoa(s.Port))
 	if err != nil {
-		return errors.Wrap(err, "failed to listen")
+		return xerrors.Errorf("failed to listen: %w", err)
 	}
 
 	// Set up an interceptor function to log any panics we get from request
@@ -118,7 +118,7 @@ func (s *Server) Start() error {
 
 	err = server.Serve(lis)
 	if err != nil {
-		err = errors.Wrap(err, "failed to serve")
+		err = xerrors.Errorf("failed to serve: %w", err)
 	}
 
 	// inform Stop() that is it is OK to stop now

--- a/hub/upgrade_primaries.go
+++ b/hub/upgrade_primaries.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
@@ -44,7 +45,7 @@ func UpgradePrimaries(args UpgradePrimaryArgs) error {
 			})
 
 			if err != nil {
-				agentErrs <- errors.Wrapf(err, "failed to upgrade primary segment on host %s", conn.Hostname)
+				agentErrs <- xerrors.Errorf("failed to upgrade primary segment on host %s: %w", conn.Hostname, err)
 			}
 		}(conn)
 	}

--- a/scripts/enforce-code-style.bats
+++ b/scripts/enforce-code-style.bats
@@ -1,0 +1,14 @@
+@test "we prefer xerrors.Errorf to errors.Wrap" {
+  local directories=(hub/ agent/ cli/ utils/)
+
+  for dir in "${directories[@]}"; do
+
+    run git grep 'errors.Wrap' "$dir"
+
+    if [ "$status" -eq 0 ]; then
+      echo "found errors.Wrap usage in $dir: $output"
+      exit 1
+    fi
+
+  done
+}

--- a/utils/cluster.go
+++ b/utils/cluster.go
@@ -48,13 +48,13 @@ const (
 func ClusterFromDB(conn *dbconn.DBConn, binDir string) (*Cluster, error) {
 	err := conn.Connect(1)
 	if err != nil {
-		return nil, errors.Wrap(err, "couldn't connect to cluster")
+		return nil, xerrors.Errorf("couldn't connect to cluster: %w", err)
 	}
 	defer conn.Close()
 
 	segments, err := GetSegmentConfiguration(conn)
 	if err != nil {
-		return nil, errors.Wrap(err, "couldn't retrieve segment configuration")
+		return nil, xerrors.Errorf("couldn't retrieve segment configuration: %w", err)
 	}
 
 	c, err := NewCluster(segments)


### PR DESCRIPTION
Starting with the hub package, let's start to enforce our preference for `xerrors.Errorf` instead of `errors.Wrap`.

This was motivated by a PR comment about the correct API to use. So, if we can automate that portion of a PR review and catch a mistake earlier, let's automate it.