### PR TITLE
Migrate panic_test, commands_test, and hub_test to Go style tests

### DIFF
--- a/agent/rsync_test.go
+++ b/agent/rsync_test.go
@@ -12,16 +12,8 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/agent"
+	"github.com/greenplum-db/gpupgrade/testutils"
 )
-
-func getTempDir(t *testing.T) string {
-	sourceDir, err := ioutil.TempDir("", "rsync-source")
-	if err != nil {
-		t.Fatalf("creating temporary directory: %+v", err)
-	}
-
-	return sourceDir
-}
 
 func writeToFile(filepath string, contents []byte, t *testing.T) {
 	err := ioutil.WriteFile(filepath, contents, 0644)
@@ -42,11 +34,11 @@ func TestRsync(t *testing.T) {
 	defer func() { agent.SetRsyncCommand(nil) }()
 
 	t.Run("it copies data from a source directory to a target directory", func(t *testing.T) {
-		sourceDir := getTempDir(t)
-		defer os.RemoveAll(sourceDir)
+		sourceDir := testutils.GetTempDir(t, "rsync-source")
+		defer testutils.MustRemoveAll(t, sourceDir)
 
-		targetDir := getTempDir(t)
-		defer os.RemoveAll(targetDir)
+		targetDir := testutils.GetTempDir(t, "rsync-target")
+		defer testutils.MustRemoveAll(t, targetDir)
 
 		writeToFile(filepath.Join(sourceDir, "hi"), []byte("hi"), t)
 
@@ -64,11 +56,11 @@ func TestRsync(t *testing.T) {
 	})
 
 	t.Run("it removes files that existed in the target directory before the sync", func(t *testing.T) {
-		sourceDir := getTempDir(t)
-		defer os.RemoveAll(sourceDir)
+		sourceDir := testutils.GetTempDir(t, "rsync-source")
+		defer testutils.MustRemoveAll(t, sourceDir)
 
-		targetDir := getTempDir(t)
-		defer os.RemoveAll(targetDir)
+		targetDir := testutils.GetTempDir(t, "rsync-target")
+		defer testutils.MustRemoveAll(t, targetDir)
 
 		writeToFile(filepath.Join(targetDir, "target-file-that-should-get-removed"), []byte("goodbye"), t)
 
@@ -84,11 +76,11 @@ func TestRsync(t *testing.T) {
 	})
 
 	t.Run("it does not copy files from the source directory when in the exclusion list", func(t *testing.T) {
-		sourceDir := getTempDir(t)
-		defer os.RemoveAll(sourceDir)
+		sourceDir := testutils.GetTempDir(t, "rsync-source")
+		defer testutils.MustRemoveAll(t, sourceDir)
 
-		targetDir := getTempDir(t)
-		defer os.RemoveAll(targetDir)
+		targetDir := testutils.GetTempDir(t, "rsync-target")
+		defer testutils.MustRemoveAll(t, targetDir)
 
 		writeToFile(filepath.Join(sourceDir, "source-file-that-should-get-excluded"), []byte("goodbye"), t)
 
@@ -105,11 +97,11 @@ func TestRsync(t *testing.T) {
 	})
 
 	t.Run("it preserves files in the target directory when in the exclusion list", func(t *testing.T) {
-		sourceDir := getTempDir(t)
-		defer os.RemoveAll(sourceDir)
+		sourceDir := testutils.GetTempDir(t, "rsync-source")
+		defer testutils.MustRemoveAll(t, sourceDir)
 
-		targetDir := getTempDir(t)
-		defer os.RemoveAll(targetDir)
+		targetDir := testutils.GetTempDir(t, "rsync-target")
+		defer testutils.MustRemoveAll(t, targetDir)
 
 		writeToFile(filepath.Join(sourceDir, "source-file-that-should-get-copied"), []byte("new file"), t)
 		writeToFile(filepath.Join(targetDir, "target-file-that-should-get-ignored"), []byte("i'm still here"), t)
@@ -140,11 +132,11 @@ func TestRsync(t *testing.T) {
 	})
 
 	t.Run("it bubbles up exec.ExitError errors as rsync errors", func(t *testing.T) {
-		sourceDir := getTempDir(t)
-		defer os.RemoveAll(sourceDir)
+		sourceDir := testutils.GetTempDir(t, "rsync-source")
+		defer testutils.MustRemoveAll(t, sourceDir)
 
 		targetDir := "/tmp/some/invalid/target/dir"
-		defer os.RemoveAll(targetDir)
+		defer testutils.MustRemoveAll(t, targetDir)
 
 		writeToFile(filepath.Join(sourceDir, "some-file"), []byte("hi"), t)
 
@@ -166,11 +158,11 @@ func TestRsync(t *testing.T) {
 		originalPath := destroyPath()
 		defer restorePath(originalPath)
 
-		sourceDir := getTempDir(t)
-		defer os.RemoveAll(sourceDir)
+		sourceDir := testutils.GetTempDir(t, "rsync-source")
+		defer testutils.MustRemoveAll(t, sourceDir)
 
 		targetDir := "/tmp/some/invalid/target/dir"
-		defer os.RemoveAll(targetDir)
+		defer testutils.MustRemoveAll(t, targetDir)
 
 		writeToFile(filepath.Join(sourceDir, "some-file"), []byte("hi"), t)
 

--- a/agent/server_test.go
+++ b/agent/server_test.go
@@ -17,7 +17,7 @@ func TestServerStart(t *testing.T) {
 	testhelper.SetupTestLogger()
 
 	t.Run("successfully starts and creates state directory if it does not exist", func(t *testing.T) {
-		tempDir := getTempDir(t)
+		tempDir := testutils.GetTempDir(t, "")
 		defer os.RemoveAll(tempDir)
 		stateDir := path.Join(tempDir, ".gpupgrade")
 
@@ -43,7 +43,7 @@ func TestServerStart(t *testing.T) {
 	})
 
 	t.Run("successfully starts if state directory already exists", func(t *testing.T) {
-		stateDir := getTempDir(t)
+		stateDir := testutils.GetTempDir(t, ".gpupgrade")
 		defer os.RemoveAll(stateDir)
 
 		server := agent.NewServer(agent.Config{

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1,14 +1,15 @@
 package db
 
 import (
-	"os"
 	"testing"
+
+	"github.com/greenplum-db/gpupgrade/testutils"
 )
 
 func TestNewDBConn(t *testing.T) {
 	t.Run("uses environment variable when database parameter is empty", func(t *testing.T) {
 		expected := "testdb"
-		resetEnv := setEnv(t, "PGDATABASE", expected)
+		resetEnv := testutils.SetEnv(t, "PGDATABASE", expected)
 		defer resetEnv()
 
 		conn := NewDBConn("localHost", 5432, "")
@@ -18,7 +19,7 @@ func TestNewDBConn(t *testing.T) {
 	})
 
 	t.Run("uses database parameter when both parameter and environment variable are set", func(t *testing.T) {
-		resetEnv := setEnv(t, "PGDATABASE", "testdb")
+		resetEnv := testutils.SetEnv(t, "PGDATABASE", "testdb")
 		defer resetEnv()
 
 		expected := "template1"
@@ -30,7 +31,7 @@ func TestNewDBConn(t *testing.T) {
 
 	t.Run("uses environment variable when host parameter is empty", func(t *testing.T) {
 		expected := "mdw"
-		resetEnv := setEnv(t, "PGHOST", expected)
+		resetEnv := testutils.SetEnv(t, "PGHOST", expected)
 		defer resetEnv()
 
 		conn := NewDBConn("", 5432, "template1")
@@ -40,7 +41,7 @@ func TestNewDBConn(t *testing.T) {
 	})
 
 	t.Run("uses host parameter when both parameter and environment variable are set", func(t *testing.T) {
-		resetEnv := setEnv(t, "PGHOST", "mdw")
+		resetEnv := testutils.SetEnv(t, "PGHOST", "mdw")
 		defer resetEnv()
 
 		expected := "localhost"
@@ -50,20 +51,4 @@ func TestNewDBConn(t *testing.T) {
 		}
 	})
 
-}
-
-func setEnv(t *testing.T, envar, value string) func() {
-	old := os.Getenv(envar)
-
-	err := os.Setenv(envar, value)
-	if err != nil {
-		t.Fatalf("setting %s environment variable to %s", envar, value)
-	}
-
-	return func() {
-		err := os.Setenv(envar, old)
-		if err != nil {
-			t.Fatalf("setting %s environment variable to %s", envar, old)
-		}
-	}
 }

--- a/integrations/commands_test.go
+++ b/integrations/commands_test.go
@@ -3,14 +3,12 @@ package integrations_test
 import (
 	"fmt"
 	"os/exec"
+	"testing"
 
 	"github.com/greenplum-db/gpupgrade/cli/commands"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("test gpupgrade help messages", func() {
+func TestHelpCommands(t *testing.T) {
 	helpMap := map[string]string{
 		"":           commands.GlobalHelp,
 		"initialize": commands.InitializeHelp,
@@ -25,23 +23,32 @@ var _ = Describe("test gpupgrade help messages", func() {
 			flag := flag
 			help := help
 
-			It(fmt.Sprintf("testing command %q with flag %q", command, flag), func() {
+			t.Run(fmt.Sprintf("testing command %q with flag %q", command, flag), func(t *testing.T) {
 				cmd := exec.Command("gpupgrade", command, flag)
 				if command == "" {
 					cmd = exec.Command("gpupgrade", flag)
 				}
 				output, err := cmd.Output()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(string(output)).To(Equal(help))
+				if err != nil {
+					t.Errorf("unexpected err: %#v", err)
+				}
+
+				if string(output) != help {
+					t.Errorf("got help output %q want %q", string(output), help)
+				}
 			})
 		}
 	}
 
-	It("testing command gpupgrade with no arguments", func() {
+	t.Run("shows global help when no arguments are passed", func(t *testing.T) {
 		cmd := exec.Command("gpupgrade")
 		output, err := cmd.Output()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(string(output)).To(Equal(commands.GlobalHelp))
-	})
+		if err != nil {
+			t.Errorf("unexpected err: %#v", err)
+		}
 
-})
+		if string(output) != commands.GlobalHelp {
+			t.Errorf("got help output %q want %q", string(output), commands.GlobalHelp)
+		}
+	})
+}

--- a/integrations/hub_test.go
+++ b/integrations/hub_test.go
@@ -1,41 +1,100 @@
 package integrations_test
 
 import (
+	"fmt"
 	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
 
 	"github.com/greenplum-db/gpupgrade/cli/commanders"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/greenplum-db/gpupgrade/testutils"
 )
 
-var _ = Describe("gpupgrade hub", func() {
+const HubPort = 7527
 
-	// XXX We should be testing the locally built artifacts, and killing only
-	// hubs that are started as part of this test. The current logic will break
-	// functional installed systems.
-	BeforeEach(func() {
-		killHub()
-	})
+func TestHub(t *testing.T) {
+	t.Run("the hub does not daemonizes unless --deamonize is passed", func(t *testing.T) {
+		killHub(t)
+		defer killHub(t)
 
-	AfterEach(func() {
-		killHub()
-	})
+		dir := testutils.GetTempDir(t, "")
+		defer testutils.MustRemoveAll(t, dir)
 
-	It("does not daemonize unless explicitly told to", func() {
+		resetEnv := testutils.SetEnv(t, "GPUPGRADE_HOME", filepath.Join(dir, ".gpupgrade"))
+		defer resetEnv()
+
 		err := commanders.CreateStateDir()
-		Expect(err).ToNot(HaveOccurred())
+		if err != nil {
+			t.Errorf("unexpected error got %#v", err)
+		}
+
 		err = commanders.CreateInitialClusterConfigs()
-		Expect(err).ToNot(HaveOccurred())
+		if err != nil {
+			t.Errorf("unexpected error got %#v", err)
+		}
 
 		cmd := exec.Command("gpupgrade", "hub")
-		done := make(chan error, 1)
+		errChan := make(chan error, 1)
 
 		go func() {
-			// We expect this to never return.
-			done <- cmd.Run()
+			errChan <- cmd.Run() // expected to never return
 		}()
 
-		Consistently(done).ShouldNot(Receive())
+		select {
+		case err := <-errChan:
+			if err != nil {
+				t.Errorf("unexpected error %#v", err)
+			}
+		case <-time.After(100 * time.Millisecond):
+			// hub daemonizes without an error
+		}
 	})
-})
+}
+
+// killHub finds all running hub processes and kills them.
+// XXX we should really use a PID file for this, and allow side-by-side hubs,
+// rather than blowing away developer state.
+func killHub(t *testing.T) {
+	t.Helper()
+
+	defer func() {
+		if isPortInUse(HubPort) {
+			t.Errorf("hub port %d is not available", HubPort)
+		}
+	}()
+
+	killCommand := exec.Command("pkill", "-f", "^gpupgrade hub")
+	err := killCommand.Run()
+	// pkill returns exit code 1 if no processes were matched, which is fine.
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		if exitErr.ExitCode() == 1 {
+			return
+		}
+	}
+
+	if err != nil {
+		t.Errorf("unexpected error got %#v", err)
+	}
+}
+
+func isPortInUse(port int) bool {
+	t := time.After(2 * time.Second)
+	select {
+	case <-t:
+		fmt.Println("timed out")
+		break
+	default:
+		cmd := exec.Command("/bin/sh", "-c", "'lsof | grep "+strconv.Itoa(port)+"'")
+		err := cmd.Run()
+		output, _ := cmd.CombinedOutput()
+		if _, ok := err.(*exec.ExitError); ok && string(output) == "" {
+			return false
+		}
+
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	return true
+}

--- a/integrations/integrations_suite_test.go
+++ b/integrations/integrations_suite_test.go
@@ -2,45 +2,23 @@ package integrations_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
-	"testing"
-	"time"
 
-	multierror "github.com/hashicorp/go-multierror"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/hashicorp/go-multierror"
 )
 
-func TestCommands(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Integration Tests Suite")
-}
-
-var (
-	testWorkspaceDir string // will be recreated for every test
-	testStateDir     string // what would normally be ~/.gpupgrade
-)
-
-const (
-	cliToHubPort = 7527
-)
-
-var _ = BeforeSuite(func() {
+func init() {
 	// All gpupgrade binaries are expected to be on the path for integration
 	// tests. Be nice to developers and check up front; warn if the binaries
 	// being tested aren't contained in a directory directly above this test
 	// file.
 	_, testPath, _, ok := runtime.Caller(0)
 	if !ok {
-		Fail("couldn't retrieve Caller() information")
+		panic("couldn't retrieve Caller() information")
 	}
 
 	var allErrs error
@@ -57,62 +35,9 @@ var _ = BeforeSuite(func() {
 		}
 	}
 	if allErrs != nil {
-		Fail(fmt.Sprintf(
+		panic(fmt.Sprintf(
 			"Please put gpupgrade binaries on your PATH before running integration tests.\n%s",
 			multierror.Flatten(allErrs),
 		))
 	}
-})
-
-// BeforeEach for the integrations suite will create the testWorkspaceDir and
-// testStateDir for tests. GPUPGRADE_HOME is set to the testStateDir, so tests
-// may run the hub without worrying about colliding with the developer
-// environment. Both directories are removed in the suite AfterEach.
-var _ = BeforeEach(func() {
-	var err error
-	testWorkspaceDir, err = ioutil.TempDir("", "")
-	Expect(err).ToNot(HaveOccurred())
-	testStateDir = filepath.Join(testWorkspaceDir, ".gpupgrade")
-	os.Setenv("GPUPGRADE_HOME", testStateDir)
-})
-
-var _ = AfterEach(func() {
-	os.RemoveAll(testWorkspaceDir)
-})
-
-// killHub finds all running hub processes and kills them.
-// XXX we should really use a PID file for this, and allow side-by-side hubs,
-// rather than blowing away developer state.
-func killHub() {
-	killCommand := exec.Command("pkill", "-f", "^gpupgrade hub")
-	err := killCommand.Run()
-
-	// pkill returns exit code 1 if no processes were matched, which is fine.
-	if err != nil {
-		Expect(err).To(MatchError("exit status 1"))
-	} else {
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	Expect(checkPortIsAvailable(cliToHubPort)).To(BeTrue())
-}
-
-func checkPortIsAvailable(port int) bool {
-	t := time.After(2 * time.Second)
-	select {
-	case <-t:
-		fmt.Println("timed out")
-		break
-	default:
-		cmd := exec.Command("/bin/sh", "-c", "'lsof | grep "+strconv.Itoa(port)+"'")
-		err := cmd.Run()
-		output, _ := cmd.CombinedOutput()
-		if _, ok := err.(*exec.ExitError); ok && string(output) == "" {
-			return true
-		}
-
-		time.Sleep(250 * time.Millisecond)
-	}
-
-	return false
 }

--- a/testutils/test_utils.go
+++ b/testutils/test_utils.go
@@ -1,7 +1,10 @@
 package testutils
 
 import (
+	"io/ioutil"
 	"net"
+	"os"
+	"testing"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 
@@ -48,4 +51,42 @@ func GetOpenPort() (int, error) {
 	defer l.Close()
 
 	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+func GetTempDir(t *testing.T, prefix string) string {
+	t.Helper()
+
+	dir, err := ioutil.TempDir("", prefix+"-")
+	if err != nil {
+		t.Fatalf("creating temporary directory: %+v", err)
+	}
+
+	return dir
+}
+
+func MustRemoveAll(t *testing.T, dir string) {
+	t.Helper()
+
+	err := os.RemoveAll(dir)
+	if err != nil {
+		t.Fatalf("removing temp dir %q: %#v", dir, err)
+	}
+}
+
+func SetEnv(t *testing.T, envar, value string) func() {
+	t.Helper()
+
+	old := os.Getenv(envar)
+
+	err := os.Setenv(envar, value)
+	if err != nil {
+		t.Fatalf("setting %s environment variable to %s", envar, value)
+	}
+
+	return func() {
+		err := os.Setenv(envar, old)
+		if err != nil {
+			t.Fatalf("setting %s environment variable to %s", envar, old)
+		}
+	}
 }

--- a/utils/log/panic_test.go
+++ b/utils/log/panic_test.go
@@ -1,39 +1,29 @@
 package log_test
 
 import (
-	"github.com/greenplum-db/gpupgrade/utils/log"
+	"strings"
+	"testing"
 
-	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gbytes"
+	"github.com/greenplum-db/gpupgrade/utils/log"
 )
 
-var _ = Describe("WritePanics", func() {
-	It("does not swallow panics", func() {
-		panicFunc := func() {
-			defer log.WritePanics()
-			panic("ahhh")
-		}
-		Expect(panicFunc).To(Panic())
+func TestWritePanics(t *testing.T) {
+	t.Run("writes panics to the log file", func(t *testing.T) {
+		_, _, buffer := testhelper.SetupTestLogger()
+
+		expected := "ahhh"
+		defer func() {
+			if e := recover(); e != nil {
+				contents := string(buffer.Contents())
+				if !strings.Contains(contents, expected) {
+					t.Errorf("expected %q in log file: %q", expected, contents)
+				}
+			}
+		}()
+
+		defer log.WritePanics()
+		panic(expected)
 	})
-
-	It("writes panic information to the gplog file only", func() {
-		oldLogger := gplog.GetLogger()
-		defer func() { gplog.SetLogger(oldLogger) }()
-
-		testout, testerr, testlog := testhelper.SetupTestLogger()
-
-		panicMsg := "aaahhhhh"
-		Expect(func() {
-			defer log.WritePanics()
-			panic(panicMsg)
-		}).To(Panic())
-
-		Expect(testout.Contents()).To(BeEmpty())
-		Expect(testerr.Contents()).To(BeEmpty())
-		Expect(testlog).To(Say(`encountered panic \("%s"\); stack trace follows`, panicMsg))
-	})
-})
+}


### PR DESCRIPTION
Migrate panic_test, commands_test, and hub_test to Go style tests. To keep things simple for now we simply ported over the similar logic.

[Test pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:go_tests)