### PR TITLE
Refactor help text generation

### DIFF
--- a/integrations/commands_test.go
+++ b/integrations/commands_test.go
@@ -13,9 +13,9 @@ import (
 var _ = Describe("test gpupgrade help messages", func() {
 	helpMap := map[string]string{
 		"":           commands.GlobalHelp,
-		"initialize": commands.GenerateHelpString(commands.InitializeHelp, commands.InitializeSubsteps),
-		"execute":    commands.GenerateHelpString(commands.ExecuteHelp, commands.ExecuteSubsteps),
-		"finalize":   commands.GenerateHelpString(commands.FinalizeHelp, commands.FinalizeSubsteps),
+		"initialize": commands.InitializeHelp,
+		"execute":    commands.ExecuteHelp,
+		"finalize":   commands.FinalizeHelp,
 	}
 
 	flagList := []string{"-?", "-h", "--help", "help"}


### PR DESCRIPTION
Move the creation of help text for initialize/execute/finalize into an `init()` block so we don't have to expose as many variables or repeat logic in tests.