### PR TITLE
Break dependency on step package from greenplum package.

### DIFF
--- a/greenplum/cluster.go
+++ b/greenplum/cluster.go
@@ -7,8 +7,6 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/pkg/errors"
 	"golang.org/x/xerrors"
-
-	"github.com/greenplum-db/gpupgrade/step"
 )
 
 var isPostmasterRunningCmd = exec.Command
@@ -269,11 +267,11 @@ func (c *Cluster) GetDirForContent(contentID int) string {
 	return c.Primaries[contentID].DataDir
 }
 
-func (c *Cluster) Start(stream step.OutStreams) error {
+func (c *Cluster) Start(stream OutStreams) error {
 	return runStartStopCmd(stream, c.BinDir, fmt.Sprintf("gpstart -a -d %[1]s", c.MasterDataDir()))
 }
 
-func (c *Cluster) Stop(stream step.OutStreams) error {
+func (c *Cluster) Stop(stream OutStreams) error {
 	// TODO: why can't we call isPostmasterRunning for the !stop case?  If we do, we get this on the pipeline:
 	// Usage: pgrep [-flvx] [-d DELIM] [-n|-o] [-P PPIDLIST] [-g PGRPLIST] [-s SIDLIST]
 	// [-u EUIDLIST] [-U UIDLIST] [-G GIDLIST] [-t TERMLIST] [PATTERN]
@@ -287,11 +285,11 @@ func (c *Cluster) Stop(stream step.OutStreams) error {
 	return runStartStopCmd(stream, c.BinDir, fmt.Sprintf("gpstop -a -d %[1]s", c.MasterDataDir()))
 }
 
-func (c *Cluster) StartMasterOnly(stream step.OutStreams) error {
+func (c *Cluster) StartMasterOnly(stream OutStreams) error {
 	return runStartStopCmd(stream, c.BinDir, fmt.Sprintf("gpstart -m -a -d %[1]s", c.MasterDataDir()))
 }
 
-func (c *Cluster) StopMasterOnly(stream step.OutStreams) error {
+func (c *Cluster) StopMasterOnly(stream OutStreams) error {
 	// TODO: why can't we call isPostmasterRunning for the !stop case?  If we do, we get this on the pipeline:
 	// Usage: pgrep [-flvx] [-d DELIM] [-n|-o] [-P PPIDLIST] [-g PGRPLIST] [-s SIDLIST]
 	// [-u EUIDLIST] [-U UIDLIST] [-G GIDLIST] [-t TERMLIST] [PATTERN]
@@ -305,7 +303,7 @@ func (c *Cluster) StopMasterOnly(stream step.OutStreams) error {
 	return runStartStopCmd(stream, c.BinDir, fmt.Sprintf("gpstop -m -a -d %[1]s", c.MasterDataDir()))
 }
 
-func runStartStopCmd(stream step.OutStreams, binDir, command string) error {
+func runStartStopCmd(stream OutStreams, binDir, command string) error {
 	commandWithEnv := fmt.Sprintf("source %[1]s/../greenplum_path.sh && %[1]s/%[2]s",
 		binDir,
 		command)
@@ -319,7 +317,7 @@ func runStartStopCmd(stream step.OutStreams, binDir, command string) error {
 /*
  * Helper functions
  */
-func isPostmasterRunning(stream step.OutStreams, masterDataDir string) error {
+func isPostmasterRunning(stream OutStreams, masterDataDir string) error {
 	cmd := isPostmasterRunningCmd("bash", "-c",
 		fmt.Sprintf("pgrep -F %s/postmaster.pid",
 			masterDataDir,

--- a/greenplum/runner.go
+++ b/greenplum/runner.go
@@ -2,20 +2,24 @@ package greenplum
 
 import (
 	"fmt"
+	"io"
 	"os/exec"
 	"path/filepath"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/kballard/go-shellquote"
-
-	"github.com/greenplum-db/gpupgrade/step"
 )
 
 type Runner interface {
 	Run(utilityName string, arguments ...string) error
 }
 
-func NewRunner(c *Cluster, streams step.OutStreams) Runner {
+type OutStreams interface {
+	Stdout() io.Writer
+	Stderr() io.Writer
+}
+
+func NewRunner(c *Cluster, streams OutStreams) Runner {
 	return &runner{
 		masterPort:          c.MasterPort(),
 		masterDataDirectory: c.MasterDataDir(),
@@ -48,5 +52,5 @@ type runner struct {
 	masterDataDirectory string
 	masterPort          int
 
-	streams step.OutStreams
+	streams OutStreams
 }


### PR DESCRIPTION
- This duplicates the OutStreams interface which will keep the
  greenplum runner from responding to changes in the step package.

See discussion on https://github.com/greenplum-db/gpupgrade/pull/271 for more context.