### PR TITLE
Remove deadcode exposed by golangci-lint.

### DIFF
--- a/integrations/integrations_suite_test.go
+++ b/integrations/integrations_suite_test.go
@@ -98,23 +98,6 @@ func killHub() {
 	Expect(checkPortIsAvailable(cliToHubPort)).To(BeTrue())
 }
 
-// killAll finds all running gpupupgrade processes and kills them.
-// XXX this is ridiculously heavy-handed
-func killAll() {
-	pkillCmd := exec.Command("pkill", "-9", "^gpupgrade_")
-	err := pkillCmd.Run()
-
-	// pkill returns exit code 1 if no processes were matched, which is fine.
-	if err != nil {
-		Expect(err).To(MatchError("exit status 1"))
-	} else {
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	Expect(checkPortIsAvailable(cliToHubPort)).To(BeTrue())
-	Expect(checkPortIsAvailable(hubToAgentPort)).To(BeTrue())
-}
-
 func checkPortIsAvailable(port int) bool {
 	t := time.After(2 * time.Second)
 	select {


### PR DESCRIPTION
integrations/integrations_suite_test.go:103:6: `killAll` is unused (deadcode)
func killAll() {
     ^