### PR TITLE
Move agent connection and server start/stop into hub/agent package.

### DIFF
--- a/hub/agent/agentclient.go
+++ b/hub/agent/agentclient.go
@@ -1,0 +1,193 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/hashicorp/go-multierror"
+	"golang.org/x/xerrors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
+
+	"github.com/greenplum-db/gpupgrade/idl"
+)
+
+// Allow exec.Command to be mocked out by exectest.NewCommand.
+var execCommand = exec.Command
+
+type Client struct {
+	connections []*Connection
+	grpcDialer  Dialer
+}
+
+func NewClient(dialer Dialer) *Client {
+	return &Client{
+		grpcDialer: dialer,
+	}
+}
+
+func (m *Client) Connect(hostnames []string, port int) error {
+	if m.connections != nil {
+		if err := m.ensureConnectionsAreReady(); err != nil {
+			gplog.Error("ensureConnsAreReady failed: %s", err)
+			return err
+		}
+
+		return nil
+	}
+
+	for _, host := range hostnames {
+		connection, err := newConnection(host, port, m.grpcDialer)
+		if err != nil {
+			return err
+		}
+
+		m.connections = append(m.connections, connection)
+	}
+
+	return nil
+}
+
+func (m *Client) Connections() []*Connection {
+	return m.connections
+}
+
+func (m *Client) StopAllAgents() error {
+	var wg sync.WaitGroup
+	errs := make(chan error, len(m.connections))
+
+	for _, conn := range m.connections {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			_, err := conn.AgentClient.StopAgent(context.Background(), &idl.StopAgentRequest{})
+			if err == nil { // no error means the agent did not terminate as expected
+				errs <- xerrors.Errorf("failed to stop agent on host: %s", conn.Hostname)
+				return
+			}
+
+			// XXX: "transport is closing" is not documented but is needed to uniquely interpret codes.Unavailable
+			// https://github.com/grpc/grpc/blob/v1.24.0/doc/statuscodes.md
+			errStatus := grpcStatus.Convert(err)
+			if errStatus.Code() != codes.Unavailable || errStatus.Message() != "transport is closing" {
+				errs <- xerrors.Errorf("failed to stop agent on host %s : %w", conn.Hostname, err)
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	var multiErr *multierror.Error
+	for err := range errs {
+		multiErr = multierror.Append(multiErr, err)
+	}
+
+	return multiErr.ErrorOrNil()
+}
+
+func (m *Client) CloseConnections() {
+	for _, conn := range m.connections {
+		defer conn.CancelContext()
+		currState := conn.Conn.GetState()
+		err := conn.Conn.Close()
+		if err != nil {
+			gplog.Info(fmt.Sprintf("Error closing hub to agent connection. host: %s, err: %s", conn.Hostname, err.Error()))
+		}
+		conn.Conn.WaitForStateChange(context.Background(), currState)
+	}
+}
+
+// TODO: make this a method on HubToAgentClient
+func RestartAllAgents(ctx context.Context,
+	dialer func(context.Context, string) (net.Conn, error),
+	hostnames []string,
+	port int,
+	stateDir string) ([]string, error) {
+
+	var wg sync.WaitGroup
+	restartedHosts := make(chan string, len(hostnames))
+	errs := make(chan error, len(hostnames))
+
+	for _, host := range hostnames {
+		wg.Add(1)
+		go func(host string) {
+			defer wg.Done()
+
+			address := host + ":" + strconv.Itoa(port)
+			timeoutCtx, cancelFunc := context.WithTimeout(ctx, 3*time.Second)
+			opts := []grpc.DialOption{
+				grpc.WithBlock(),
+				grpc.WithInsecure(),
+				grpc.FailOnNonTempDialError(true),
+			}
+			if dialer != nil {
+				opts = append(opts, grpc.WithContextDialer(dialer))
+			}
+			conn, err := grpc.DialContext(timeoutCtx, address, opts...)
+			cancelFunc()
+			if err == nil {
+				err = conn.Close()
+				if err != nil {
+					gplog.Error("failed to close agent connection to %s: %+v", host, err)
+				}
+				return
+			}
+
+			gplog.Debug("failed to dial agent on %s: %+v", host, err)
+			gplog.Info("starting agent on %s", host)
+
+			agentPath, err := getAgentPath()
+			if err != nil {
+				errs <- err
+				return
+			}
+			cmd := execCommand("ssh", host,
+				fmt.Sprintf("bash -c \"%s agent --daemonize --state-directory %s\"", agentPath, stateDir))
+			stdout, err := cmd.Output()
+			if err != nil {
+				errs <- err
+				return
+			}
+
+			gplog.Debug(string(stdout))
+			restartedHosts <- host
+		}(host)
+	}
+
+	wg.Wait()
+	close(errs)
+	close(restartedHosts)
+
+	var hosts []string
+	for h := range restartedHosts {
+		hosts = append(hosts, h)
+	}
+
+	var multiErr *multierror.Error
+	for err := range errs {
+		multiErr = multierror.Append(multiErr, err)
+	}
+
+	return hosts, multiErr.ErrorOrNil()
+}
+
+func getAgentPath() (string, error) {
+	hubPath, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(filepath.Dir(hubPath), "gpupgrade"), nil
+}

--- a/hub/agent/agentclient.go
+++ b/hub/agent/agentclient.go
@@ -62,7 +62,7 @@ func (c *Client) Connections() []*Connection {
 
 func (c *Client) CloseConnections() {
 	for _, conn := range c.connections {
-		defer conn.CancelContext()
+		defer conn.cancelContext()
 		currState := conn.conn.GetState()
 		err := conn.conn.Close()
 		if err != nil {

--- a/hub/agent/agentclient.go
+++ b/hub/agent/agentclient.go
@@ -63,12 +63,12 @@ func (c *Client) Connections() []*Connection {
 func (c *Client) CloseConnections() {
 	for _, conn := range c.connections {
 		defer conn.CancelContext()
-		currState := conn.Conn.GetState()
-		err := conn.Conn.Close()
+		currState := conn.conn.GetState()
+		err := conn.conn.Close()
 		if err != nil {
 			gplog.Info(fmt.Sprintf("Error closing hub to agent connection. host: %s, err: %s", conn.Hostname, err.Error()))
 		}
-		conn.Conn.WaitForStateChange(context.Background(), currState)
+		conn.conn.WaitForStateChange(context.Background(), currState)
 	}
 }
 

--- a/hub/agent/common_test.go
+++ b/hub/agent/common_test.go
@@ -1,0 +1,20 @@
+package agent
+
+import (
+	"os"
+	"testing"
+
+	"github.com/greenplum-db/gpupgrade/testutils/exectest"
+)
+
+func SetExecCommand(cmdFunc exectest.Command) {
+	execCommand = cmdFunc
+}
+
+func ResetExecCommand() {
+	execCommand = nil
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(exectest.Run(m))
+}

--- a/hub/agent/connection.go
+++ b/hub/agent/connection.go
@@ -1,0 +1,61 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+
+	"github.com/greenplum-db/gpupgrade/idl"
+)
+
+type Connection struct {
+	// TODO: make these members package private
+	Conn          *grpc.ClientConn
+	AgentClient   idl.AgentClient
+	Hostname      string
+	CancelContext func()
+}
+
+func newConnection(host string, port int, dialer Dialer) (*Connection, error) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), DialTimeout)
+
+	conn, err := dialer(ctx,
+		host+":"+strconv.Itoa(port),
+		grpc.WithInsecure(), grpc.WithBlock())
+
+	if err != nil {
+		err = errors.Errorf("grpcDialer failed: %s", err.Error())
+		gplog.Error(err.Error())
+		cancelFunc()
+		return nil, err
+	}
+
+	return &Connection{
+		Conn:          conn,
+		AgentClient:   idl.NewAgentClient(conn),
+		Hostname:      host,
+		CancelContext: cancelFunc,
+	}, nil
+}
+
+func (m *Client) ensureConnectionsAreReady() error {
+	notReadyHostnames := []string{}
+
+	for _, conn := range m.connections {
+		if conn.Conn.GetState() != connectivity.Ready {
+			notReadyHostnames = append(notReadyHostnames, conn.Hostname)
+		}
+	}
+
+	if len(notReadyHostnames) > 0 {
+		return fmt.Errorf("the connections to the following hosts were not ready: %s", strings.Join(notReadyHostnames, ","))
+	}
+
+	return nil
+}

--- a/hub/agent/connection.go
+++ b/hub/agent/connection.go
@@ -47,10 +47,10 @@ func newConnection(host string, port int, dialer Dialer) (*Connection, error) {
 	}, nil
 }
 
-func (m *Client) ensureConnectionsAreReady() error {
+func (c *Client) ensureConnectionsAreReady() error {
 	notReadyHostnames := []string{}
 
-	for _, conn := range m.connections {
+	for _, conn := range c.connections {
 		if conn.Conn.GetState() != connectivity.Ready {
 			notReadyHostnames = append(notReadyHostnames, conn.Hostname)
 		}

--- a/hub/agent/connection.go
+++ b/hub/agent/connection.go
@@ -22,7 +22,7 @@ type Connection struct {
 	conn          *grpc.ClientConn
 	AgentClient   idl.AgentClient
 	Hostname      string
-	CancelContext func()
+	cancelContext func()
 }
 
 func (c *Connection) State() connectivity.State {
@@ -47,7 +47,7 @@ func newConnection(host string, port int, dialer Dialer) (*Connection, error) {
 		conn:          conn,
 		AgentClient:   idl.NewAgentClient(conn),
 		Hostname:      host,
-		CancelContext: cancelFunc,
+		cancelContext: cancelFunc,
 	}, nil
 }
 

--- a/hub/agent/connection.go
+++ b/hub/agent/connection.go
@@ -19,10 +19,14 @@ const dialTimeout = 3 * time.Second
 
 type Connection struct {
 	// TODO: make these members package private
-	Conn          *grpc.ClientConn
+	conn          *grpc.ClientConn
 	AgentClient   idl.AgentClient
 	Hostname      string
 	CancelContext func()
+}
+
+func (c *Connection) State() connectivity.State {
+	return c.conn.GetState()
 }
 
 func newConnection(host string, port int, dialer Dialer) (*Connection, error) {
@@ -40,7 +44,7 @@ func newConnection(host string, port int, dialer Dialer) (*Connection, error) {
 	}
 
 	return &Connection{
-		Conn:          conn,
+		conn:          conn,
 		AgentClient:   idl.NewAgentClient(conn),
 		Hostname:      host,
 		CancelContext: cancelFunc,
@@ -51,7 +55,7 @@ func (c *Client) ensureConnectionsAreReady() error {
 	notReadyHostnames := []string{}
 
 	for _, conn := range c.connections {
-		if conn.Conn.GetState() != connectivity.Ready {
+		if conn.conn.GetState() != connectivity.Ready {
 			notReadyHostnames = append(notReadyHostnames, conn.Hostname)
 		}
 	}

--- a/hub/agent/connection.go
+++ b/hub/agent/connection.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/pkg/errors"
@@ -13,6 +14,8 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/idl"
 )
+
+const dialTimeout = 3 * time.Second
 
 type Connection struct {
 	// TODO: make these members package private
@@ -23,7 +26,7 @@ type Connection struct {
 }
 
 func newConnection(host string, port int, dialer Dialer) (*Connection, error) {
-	ctx, cancelFunc := context.WithTimeout(context.Background(), DialTimeout)
+	ctx, cancelFunc := context.WithTimeout(context.Background(), dialTimeout)
 
 	conn, err := dialer(ctx,
 		host+":"+strconv.Itoa(port),

--- a/hub/agent/dialer.go
+++ b/hub/agent/dialer.go
@@ -1,0 +1,12 @@
+package agent
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+var DialTimeout = 3 * time.Second
+
+type Dialer func(ctx context.Context, target string, opts ...grpc.DialOption) (*grpc.ClientConn, error)

--- a/hub/agent/dialer.go
+++ b/hub/agent/dialer.go
@@ -2,11 +2,8 @@ package agent
 
 import (
 	"context"
-	"time"
 
 	"google.golang.org/grpc"
 )
-
-var DialTimeout = 3 * time.Second
 
 type Dialer func(ctx context.Context, target string, opts ...grpc.DialOption) (*grpc.ClientConn, error)

--- a/hub/check_disk_space.go
+++ b/hub/check_disk_space.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
+	"github.com/greenplum-db/gpupgrade/hub/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils/disk"
 )
@@ -25,7 +26,7 @@ func (s *Server) CheckDiskSpace(ctx context.Context, in *idl.CheckDiskSpaceReque
 	return reply, err
 }
 
-func checkDiskSpace(ctx context.Context, cluster *greenplum.Cluster, agents []*Connection, d disk.Disk, in *idl.CheckDiskSpaceRequest) (disk.SpaceFailures, error) {
+func checkDiskSpace(ctx context.Context, cluster *greenplum.Cluster, agents []*agent.Connection, d disk.Disk, in *idl.CheckDiskSpaceRequest) (disk.SpaceFailures, error) {
 	var wg sync.WaitGroup
 	errs := make(chan error, len(agents)+1)
 	failures := make(chan disk.SpaceFailures, len(agents)+1)

--- a/hub/check_disk_space_test.go
+++ b/hub/check_disk_space_test.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
+	"github.com/greenplum-db/gpupgrade/hub/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
 	"github.com/greenplum-db/gpupgrade/utils/disk"
@@ -24,7 +25,7 @@ import (
 func TestCheckDiskSpace(t *testing.T) {
 	var d halfFullDisk
 	var c *greenplum.Cluster
-	var agents []*Connection
+	var agents []*agent.Connection
 	var req *idl.CheckDiskSpaceRequest
 	ctx := context.Background()
 
@@ -130,7 +131,7 @@ func TestCheckDiskSpace(t *testing.T) {
 				Failed: disk.SpaceFailures{"/": usage},
 			}, nil)
 
-		agents = []*Connection{
+		agents = []*agent.Connection{
 			{Hostname: "smdw", AgentClient: smdw},
 			{Hostname: "sdw1", AgentClient: sdw1},
 			{Hostname: "sdw2", AgentClient: sdw2},
@@ -169,7 +170,7 @@ func TestCheckDiskSpace(t *testing.T) {
 		// The other agent doesn't have any segments, so we expect no calls.
 		sdw2 := mock_idl.NewMockAgentClient(ctrl)
 
-		agents = []*Connection{
+		agents = []*agent.Connection{
 			{Hostname: "sdw1", AgentClient: sdw1},
 			{Hostname: "sdw2", AgentClient: sdw2}, // invalid hostname
 		}

--- a/hub/check_upgrade.go
+++ b/hub/check_upgrade.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 
+	"github.com/greenplum-db/gpupgrade/hub/agent"
 	"github.com/greenplum-db/gpupgrade/step"
 )
 
@@ -25,12 +26,12 @@ func (upgradeChecker) UpgradePrimaries(args UpgradePrimaryArgs) error {
 }
 
 type AgentConnProvider interface {
-	GetAgents(s *Server) ([]*Connection, error)
+	GetAgents(s *Server) ([]*agent.Connection, error)
 }
 
 type agentConnProvider struct{}
 
-func (agentConnProvider) GetAgents(s *Server) ([]*Connection, error) {
+func (agentConnProvider) GetAgents(s *Server) ([]*agent.Connection, error) {
 	return s.AgentConns()
 }
 

--- a/hub/check_upgrade_test.go
+++ b/hub/check_upgrade_test.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
+	"github.com/greenplum-db/gpupgrade/hub/agent"
 )
 
 type upgraderMock struct {
@@ -24,14 +25,18 @@ func (u upgraderMock) UpgradePrimaries(args UpgradePrimaryArgs) error {
 }
 
 type agentConnSourceMock struct {
-	conns []*Connection
+	conns []*agent.Connection
 }
 
-func (a agentConnSourceMock) GetAgents(s *Server) ([]*Connection, error) {
+func (a agentConnSourceMock) GetAgents(s *Server) ([]*agent.Connection, error) {
 	return a.conns, nil
 }
 
-var agentsSource = agentConnSourceMock{[]*Connection{&Connection{Conn: nil, Hostname: "bengie"}}}
+var agentsSource = agentConnSourceMock{
+	[]*agent.Connection{
+		{Conn: nil, Hostname: "bengie"},
+	},
+}
 
 func setUpgrader(updated UpgradeChecker) {
 	upgrader = updated

--- a/hub/check_upgrade_test.go
+++ b/hub/check_upgrade_test.go
@@ -34,7 +34,7 @@ func (a agentConnSourceMock) GetAgents(s *Server) ([]*agent.Connection, error) {
 
 var agentsSource = agentConnSourceMock{
 	[]*agent.Connection{
-		{Conn: nil, Hostname: "bengie"},
+		{Hostname: "bengie"},
 	},
 }
 

--- a/hub/delete_data_directories.go
+++ b/hub/delete_data_directories.go
@@ -8,10 +8,11 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
+	"github.com/greenplum-db/gpupgrade/hub/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
 )
 
-func DeleteMirrorAndStandbyDirectories(agentConns []*Connection, cluster *greenplum.Cluster) error {
+func DeleteMirrorAndStandbyDirectories(agentConns []*agent.Connection, cluster *greenplum.Cluster) error {
 	wg := sync.WaitGroup{}
 	errChan := make(chan error, len(agentConns))
 
@@ -30,7 +31,7 @@ func DeleteMirrorAndStandbyDirectories(agentConns []*Connection, cluster *greenp
 		}
 
 		wg.Add(1)
-		go func(c *Connection) {
+		go func(c *agent.Connection) {
 			defer wg.Done()
 
 			req := new(idl.DeleteDirectoriesRequest)

--- a/hub/delete_data_directories_test.go
+++ b/hub/delete_data_directories_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/hub"
+	"github.com/greenplum-db/gpupgrade/hub/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
-
 )
 
 func TestDeleteSegmentDataDirs(t *testing.T) {
@@ -57,11 +57,11 @@ func TestDeleteSegmentDataDirs(t *testing.T) {
 		masterClient := mock_idl.NewMockAgentClient(ctrl)
 		// NOTE: we expect no call to the master
 
-		agentConns := []*hub.Connection{
-			{nil, sdw1Client, "sdw1", nil},
-			{nil, sdw2Client, "sdw2", nil},
-			{nil, standbyClient, "standby", nil},
-			{nil, masterClient, "master", nil},
+		agentConns := []*agent.Connection{
+			{AgentClient: sdw1Client, Hostname: "sdw1"},
+			{AgentClient: sdw2Client, Hostname: "sdw2"},
+			{AgentClient: standbyClient, Hostname: "standby"},
+			{AgentClient: masterClient, Hostname: "master"},
 		}
 
 		err := hub.DeleteMirrorAndStandbyDirectories(agentConns, c)
@@ -87,9 +87,9 @@ func TestDeleteSegmentDataDirs(t *testing.T) {
 			gomock.Any(),
 		).Return(nil, expected)
 
-		agentConns := []*hub.Connection{
-			{nil, sdw1Client, "sdw1", nil},
-			{nil, sdw2ClientFailed, "sdw2", nil},
+		agentConns := []*agent.Connection{
+			{AgentClient: sdw1Client, Hostname: "sdw1"},
+			{AgentClient: sdw2ClientFailed, Hostname: "sdw2"},
 		}
 
 		err := hub.DeleteMirrorAndStandbyDirectories(agentConns, c)

--- a/hub/fill_cluster_configs.go
+++ b/hub/fill_cluster_configs.go
@@ -2,8 +2,6 @@ package hub
 
 import (
 	"database/sql"
-	"os"
-	"path/filepath"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -168,13 +166,4 @@ func sanitize(ports []int) []int {
 	}
 
 	return dedupe
-}
-
-func getAgentPath() (string, error) {
-	hubPath, err := os.Executable()
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(filepath.Dir(hubPath), "gpupgrade"), nil
 }

--- a/hub/init_target_cluster.go
+++ b/hub/init_target_cluster.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/db"
 	"github.com/greenplum-db/gpupgrade/greenplum"
+	"github.com/greenplum-db/gpupgrade/hub/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/utils"
@@ -174,7 +175,7 @@ func WriteSegmentArray(config []string, targetInitializeConfig InitializeConfig)
 	return config, nil
 }
 
-func CreateAllDataDirectories(agentConns []*Connection, source *greenplum.Cluster) error {
+func CreateAllDataDirectories(agentConns []*agent.Connection, source *greenplum.Cluster) error {
 	targetDataDir := path.Dir(source.MasterDataDir()) + "_upgrade"
 	err := utils.CreateDataDirectory(targetDataDir)
 	if err != nil {
@@ -230,7 +231,7 @@ func GetMasterSegPrefix(datadir string) (string, error) {
 	return segPrefix, nil
 }
 
-func CreateSegmentDataDirectories(agentConns []*Connection, cluster *greenplum.Cluster) error {
+func CreateSegmentDataDirectories(agentConns []*agent.Connection, cluster *greenplum.Cluster) error {
 	wg := sync.WaitGroup{}
 	errChan := make(chan error, len(agentConns))
 
@@ -243,7 +244,7 @@ func CreateSegmentDataDirectories(agentConns []*Connection, cluster *greenplum.C
 		}
 
 		wg.Add(1)
-		go func(c *Connection) {
+		go func(c *agent.Connection) {
 			defer wg.Done()
 
 			segments := cluster.SelectSegments(primaries)

--- a/hub/init_target_cluster_test.go
+++ b/hub/init_target_cluster_test.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
+	"github.com/greenplum-db/gpupgrade/hub/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
@@ -170,7 +171,7 @@ func TestCreateSegmentDataDirectories(t *testing.T) {
 	// should not receive any connections as it contains only mirrors
 	mirrorClient := mock_idl.NewMockAgentClient(ctrl)
 
-	agentConns := []*Connection{
+	agentConns := []*agent.Connection{
 		{nil, client, "host1", nil},
 		{nil, failedClient, "host2", nil},
 		{nil, mirrorClient, "host3", nil},

--- a/hub/init_target_cluster_test.go
+++ b/hub/init_target_cluster_test.go
@@ -172,9 +172,9 @@ func TestCreateSegmentDataDirectories(t *testing.T) {
 	mirrorClient := mock_idl.NewMockAgentClient(ctrl)
 
 	agentConns := []*agent.Connection{
-		{nil, client, "host1", nil},
-		{nil, failedClient, "host2", nil},
-		{nil, mirrorClient, "host3", nil},
+		{AgentClient: client, Hostname: "host1"},
+		{AgentClient: failedClient, Hostname: "host2"},
+		{AgentClient: mirrorClient, Hostname: "host3"},
 	}
 
 	err := CreateSegmentDataDirectories(agentConns, c)

--- a/hub/initialize.go
+++ b/hub/initialize.go
@@ -48,7 +48,7 @@ func (s *Server) Initialize(in *idl.InitializeRequest, stream idl.CliToHub_Initi
 
 	st.Run(idl.Substep_START_AGENTS, func(_ step.OutStreams) error {
 		_, err := s.agentClient.RestartAllAgents(context.Background(),
-			SegmentHosts(s.Source),
+			AgentHosts(s.Source),
 			s.AgentPort,
 			s.StateDir)
 		return err

--- a/hub/initialize.go
+++ b/hub/initialize.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"golang.org/x/xerrors"
 
-	"github.com/greenplum-db/gpupgrade/hub/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/step"
 )
@@ -48,8 +47,7 @@ func (s *Server) Initialize(in *idl.InitializeRequest, stream idl.CliToHub_Initi
 	})
 
 	st.Run(idl.Substep_START_AGENTS, func(_ step.OutStreams) error {
-		_, err := agent.RestartAllAgents(context.Background(),
-			nil,
+		_, err := s.agentClient.RestartAllAgents(context.Background(),
 			SegmentHosts(s.Source),
 			s.AgentPort,
 			s.StateDir)

--- a/hub/initialize.go
+++ b/hub/initialize.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"golang.org/x/xerrors"
 
+	"github.com/greenplum-db/gpupgrade/hub/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/step"
 )
@@ -47,7 +48,11 @@ func (s *Server) Initialize(in *idl.InitializeRequest, stream idl.CliToHub_Initi
 	})
 
 	st.Run(idl.Substep_START_AGENTS, func(_ step.OutStreams) error {
-		_, err := RestartAgents(context.Background(), nil, AgentHosts(s.Source), s.AgentPort, s.StateDir)
+		_, err := agent.RestartAllAgents(context.Background(),
+			nil,
+			SegmentHosts(s.Source),
+			s.AgentPort,
+			s.StateDir)
 		return err
 	})
 

--- a/hub/rename_data_directories.go
+++ b/hub/rename_data_directories.go
@@ -29,7 +29,7 @@ func (s *Server) UpdateDataDirectories() error {
 
 	// in --link mode, remove the mirror and standby data directories
 	if s.Config.UseLinkMode {
-		if err := DeleteMirrorAndStandbyDirectories(s.agentConns, s.Source); err != nil {
+		if err := DeleteMirrorAndStandbyDirectories(agentConnections, s.Source); err != nil {
 			return xerrors.Errorf("removing source cluster standby and mirror segment data directories: %w", err)
 		}
 	}

--- a/hub/rename_data_directories_test.go
+++ b/hub/rename_data_directories_test.go
@@ -119,9 +119,9 @@ func TestRenameSegmentDataDirs(t *testing.T) {
 		// NOTE: we expect no call to the standby
 
 		agentConns := []*agent.Connection{
-			{nil, client1, "sdw1", nil},
-			{nil, client2, "sdw2", nil},
-			{nil, client3, "standby", nil},
+			{AgentClient: client1, Hostname: "sdw1"},
+			{AgentClient: client2, Hostname: "sdw2"},
+			{AgentClient: client3, Hostname: "standby"},
 		}
 
 		err := hub.RenameSegmentDataDirs(agentConns, c, hub.UpgradeSuffix, "", true)
@@ -174,9 +174,9 @@ func TestRenameSegmentDataDirs(t *testing.T) {
 		).Return(&idl.RenameDirectoriesReply{}, nil)
 
 		agentConns := []*agent.Connection{
-			{nil, client1, "sdw1", nil},
-			{nil, client2, "sdw2", nil},
-			{nil, client3, "standby", nil},
+			{AgentClient: client1, Hostname: "sdw1"},
+			{AgentClient: client2, Hostname: "sdw2"},
+			{AgentClient: client3, Hostname: "standby"},
 		}
 
 		err := hub.RenameSegmentDataDirs(agentConns, c, "", hub.OldSuffix, false)
@@ -203,8 +203,8 @@ func TestRenameSegmentDataDirs(t *testing.T) {
 		).Return(nil, expected)
 
 		agentConns := []*agent.Connection{
-			{nil, client, "sdw1", nil},
-			{nil, failedClient, "sdw2", nil},
+			{AgentClient: client, Hostname: "sdw1"},
+			{AgentClient: failedClient, Hostname: "sdw2"},
 		}
 
 		err := hub.RenameSegmentDataDirs(agentConns, c, hub.UpgradeSuffix, "", true)

--- a/hub/rename_data_directories_test.go
+++ b/hub/rename_data_directories_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/hub"
+	"github.com/greenplum-db/gpupgrade/hub/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
 	"github.com/greenplum-db/gpupgrade/utils"
@@ -117,7 +118,7 @@ func TestRenameSegmentDataDirs(t *testing.T) {
 		client3 := mock_idl.NewMockAgentClient(ctrl)
 		// NOTE: we expect no call to the standby
 
-		agentConns := []*hub.Connection{
+		agentConns := []*agent.Connection{
 			{nil, client1, "sdw1", nil},
 			{nil, client2, "sdw2", nil},
 			{nil, client3, "standby", nil},
@@ -172,7 +173,7 @@ func TestRenameSegmentDataDirs(t *testing.T) {
 			},
 		).Return(&idl.RenameDirectoriesReply{}, nil)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*agent.Connection{
 			{nil, client1, "sdw1", nil},
 			{nil, client2, "sdw2", nil},
 			{nil, client3, "standby", nil},
@@ -201,7 +202,7 @@ func TestRenameSegmentDataDirs(t *testing.T) {
 			gomock.Any(),
 		).Return(nil, expected)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*agent.Connection{
 			{nil, client, "sdw1", nil},
 			{nil, failedClient, "sdw2", nil},
 		}

--- a/hub/server.go
+++ b/hub/server.go
@@ -151,7 +151,7 @@ func (s *Server) Stop(closeAgentConns bool) {
 
 func (s *Server) RestartAgents(ctx context.Context, in *idl.RestartAgentsRequest) (*idl.RestartAgentsReply, error) {
 	restartedHosts, err := s.agentClient.RestartAllAgents(ctx,
-		SegmentHosts(s.Source),
+		AgentHosts(s.Source),
 		s.AgentPort,
 		s.StateDir)
 
@@ -167,7 +167,7 @@ func (s *Server) AgentConns() ([]*agent.Connection, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	err := s.agentClient.Connect(SegmentHosts(s.Source), s.AgentPort)
+	err := s.agentClient.Connect(AgentHosts(s.Source), s.AgentPort)
 
 	if err != nil {
 		return nil, err
@@ -250,7 +250,10 @@ func LoadConfig(conf *Config, path string) error {
 	return nil
 }
 
-func SegmentHosts(c *greenplum.Cluster) []string {
+//
+// Returns all of the hostnames where agents should run
+//
+func AgentHosts(c *greenplum.Cluster) []string {
 	uniqueHosts := make(map[string]bool)
 
 	excludingMaster := func(seg *greenplum.SegConfig) bool {

--- a/hub/server.go
+++ b/hub/server.go
@@ -150,8 +150,7 @@ func (s *Server) Stop(closeAgentConns bool) {
 }
 
 func (s *Server) RestartAgents(ctx context.Context, in *idl.RestartAgentsRequest) (*idl.RestartAgentsReply, error) {
-	restartedHosts, err := agent.RestartAllAgents(ctx,
-		nil,
+	restartedHosts, err := s.agentClient.RestartAllAgents(ctx,
 		SegmentHosts(s.Source),
 		s.AgentPort,
 		s.StateDir)

--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -318,7 +318,7 @@ func TestAgentHosts(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual := hub.SegmentHosts(c.cluster)
+			actual := hub.AgentHosts(c.cluster)
 			sort.Strings(actual) // order not guaranteed
 
 			if !reflect.DeepEqual(actual, c.expected) {

--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/hub"
+	"github.com/greenplum-db/gpupgrade/hub/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/testutils/mock_agent"
@@ -45,7 +46,7 @@ var _ = Describe("Hub", func() {
 		target         *greenplum.Cluster
 		conf           *hub.Config
 		err            error
-		mockDialer     hub.Dialer
+		mockDialer     agent.Dialer
 		useLinkMode    bool
 	)
 
@@ -166,7 +167,7 @@ var _ = Describe("Hub", func() {
 		Expect(newConns).To(ConsistOf(savedConns))
 	})
 
-	// XXX This test takes 1.5 seconds because of EnsureConnsAreReady(...)
+	// XXX This test takes 1.5 seconds because of EnsureConnectionsAreReady(...)
 	It("returns an error if any connections have non-ready states", func() {
 		h := hub.New(conf, mockDialer, "")
 
@@ -317,7 +318,7 @@ func TestAgentHosts(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual := hub.AgentHosts(c.cluster)
+			actual := hub.SegmentHosts(c.cluster)
 			sort.Strings(actual) // order not guaranteed
 
 			if !reflect.DeepEqual(actual, c.expected) {

--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -124,7 +124,7 @@ var _ = Describe("Hub", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		for _, conn := range conns {
-			Eventually(func() connectivity.State { return conn.Conn.GetState() }).Should(Equal(connectivity.Ready))
+			Eventually(func() connectivity.State { return conn.State() }).Should(Equal(connectivity.Ready))
 		}
 
 		By("closing the connections")
@@ -132,7 +132,7 @@ var _ = Describe("Hub", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		for _, conn := range conns {
-			Eventually(func() connectivity.State { return conn.Conn.GetState() }).Should(Equal(connectivity.Shutdown))
+			Eventually(func() connectivity.State { return conn.State() }).Should(Equal(connectivity.Shutdown))
 		}
 	})
 
@@ -143,7 +143,7 @@ var _ = Describe("Hub", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		for _, conn := range conns {
-			Eventually(func() connectivity.State { return conn.Conn.GetState() }).Should(Equal(connectivity.Ready))
+			Eventually(func() connectivity.State { return conn.State() }).Should(Equal(connectivity.Ready))
 		}
 
 		var allHosts []string
@@ -177,7 +177,7 @@ var _ = Describe("Hub", func() {
 		agentA.Stop()
 
 		for _, conn := range conns {
-			Eventually(func() connectivity.State { return conn.Conn.GetState() }).Should(Equal(connectivity.TransientFailure))
+			Eventually(func() connectivity.State { return conn.State() }).Should(Equal(connectivity.TransientFailure))
 		}
 
 		_, err = h.AgentConns()

--- a/hub/services_suite_test.go
+++ b/hub/services_suite_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/hub"
+	"github.com/greenplum-db/gpupgrade/hub/agent"
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
@@ -29,7 +30,7 @@ var (
 	dbConnector *dbconn.DBConn
 	mock        sqlmock.Sqlmock
 	mockAgent   *mock_agent.MockAgentServer
-	dialer      hub.Dialer
+	dialer      agent.Dialer
 	client      *mock_idl.MockAgentClient
 	port        int
 	dir         string

--- a/hub/upgrade_primaries.go
+++ b/hub/upgrade_primaries.go
@@ -10,13 +10,14 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
+	"github.com/greenplum-db/gpupgrade/hub/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
 )
 
 type UpgradePrimaryArgs struct {
 	CheckOnly       bool
 	MasterBackupDir string
-	AgentConns      []*Connection
+	AgentConns      []*agent.Connection
 	DataDirPairMap  map[string][]*idl.DataDirPair
 	Source          *greenplum.Cluster
 	Target          *greenplum.Cluster
@@ -30,7 +31,7 @@ func UpgradePrimaries(args UpgradePrimaryArgs) error {
 	for _, conn := range args.AgentConns {
 		wg.Add(1)
 
-		go func(conn *Connection) {
+		go func(conn *agent.Connection) {
 			defer wg.Done()
 
 			_, err := conn.AgentClient.UpgradePrimaries(context.Background(), &idl.UpgradePrimariesRequest{

--- a/hub/upgrade_primaries_test.go
+++ b/hub/upgrade_primaries_test.go
@@ -88,8 +88,8 @@ func TestUpgradePrimaries(t *testing.T) {
 		).Return(&idl.UpgradePrimariesReply{}, nil)
 
 		agentConns := []*agent.Connection{
-			{nil, client1, "sdw1", nil},
-			{nil, client2, "sdw2", nil},
+			{AgentClient: client1, Hostname: "sdw1"},
+			{AgentClient: client2, Hostname: "sdw2"},
 		}
 
 		err := hub.UpgradePrimaries(hub.UpgradePrimaryArgs{
@@ -140,8 +140,8 @@ func TestUpgradePrimaries(t *testing.T) {
 		).Return(&idl.UpgradePrimariesReply{}, expected)
 
 		agentConns := []*agent.Connection{
-			{nil, client1, "sdw1", nil},
-			{nil, failedClient, "sdw2", nil},
+			{AgentClient: client1, Hostname: "sdw1"},
+			{AgentClient: failedClient, Hostname: "sdw2"},
 		}
 
 		err := hub.UpgradePrimaries(hub.UpgradePrimaryArgs{

--- a/hub/upgrade_primaries_test.go
+++ b/hub/upgrade_primaries_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/hub"
+	"github.com/greenplum-db/gpupgrade/hub/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
 )
@@ -86,7 +87,7 @@ func TestUpgradePrimaries(t *testing.T) {
 			},
 		).Return(&idl.UpgradePrimariesReply{}, nil)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*agent.Connection{
 			{nil, client1, "sdw1", nil},
 			{nil, client2, "sdw2", nil},
 		}
@@ -138,7 +139,7 @@ func TestUpgradePrimaries(t *testing.T) {
 			},
 		).Return(&idl.UpgradePrimariesReply{}, expected)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*agent.Connection{
 			{nil, client1, "sdw1", nil},
 			{nil, failedClient, "sdw2", nil},
 		}

--- a/testutils/mock_agent/mock_agent_server.go
+++ b/testutils/mock_agent/mock_agent_server.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"sync"
 
-	"github.com/greenplum-db/gpupgrade/hub"
+	"github.com/greenplum-db/gpupgrade/hub/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
 
 	"google.golang.org/grpc"
@@ -32,7 +32,7 @@ type MockAgentServer struct {
 //
 // XXX Why is the Dialer type that we need for this agent defined in the hub
 // package?
-func NewMockAgentServer() (*MockAgentServer, hub.Dialer, int) {
+func NewMockAgentServer() (*MockAgentServer, agent.Dialer, int) {
 	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Move agent connection plus agent start stop logic into an `agent` package within hub.

The interesting work here is in `server.go` where we've moved all of the Agent work into an `agentClient` struct on the Server object. `AgentConns()` still remains, but the rest of the server methods for managing agent connections and agent start/stop now belong to the `agent.Client`.


This is the public interface to an agent client after the move.
```
package agent

type Client struct {
...
}

type Connection struct {
...
}

type Dialer func (...) 

func NewClient(dialer Dialer) *Client

func (c *Client) Connect(hostnames []string, port int) error

func (c *Client) Connections() []*Connection

func (c *Client) StopAllAgents() error

func (c *Client) CloseConnections() 

func (c *Client) RestartAllAgents(hostnames []string, port int, stateDir string)
```