### PR TITLE
Remove unused test variable hubConf

### DIFF
--- a/hub/services_suite_test.go
+++ b/hub/services_suite_test.go
@@ -33,7 +33,6 @@ var (
 	client      *mock_idl.MockAgentClient
 	port        int
 	dir         string
-	hubConf     *hub.Config
 	source      *greenplum.Cluster
 	target      *greenplum.Cluster
 	testHub     *hub.Server


### PR DESCRIPTION
hub/services_suite_test.go:35:2: `hubConf` is unused (deadcode)
	hubConf     *hub.Config
	^