### PR TITLE
Unique upgrade directories 

### DIFF
--- a/hub/fill_cluster_configs_test.go
+++ b/hub/fill_cluster_configs_test.go
@@ -1,14 +1,24 @@
 package hub
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/greenplum-db/gpupgrade/upgrade"
 
 	cluster2 "github.com/greenplum-db/gpupgrade/greenplum"
 )
 
-func TestAssignPorts(t *testing.T) {
+func TestAssignDataDirsAndPorts(t *testing.T) {
 
+	upgradeID := upgrade.NewID()
+	expectedDataDir := func(sourceDir string) string {
+		return fmt.Sprintf("%s_%s", sourceDir, upgradeID)
+	}
+	expectedDataDirMaster := func(sourceDir string) string {
+		return fmt.Sprintf("%s_%s-1", sourceDir, upgradeID)
+	}
 	cases := []struct {
 		name string
 
@@ -24,10 +34,10 @@ func TestAssignPorts(t *testing.T) {
 		}),
 		ports: []int{10, 9, 10, 9, 10, 8},
 		expected: InitializeConfig{
-			Master: cluster2.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir_upgrade/seg-1", Role: "p", Port: 8},
+			Master: cluster2.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDirMaster("/data/qddir/seg-1"), Role: "p", Port: 8},
 			Primaries: []cluster2.SegConfig{
-				{ContentID: 0, DbID: 2, Hostname: "mdw", DataDir: "/data/dbfast1_upgrade/seg1", Role: "p", Port: 9},
-				{ContentID: 1, DbID: 3, Hostname: "mdw", DataDir: "/data/dbfast2_upgrade/seg2", Role: "p", Port: 10},
+				{ContentID: 0, DbID: 2, Hostname: "mdw", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 9},
+				{ContentID: 1, DbID: 3, Hostname: "mdw", DataDir: expectedDataDir("/data/dbfast2/seg2"), Role: "p", Port: 10},
 			}},
 	}, {
 		name: "uses default port range when port list is empty",
@@ -39,11 +49,11 @@ func TestAssignPorts(t *testing.T) {
 		}),
 		ports: []int{},
 		expected: InitializeConfig{
-			Master: cluster2.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir_upgrade/seg-1", Role: "p", Port: 50432},
+			Master: cluster2.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDirMaster("/data/qddir/seg-1"), Role: "p", Port: 50432},
 			Primaries: []cluster2.SegConfig{
-				{ContentID: 0, DbID: 2, Hostname: "mdw", DataDir: "/data/dbfast1_upgrade/seg1", Role: "p", Port: 50433},
-				{ContentID: 1, DbID: 3, Hostname: "mdw", DataDir: "/data/dbfast2_upgrade/seg2", Role: "p", Port: 50434},
-				{ContentID: 2, DbID: 4, Hostname: "sdw1", DataDir: "/data/dbfast3_upgrade/seg3", Role: "p", Port: 50433},
+				{ContentID: 0, DbID: 2, Hostname: "mdw", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 50433},
+				{ContentID: 1, DbID: 3, Hostname: "mdw", DataDir: expectedDataDir("/data/dbfast2/seg2"), Role: "p", Port: 50434},
+				{ContentID: 2, DbID: 4, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast3/seg3"), Role: "p", Port: 50433},
 			}},
 	}, {
 		name: "gives master its own port regardless of host layout",
@@ -55,11 +65,11 @@ func TestAssignPorts(t *testing.T) {
 		}),
 		ports: []int{},
 		expected: InitializeConfig{
-			Master: cluster2.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir_upgrade/seg-1", Role: "p", Port: 50432},
+			Master: cluster2.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDirMaster("/data/qddir/seg-1"), Role: "p", Port: 50432},
 			Primaries: []cluster2.SegConfig{
-				{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1_upgrade/seg1", Role: "p", Port: 50433},
-				{ContentID: 1, DbID: 3, Hostname: "sdw1", DataDir: "/data/dbfast2_upgrade/seg2", Role: "p", Port: 50434},
-				{ContentID: 2, DbID: 4, Hostname: "sdw1", DataDir: "/data/dbfast3_upgrade/seg3", Role: "p", Port: 50435},
+				{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 50433},
+				{ContentID: 1, DbID: 3, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast2/seg2"), Role: "p", Port: 50434},
+				{ContentID: 2, DbID: 4, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast3/seg3"), Role: "p", Port: 50435},
 			}},
 	}, {
 		name: "when using default ports, it sets up mirrors as expected in the InitializeConfig",
@@ -72,14 +82,14 @@ func TestAssignPorts(t *testing.T) {
 		}),
 		ports: []int{},
 		expected: InitializeConfig{
-			Master: cluster2.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir_upgrade/seg-1", Role: "p", Port: 50432},
+			Master: cluster2.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDirMaster("/data/qddir/seg-1"), Role: "p", Port: 50432},
 			Primaries: []cluster2.SegConfig{
-				{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1_upgrade/seg1", Role: "p", Port: 50433},
-				{ContentID: 1, DbID: 3, Hostname: "sdw1", DataDir: "/data/dbfast2_upgrade/seg2", Role: "p", Port: 50434},
+				{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 50433},
+				{ContentID: 1, DbID: 3, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast2/seg2"), Role: "p", Port: 50434},
 			},
 			Mirrors: []cluster2.SegConfig{
-				{ContentID: 0, DbID: 4, Hostname: "sdw1", DataDir: "/data/dbfast_mirror1_upgrade/seg1", Role: "m", Port: 50435},
-				{ContentID: 1, DbID: 5, Hostname: "sdw1", DataDir: "/data/dbfast_mirror2_upgrade/seg2", Role: "m", Port: 50436},
+				{ContentID: 0, DbID: 4, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast_mirror1/seg1"), Role: "m", Port: 50435},
+				{ContentID: 1, DbID: 5, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast_mirror2/seg2"), Role: "m", Port: 50436},
 			},
 		},
 	}, {
@@ -91,9 +101,9 @@ func TestAssignPorts(t *testing.T) {
 		}),
 		ports: []int{},
 		expected: InitializeConfig{
-			Master:    cluster2.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir_upgrade/seg-1", Role: "p", Port: 50432},
-			Standby:   cluster2.SegConfig{ContentID: -1, DbID: 2, Hostname: "smdw", DataDir: "/data/standby_upgrade", Role: "m", Port: 50433},
-			Primaries: []cluster2.SegConfig{{ContentID: 0, DbID: 3, Hostname: "sdw1", DataDir: "/data/dbfast1_upgrade/seg1", Role: "p", Port: 50434}},
+			Master:    cluster2.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDirMaster("/data/qddir/seg-1"), Role: "p", Port: 50432},
+			Standby:   cluster2.SegConfig{ContentID: -1, DbID: 2, Hostname: "smdw", DataDir: expectedDataDir("/data/standby"), Role: "m", Port: 50433},
+			Primaries: []cluster2.SegConfig{{ContentID: 0, DbID: 3, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 50434}},
 		},
 	}, {
 		name: "deals with master and standby on the same host",
@@ -104,9 +114,9 @@ func TestAssignPorts(t *testing.T) {
 		}),
 		ports: []int{},
 		expected: InitializeConfig{
-			Master:    cluster2.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir_upgrade/seg-1", Role: "p", Port: 50432},
-			Standby:   cluster2.SegConfig{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: "/data/standby_upgrade", Role: "m", Port: 50433},
-			Primaries: []cluster2.SegConfig{{ContentID: 0, DbID: 3, Hostname: "sdw1", DataDir: "/data/dbfast1_upgrade/seg1", Role: "p", Port: 50434}},
+			Master:    cluster2.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDirMaster("/data/qddir/seg-1"), Role: "p", Port: 50432},
+			Standby:   cluster2.SegConfig{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: expectedDataDir("/data/standby"), Role: "m", Port: 50433},
+			Primaries: []cluster2.SegConfig{{ContentID: 0, DbID: 3, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 50434}},
 		},
 	}, {
 		name: "deals with master and standby on the same host as other segments",
@@ -117,9 +127,9 @@ func TestAssignPorts(t *testing.T) {
 		}),
 		ports: []int{},
 		expected: InitializeConfig{
-			Master:    cluster2.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir_upgrade/seg-1", Role: "p", Port: 50432},
-			Standby:   cluster2.SegConfig{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: "/data/standby_upgrade", Role: "m", Port: 50433},
-			Primaries: []cluster2.SegConfig{{ContentID: 0, DbID: 3, Hostname: "mdw", DataDir: "/data/dbfast1_upgrade/seg1", Role: "p", Port: 50434}},
+			Master:    cluster2.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDirMaster("/data/qddir/seg-1"), Role: "p", Port: 50432},
+			Standby:   cluster2.SegConfig{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: expectedDataDir("/data/standby"), Role: "m", Port: 50433},
+			Primaries: []cluster2.SegConfig{{ContentID: 0, DbID: 3, Hostname: "mdw", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 50434}},
 		},
 	}, {
 		name: "assigns provided ports to the standby",
@@ -130,9 +140,9 @@ func TestAssignPorts(t *testing.T) {
 		}),
 		ports: []int{1, 2, 3},
 		expected: InitializeConfig{
-			Master:    cluster2.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir_upgrade/seg-1", Role: "p", Port: 1},
-			Standby:   cluster2.SegConfig{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: "/data/standby_upgrade", Role: "m", Port: 2},
-			Primaries: []cluster2.SegConfig{{ContentID: 0, DbID: 3, Hostname: "mdw", DataDir: "/data/dbfast1_upgrade/seg1", Role: "p", Port: 3}},
+			Master:    cluster2.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDirMaster("/data/qddir/seg-1"), Role: "p", Port: 1},
+			Standby:   cluster2.SegConfig{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: expectedDataDir("/data/standby"), Role: "m", Port: 2},
+			Primaries: []cluster2.SegConfig{{ContentID: 0, DbID: 3, Hostname: "mdw", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 3}},
 		},
 	}, {
 		name: "assigns provided ports to cluster with standby and multiple primaries and multiple mirrors",
@@ -148,24 +158,24 @@ func TestAssignPorts(t *testing.T) {
 		}),
 		ports: []int{1, 2, 3, 4, 5},
 		expected: InitializeConfig{
-			Master:  cluster2.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir_upgrade/seg-1", Role: "p", Port: 1},
-			Standby: cluster2.SegConfig{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: "/data/standby_upgrade", Role: "m", Port: 2},
+			Master:  cluster2.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDirMaster("/data/qddir/seg-1"), Role: "p", Port: 1},
+			Standby: cluster2.SegConfig{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: expectedDataDir("/data/standby"), Role: "m", Port: 2},
 			Primaries: []cluster2.SegConfig{
-				{ContentID: 0, DbID: 3, Hostname: "sdw1", DataDir: "/data/dbfast1_upgrade/seg1", Role: "p", Port: 3},
-				{ContentID: 1, DbID: 4, Hostname: "sdw2", DataDir: "/data/dbfast2_upgrade/seg2", Role: "p", Port: 3},
-				{ContentID: 2, DbID: 5, Hostname: "sdw3", DataDir: "/data/dbfast3_upgrade/seg3", Role: "p", Port: 3},
+				{ContentID: 0, DbID: 3, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 3},
+				{ContentID: 1, DbID: 4, Hostname: "sdw2", DataDir: expectedDataDir("/data/dbfast2/seg2"), Role: "p", Port: 3},
+				{ContentID: 2, DbID: 5, Hostname: "sdw3", DataDir: expectedDataDir("/data/dbfast3/seg3"), Role: "p", Port: 3},
 			},
 			Mirrors: []cluster2.SegConfig{
-				{ContentID: 0, DbID: 6, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1_upgrade/seg1", Role: "m", Port: 4},
-				{ContentID: 1, DbID: 7, Hostname: "sdw3", DataDir: "/data/dbfast_mirror2_upgrade/seg2", Role: "m", Port: 4},
-				{ContentID: 2, DbID: 8, Hostname: "sdw1", DataDir: "/data/dbfast_mirror3_upgrade/seg3", Role: "m", Port: 4},
+				{ContentID: 0, DbID: 6, Hostname: "sdw2", DataDir: expectedDataDir("/data/dbfast_mirror1/seg1"), Role: "m", Port: 4},
+				{ContentID: 1, DbID: 7, Hostname: "sdw3", DataDir: expectedDataDir("/data/dbfast_mirror2/seg2"), Role: "m", Port: 4},
+				{ContentID: 2, DbID: 8, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast_mirror3/seg3"), Role: "m", Port: 4},
 			},
 		},
 	}}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := AssignDatadirsAndPorts(c.cluster, c.ports)
