### PR TITLE
Remove unused code.

### DIFF
--- a/integrations/integrations_suite_test.go
+++ b/integrations/integrations_suite_test.go
@@ -30,8 +30,7 @@ var (
 )
 
 const (
-	cliToHubPort   = 7527
-	hubToAgentPort = 6416
+	cliToHubPort = 7527
 )
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
integrations/integrations_suite_test.go:34:2: `hubToAgentPort` is unused (varcheck)
	hubToAgentPort = 6416
	^