### PR TITLE
Give the cluster the responsibility of creating the GreenplumRunner

### DIFF
--- a/greenplum/runner.go
+++ b/greenplum/runner.go
@@ -1,4 +1,4 @@
-package hub
+package greenplum
 
 import (
 	"fmt"
@@ -11,11 +11,20 @@ import (
 	"github.com/greenplum-db/gpupgrade/step"
 )
 
-type GreenplumRunner interface {
+type Runner interface {
 	Run(utilityName string, arguments ...string) error
 }
 
-func (e *greenplumRunner) Run(utilityName string, arguments ...string) error {
+func NewRunner(c *Cluster, streams step.OutStreams) Runner {
+	return &runner{
+		masterPort:          c.MasterPort(),
+		masterDataDirectory: c.MasterDataDir(),
+		binDir:              c.BinDir,
+		streams:             streams,
+	}
+}
+
+func (e *runner) Run(utilityName string, arguments ...string) error {
 	path := filepath.Join(e.binDir, utilityName)
 
 	arguments = append([]string{path}, arguments...)
@@ -34,7 +43,7 @@ func (e *greenplumRunner) Run(utilityName string, arguments ...string) error {
 	return command.Run()
 }
 
-type greenplumRunner struct {
+type runner struct {
 	binDir              string
 	masterDataDirectory string
 	masterPort          int

--- a/hub/upgrade_mirrors.go
+++ b/hub/upgrade_mirrors.go
@@ -26,7 +26,7 @@ func writeGpAddmirrorsConfig(mirrors []greenplum.SegConfig, out io.Writer) error
 	return nil
 }
 
-func runAddMirrors(r GreenplumRunner, filepath string) error {
+func runAddMirrors(r greenplum.Runner, filepath string) error {
 	return r.Run("gpaddmirrors",
 		"-a",
 		"-i", filepath,
@@ -86,7 +86,7 @@ func waitForFTS(db *sql.DB, timeout time.Duration) error {
 	}
 }
 
-func UpgradeMirrors(stateDir string, masterPort int, mirrors []greenplum.SegConfig, targetRunner GreenplumRunner) (err error) {
+func UpgradeMirrors(stateDir string, masterPort int, mirrors []greenplum.SegConfig, targetRunner greenplum.Runner) (err error) {
 	connURI := fmt.Sprintf("postgresql://localhost:%d/template1?gp_session_role=utility&search_path=", masterPort)
 	db, err := utils.System.SqlOpen("pgx", connURI)
 	if err != nil {
@@ -98,7 +98,7 @@ func UpgradeMirrors(stateDir string, masterPort int, mirrors []greenplum.SegConf
 	return doUpgrade(db, stateDir, mirrors, targetRunner)
 }
 
-func doUpgrade(db *sql.DB, stateDir string, mirrors []greenplum.SegConfig, targetRunner GreenplumRunner) (err error) {
+func doUpgrade(db *sql.DB, stateDir string, mirrors []greenplum.SegConfig, targetRunner greenplum.Runner) (err error) {
 	path := filepath.Join(stateDir, "add_mirrors_config")
 	// calling Close() on a file twice results in an error
 	// only call Close() in the defer if we haven't yet tried to close it.

--- a/hub/upgrade_mirrors_test.go
+++ b/hub/upgrade_mirrors_test.go
@@ -123,7 +123,7 @@ func TestRunAddMirrors(t *testing.T) {
 		}
 
 		if !runCalled {
-			t.Errorf("GreenplumRunner.Run() was not called")
+			t.Errorf("Runner.Run() was not called")
 		}
 	})
 
@@ -237,7 +237,7 @@ func TestDoUpgrade(t *testing.T) {
 		}
 
 		if !runCalled {
-			t.Errorf("GreenplumRunner.Run() was not called")
+			t.Errorf("Runner.Run() was not called")
 		}
 	})
 

--- a/hub/upgrade_standby.go
+++ b/hub/upgrade_standby.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
+
+	"github.com/greenplum-db/gpupgrade/greenplum"
 )
 
 type StandbyConfig struct {
@@ -20,7 +22,7 @@ type StandbyConfig struct {
 // In the happy-path, we expect this to fail as there should not be an existing
 // standby for the cluster.
 //
-func UpgradeStandby(r GreenplumRunner, standbyConfig StandbyConfig) error {
+func UpgradeStandby(r greenplum.Runner, standbyConfig StandbyConfig) error {
 	gplog.Info(fmt.Sprintf("removing any existing standby master on target cluster"))
 
 	err := r.Run("gpinitstandby", "-r", "-a")


### PR DESCRIPTION
Renames GreenplumRunner to `greenplum.Runner` and move it into this package along with Cluster and SegConfig.