### PR TITLE
init_target_cluster: Remove replication port

### DIFF
--- a/hub/init_target_cluster.go
+++ b/hub/init_target_cluster.go
@@ -148,7 +148,7 @@ func WriteSegmentArray(config []string, targetInitializeConfig InitializeConfig)
 
 	master := targetInitializeConfig.Master
 	config = append(config,
-		fmt.Sprintf("QD_PRIMARY_ARRAY=%s~%d~%s~%d~%d~0",
+		fmt.Sprintf("QD_PRIMARY_ARRAY=%s~%d~%s~%d~%d",
 			master.Hostname,
 			master.Port,
 			master.DataDir,
@@ -160,7 +160,7 @@ func WriteSegmentArray(config []string, targetInitializeConfig InitializeConfig)
 	config = append(config, "declare -a PRIMARY_ARRAY=(")
 	for _, segment := range targetInitializeConfig.Primaries {
 		config = append(config,
-			fmt.Sprintf("\t%s~%d~%s~%d~%d~0",
+			fmt.Sprintf("\t%s~%d~%s~%d~%d",
 				segment.Hostname,
 				segment.Port,
 				segment.DataDir,

--- a/hub/init_target_cluster_test.go
+++ b/hub/init_target_cluster_test.go
@@ -118,10 +118,10 @@ func TestWriteSegmentArray(t *testing.T) {
 		}
 
 		test(t, config, []string{
-			"QD_PRIMARY_ARRAY=mdw~15433~/data/qddir_upgrade/seg-1~1~-1~0",
+			"QD_PRIMARY_ARRAY=mdw~15433~/data/qddir_upgrade/seg-1~1~-1",
 			"declare -a PRIMARY_ARRAY=(",
-			"\tsdw1~15434~/data/dbfast1_upgrade/seg1~2~0~0",
-			"\tsdw2~15434~/data/dbfast2_upgrade/seg2~3~1~0",
+			"\tsdw1~15434~/data/dbfast1_upgrade/seg1~2~0",
+			"\tsdw2~15434~/data/dbfast2_upgrade/seg2~3~1",
 			")",
 		})
 	})


### PR DESCRIPTION
When creating the gpintisystem config for the target cluster do not add the replication port as it is not needed since gpupgrade only supports upgrading a target cluster from GPDB 6X onwards.

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:remove_replication_port)