### PR TITLE
CI: stabilize install-tests

### DIFF
--- a/installcheck.bats
+++ b/installcheck.bats
@@ -27,6 +27,7 @@ teardown() {
               --source-bindir "$GPHOME"/bin \
               --target-bindir "$GPHOME_NEW"/bin \
               --source-master-port $PGPORT \
+              --temp-port-range 6020-6040 \
               --disk-free-ratio=0 \
               3>&-
 

--- a/test/execute.bats
+++ b/test/execute.bats
@@ -94,6 +94,7 @@ reset_master_and_primary_pg_control_files() {
         --source-bindir="$GPHOME/bin" \
         --target-bindir="$GPHOME/bin" \
         --source-master-port="${PGPORT}" \
+        --temp-port-range 6020-6040 \
         --link \
         --disk-free-ratio 0 \
         --verbose
@@ -103,7 +104,7 @@ reset_master_and_primary_pg_control_files() {
     gpupgrade execute --verbose
     TEARDOWN_FUNCTIONS+=( reset_master_and_primary_pg_control_files )
 
-    PGPORT=50432 ensure_hardlinks_for_relfilenode_on_master_and_segments 'test_linking' 2
+    PGPORT=6020 ensure_hardlinks_for_relfilenode_on_master_and_segments 'test_linking' 2
 }
 
 @test "gpupgrade execute step to upgrade master should always rsync the master data dir from backup" {
@@ -116,6 +117,7 @@ reset_master_and_primary_pg_control_files() {
         --source-bindir="$GPHOME/bin" \
         --target-bindir="$GPHOME/bin" \
         --source-master-port="${PGPORT}" \
+        --temp-port-range 6020-6040 \
         --link \
         --disk-free-ratio 0 \
         --verbose
@@ -151,6 +153,7 @@ reset_master_and_primary_pg_control_files() {
         --source-bindir="$GPHOME/bin" \
         --target-bindir="$GPHOME/bin" \
         --source-master-port="${PGPORT}"\
+        --temp-port-range 6020-6040 \
         --disk-free-ratio 0 \
         --verbose 3>&-
 

--- a/test/finalize.bats
+++ b/test/finalize.bats
@@ -76,6 +76,7 @@ upgrade_cluster() {
             --source-bindir="$GPHOME/bin" \
             --target-bindir="$GPHOME/bin" \
             --source-master-port="${PGPORT}" \
+            --temp-port-range 6020-6040 \
             --disk-free-ratio 0 \
             $LINK_MODE \
             --verbose 3>&-

--- a/test/gpinitsystem.bats
+++ b/test/gpinitsystem.bats
@@ -57,13 +57,14 @@ expected_datadir() {
     done <<< "$output"
 
     local masterdir="${olddirs[$PGPORT]}"
-    local newport=50432
+    local newport=6020
 
     gpupgrade initialize \
         --verbose \
         --source-bindir "$GPHOME/bin" \
         --target-bindir "$GPHOME/bin" \
         --source-master-port "$PGPORT" \
+        --temp-port-range 6020-6040 \
         --disk-free-ratio 0 3>&-
 
     # Make sure we clean up during teardown().
@@ -91,7 +92,7 @@ expected_datadir() {
         local newdir="${newdirs[$newport]}"
         (( newport++ ))
 
-        if [ "$newport" = 50433 ]; then
+        if [ "$newport" = 6021 ]; then
             # This port should be reserved for the standby, which isn't created
             # during initialize. Skip it.
             (( newport++ ))
@@ -111,11 +112,11 @@ expected_datadir() {
     local newport=15432
 
     gpupgrade initialize \
-        --temp-port-range $expected_ports,$standby_port,$mirror_ports \
         --verbose \
         --source-bindir "$GPHOME/bin" \
         --target-bindir "$GPHOME/bin" \
         --source-master-port "$PGPORT" \
+        --temp-port-range $expected_ports,$standby_port,$mirror_ports \
         --disk-free-ratio 0 3>&-
 
     # Make sure we clean up during teardown().

--- a/test/initialize.bats
+++ b/test/initialize.bats
@@ -232,6 +232,7 @@ wait_for_port_change() {
         --source-bindir="$GPHOME/bin" \
         --target-bindir="$GPHOME/bin" \
         --source-master-port="${PGPORT}" \
+        --temp-port-range 6020-6040 \
         --disk-free-ratio 0 \
         --verbose 3>&-
 
@@ -245,6 +246,7 @@ wait_for_port_change() {
         --source-bindir="$GPHOME/bin" \
         --target-bindir="$GPHOME/bin" \
         --source-master-port="${PGPORT}" \
+        --temp-port-range 6020-6040 \
         --disk-free-ratio 0 \
         --verbose 3>&-
 
@@ -270,6 +272,7 @@ wait_for_port_change() {
         --source-bindir="$GPHOME/bin" \
         --target-bindir="$GPHOME/bin" \
         --source-master-port="${PGPORT}"\
+        --temp-port-range 6020-6040 \
         --disk-free-ratio 0 \
         --verbose 3>&-
 
@@ -283,6 +286,7 @@ wait_for_port_change() {
         --source-bindir="$GPHOME/bin" \
         --target-bindir="$GPHOME/bin" \
         --source-master-port="${PGPORT}"\
+        --temp-port-range 6020-6040 \
         --disk-free-ratio 0 \
         --verbose 3>&-
 }

--- a/test/pg_upgrade.bats
+++ b/test/pg_upgrade.bats
@@ -51,6 +51,7 @@ teardown() {
         --source-bindir "$GPHOME/bin" \
         --target-bindir "$GPHOME/bin" \
         --source-master-port "$PGPORT" \
+        --temp-port-range 6020-6040 \
         --disk-free-ratio=0 \
         --verbose 3>&- || status=$?
     [ "$status" -eq 1 ]
@@ -72,6 +73,7 @@ teardown() {
         --source-bindir "$GPHOME/bin" \
         --target-bindir "$GPHOME/bin" \
         --source-master-port "$PGPORT" \
+        --temp-port-range 6020-6040 \
         --disk-free-ratio=0 3>&-
 
     NEW_CLUSTER="$(gpupgrade config show --target-datadir)"
@@ -112,12 +114,13 @@ count_primary_gp_dbids() {
         --source-bindir "$GPHOME/bin" \
         --target-bindir "$GPHOME/bin" \
         --source-master-port "$PGPORT" \
+        --temp-port-range 6020-6040 \
         --disk-free-ratio=0 3>&-
     NEW_CLUSTER="$(gpupgrade config show --target-datadir)"
 
     gpupgrade execute --verbose
 
-    local new_dbid_num=$(count_primary_gp_dbids 50432)
+    local new_dbid_num=$(count_primary_gp_dbids 6020)
 
     [ $old_dbid_num -eq $new_dbid_num ] || fail "expected $old_dbid_num distinct DBIDs; got $new_dbid_num"
 


### PR DESCRIPTION
Specify a temp-port-range from 6020-6040 for all bats tests which is closer to
the working 6000-6007 range of the source cluster.  We have not seen any port
contention in the 6000-6007 range that the source cluster uses, so we stay near
that range for the target cluster to fix the ephemeral port conflicts we have
seen around 10-20% of the time.