### PR TITLE
fixup: validate mirrors and standby in BATS and CI

### DIFF
--- a/test/finalize_checks.bash
+++ b/test/finalize_checks.bash
@@ -246,7 +246,7 @@ validate_mirrors_and_standby() {
     wait_can_start_transactions $standby_host "${standby_port}"  #TODO: is this necessary?
 
     # sanity check both the demo cluster and CI cluster cases
-    if [[ $master_data_dir != *qddir/demoDataDir* && $master_data_dir != */data/gpdata/master/gpseg-1* ]]; then
+    if [[ $master_data_dir != *datadirs/qddir/demoDataDir* && $master_data_dir != */data/gpdata/master/gpseg-1* ]]; then
         echo "cowardly refusing to delete $master_data_dir which does not look like a demo or CI master data dir"
         exit 1
     fi
@@ -285,7 +285,7 @@ validate_mirrors_and_standby() {
     # 4d: rebalance standby
 
     # sanity check both the demo cluster and CI cluster cases
-    if [[ $standby_data_dir != *standby* && $standby_data_dir != */data/gpdata/master/gpseg-1* ]]; then
+    if [[ $standby_data_dir != *datadirs/standby* && $standby_data_dir != */data/gpdata/master/gpseg-1* ]]; then
         echo "cowardly refusing to delete $standby_data_dir which does not look like a demo or CI standby data dir"
         exit 1
     fi


### PR DESCRIPTION
add a stronger directory check before deleting a local demo
cluster to prevent accidental deletion of the wrong directory.

This passed in CI, and finalize.bats ran successfully on my machine on a demo cluster.