### PR TITLE
Break dependency between greenplum and step packages

### DIFF
--- a/hub/greenplum_runner.go
+++ b/hub/greenplum_runner.go
@@ -2,14 +2,18 @@ package hub
 
 import (
 	"fmt"
+	"io"
 	"os/exec"
 	"path/filepath"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/kballard/go-shellquote"
-
-	"github.com/greenplum-db/gpupgrade/step"
 )
+
+type OutStreams interface {
+	Stdout() io.Writer
+	Stderr() io.Writer
+}
 
 type GreenplumRunner interface {
 	Run(utilityName string, arguments ...string) error
@@ -39,5 +43,5 @@ type greenplumRunner struct {
 	masterDataDirectory string
 	masterPort          int
 
-	streams step.OutStreams
+	streams OutStreams
 }


### PR DESCRIPTION
Duplicates the OutputStreams type. This should let them grow independenly if the need to, and reduces
the chance that changes to the step package have downstream effects on the Greenplum package. Now,
only the hub package will need to respond to changes in the step design.

This PR has been opened in favor over https://github.com/greenplum-db/gpupgrade/pull/271