### PR TITLE
Reduce threading of streams and cluster data through Start/Stop.

### DIFF
--- a/greenplum/cluster.go
+++ b/greenplum/cluster.go
@@ -271,23 +271,30 @@ func (c *Cluster) MasterPidFile() string {
 // Cluster Manager facade
 //
 func (c *Cluster) Start(stream OutStreams) error {
-	return c.gpUtilities(stream).start()
+	return c.GpStart(stream).start()
 }
 
 func (c *Cluster) Stop(stream OutStreams) error {
-	return c.gpUtilities(stream).stop()
+	return c.GpStop(stream).stop()
 }
 
 func (c *Cluster) StartMasterOnly(stream OutStreams) error {
-	return c.gpUtilities(stream).startMasterOnly()
+	return c.GpStart(stream).startMasterOnly()
 }
 
 func (c *Cluster) StopMasterOnly(stream OutStreams) error {
-	return c.gpUtilities(stream).stopMasterOnly()
+	return c.GpStop(stream).stopMasterOnly()
 }
 
-func (c *Cluster) gpUtilities(stream OutStreams) *gpUtilities {
-	return newGpUtilities(
+func (c *Cluster) GpStart(stream OutStreams) *gpStart {
+	return newGpStart(
+		c,
+		NewRunner(c, stream),
+	)
+}
+
+func (c *Cluster) GpStop(stream OutStreams) *gpStop {
+	return newGpStop(
 		c,
 		NewRunner(c, stream),
 		&pgrepCommand{streams: stream},

--- a/greenplum/cluster.go
+++ b/greenplum/cluster.go
@@ -281,6 +281,6 @@ func (c *Cluster) GpStop(stream OutStreams) *gpStop {
 	return newGpStop(
 		c,
 		NewRunner(c, stream),
-		&pgrepCommand{streams: stream},
+		newPgrepCommand(stream),
 	)
 }

--- a/greenplum/cluster.go
+++ b/greenplum/cluster.go
@@ -271,21 +271,25 @@ func (c *Cluster) MasterPidFile() string {
 // Cluster Manager facade
 //
 func (c *Cluster) Start(stream OutStreams) error {
-	cm := newGpUtilities(c, stream)
-	return cm.start()
+	return c.gpUtilities(stream).start()
 }
 
 func (c *Cluster) Stop(stream OutStreams) error {
-	cm := newGpUtilities(c, stream)
-	return cm.stop()
+	return c.gpUtilities(stream).stop()
 }
 
 func (c *Cluster) StartMasterOnly(stream OutStreams) error {
-	cm := newGpUtilities(c, stream)
-	return cm.startMasterOnly()
+	return c.gpUtilities(stream).startMasterOnly()
 }
 
 func (c *Cluster) StopMasterOnly(stream OutStreams) error {
-	cm := newGpUtilities(c, stream)
-	return cm.stopMasterOnly()
+	return c.gpUtilities(stream).stopMasterOnly()
+}
+
+func (c *Cluster) gpUtilities(stream OutStreams) *gpUtilities {
+	return newGpUtilities(
+		c,
+		NewRunner(c, stream),
+		&pgrepCommand{streams: stream},
+	)
 }

--- a/greenplum/cluster.go
+++ b/greenplum/cluster.go
@@ -268,24 +268,8 @@ func (c *Cluster) MasterPidFile() string {
 }
 
 //
-// Cluster Manager facade
+// Cluster utilities facade
 //
-func (c *Cluster) Start(stream OutStreams) error {
-	return c.GpStart(stream).start()
-}
-
-func (c *Cluster) Stop(stream OutStreams) error {
-	return c.GpStop(stream).stop()
-}
-
-func (c *Cluster) StartMasterOnly(stream OutStreams) error {
-	return c.GpStart(stream).startMasterOnly()
-}
-
-func (c *Cluster) StopMasterOnly(stream OutStreams) error {
-	return c.GpStop(stream).stopMasterOnly()
-}
-
 func (c *Cluster) GpStart(stream OutStreams) *gpStart {
 	return newGpStart(
 		c,

--- a/greenplum/cluster.go
+++ b/greenplum/cluster.go
@@ -263,6 +263,10 @@ func (c *Cluster) GetDirForContent(contentID int) string {
 	return c.Primaries[contentID].DataDir
 }
 
+func (c *Cluster) MasterPidFile() string {
+	return fmt.Sprintf("%s/postmaster.pid", c.MasterDataDir())
+}
+
 //
 // Cluster Manager facade
 //

--- a/greenplum/cluster_manager.go
+++ b/greenplum/cluster_manager.go
@@ -32,11 +32,11 @@ func newGpStop(cluster *Cluster, runner Runner, pgrepCommand *pgrepCommand) *gpS
 	}
 }
 
-func (m *gpStart) start() error {
+func (m *gpStart) Start() error {
 	return m.runner.Run("gpstart", "-a", "-d", m.cluster.MasterDataDir())
 }
 
-func (m *gpStop) stopMasterOnly() error {
+func (m *gpStop) StopMasterOnly() error {
 	// TODO: why can't we call isPostmasterRunning for the !stop case?  If we do, we get this on the pipeline:
 	// Usage: pgrep [-flvx] [-d DELIM] [-n|-o] [-P PPIDLIST] [-g PGRPLIST] [-s SIDLIST]
 	// [-u EUIDLIST] [-U UIDLIST] [-G GIDLIST] [-t TERMLIST] [PATTERN]
@@ -51,11 +51,11 @@ func (m *gpStop) stopMasterOnly() error {
 	return m.runner.Run("gpstop", "-m", "-a", "-d", m.cluster.MasterDataDir())
 }
 
-func (m *gpStart) startMasterOnly() error {
+func (m *gpStart) StartMasterOnly() error {
 	return m.runner.Run("gpstart", "-m", "-a", "-d", m.cluster.MasterDataDir())
 }
 
-func (m *gpStop) stop() error {
+func (m *gpStop) Stop() error {
 	// TODO: why can't we call isPostmasterRunning for the !stop case?  If we do, we get this on the pipeline:
 	// Usage: pgrep [-flvx] [-d DELIM] [-n|-o] [-P PPIDLIST] [-g PGRPLIST] [-s SIDLIST]
 	// [-u EUIDLIST] [-U UIDLIST] [-G GIDLIST] [-t TERMLIST] [PATTERN]

--- a/greenplum/cluster_manager.go
+++ b/greenplum/cluster_manager.go
@@ -4,7 +4,12 @@ import (
 	"os/exec"
 )
 
-type gpUtilities struct {
+type gpStart struct {
+	cluster *Cluster
+	runner  Runner
+}
+
+type gpStop struct {
 	cluster      *Cluster
 	runner       Runner
 	pgrepCommand *pgrepCommand
@@ -12,19 +17,26 @@ type gpUtilities struct {
 
 var startStopCmd = exec.Command
 
-func newGpUtilities(cluster *Cluster, runner Runner, pgrepCommand *pgrepCommand) *gpUtilities {
-	return &gpUtilities{
+func newGpStart(cluster *Cluster, runner Runner) *gpStart {
+	return &gpStart{
+		cluster: cluster,
+		runner:  runner,
+	}
+}
+
+func newGpStop(cluster *Cluster, runner Runner, pgrepCommand *pgrepCommand) *gpStop {
+	return &gpStop{
 		cluster:      cluster,
 		runner:       runner,
 		pgrepCommand: pgrepCommand,
 	}
 }
 
-func (m *gpUtilities) start() error {
+func (m *gpStart) start() error {
 	return m.runner.Run("gpstart", "-a", "-d", m.cluster.MasterDataDir())
 }
 
-func (m *gpUtilities) stopMasterOnly() error {
+func (m *gpStop) stopMasterOnly() error {
 	// TODO: why can't we call isPostmasterRunning for the !stop case?  If we do, we get this on the pipeline:
 	// Usage: pgrep [-flvx] [-d DELIM] [-n|-o] [-P PPIDLIST] [-g PGRPLIST] [-s SIDLIST]
 	// [-u EUIDLIST] [-U UIDLIST] [-G GIDLIST] [-t TERMLIST] [PATTERN]
@@ -39,11 +51,11 @@ func (m *gpUtilities) stopMasterOnly() error {
 	return m.runner.Run("gpstop", "-m", "-a", "-d", m.cluster.MasterDataDir())
 }
 
-func (m *gpUtilities) startMasterOnly() error {
+func (m *gpStart) startMasterOnly() error {
 	return m.runner.Run("gpstart", "-m", "-a", "-d", m.cluster.MasterDataDir())
 }
 
-func (m *gpUtilities) stop() error {
+func (m *gpStop) stop() error {
 	// TODO: why can't we call isPostmasterRunning for the !stop case?  If we do, we get this on the pipeline:
 	// Usage: pgrep [-flvx] [-d DELIM] [-n|-o] [-P PPIDLIST] [-g PGRPLIST] [-s SIDLIST]
 	// [-u EUIDLIST] [-U UIDLIST] [-G GIDLIST] [-t TERMLIST] [PATTERN]

--- a/greenplum/cluster_manager.go
+++ b/greenplum/cluster_manager.go
@@ -1,0 +1,94 @@
+package greenplum
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+type gpUtilities struct {
+	cluster *Cluster
+	streams OutStreams
+}
+
+var isPostmasterRunningCmd = exec.Command
+var startStopCmd = exec.Command
+
+func newGpUtilities(cluster *Cluster, streams OutStreams) *gpUtilities {
+	return &gpUtilities{
+		cluster: cluster,
+		streams: streams,
+	}
+}
+
+func (m *gpUtilities) masterDataDir() string {
+	return m.cluster.MasterDataDir()
+}
+
+func (m *gpUtilities) start() error {
+	return m.runStartStopCmd(
+		fmt.Sprintf("gpstart -a -d %[1]s", m.masterDataDir()),
+	)
+}
+
+func (m *gpUtilities) stopMasterOnly() error {
+	// TODO: why can't we call isPostmasterRunning for the !stop case?  If we do, we get this on the pipeline:
+	// Usage: pgrep [-flvx] [-d DELIM] [-n|-o] [-P PPIDLIST] [-g PGRPLIST] [-s SIDLIST]
+	// [-u EUIDLIST] [-U UIDLIST] [-G GIDLIST] [-t TERMLIST] [PATTERN]
+	//  pgrep: pidfile not valid
+	// TODO: should we actually return an error if we try to gpstop an already stopped cluster?
+	err := m.isPostmasterRunning()
+
+	if err != nil {
+		return err
+	}
+
+	return m.runStartStopCmd(
+		fmt.Sprintf("gpstop -m -a -d %[1]s", m.masterDataDir()))
+}
+
+func (m *gpUtilities) startMasterOnly() error {
+	return m.runStartStopCmd(
+		fmt.Sprintf("gpstart -m -a -d %[1]s", m.masterDataDir()))
+}
+
+func (m *gpUtilities) stop() error {
+	// TODO: why can't we call isPostmasterRunning for the !stop case?  If we do, we get this on the pipeline:
+	// Usage: pgrep [-flvx] [-d DELIM] [-n|-o] [-P PPIDLIST] [-g PGRPLIST] [-s SIDLIST]
+	// [-u EUIDLIST] [-U UIDLIST] [-G GIDLIST] [-t TERMLIST] [PATTERN]
+	//  pgrep: pidfile not valid
+	// TODO: should we actually return an error if we try to gpstop an already stopped cluster?
+	err := m.isPostmasterRunning()
+
+	if err != nil {
+		return err
+	}
+
+	return m.runStartStopCmd(
+		fmt.Sprintf("gpstop -a -d %[1]s", m.masterDataDir()))
+}
+
+/*
+ * Helper functions
+ */
+func (m *gpUtilities) isPostmasterRunning() error {
+	cmd := isPostmasterRunningCmd("bash", "-c",
+		fmt.Sprintf("pgrep -F %s/postmaster.pid",
+			m.cluster.MasterDataDir(),
+		))
+
+	cmd.Stdout = m.streams.Stdout()
+	cmd.Stderr = m.streams.Stderr()
+
+	return cmd.Run()
+}
+
+func (m *gpUtilities) runStartStopCmd(command string) error {
+	commandWithEnv := fmt.Sprintf("source %[1]s/../greenplum_path.sh && %[1]s/%[2]s",
+		m.cluster.BinDir,
+		command)
+
+	cmd := startStopCmd("bash", "-c", commandWithEnv)
+	cmd.Stdout = m.streams.Stdout()
+	cmd.Stderr = m.streams.Stderr()
+	return cmd.Run()
+}

--- a/greenplum/gpstart.go
+++ b/greenplum/gpstart.go
@@ -1,0 +1,27 @@
+package greenplum
+
+import (
+	"os/exec"
+)
+
+type gpStart struct {
+	cluster *Cluster
+	runner  Runner
+}
+
+var startStopCmd = exec.Command
+
+func newGpStart(cluster *Cluster, runner Runner) *gpStart {
+	return &gpStart{
+		cluster: cluster,
+		runner:  runner,
+	}
+}
+
+func (m *gpStart) Start() error {
+	return m.runner.Run("gpstart", "-a", "-d", m.cluster.MasterDataDir())
+}
+
+func (m *gpStart) StartMasterOnly() error {
+	return m.runner.Run("gpstart", "-m", "-a", "-d", m.cluster.MasterDataDir())
+}

--- a/greenplum/gpstart.go
+++ b/greenplum/gpstart.go
@@ -1,15 +1,9 @@
 package greenplum
 
-import (
-	"os/exec"
-)
-
 type gpStart struct {
 	cluster *Cluster
 	runner  Runner
 }
-
-var startStopCmd = exec.Command
 
 func newGpStart(cluster *Cluster, runner Runner) *gpStart {
 	return &gpStart{

--- a/greenplum/gpstop.go
+++ b/greenplum/gpstop.go
@@ -1,27 +1,9 @@
 package greenplum
 
-import (
-	"os/exec"
-)
-
-type gpStart struct {
-	cluster *Cluster
-	runner  Runner
-}
-
 type gpStop struct {
 	cluster      *Cluster
 	runner       Runner
 	pgrepCommand *pgrepCommand
-}
-
-var startStopCmd = exec.Command
-
-func newGpStart(cluster *Cluster, runner Runner) *gpStart {
-	return &gpStart{
-		cluster: cluster,
-		runner:  runner,
-	}
 }
 
 func newGpStop(cluster *Cluster, runner Runner, pgrepCommand *pgrepCommand) *gpStop {
@@ -30,10 +12,6 @@ func newGpStop(cluster *Cluster, runner Runner, pgrepCommand *pgrepCommand) *gpS
 		runner:       runner,
 		pgrepCommand: pgrepCommand,
 	}
-}
-
-func (m *gpStart) Start() error {
-	return m.runner.Run("gpstart", "-a", "-d", m.cluster.MasterDataDir())
 }
 
 func (m *gpStop) StopMasterOnly() error {
@@ -49,10 +27,6 @@ func (m *gpStop) StopMasterOnly() error {
 	}
 
 	return m.runner.Run("gpstop", "-m", "-a", "-d", m.cluster.MasterDataDir())
-}
-
-func (m *gpStart) StartMasterOnly() error {
-	return m.runner.Run("gpstart", "-m", "-a", "-d", m.cluster.MasterDataDir())
 }
 
 func (m *gpStop) Stop() error {

--- a/greenplum/gputilities_test.go
+++ b/greenplum/gputilities_test.go
@@ -109,7 +109,7 @@ func TestStartOrStopCluster(t *testing.T) {
 		runner := spyrunner.New()
 
 		gpUtilities := newGpStop(source, runner, pgrepCommand)
-		err := gpUtilities.stop()
+		err := gpUtilities.Stop()
 
 		if err != nil {
 			t.Fatalf("unexpected error while running gpstop: %v", err)
@@ -138,7 +138,7 @@ func TestStartOrStopCluster(t *testing.T) {
 			})
 
 		gpUtilities := newGpStop(source, spyrunner.New(), pgrepCommand)
-		err := gpUtilities.stop()
+		err := gpUtilities.Stop()
 
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(skippedStopClusterCommand).To(Equal(true))
@@ -148,7 +148,7 @@ func TestStartOrStopCluster(t *testing.T) {
 		runner := spyrunner.New()
 
 		gpStart := newGpStart(source, runner)
-		err := gpStart.start()
+		err := gpStart.Start()
 
 		if err != nil {
 			t.Fatalf("unexpected error while running gpstart: %v", err)
@@ -172,7 +172,7 @@ func TestStartOrStopCluster(t *testing.T) {
 
 		gpStart := newGpStart(source, runner)
 
-		err := gpStart.startMasterOnly()
+		err := gpStart.StartMasterOnly()
 		if err != nil {
 			t.Fatalf("unexpected error while running gpstart: %v", err)
 		}
@@ -199,8 +199,8 @@ func TestStartOrStopCluster(t *testing.T) {
 
 		runner := spyrunner.New()
 
-		gpUtilities := newGpStop(source, runner, pgrepCommand)
-		err := gpUtilities.stopMasterOnly()
+		gpStop := newGpStop(source, runner, pgrepCommand)
+		err := gpStop.StopMasterOnly()
 
 		if err != nil {
 			t.Fatalf("unexpected error while running gpstop: %v", err)

--- a/greenplum/gputilities_test.go
+++ b/greenplum/gputilities_test.go
@@ -131,17 +131,16 @@ func TestStartOrStopCluster(t *testing.T) {
 	t.Run("stop cluster detects that cluster is already shutdown", func(t *testing.T) {
 		pgrepCmd = exectest.NewCommand(PgrepCmd_Errors)
 
-		var skippedStopClusterCommand = true
-		startStopCmd = exectest.NewCommandWithVerifier(PgrepCmd,
-			func(path string, args ...string) {
-				skippedStopClusterCommand = false
-			})
-
-		gpUtilities := newGpStop(source, spyrunner.New(), pgrepCommand)
+		runner := spyrunner.New()
+		gpUtilities := newGpStop(source, runner, pgrepCommand)
 		err := gpUtilities.Stop()
 
+		if runner.TimesRunWasCalledWith("gpstop") != 0 {
+			t.Errorf("got %v calls to gpstop, expected zero",
+				runner.TimesRunWasCalledWith("gpstop"))
+		}
+
 		g.Expect(err).To(HaveOccurred())
-		g.Expect(skippedStopClusterCommand).To(Equal(true))
 	})
 
 	t.Run("start cluster successfully starts up cluster", func(t *testing.T) {

--- a/greenplum/gputilities_test.go
+++ b/greenplum/gputilities_test.go
@@ -108,7 +108,7 @@ func TestStartOrStopCluster(t *testing.T) {
 
 		runner := spyrunner.New()
 
-		gpUtilities := newGpUtilities(source, runner, pgrepCommand)
+		gpUtilities := newGpStop(source, runner, pgrepCommand)
 		err := gpUtilities.stop()
 
 		if err != nil {
@@ -137,7 +137,7 @@ func TestStartOrStopCluster(t *testing.T) {
 				skippedStopClusterCommand = false
 			})
 
-		gpUtilities := newGpUtilities(source, spyrunner.New(), pgrepCommand)
+		gpUtilities := newGpStop(source, spyrunner.New(), pgrepCommand)
 		err := gpUtilities.stop()
 
 		g.Expect(err).To(HaveOccurred())
@@ -147,13 +147,9 @@ func TestStartOrStopCluster(t *testing.T) {
 	t.Run("start cluster successfully starts up cluster", func(t *testing.T) {
 		runner := spyrunner.New()
 
-		gpUtility := gpUtilities{
-			cluster:      source,
-			runner:       runner,
-			pgrepCommand: pgrepCommand,
-		}
+		gpStart := newGpStart(source, runner)
+		err := gpStart.start()
 
-		err := gpUtility.start()
 		if err != nil {
 			t.Fatalf("unexpected error while running gpstart: %v", err)
 		}
@@ -174,13 +170,9 @@ func TestStartOrStopCluster(t *testing.T) {
 	t.Run("start master successfully starts up master only", func(t *testing.T) {
 		runner := spyrunner.New()
 
-		gpUtility := gpUtilities{
-			cluster:      source,
-			runner:       runner,
-			pgrepCommand: pgrepCommand,
-		}
+		gpStart := newGpStart(source, runner)
 
-		err := gpUtility.startMasterOnly()
+		err := gpStart.startMasterOnly()
 		if err != nil {
 			t.Fatalf("unexpected error while running gpstart: %v", err)
 		}
@@ -207,7 +199,7 @@ func TestStartOrStopCluster(t *testing.T) {
 
 		runner := spyrunner.New()
 
-		gpUtilities := newGpUtilities(source, runner, pgrepCommand)
+		gpUtilities := newGpStop(source, runner, pgrepCommand)
 		err := gpUtilities.stopMasterOnly()
 
 		if err != nil {

--- a/greenplum/pgrep.go
+++ b/greenplum/pgrep.go
@@ -11,6 +11,10 @@ type pgrepCommand struct {
 
 var pgrepCmd = exec.Command
 
+func newPgrepCommand(stream OutStreams) *pgrepCommand {
+	return &pgrepCommand{streams: stream}
+}
+
 func (m *pgrepCommand) isRunning(pidFile string) error {
 	cmd := pgrepCmd("bash", "-c", fmt.Sprintf("pgrep -F %s", pidFile))
 

--- a/greenplum/pgrep.go
+++ b/greenplum/pgrep.go
@@ -1,0 +1,21 @@
+package greenplum
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+type pgrepCommand struct {
+	streams OutStreams
+}
+
+var pgrepCmd = exec.Command
+
+func (m *pgrepCommand) isRunning(pidFile string) error {
+	cmd := pgrepCmd("bash", "-c", fmt.Sprintf("pgrep -F %s", pidFile))
+
+	cmd.Stdout = m.streams.Stdout()
+	cmd.Stderr = m.streams.Stderr()
+
+	return cmd.Run()
+}

--- a/greenplum/start_or_stop_cluster_test.go
+++ b/greenplum/start_or_stop_cluster_test.go
@@ -89,14 +89,16 @@ func TestStartOrStopCluster(t *testing.T) {
 				g.Expect(args).To(Equal([]string{"-c", "pgrep -F basedir/seg-1/postmaster.pid"}))
 			})
 
-		err := isPostmasterRunning(DevNull, source.MasterDataDir())
+		cm := newGpUtilities(source, DevNull)
+
+		err := cm.isPostmasterRunning()
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 
 	t.Run("isPostmasterRunning fails", func(t *testing.T) {
 		isPostmasterRunningCmd = exectest.NewCommand(IsPostmasterRunningCmd_Errors)
 
-		err := isPostmasterRunning(DevNull, source.MasterDataDir())
+		err := newGpUtilities(source, DevNull).isPostmasterRunning()
 		g.Expect(err).To(HaveOccurred())
 	})
 

--- a/hub/execute.go
+++ b/hub/execute.go
@@ -35,7 +35,7 @@ func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_Execut
 	}()
 
 	st.Run(idl.Substep_SHUTDOWN_SOURCE_CLUSTER, func(streams step.OutStreams) error {
-		err := s.Source.Stop(streams)
+		err := s.Source.GpStop(streams).Stop()
 
 		if err != nil {
 			return xerrors.Errorf("failed to stop source cluster: %w", err)
@@ -85,7 +85,7 @@ func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_Execut
 	})
 
 	st.Run(idl.Substep_START_TARGET_CLUSTER, func(streams step.OutStreams) error {
-		err := s.Target.Start(streams)
+		err := s.Target.GpStart(streams).Start()
 
 		if err != nil {
 			return xerrors.Errorf("failed to start target cluster: %w", err)

--- a/hub/finalize.go
+++ b/hub/finalize.go
@@ -29,7 +29,7 @@ func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeSe
 	}()
 
 	st.Run(idl.Substep_FINALIZE_SHUTDOWN_TARGET_CLUSTER, func(streams step.OutStreams) error {
-		err := s.Target.Stop(streams)
+		err := s.Target.GpStop(streams).Stop()
 
 		if err != nil {
 			return xerrors.Errorf("failed to stop target cluster: %w", err)
@@ -55,7 +55,7 @@ func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeSe
 	})
 
 	st.Run(idl.Substep_FINALIZE_START_TARGET_CLUSTER, func(streams step.OutStreams) error {
-		err := s.Target.Start(streams)
+		err := s.Target.GpStart(streams).Start()
 
 		if err != nil {
 			return xerrors.Errorf("failed to start target cluster: %w", err)

--- a/hub/initialize.go
+++ b/hub/initialize.go
@@ -79,7 +79,7 @@ func (s *Server) InitializeCreateCluster(in *idl.InitializeCreateClusterRequest,
 	})
 
 	st.Run(idl.Substep_SHUTDOWN_TARGET_CLUSTER, func(stream step.OutStreams) error {
-		err := s.Target.Stop(stream)
+		err := s.Target.GpStop(stream).Stop()
 
 		if err != nil {
 			return xerrors.Errorf("failed to stop target cluster: %w", err)

--- a/hub/update_catalog.go
+++ b/hub/update_catalog.go
@@ -18,7 +18,7 @@ import (
 // TODO: When in copy mode should we update the catalog and in-memory object of
 //  the source cluster?
 func (s *Server) UpdateCatalogAndClusterConfig(streams step.OutStreams) (err error) {
-	err = s.Target.StartMasterOnly(streams)
+	err = s.Target.GpStart(streams).StartMasterOnly()
 	if err != nil {
 		return xerrors.Errorf("failed to start target master: %w", err)
 	}
@@ -38,7 +38,7 @@ func (s *Server) UpdateCatalogAndClusterConfig(streams step.OutStreams) (err err
 	segs := map[int]greenplum.SegConfig{-1: master}
 	oldTarget := &greenplum.Cluster{Primaries: segs, BinDir: s.Target.BinDir}
 
-	err = oldTarget.StopMasterOnly(streams)
+	err = oldTarget.GpStop(streams).StopMasterOnly()
 	if err != nil {
 		return xerrors.Errorf("failed to stop target master: %w", err)
 	}

--- a/hub/upgrade_standby_test.go
+++ b/hub/upgrade_standby_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 
 	"github.com/greenplum-db/gpupgrade/hub"
+	"github.com/greenplum-db/gpupgrade/testutils/spyrunner"
 )
 
 func TestUpgradeStandby(t *testing.T) {
@@ -18,7 +19,7 @@ func TestUpgradeStandby(t *testing.T) {
 			DataDirectory: "/some/standby/data/directory",
 		}
 
-		runner := newSpyRunner()
+		runner := spyrunner.New()
 		hub.UpgradeStandby(runner, config)
 
 		if runner.TimesRunWasCalledWith("gpinitstandby") != 2 {
@@ -70,70 +71,4 @@ func TestUpgradeStandby(t *testing.T) {
 			t.Error("got automatic argument to be set, it was not")
 		}
 	})
-}
-
-type spyRunner struct {
-	calls map[string][]*spyCall
-}
-
-type spyCall struct {
-	arguments []string
-}
-
-func newSpyRunner() *spyRunner {
-	return &spyRunner{
-		calls: make(map[string][]*spyCall),
-	}
-}
-
-// implements GreenplumRunner
-func (e *spyRunner) Run(utilityName string, arguments ...string) error {
-	if e.calls == nil {
-		e.calls = make(map[string][]*spyCall)
-	}
-
-	calls := e.calls[utilityName]
-	e.calls[utilityName] = append(calls, &spyCall{arguments: arguments})
-
-	return nil
-}
-
-func (e *spyRunner) TimesRunWasCalledWith(utilityName string) int {
-	return len(e.calls[utilityName])
-}
-
-func (e *spyRunner) Call(utilityName string, nthCall int) *spyCall {
-	callsToUtility := e.calls[utilityName]
-
-	if len(callsToUtility) == 0 {
-		return &spyCall{}
-	}
-
-	if len(callsToUtility) >= nthCall-1 {
-		return callsToUtility[nthCall-1]
-	}
-
-	return &spyCall{}
-}
-
-func (c *spyCall) ArgumentsInclude(argName string) bool {
-	for _, arg := range c.arguments {
-		if argName == arg {
-			return true
-		}
-	}
-	return false
-}
-
-func (c *spyCall) ArgumentValue(flag string) string {
-	for i := 0; i < len(c.arguments)-1; i++ {
-		current := c.arguments[i]
-		next := c.arguments[i+1]
-
-		if flag == current {
-			return next
-		}
-	}
-
-	return ""
 }

--- a/testutils/spyrunner/spy.go
+++ b/testutils/spyrunner/spy.go
@@ -1,0 +1,67 @@
+package spyrunner
+
+type spyRunner struct {
+	calls map[string][]*spyCall
+}
+
+type spyCall struct {
+	arguments []string
+}
+
+func New() *spyRunner {
+	return &spyRunner{
+		calls: make(map[string][]*spyCall),
+	}
+}
+
+// implements GreenplumRunner
+func (e *spyRunner) Run(utilityName string, arguments ...string) error {
+	if e.calls == nil {
+		e.calls = make(map[string][]*spyCall)
+	}
+
+	calls := e.calls[utilityName]
+	e.calls[utilityName] = append(calls, &spyCall{arguments: arguments})
+
+	return nil
+}
+
+func (e *spyRunner) TimesRunWasCalledWith(utilityName string) int {
+	return len(e.calls[utilityName])
+}
+
+func (e *spyRunner) Call(utilityName string, nthCall int) *spyCall {
+	callsToUtility := e.calls[utilityName]
+
+	if len(callsToUtility) == 0 {
+		return &spyCall{}
+	}
+
+	if len(callsToUtility) >= nthCall-1 {
+		return callsToUtility[nthCall-1]
+	}
+
+	return &spyCall{}
+}
+
+func (c *spyCall) ArgumentsInclude(argName string) bool {
+	for _, arg := range c.arguments {
+		if argName == arg {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *spyCall) ArgumentValue(flag string) string {
+	for i := 0; i < len(c.arguments)-1; i++ {
+		current := c.arguments[i]
+		next := c.arguments[i+1]
+
+		if flag == current {
+			return next
+		}
+	}
+
+	return ""
+}


### PR DESCRIPTION
- Introduces a facade on Cluster to pass through to GpStart and GpStop utilities
  that is responsible for start/stop operations. 

- Replaces startStopCommand with Runner system.

```
// for example:

target.GpStart(streams).Start()
source.GpStop(streams).Stop()

```
