### PR TITLE
Expose streams from step

### DIFF
--- a/step/step.go
+++ b/step/step.go
@@ -92,15 +92,15 @@ func (s *Step) Err() error {
 	return s.err
 }
 
-func (s *Step) AlwaysRun(substep idl.Substep, f func(OutStreams) error) {
+func (s *Step) AlwaysRun(substep idl.Substep, f func() error) {
 	s.run(substep, f, true)
 }
 
-func (s *Step) Run(substep idl.Substep, f func(OutStreams) error) {
+func (s *Step) Run(substep idl.Substep, f func() error) {
 	s.run(substep, f, false)
 }
 
-func (s *Step) run(substep idl.Substep, f func(OutStreams) error, alwaysRun bool) {
+func (s *Step) run(substep idl.Substep, f func() error, alwaysRun bool) {
 	var err error
 	defer func() {
 		if err != nil {
@@ -141,7 +141,7 @@ func (s *Step) run(substep idl.Substep, f func(OutStreams) error, alwaysRun bool
 		return
 	}
 
-	err = f(s.streams)
+	err = f()
 	if err != nil {
 		if werr := s.write(substep, idl.Status_FAILED); werr != nil {
 			err = multierror.Append(err, werr).ErrorOrNil()
@@ -171,4 +171,8 @@ func (s *Step) sendStatus(substep idl.Substep, status idl.Status) {
 			Status: status,
 		}},
 	})
+}
+
+func (s *Step) Streams() OutStreams {
+	return s.streams
 }

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -36,7 +36,7 @@ func TestStepRun(t *testing.T) {
 		s := step.New("Initialize", server, &TestStore{}, DevNull)
 
 		var called bool
-		s.Run(idl.Substep_CONFIG, func(streams step.OutStreams) error {
+		s.Run(idl.Substep_CONFIG, func() error {
 			called = true
 			return nil
 		})
@@ -66,7 +66,7 @@ func TestStepRun(t *testing.T) {
 		s := step.New("Initialize", server, store, DevNull)
 
 		var status idl.Status
-		s.Run(idl.Substep_CONFIG, func(streams step.OutStreams) error {
+		s.Run(idl.Substep_CONFIG, func() error {
 			// save off status to verify that it is running
 			status = store.Status
 			return nil
@@ -103,7 +103,7 @@ func TestStepRun(t *testing.T) {
 		s := step.New("Initialize", server, store, DevNull)
 
 		var called bool
-		s.AlwaysRun(idl.Substep_CHECK_UPGRADE, func(streams step.OutStreams) error {
+		s.AlwaysRun(idl.Substep_CHECK_UPGRADE, func() error {
 			called = true
 			return nil
 		})
@@ -132,7 +132,7 @@ func TestStepRun(t *testing.T) {
 		s := step.New("Initialize", server, &TestStore{}, DevNull)
 
 		var called bool
-		s.Run(idl.Substep_CONFIG, func(streams step.OutStreams) error {
+		s.Run(idl.Substep_CONFIG, func() error {
 			called = true
 			return errors.New("oops")
 		})
@@ -152,7 +152,7 @@ func TestStepRun(t *testing.T) {
 		s := step.New("Initialize", server, failingStore, DevNull)
 
 		var called bool
-		s.Run(idl.Substep_CHECK_UPGRADE, func(streams step.OutStreams) error {
+		s.Run(idl.Substep_CHECK_UPGRADE, func() error {
 			called = true
 			return nil
 		})
@@ -181,7 +181,7 @@ func TestStepRun(t *testing.T) {
 		s := step.New("Initialize", server, store, DevNull)
 
 		var called bool
-		s.Run(idl.Substep_CHECK_UPGRADE, func(streams step.OutStreams) error {
+		s.Run(idl.Substep_CHECK_UPGRADE, func() error {
 			called = true
 			return nil
 		})
@@ -201,12 +201,12 @@ func TestStepRun(t *testing.T) {
 		s := step.New("Initialize", server, &TestStore{}, DevNull)
 
 		expected := errors.New("oops")
-		s.Run(idl.Substep_CONFIG, func(streams step.OutStreams) error {
+		s.Run(idl.Substep_CONFIG, func() error {
 			return expected
 		})
 
 		var called bool
-		s.Run(idl.Substep_START_AGENTS, func(streams step.OutStreams) error {
+		s.Run(idl.Substep_START_AGENTS, func() error {
 			called = true
 			return nil
 		})
@@ -231,7 +231,7 @@ func TestStepRun(t *testing.T) {
 		s := step.New("Initialize", server, store, DevNull)
 
 		var called bool
-		s.Run(idl.Substep_CONFIG, func(streams step.OutStreams) error {
+		s.Run(idl.Substep_CONFIG, func() error {
 			called = true
 			return nil
 		})


### PR DESCRIPTION
Many substep functions do not use the stream they have been given, signaling a possible design change.

This exposes the streams as a function on Step, the owner of the streams.