### PR TITLE
Push response to the client into the step subsystem

### DIFF
--- a/hub/execute.go
+++ b/hub/execute.go
@@ -94,10 +94,11 @@ func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_Execut
 		return nil
 	})
 
-	message := MakeTargetClusterMessage(s.Target)
-	if err = stream.Send(message); err != nil {
-		return err
-	}
+	st.SendResponse(func(sender idl.MessageSender) error {
+		return stream.Send(
+			MakeTargetClusterMessage(s.Target),
+		)
+	})
 
 	return st.Err()
 }

--- a/hub/finalize.go
+++ b/hub/finalize.go
@@ -109,10 +109,11 @@ func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeSe
 		})
 	}
 
-	message := MakeTargetClusterMessage(s.Target)
-	if err = stream.Send(message); err != nil {
-		return err
-	}
+	st.SendResponse(func(sender idl.MessageSender) error {
+		return sender.Send(
+			MakeTargetClusterMessage(s.Target),
+		)
+	})
 
 	return st.Err()
 }


### PR DESCRIPTION
Helps response become a pseudo-step but not report to the UI via a new idl.Substep. We gain access to the step's MessageSender, and we also get to use the step's error tracking system.