### PR TITLE
Rename user facing instances of old and new to source and target.

### DIFF
--- a/ci/scripts/upgrade-cluster.bash
+++ b/ci/scripts/upgrade-cluster.bash
@@ -79,7 +79,7 @@ for host in "${hosts[@]}"; do
     ssh centos@$host "sudo mv /tmp/gpupgrade /usr/local/bin"
 done
 
-echo 'Loading SQL dump into old cluster...'
+echo 'Loading SQL dump into source cluster...'
 time ssh mdw bash <<EOF
     set -eux -o pipefail
 

--- a/cli/commanders/steps.go
+++ b/cli/commanders/steps.go
@@ -36,12 +36,12 @@ var SubstepDescriptions = map[idl.Substep]string{
 	idl.Substep_START_TARGET_CLUSTER:                              "Starting target cluster...",
 	idl.Substep_FINALIZE_UPGRADE_STANDBY:                          "Upgrading standby...",
 	idl.Substep_FINALIZE_UPGRADE_MIRRORS:                          "Upgrading mirrors...",
-	idl.Substep_FINALIZE_SHUTDOWN_TARGET_CLUSTER:                  "Stopping new cluster...",
-	idl.Substep_FINALIZE_UPDATE_TARGET_CATALOG_AND_CLUSTER_CONFIG: "Updating new master catalog...",
+	idl.Substep_FINALIZE_SHUTDOWN_TARGET_CLUSTER:                  "Stopping target cluster...",
+	idl.Substep_FINALIZE_UPDATE_TARGET_CATALOG_AND_CLUSTER_CONFIG: "Updating target master catalog...",
 	idl.Substep_FINALIZE_RENAME_DATA_DIRECTORIES:                  "Renaming data directories...",
-	idl.Substep_FINALIZE_UPDATE_TARGET_CONF_FILES:                 "Updating new master postgreql.conf and gpperfmon.conf files...",
+	idl.Substep_FINALIZE_UPDATE_TARGET_CONF_FILES:                 "Updating target master postgreql.conf and gpperfmon.conf files...",
 	idl.Substep_FINALIZE_UPDATE_RECOVERY_CONFS:                    "Updating recovery.conf files on mirrors...",
-	idl.Substep_FINALIZE_START_TARGET_CLUSTER:                     "Starting new cluster...",
+	idl.Substep_FINALIZE_START_TARGET_CLUSTER:                     "Starting target cluster...",
 }
 
 var indicators = map[idl.Status]string{

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -176,8 +176,8 @@ func createConfigSetSubcommand() *cobra.Command {
 		},
 	}
 
-	subSet.Flags().String("source-bindir", "", "install directory for old gpdb version")
-	subSet.Flags().String("target-bindir", "", "install directory for new gpdb version")
+	subSet.Flags().String("source-bindir", "", "install directory for source gpdb version")
+	subSet.Flags().String("target-bindir", "", "install directory for target gpdb version")
 
 	return subSet
 }
