### PR TITLE
Fix golangci-lint errors.

### DIFF
--- a/agent/rsync_test.go
+++ b/agent/rsync_test.go
@@ -56,7 +56,7 @@ func TestRsync(t *testing.T) {
 
 		targetContents, _ := ioutil.ReadFile(filepath.Join(targetDir, "/hi"))
 
-		if bytes.Compare(targetContents, []byte("hi")) != 0 {
+		if !bytes.Equal(targetContents, []byte("hi")) {
 			t.Errorf("target directory file 'hi' contained %v, wanted %v",
 				targetContents,
 				"hi")

--- a/agent/server.go
+++ b/agent/server.go
@@ -102,7 +102,11 @@ func (s *Server) Stop() {
 }
 
 func createIfNotExists(dir string) {
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		os.Mkdir(dir, 0777)
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		return
+	}
+
+	if err := os.Mkdir(dir, 0777); err != nil {
+		gplog.Fatal(err, "failed to create state directory %q", dir)
 	}
 }

--- a/agent/server_test.go
+++ b/agent/server_test.go
@@ -93,8 +93,5 @@ func doesPathEventuallyExist(path string) (bool, error) {
 
 func pathExists(path string) bool {
 	_, err := os.Stat(path)
-	if os.IsNotExist(err) {
-		return false
-	}
-	return true
+	return !os.IsNotExist(err)
 }

--- a/ci/scripts/filter/filter.go
+++ b/ci/scripts/filter/filter.go
@@ -107,10 +107,9 @@ nextline:
 		log.Fatalf("scanning stdin: %+v", scanner.Err())
 	}
 
-	// Flush and empty our buffer.
+	// Flush our buffer.
 	if len(buf) > 0 {
 		write(out, buf...)
-		buf = buf[:0]
 	}
 }
 

--- a/cli/commanders/steps.go
+++ b/cli/commanders/steps.go
@@ -216,7 +216,7 @@ func UILoop(stream receiver, verbose bool) (map[string]string, error) {
 			}
 			lastStep = x.Status.Step
 
-			fmt.Printf(FormatStatus(x.Status))
+			fmt.Print(FormatStatus(x.Status))
 			if verbose {
 				fmt.Println()
 			}

--- a/cli/commanders/steps_test.go
+++ b/cli/commanders/steps_test.go
@@ -242,7 +242,11 @@ func TestUILoop(t *testing.T) {
 				}()
 
 				msgs := &msgStream{c.msg}
-				commanders.UILoop(msgs, false)
+				_, err := commanders.UILoop(msgs, false)
+
+				if err != nil {
+					t.Fatalf("got an error, expected panic: %q", err)
+				}
 			})
 		}
 	})

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -694,7 +694,7 @@ func addHelpToCommand(cmd *cobra.Command, help string) *cobra.Command {
 		Short: "",
 		Long:  "",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Printf(help)
+			fmt.Print(help)
 			return nil
 		},
 	})