+			actual, err := AssignDatadirsAndPorts(c.cluster, c.ports, upgradeID)
 			if err != nil {
 				t.Errorf("returned error %+v", err)
 			}
@@ -242,10 +252,33 @@ func TestAssignPorts(t *testing.T) {
 
 	for _, c := range errCases {
 		t.Run(c.name, func(t *testing.T) {
-			_, err := AssignDatadirsAndPorts(c.cluster, c.ports)
+			_, err := AssignDatadirsAndPorts(c.cluster, c.ports, 0)
 			if err == nil {
 				t.Errorf("AssignDatadirsAndPorts(<cluster>, %v) returned nil, want error", c.ports)
 			}
 		})
 	}
 }
+
+//
+//func TestFillClusterConfigsSubStep(t *testing.T) {
+//	t.Run("assigns an UpgradeID on the config", func(t *testing.T) {
+//		config := &Config{}
+//		mockSaveConfig := func() error {
+//			return nil
+//		}
+//		conn, mockDB, err := sqlmock.New()
+//		if err != nil {
+//			t.Fatalf("error creating sqlmock %+v", err)
+//		}
+//		err = FillClusterConfigsSubStep(config, conn, nil, &idl.InitializeRequest{}, mockSaveConfig)
+//
+//		if err != nil {
+//			t.Errorf("FillClusterConfigsSubStep returned unexpected error: %+v", err)
+//		}
+//
+//		if config.UpgradeID == 0 {
+//			t.Errorf("Got UpgradeID 0")
+//		}
+//	})
+//}