@@ -344,13 +344,13 @@ After executing, you will need to finalize.`)
 	subInit.MarkFlagRequired("source-bindir")
 	subInit.Flags().StringVar(&targetBinDir, "target-bindir", "", "install directory for target gpdb version")
 	subInit.MarkFlagRequired("target-bindir")
-	subInit.Flags().IntVar(&sourcePort, "source-master-port", 0, "master port for old gpdb cluster")
+	subInit.Flags().IntVar(&sourcePort, "source-master-port", 0, "master port for source gpdb cluster")
 	subInit.MarkFlagRequired("source-master-port")
 	subInit.Flags().BoolVar(&stopBeforeClusterCreation, "stop-before-cluster-creation", false, "only run up to pre-init")
 	subInit.Flags().MarkHidden("stop-before-cluster-creation")
 	subInit.Flags().Float64Var(&diskFreeRatio, "disk-free-ratio", 0.60, "percentage of disk space that must be available (from 0.0 - 1.0)")
 	subInit.Flags().BoolVarP(&verbose, "verbose", "v", false, "print the output stream from all substeps")
-	subInit.Flags().StringVar(&ports, "temp-port-range", "", "set of ports to use when initializing the new cluster")
+	subInit.Flags().StringVar(&ports, "temp-port-range", "", "set of ports to use when initializing the target cluster")
 	subInit.Flags().BoolVar(&linkMode, "link", false, "performs upgrade in link mode")
 
 	return addHelpToCommand(subInit, InitializeHelp)

--- a/hub/check_upgrade.go
+++ b/hub/check_upgrade.go
@@ -66,7 +66,7 @@ func (s *Server) CheckUpgrade(stream step.OutStreams) error {
 
 		dataDirPairMap, dataDirPairsErr := s.GetDataDirPairs()
 		if dataDirPairsErr != nil {
-			checkErrs <- errors.Wrap(dataDirPairsErr, "failed to get old and new primary data directories")
+			checkErrs <- errors.Wrap(dataDirPairsErr, "failed to get source and target primary data directories")
 			return
 		}
 

--- a/hub/execute.go
+++ b/hub/execute.go
@@ -70,7 +70,7 @@ func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_Execut
 		dataDirPair, err := s.GetDataDirPairs()
 
 		if err != nil {
-			return errors.Wrap(err, "failed to get old and new primary data directories")
+			return errors.Wrap(err, "failed to get source and target primary data directories")
 		}
 
 		return UpgradePrimaries(UpgradePrimaryArgs{

--- a/hub/fill_cluster_configs.go
+++ b/hub/fill_cluster_configs.go
@@ -14,7 +14,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/utils"
 )
 
-// create old/new clusters, write to disk and re-read from disk to make sure it is "durable"
+// create source/target clusters, write to disk and re-read from disk to make sure it is "durable"
 func (s *Server) FillClusterConfigsSubStep(config *Config, conn *sql.DB, _ step.OutStreams, request *idl.InitializeRequest, saveConfig func() error) error {
 	if err := CheckSourceClusterConfiguration(conn); err != nil {
 		return err

--- a/hub/init_target_cluster.go
+++ b/hub/init_target_cluster.go
@@ -142,7 +142,7 @@ func upgradeDataDir(path string) string {
 func WriteSegmentArray(config []string, targetInitializeConfig InitializeConfig) ([]string, error) {
 	//Partition segments by host in order to correctly assign ports.
 	if targetInitializeConfig.Master == (utils.SegConfig{}) {
-		return nil, errors.New("old cluster contains no master segment")
+		return nil, errors.New("source cluster contains no master segment")
 	}
 
 	master := targetInitializeConfig.Master

--- a/hub/init_target_cluster_test.go
+++ b/hub/init_target_cluster_test.go
@@ -125,7 +125,7 @@ func TestWriteSegmentArray(t *testing.T) {
 		})
 	})
 
-	t.Run("errors when old cluster contains no master segment", func(t *testing.T) {
+	t.Run("errors when source cluster contains no master segment", func(t *testing.T) {
 		_, err := WriteSegmentArray([]string{}, InitializeConfig{})
 
 		if err == nil {

--- a/hub/rename_data_directories.go
+++ b/hub/rename_data_directories.go
@@ -18,19 +18,19 @@ const UpgradeSuffix = "_upgrade"
 
 func (s *Server) RenameDataDirectories() error {
 	if err := RenameMasterDataDir(s.Source.MasterDataDir(), true); err != nil {
-		return xerrors.Errorf("renaming old cluster master data directory: %w", err)
+		return xerrors.Errorf("renaming source cluster master data directory: %w", err)
 	}
 
 	if err := RenameSegmentDataDirs(s.agentConns, s.Source, OldSuffix, false); err != nil {
-		return xerrors.Errorf("renaming old cluster segment data directories: %w", err)
+		return xerrors.Errorf("renaming source cluster segment data directories: %w", err)
 	}
 
 	if err := RenameMasterDataDir(s.Target.MasterDataDir(), false); err != nil {
-		return xerrors.Errorf("renaming new cluster master data directory: %w", err)
+		return xerrors.Errorf("renaming target cluster master data directory: %w", err)
 	}
 
 	if err := RenameSegmentDataDirs(s.agentConns, s.Target, UpgradeSuffix, true); err != nil {
-		return xerrors.Errorf("renaming new cluster segment data directories: %w", err)
+		return xerrors.Errorf("renaming target cluster segment data directories: %w", err)
 	}
 
 	return nil

--- a/hub/update_catalog.go
+++ b/hub/update_catalog.go
@@ -55,7 +55,7 @@ func WithinDbConnection(masterPort int, operation func(connection *sql.DB) error
 	defer func() {
 		closeErr := connection.Close()
 		if closeErr != nil {
-			closeErr = xerrors.Errorf("closing connection to new master: %w", closeErr)
+			closeErr = xerrors.Errorf("closing connection to target master: %w", closeErr)
 			err = multierror.Append(err, closeErr)
 		}
 	}()

--- a/hub/upgrade_primaries.go
+++ b/hub/upgrade_primaries.go
@@ -63,7 +63,7 @@ func UpgradePrimaries(args UpgradePrimaryArgs) error {
 
 // ErrInvalidCluster is returned by GetDataDirPairs if the source and target
 // clusters content id's clusters do not match.
-var ErrInvalidCluster = errors.New("Old and new clusters do not match")
+var ErrInvalidCluster = errors.New("Source and target clusters do not match")
 
 func (s *Server) GetDataDirPairs() (map[string][]*idl.DataDirPair, error) {
 	dataDirPairMap := make(map[string][]*idl.DataDirPair)
@@ -71,13 +71,13 @@ func (s *Server) GetDataDirPairs() (map[string][]*idl.DataDirPair, error) {
 	sourceContents := s.Source.ContentIDs
 	targetContents := s.Target.ContentIDs
 	if len(sourceContents) != len(targetContents) {
-		return nil, newInvalidClusterError("Old cluster has %d segments, and new cluster has %d segments.", len(sourceContents), len(targetContents))
+		return nil, newInvalidClusterError("Source cluster has %d segments, and target cluster has %d segments.", len(sourceContents), len(targetContents))
 	}
 	sort.Ints(sourceContents)
 	sort.Ints(targetContents)
 	for i := range sourceContents {
 		if sourceContents[i] != targetContents[i] {
-			return nil, newInvalidClusterError("Old cluster with content %d, does not match new cluster with content %d.", sourceContents[i], targetContents[i])
+			return nil, newInvalidClusterError("Source cluster with content %d, does not match target cluster with content %d.", sourceContents[i], targetContents[i])
 		}
 	}
 
@@ -119,7 +119,7 @@ func newInvalidClusterError(format string, a ...interface{}) *InvalidClusterErro
 }
 
 func (i *InvalidClusterError) Error() string {
-	return fmt.Sprintf("Old and new clusters do not match: %s", i.msg)
+	return fmt.Sprintf("Source and target clusters do not match: %s", i.msg)
 }
 
 func (i *InvalidClusterError) Is(err error) bool {

--- a/hub/upgrade_primaries.go
+++ b/hub/upgrade_primaries.go
@@ -88,7 +88,10 @@ func (s *Server) GetDataDirPairs() (map[string][]*idl.DataDirPair, error) {
 		sourceSeg := s.Source.Primaries[contentID]
 		targetSeg := s.Target.Primaries[contentID]
 		if sourceSeg.Hostname != targetSeg.Hostname {
-			return nil, newInvalidClusterError("hostnames do not match between old and new cluster with content ID %d. Found old cluster hostname: '%s', and new cluster hostname: '%s'", contentID, sourceSeg.Hostname, targetSeg.Hostname)
+			return nil, newInvalidClusterError(
+				"hostnames do not match between source and target cluster with content ID %d. "+
+					"Found source cluster hostname: '%s', and target cluster hostname: '%s'",
+				contentID, sourceSeg.Hostname, targetSeg.Hostname)
 		}
 
 		dataPair := &idl.DataDirPair{

--- a/hub/upgrade_standby.go
+++ b/hub/upgrade_standby.go
@@ -21,7 +21,7 @@ type StandbyConfig struct {
 // standby for the cluster.
 //
 func UpgradeStandby(r GreenplumRunner, standbyConfig StandbyConfig) error {
-	gplog.Info(fmt.Sprintf("removing any existing standby master on new cluster"))
+	gplog.Info(fmt.Sprintf("removing any existing standby master on target cluster"))
 
 	err := r.Run("gpinitstandby", "-r", "-a")
 
@@ -31,7 +31,7 @@ func UpgradeStandby(r GreenplumRunner, standbyConfig StandbyConfig) error {
 			err))
 	}
 
-	gplog.Info(fmt.Sprintf("creating new standby master: %#v", standbyConfig))
+	gplog.Info(fmt.Sprintf("creating target standby master: %#v", standbyConfig))
 
 	return r.Run("gpinitstandby",
 		"-P", strconv.Itoa(standbyConfig.Port),

--- a/test/finalize-standby-and-mirrors.bats
+++ b/test/finalize-standby-and-mirrors.bats
@@ -32,7 +32,7 @@ teardown() {
     gpstart -a
 }
 
-@test "finalize brings up the standby and mirrors for the new cluster" {
+@test "finalize brings up the standby and mirrors for the target cluster" {
     local source_mirrors_count=$(number_of_mirrors)
     gpupgrade initialize \
         --source-bindir="$GPHOME/bin" \


### PR DESCRIPTION
Did a search and replace for "old " and "new " within the codebase and renamed to "source " and "target ".

I didn't find any instances of "current " used anywhere.