@@ -702,7 +702,7 @@ func addHelpToCommand(cmd *cobra.Command, help string) *cobra.Command {
 
 	// Override the built-in "-h" and "--help" flags
 	cmd.SetHelpFunc(func(cmd *cobra.Command, strs []string) {
-		fmt.Printf(help)
+		fmt.Print(help)
 	})
 
 	return cmd

--- a/greenplum/cluster.go
+++ b/greenplum/cluster.go
@@ -98,7 +98,7 @@ func (c *Cluster) HasMirrors() bool {
 
 // XXX This does not provide mirror hostnames yet.
 func (c *Cluster) GetHostnames() []string {
-	hostnameMap := make(map[string]bool, 0)
+	hostnameMap := make(map[string]bool)
 	for _, seg := range c.Primaries {
 		hostnameMap[seg.Hostname] = true
 	}
@@ -110,7 +110,7 @@ func (c *Cluster) GetHostnames() []string {
 }
 
 func (c *Cluster) PrimaryHostnames() []string {
-	hostnames := make(map[string]bool, 0)
+	hostnames := make(map[string]bool)
 	for _, seg := range c.Primaries {
 		// Ignore the master.
 		if seg.ContentID >= 0 {

--- a/hub/check_disk_space.go
+++ b/hub/check_disk_space.go
@@ -59,7 +59,7 @@ func checkDiskSpace(ctx context.Context, cluster *greenplum.Cluster, agents []*C
 
 			segments := cluster.SelectSegments(excludingMaster)
 			if len(segments) == 0 {
-				errs <- greenplum.UnknownHostError{agent.Hostname}
+				errs <- greenplum.UnknownHostError{Hostname: agent.Hostname}
 				return
 			}
 

--- a/hub/check_source_cluster_configuration.go
+++ b/hub/check_source_cluster_configuration.go
@@ -11,12 +11,12 @@ import (
 
 const (
 	Primary Role = "p"
-	Mirror       = "m"
+	Mirror  Role = "m"
 )
 
 const (
 	Up   Status = "u"
-	Down        = "d"
+	Down Status = "d"
 )
 
 type DBID int

--- a/hub/check_upgrade_test.go
+++ b/hub/check_upgrade_test.go
@@ -1,7 +1,6 @@
 package hub
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -106,26 +105,26 @@ func UpgradeMasterMock(result UpgradeMasterArgs, expected *Server) error {
 
 func UpgradePrimariesMock(result UpgradePrimaryArgs, expected *Server) error {
 	if result.CheckOnly != true {
-		return errors.New(fmt.Sprintf("got %#v expected %#v", result.CheckOnly, true))
+		return fmt.Errorf("got %#v expected %#v", result.CheckOnly, true)
 	}
 	if result.MasterBackupDir != "" {
-		return errors.New(fmt.Sprintf("got %#v expected %#v", result.MasterBackupDir, ""))
+		return fmt.Errorf("got %#v expected %#v", result.MasterBackupDir, "")
 	}
 	if !reflect.DeepEqual(result.AgentConns, agentsSource.conns) {
-		return errors.New(fmt.Sprintf("got %#v expected %#v", result.AgentConns, agentsSource.conns))
+		return fmt.Errorf("got %#v expected %#v", result.AgentConns, agentsSource.conns)
 	}
 	expectedDataDirs, _ := expected.GetDataDirPairs()
 	if !reflect.DeepEqual(result.DataDirPairMap, expectedDataDirs) {
-		return errors.New(fmt.Sprintf("got %#v expected %#v", result.DataDirPairMap, expectedDataDirs))
+		return fmt.Errorf("got %#v expected %#v", result.DataDirPairMap, expectedDataDirs)
 	}
 	if !reflect.DeepEqual(result.Source, expected.Source) {
-		return errors.New(fmt.Sprintf("got %#v, expected %#v", result.Source, expected.Source))
+		return fmt.Errorf("got %#v, expected %#v", result.Source, expected.Source)
 	}
 	if !reflect.DeepEqual(result.Target, expected.Target) {
-		return errors.New(fmt.Sprintf("got %#v, expected %#v", result.Target, expected.Target))
+		return fmt.Errorf("got %#v, expected %#v", result.Target, expected.Target)
 	}
 	if result.UseLinkMode != expected.UseLinkMode {
-		return errors.New(fmt.Sprintf("got %#v expected %#v", result.UseLinkMode, expected.UseLinkMode))
+		return fmt.Errorf("got %#v expected %#v", result.UseLinkMode, expected.UseLinkMode)
 	}
 	return nil
 }

--- a/hub/check_upgrade_test.go
+++ b/hub/check_upgrade_test.go
@@ -86,20 +86,20 @@ func TestMasterIsCheckedLinkModeTrue(t *testing.T) {
 
 func UpgradeMasterMock(result UpgradeMasterArgs, expected *Server) error {
 	if !reflect.DeepEqual(result.Source, expected.Source) {
-		return errors.New(fmt.Sprintf("got %#v, expected %#v", result.Source, expected.Source))
+		return fmt.Errorf("got %#v, expected %#v", result.Source, expected.Source)
 	}
 	if !reflect.DeepEqual(result.Target, expected.Target) {
-		return errors.New(fmt.Sprintf("got %#v, expected %#v", result.Target, expected.Target))
+		return fmt.Errorf("got %#v, expected %#v", result.Target, expected.Target)
 	}
 	if result.StateDir != expected.StateDir {
-		return errors.New(fmt.Sprintf("got %#v expected %#v", result.StateDir, expected.StateDir))
+		return fmt.Errorf("got %#v expected %#v", result.StateDir, expected.StateDir)
 	}
 	// does not seem worth testing stream right now
 	if result.CheckOnly != true {
-		return errors.New(fmt.Sprintf("got %#v expected %#v", result.CheckOnly, true))
+		return fmt.Errorf("got %#v expected %#v", result.CheckOnly, true)
 	}
 	if result.UseLinkMode != expected.UseLinkMode {
-		return errors.New(fmt.Sprintf("got %#v expected %#v", result.UseLinkMode, expected.UseLinkMode))
+		return fmt.Errorf("got %#v expected %#v", result.UseLinkMode, expected.UseLinkMode)
 	}
 	return nil
 }

--- a/hub/server.go
+++ b/hub/server.go
@@ -154,7 +154,7 @@ func (s *Server) StopAgents() error {
 	for _, conn := range s.agentConns {
 		wg.Add(1)
 
-		go func() {
+		go func(conn *Connection) {
 			defer wg.Done()
 
 			_, err := conn.AgentClient.StopAgent(context.Background(), &idl.StopAgentRequest{})
@@ -169,7 +169,7 @@ func (s *Server) StopAgents() error {
 			if errStatus.Code() != codes.Unavailable || errStatus.Message() != "transport is closing" {
 				errs <- xerrors.Errorf("failed to stop agent on host %s : %w", conn.Hostname, err)
 			}
-		}()
+		}(conn)
 	}
 
 	wg.Wait()

--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/hub"
-	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/testutils/mock_agent"
 	"github.com/greenplum-db/gpupgrade/utils"
@@ -25,16 +24,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
-
-// msgStream is a mock server stream for InitializeStep().
-type msgStream struct {
-	LastStatus idl.Status
-}
-
-func (m *msgStream) Send(msg *idl.Message) error {
-	m.LastStatus = msg.GetStatus().Status
-	return nil
-}
 
 var _ = Describe("Hub", func() {
 	var (

--- a/hub/services_suite_test.go
+++ b/hub/services_suite_test.go
@@ -33,7 +33,6 @@ var (
 	client      *mock_idl.MockAgentClient
 	port        int
 	dir         string
-	hubConf     *hub.Config
 	source      *greenplum.Cluster
 	target      *greenplum.Cluster
 	testHub     *hub.Server

--- a/hub/upgrade_mirrors_test.go
+++ b/hub/upgrade_mirrors_test.go
@@ -321,6 +321,10 @@ func TestUpgradeMirrors(t *testing.T) {
 		defer testutils.FinishMock(mock, t)
 
 		_, writePipe, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("couldn't create pipe: %v", err)
+		}
+
 		utils.System.Create = func(name string) (*os.File, error) {
 			return writePipe, nil
 		}

--- a/hub/upgrade_standby_test.go
+++ b/hub/upgrade_standby_test.go
@@ -19,7 +19,11 @@ func TestUpgradeStandby(t *testing.T) {
 		}
 
 		runner := newSpyRunner()
-		hub.UpgradeStandby(runner, config)
+		err := hub.UpgradeStandby(runner, config)
+
+		if err != nil {
+			t.Errorf("unexpected error while running UpgradeStandby: %v", err)
+		}
 
 		if runner.TimesRunWasCalledWith("gpinitstandby") != 2 {
 			t.Errorf("got %v calls to config.Run, wanted %v calls",

--- a/integrations/integrations_suite_test.go
+++ b/integrations/integrations_suite_test.go
@@ -98,23 +98,6 @@ func killHub() {
 	Expect(checkPortIsAvailable(cliToHubPort)).To(BeTrue())
 }
 
-// killAll finds all running gpupupgrade processes and kills them.
-// XXX this is ridiculously heavy-handed
-func killAll() {
-	pkillCmd := exec.Command("pkill", "-9", "^gpupgrade_")
-	err := pkillCmd.Run()
-
-	// pkill returns exit code 1 if no processes were matched, which is fine.
-	if err != nil {
-		Expect(err).To(MatchError("exit status 1"))
-	} else {
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	Expect(checkPortIsAvailable(cliToHubPort)).To(BeTrue())
-	Expect(checkPortIsAvailable(hubToAgentPort)).To(BeTrue())
-}
-
 func checkPortIsAvailable(port int) bool {
 	t := time.After(2 * time.Second)
 	select {

--- a/integrations/integrations_suite_test.go
+++ b/integrations/integrations_suite_test.go
@@ -30,8 +30,7 @@ var (
 )
 
 const (
-	cliToHubPort   = 7527
-	hubToAgentPort = 6416
+	cliToHubPort = 7527
 )
 
 var _ = BeforeSuite(func() {

--- a/step/stream_test.go
+++ b/step/stream_test.go
@@ -61,8 +61,14 @@ func TestMultiplexedStream(t *testing.T) {
 
 		// Write 10 bytes to each stream.
 		for i := 0; i < 10; i++ {
-			stream.Stdout().Write([]byte{'O'})
-			stream.Stderr().Write([]byte{'E'})
+			_, err := stream.Stdout().Write([]byte{'O'})
+			if err != nil {
+				t.Fatalf("got error, expected no error: %v", err)
+			}
+			_, err = stream.Stderr().Write([]byte{'E'})
+			if err != nil {
+				t.Fatalf("got error, expected no error: %v", err)
+			}
 		}
 
 		expected := "OEOEOEOEOEOEOEOEOEOE"
@@ -89,8 +95,11 @@ func TestMultiplexedStream(t *testing.T) {
 
 		// Write 10 bytes to each stream.
 		for i := 0; i < 10; i++ {
-			stream.Stdout().Write([]byte{'O'})
-			stream.Stderr().Write([]byte{'E'})
+			_, err := stream.Stdout().Write([]byte{'O'})
+			g.Expect(err).To(BeNil())
+
+			_, err = stream.Stderr().Write([]byte{'E'})
+			g.Expect(err).To(BeNil())
 		}
 
 		// The Writer should not have been affected in any way.

--- a/testutils/insert_target_config/main.go
+++ b/testutils/insert_target_config/main.go
@@ -45,6 +45,9 @@ func main() {
 	// populate the contents of target cluster to config
 	conn := dbconn.NewDBConnFromEnvironment("postgres")
 	config.Target, err = greenplum.ClusterFromDB(conn, binDir)
+	if err != nil {
+		log.Fatal(err)
+	}
 	config.TargetInitializeConfig, err = hub.AssignDatadirsAndPorts(config.Source, []int{})
 	if err != nil {
 		log.Fatal(err)

--- a/testutils/mock_agent/mock_agent_server.go
+++ b/testutils/mock_agent/mock_agent_server.go
@@ -47,7 +47,7 @@ func NewMockAgentServer() (*MockAgentServer, hub.Dialer, int) {
 	idl.RegisterAgentServer(mockServer.grpcServer, mockServer)
 
 	go func() {
-		mockServer.grpcServer.Serve(lis)
+		_ = mockServer.grpcServer.Serve(lis)
 	}()
 
 	// Target this running server during dial.

--- a/utils/daemon/daemon_test.go
+++ b/utils/daemon/daemon_test.go
@@ -164,8 +164,9 @@ var _ = Describe("waitForDaemon", func() {
 		errput := []byte("this is an error\n")
 
 		cmd := MockDaemonizableCommand{StdoutBuf: output, StderrBuf: errput}
-		waitForDaemon(&cmd, outbuf, errbuf, 0)
+		err := waitForDaemon(&cmd, outbuf, errbuf, 0)
 
+		Expect(err).To(BeNil())
 		Expect(outbuf.Bytes()).To(Equal(output))
 		Expect(errbuf.Bytes()).To(Equal(errput))
 	})


### PR DESCRIPTION
For each of these commits I've included the linter error message along with the minimal fix for the issue.

```
integrations/integrations_suite_test.go:103:6: `killAll` is unused (deadcode)
func killAll() {
     ^
```