### PR TITLE
validate mirrors and standby in BATS and in CI

### DIFF
--- a/ci/scripts/upgrade-cluster.bash
+++ b/ci/scripts/upgrade-cluster.bash
@@ -121,7 +121,12 @@ if ! compare_dumps /tmp/old.sql /tmp/new.sql; then
 fi
 
 # Test that mirrors actually work
-echo 'Doing failover tests of mirrors...'
-check_mirror_validity "${GPHOME_NEW}" mdw $MASTER_PORT
+mirrorless=$(contents_without_mirror "${GPHOME_NEW}" mdw $MASTER_PORT)
+if [ -n "$mirrorless" ]; then
+    echo "skipping validate_mirrors_and_standby since these content ids do not have mirrors: ${mirrorless}"
+else
+    echo 'Doing failover tests of mirrors and standby...'
+    validate_mirrors_and_standby "${GPHOME_NEW}" mdw $MASTER_PORT
+fi
 
 echo 'Upgrade successful.'


### PR DESCRIPTION
Runs a cluster with mirrors+standby through its full paces:
* promotion of mirrors+standby to primaries+master
* readding mirrors+standby
* rebalancing the cluster
* at each relevant step, data tables are added and validated

There is a single test function, that errors out if it is called
to test a cluster that lacks either a mirror or a standby.

This runs in finalize.bats and in the CI GPDB-X->GPDB-Y tests.

NOTE TO REVIEWERS: it is probably easiest to review the test/finalize_checks.bash in side-by-side mode. 