--- a/hub/initialize.go
+++ b/hub/initialize.go
@@ -43,7 +43,7 @@ func (s *Server) Initialize(in *idl.InitializeRequest, stream idl.CliToHub_Initi
 			}
 		}()
 
-		return s.FillClusterConfigsSubStep(s.Config, conn, stream, in, s.SaveConfig)
+		return FillClusterConfigsSubStep(s.Config, conn, stream, in, s.SaveConfig)
 	})
 
 	st.Run(idl.Substep_START_AGENTS, func(_ step.OutStreams) error {

--- a/hub/server.go
+++ b/hub/server.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/upgrade"
 	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/greenplum-db/gpupgrade/utils/daemon"
 	"github.com/greenplum-db/gpupgrade/utils/log"
@@ -373,6 +374,7 @@ type Config struct {
 	Port        int
 	AgentPort   int
 	UseLinkMode bool
+	UpgradeID   upgrade.ID
 }
 
 func (c *Config) Load(r io.Reader) error {

--- a/hub/server_internal_test.go
+++ b/hub/server_internal_test.go
@@ -14,7 +14,7 @@ func TestConfig(t *testing.T) {
 	t.Run("saves itself to the provided stream", func(t *testing.T) {
 		source, target := testutils.CreateMultinodeSampleClusterPair("/tmp")
 		targetInitializeConfig := InitializeConfig{Master: greenplum.SegConfig{Hostname: "mdw"}}
-		original := &Config{source, target, targetInitializeConfig, 12345, 54321, false}
+		original := &Config{source, target, targetInitializeConfig, 12345, 54321, false, 12345}
 
 		buf := new(bytes.Buffer)
 		err := original.Save(buf)

--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Hub", func() {
 			1:  {ContentID: 1, DbID: 3, Port: 25435, Hostname: "mirror-host2", DataDir: "/seg2"},
 		}
 		useLinkMode = false
-		conf = &hub.Config{source, target, hub.InitializeConfig{}, cliToHubPort, hubToAgentPort, useLinkMode}
+		conf = &hub.Config{source, target, hub.InitializeConfig{}, cliToHubPort, hubToAgentPort, useLinkMode, 0}
 	})
 
 	AfterEach(func() {
@@ -198,7 +198,7 @@ var _ = Describe("Hub", func() {
 func TestHubSaveConfig(t *testing.T) {
 	source, target := testutils.CreateMultinodeSampleClusterPair("/tmp")
 	useLinkMode := false
-	conf := &hub.Config{source, target, hub.InitializeConfig{}, 12345, 54321, useLinkMode}
+	conf := &hub.Config{source, target, hub.InitializeConfig{}, 12345, 54321, useLinkMode, 0}
 
 	h := hub.New(conf, nil, "")
 

--- a/hub/services_suite_test.go
+++ b/hub/services_suite_test.go
@@ -62,7 +62,7 @@ var _ = BeforeEach(func() {
 	mockAgent, dialer, port = mock_agent.NewMockAgentServer()
 	client = mock_idl.NewMockAgentClient(ctrl)
 	useLinkMode = false
-	conf := &hub.Config{source, target, hub.InitializeConfig{}, 0, port, useLinkMode}
+	conf := &hub.Config{source, target, hub.InitializeConfig{}, 0, port, useLinkMode, 0}
 	testHub = hub.New(conf, dialer, dir)
 })
 

--- a/hub/update_catalog.go
+++ b/hub/update_catalog.go
@@ -35,8 +35,7 @@ func (s *Server) UpdateCatalogAndClusterConfig(streams step.OutStreams) (err err
 	// data directories which have yet to be reflected on disk in a later substep.
 	master := s.Target.Primaries[-1]
 
-	//TODO: fix this!...it should use the config's upgradeID
-	master.DataDir = upgradeDataDir(master.DataDir, 0)
+	master.DataDir = upgradeDataDirMaster(master.DataDir, s.Config.UpgradeID)
 	segs := map[int]greenplum.SegConfig{-1: master}
 	oldTarget := &greenplum.Cluster{Primaries: segs, BinDir: s.Target.BinDir}
 

--- a/hub/update_catalog.go
+++ b/hub/update_catalog.go
@@ -34,7 +34,9 @@ func (s *Server) UpdateCatalogAndClusterConfig(streams step.OutStreams) (err err
 	// UpdateCatalogAndClusterConfig mutates the target cluster with the new
 	// data directories which have yet to be reflected on disk in a later substep.
 	master := s.Target.Primaries[-1]
-	master.DataDir = upgradeDataDir(master.DataDir)
+
+	//TODO: fix this!...it should use the config's upgradeID
+	master.DataDir = upgradeDataDir(master.DataDir, 0)
 	segs := map[int]greenplum.SegConfig{-1: master}
 	oldTarget := &greenplum.Cluster{Primaries: segs, BinDir: s.Target.BinDir}
 

--- a/hub/update_catalog_test.go
+++ b/hub/update_catalog_test.go
@@ -79,7 +79,7 @@ func TestUpdateCatalog(t *testing.T) {
 		t.Fatalf("creating %s: %+v", config, err)
 	}
 
-	conf := &Config{src, &greenplum.Cluster{}, InitializeConfig{}, 0, port, useLinkMode}
+	conf := &Config{src, &greenplum.Cluster{}, InitializeConfig{}, 0, port, useLinkMode, 0}
 	server := New(conf, nil, tempDir)
 
 	t.Run("updates ports for every segment", func(t *testing.T) {

--- a/hub/upgrade_primaries_test.go
+++ b/hub/upgrade_primaries_test.go
@@ -177,7 +177,7 @@ func TestGetDataDirPairs(t *testing.T) {
 			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: greenplum.PrimaryRole},
 		})
 
-		conf := &hub.Config{source, target, hub.InitializeConfig{}, 0, port, useLinkMode}
+		conf := &hub.Config{source, target, hub.InitializeConfig{}, 0, port, useLinkMode, 0}
 		server := hub.New(conf, nil, "")
 
 		_, err := server.GetDataDirPairs()
@@ -199,7 +199,7 @@ func TestGetDataDirPairs(t *testing.T) {
 			{ContentID: 2, DbID: 3, Hostname: "mdw", DataDir: "/data/dbfast2/seg2", Role: greenplum.PrimaryRole},
 		})
 
-		conf := &hub.Config{source, target, hub.InitializeConfig{}, 0, port, useLinkMode}
+		conf := &hub.Config{source, target, hub.InitializeConfig{}, 0, port, useLinkMode, 0}
 		server := hub.New(conf, nil, "")
 
 		_, err := server.GetDataDirPairs()
@@ -221,7 +221,7 @@ func TestGetDataDirPairs(t *testing.T) {
 			{ContentID: 1, DbID: 3, Hostname: "localhost", DataDir: "/data/dbfast2/seg2", Role: greenplum.PrimaryRole},
 		})
 
-		conf := &hub.Config{source, target, hub.InitializeConfig{}, 0, port, useLinkMode}
+		conf := &hub.Config{source, target, hub.InitializeConfig{}, 0, port, useLinkMode, 0}
 		server := hub.New(conf, nil, "")
 
 		_, err := server.GetDataDirPairs()

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -37,7 +37,8 @@ delete_cluster() {
     local masterdir="$1"
 
     # Sanity check.
-    if [[ $masterdir != *_upgrade/demoDataDir* ]]; then
+    # TODO: this dir has a upgradeID in it...how to check that it's an upgraded cluster?
+    if [[ $masterdir != *qddir/demoDataDir-1_* ]]; then
         abort "cowardly refusing to delete $masterdir which does not look like an upgraded demo data directory"
     fi
 
@@ -60,7 +61,7 @@ delete_finalized_cluster() {
     local masterdir="$1"
 
     # Sanity check.
-    local old_qddir_path=$(dirname $masterdir)"_old/demoDataDir-1"
+    local old_qddir_path=$(dirname $masterdir)"/demoDataDir-1_old"
     if [[ ! -d "$old_qddir_path" ]]; then
         abort "cowardly refusing to delete $masterdir which does not look like an upgraded demo data directory. expected old directory of
             $old_qddir_path"
@@ -88,7 +89,8 @@ delete_finalized_cluster() {
 delete_target_datadirs() {
     local masterdir="$1"
     local datadir=$(dirname $(dirname "$masterdir"))
-    rm -rf "${datadir}"/*_upgrade
+    # TODO: how do we identify upgraded datadirs now?
+    #rm -rf "${datadir}"/*_upgrade
 }
 
 # require_gnu_stat tries to find a GNU stat program. If one is found, it will be

--- a/upgrade/id.go
+++ b/upgrade/id.go
@@ -1,0 +1,40 @@
+package upgrade
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+)
+
+// ID is a unique identifier for a cluster upgrade.
+type ID uint64
+
+// NewID creates a new unique ID. It should be reasonably unique across
+// executions of the process.
+func NewID() ID {
+	var bytes [8]byte // 64 bits
+
+	// Use crypto/rand for this to avoid chicken-and-egg (i.e. what should we
+	// seed math/rand with?). This is more expensive, but we expect this to be
+	// called only once per upgrade anyway.
+	_, err := rand.Read(bytes[:])
+	if err != nil {
+		// TODO: should we fall back in this case? It will be system-dependent.
+		panic(fmt.Sprintf("unable to get random data: %+v", err))
+	}
+
+	num := binary.LittleEndian.Uint64(bytes[:])
+	return ID(num)
+}
+
+// String returns an unpadded, filesystem-safe base64 encoding of the
+// identifier.
+func (id ID) String() string {
+	var bytes [8]byte // 64 bits
+	binary.LittleEndian.PutUint64(bytes[:], uint64(id))
+
+	// RawURLEncoding omits padding (which we don't need) and uses a
+	// filesystem-safe character set.
+	return base64.RawURLEncoding.EncodeToString(bytes[:])
+}

--- a/upgrade/id_test.go
+++ b/upgrade/id_test.go
@@ -1,0 +1,72 @@
+package upgrade_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/greenplum-db/gpupgrade/upgrade"
+)
+
+func TestID(t *testing.T) {
+	t.Run("NewID gives a unique identifier for each run", func(t *testing.T) {
+		one := upgrade.NewID()
+		two := upgrade.NewID()
+
+		if one == two {
+			t.Errorf("second generated ID was equal to first ID (%d)", one)
+		}
+	})
+
+	t.Run("String gives a base64 representation of the ID", func(t *testing.T) {
+		var id upgrade.ID
+
+		actual := fmt.Sprintf("%s", id)
+		expected := "AAAAAAAAAAA" // all zeroes in base64. 8 bytes decoded -> 11 bytes encoded
+
+		if actual != expected {
+			t.Errorf("String() returned %q, want %q", actual, expected)
+		}
+	})
+}
+
+// TestNewIDCrossProcess ensures that NewID returns different results across
+// invocations of an executable (i.e. that the ID source is seeded correctly).
+func TestNewIDCrossProcess(t *testing.T) {
+	cmd1 := idCommand()
+	cmd2 := idCommand()
+
+	out1, err := cmd1.Output()
+	if err != nil {
+		t.Errorf("first execution: unexpected error %+v", err)
+	}
+
+	out2, err := cmd2.Output()
+	if err != nil {
+		t.Errorf("second execution: unexpected error %+v", err)
+	}
+
+	if string(out1) == string(out2) {
+		t.Errorf("second generated ID was equal to first ID (%s)", string(out1))
+	}
+}
+
+// idCommand creates an exec.Cmd that will run upgrade.NewID() in a brand-new
+// process. It uses the TestIDCommand entry point to do its work.
+func idCommand() *exec.Cmd {
+	cmd := exec.Command(os.Args[0], "-test.run=TestIDCommand")
+	cmd.Env = append(cmd.Env, "GO_RUN_NEW_ID=1")
+	return cmd
+}
+
+// TestIDCommand is the entry point for the idCommand(). It simply prints the
+// result of an upgrade.NewID().
+func TestIDCommand(_ *testing.T) {
+	if os.Getenv("GO_RUN_NEW_ID") != "1" {
+		return
+	}
+
+	fmt.Printf("%d", upgrade.NewID())
+	os.Exit(0)
+}


### PR DESCRIPTION
This DRAFT PR is a draft PR in the true sense...the code is a bit rough, but shows the essential ideas.  Please take a look at the big ideas shown in the code...we will continue working on make it higher quality, and fixing the tests.

The main idea is that upgraded datadirs now have a unique has as a suffix, NOT _upgrade as the parent dir suffix.  So, for instance,
```
qddir/demoDataDir-1  ---> qddir/demoDataDir-1_StaMaLJlyh0-1
dbfast/demoDataDir2 ---> dbfast/demoDataDir2_StaMaLJlyh0
```
This scheme ends up significantly cleaning up the code, since now we centralize upgrade datadir naming in one place in Initialize and propagate that through the code.  It also solves the motivating bug: to allow multiple datadirs under the same parent directory.

This code also allows "ownership" of directories, as the hash(`StaMaLJlyh0` in the above) is stored in config.json and allows an upgrade to know "its directories". 

This code passes all the CI's upgrade `X->Y` jobs, but not the BATS tests, as those hard-code assumptions about the upgrade datadir names. 
