### PR TITLE
sed: simplify call for safety and fix pattern bugs

### DIFF
--- a/hub/replace_string_within_file.go
+++ b/hub/replace_string_within_file.go
@@ -25,7 +25,13 @@ func replaceStringWithinFile(pattern string, replacement string, pathToFile stri
 	// XXX this isn't safe if the pattern or replacement contains @-signs
 	substitutionString := fmt.Sprintf("s@%s@%s@", pattern, replacement)
 
-	cmd := execCommand("sed", "-i.bak", substitutionString, pathToFile)
+	cmd := execCommand(
+		"sed",
+		"-E",     // use POSIX extended regexes
+		"-i.bak", // in-place substitution with .bak backup extension
+		substitutionString,
+		pathToFile,
+	)
 
 	// TODO: stream back output through the connection
 	_, err := cmd.Output()

--- a/hub/update_conf_files.go
+++ b/hub/update_conf_files.go
@@ -24,9 +24,12 @@ func UpdateGpperfmonConf(masterDataDir string) error {
 	logDir := filepath.Join(masterDataDir, "gpperfmon", "logs")
 	replacement := fmt.Sprintf("log_location = %s", logDir)
 
-	return ReplaceStringWithinFile("log_location = .*$",
+	// TODO: allow arbitrary whitespace around the = sign?
+	return ReplaceStringWithinFile(
+		"^log_location = .*$",
 		replacement,
-		configFile)
+		configFile,
+	)
 }
 
 // oldTargetPort is the old port on which the target cluster was initialized.

--- a/hub/update_conf_files.go
+++ b/hub/update_conf_files.go
@@ -35,8 +35,8 @@ func UpdateGpperfmonConf(masterDataDir string) error {
 // catalog in a previous substep.
 func UpdatePostgresqlConf(oldTargetPort int, target *utils.Cluster, source *utils.Cluster) error {
 	return ReplaceStringWithinFile(
-		fmt.Sprintf("port=%d", oldTargetPort),
-		fmt.Sprintf("port=%d", source.MasterPort()),
+		fmt.Sprintf(`(^port[ \t]*=[ \t]*)%d([^0-9]|$)`, oldTargetPort),
+		fmt.Sprintf(`\1%d\2`, source.MasterPort()),
 		filepath.Join(target.MasterDataDir(), "postgresql.conf"),
 	)
 }

--- a/hub/update_conf_files.go
+++ b/hub/update_conf_files.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/greenplum-db/gpupgrade/utils"
 )
@@ -19,8 +20,9 @@ func (s *Server) UpdateConfFiles() error {
 }
 
 func UpdateGpperfmonConf(masterDataDir string) error {
-	configFile := fmt.Sprintf("%[1]s/gpperfmon/conf/gpperfmon.conf", masterDataDir)
-	replacement := fmt.Sprintf("log_location = %[1]s/gpperfmon/logs", masterDataDir)
+	configFile := filepath.Join(masterDataDir, "gpperfmon", "conf", "gpperfmon.conf")
+	logDir := filepath.Join(masterDataDir, "gpperfmon", "logs")
+	replacement := fmt.Sprintf("log_location = %s", logDir)
 
 	return ReplaceStringWithinFile("log_location = .*$",
 		replacement,
@@ -35,6 +37,6 @@ func UpdatePostgresqlConf(oldTargetPort int, target *utils.Cluster, source *util
 	return ReplaceStringWithinFile(
 		fmt.Sprintf("port=%d", oldTargetPort),
 		fmt.Sprintf("port=%d", source.MasterPort()),
-		fmt.Sprintf("%[1]s/postgresql.conf", target.MasterDataDir()),
+		filepath.Join(target.MasterDataDir(), "postgresql.conf"),
 	)
 }


### PR DESCRIPTION
So that we don't fail halfway through (after the move to a `.bak`) and leave the cluster without a file, use sed's builtin replacement.

Additionally, the current implementation won't be idempotent if, say, we replace the port number with a number that is a superstring of the previous one.

Example, replacing 5000 with 50000:

     port=5000 -> port=50000

The second run will match `port=5000` again:

     port=50000 -> port=500000

While fixing this, we discovered some additional anchoring bugs related to the GUC name and comments, so we added a suite to fix them all. The current test subsumes the previous test, which was simply checking argument equality, so we've replaced it entirely.

This work suggests several refactors, which I will create a new PR for. This PR will wait until the standby/mirror reordering hits master.