### PR TITLE
Linter: remove dead code and address unhandled errors

### DIFF
--- a/agent/server.go
+++ b/agent/server.go
@@ -102,7 +102,11 @@ func (s *Server) Stop() {
 }
 
 func createIfNotExists(dir string) {
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		os.Mkdir(dir, 0777)
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		return
+	}
+
+	if err := os.Mkdir(dir, 0777); err != nil {
+		gplog.Fatal(err, "failed to create state directory %q", dir)
 	}
 }

--- a/cli/commanders/steps_test.go
+++ b/cli/commanders/steps_test.go
@@ -242,7 +242,10 @@ func TestUILoop(t *testing.T) {
 				}()
 
 				msgs := &msgStream{c.msg}
-				commanders.UILoop(msgs, false)
+				_, err := commanders.UILoop(msgs, false)
+				if err != nil {
+					t.Fatalf("got error %q want panic", err)
+				}
 			})
 		}
 	})

--- a/hub/check_upgrade.go
+++ b/hub/check_upgrade.go
@@ -24,16 +24,6 @@ func (upgradeChecker) UpgradePrimaries(args UpgradePrimaryArgs) error {
 	return UpgradePrimaries(args)
 }
 
-type AgentConnProvider interface {
-	GetAgents(s *Server) ([]*Connection, error)
-}
-
-type agentConnProvider struct{}
-
-func (agentConnProvider) GetAgents(s *Server) ([]*Connection, error) {
-	return s.AgentConns()
-}
-
 var upgrader UpgradeChecker = upgradeChecker{}
 
 func (s *Server) CheckUpgrade(stream step.OutStreams, conns []*Connection) error {

--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/hub"
-	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/testutils/mock_agent"
 	"github.com/greenplum-db/gpupgrade/utils"
@@ -25,16 +24,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
-
-// msgStream is a mock server stream for InitializeStep().
-type msgStream struct {
-	LastStatus idl.Status
-}
-
-func (m *msgStream) Send(msg *idl.Message) error {
-	m.LastStatus = msg.GetStatus().Status
-	return nil
-}
 
 var _ = Describe("Hub", func() {
 	var (

--- a/hub/services_suite_test.go
+++ b/hub/services_suite_test.go
@@ -33,7 +33,6 @@ var (
 	client      *mock_idl.MockAgentClient
 	port        int
 	dir         string
-	hubConf     *hub.Config
 	source      *greenplum.Cluster
 	target      *greenplum.Cluster
 	testHub     *hub.Server

--- a/hub/upgrade_mirrors_test.go
+++ b/hub/upgrade_mirrors_test.go
@@ -321,6 +321,10 @@ func TestUpgradeMirrors(t *testing.T) {
 		defer testutils.FinishMock(mock, t)
 
 		_, writePipe, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("couldn't create pipe: %v", err)
+		}
+
 		utils.System.Create = func(name string) (*os.File, error) {
 			return writePipe, nil
 		}

--- a/hub/upgrade_standby_test.go
+++ b/hub/upgrade_standby_test.go
@@ -19,7 +19,10 @@ func TestUpgradeStandby(t *testing.T) {
 		}
 
 		runner := newSpyRunner()
-		hub.UpgradeStandby(runner, config)
+		err := hub.UpgradeStandby(runner, config)
+		if err != nil {
+			t.Errorf("unexpected error: %+v", err)
+		}
 
 		if runner.TimesRunWasCalledWith("gpinitstandby") != 2 {
 			t.Errorf("got %v calls to config.Run, wanted %v calls",

--- a/integrations/integrations_suite_test.go
+++ b/integrations/integrations_suite_test.go
@@ -30,8 +30,7 @@ var (
 )
 
 const (
-	cliToHubPort   = 7527
-	hubToAgentPort = 6416
+	cliToHubPort = 7527
 )
 
 var _ = BeforeSuite(func() {
@@ -96,23 +95,6 @@ func killHub() {
 	}
 
 	Expect(checkPortIsAvailable(cliToHubPort)).To(BeTrue())
-}
-
-// killAll finds all running gpupupgrade processes and kills them.
-// XXX this is ridiculously heavy-handed
-func killAll() {
-	pkillCmd := exec.Command("pkill", "-9", "^gpupgrade_")
-	err := pkillCmd.Run()
-
-	// pkill returns exit code 1 if no processes were matched, which is fine.
-	if err != nil {
-		Expect(err).To(MatchError("exit status 1"))
-	} else {
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	Expect(checkPortIsAvailable(cliToHubPort)).To(BeTrue())
-	Expect(checkPortIsAvailable(hubToAgentPort)).To(BeTrue())
 }
 
 func checkPortIsAvailable(port int) bool {

--- a/step/stream_test.go
+++ b/step/stream_test.go
@@ -61,8 +61,14 @@ func TestMultiplexedStream(t *testing.T) {
 
 		// Write 10 bytes to each stream.
 		for i := 0; i < 10; i++ {
-			stream.Stdout().Write([]byte{'O'})
-			stream.Stderr().Write([]byte{'E'})
+			_, err := stream.Stdout().Write([]byte{'O'})
+			if err != nil {
+				t.Errorf("writing stdout: %#v", err)
+			}
+			_, err = stream.Stderr().Write([]byte{'E'})
+			if err != nil {
+				t.Errorf("writing stderr: %#v", err)
+			}
 		}
 
 		expected := "OEOEOEOEOEOEOEOEOEOE"
@@ -89,8 +95,11 @@ func TestMultiplexedStream(t *testing.T) {
 
 		// Write 10 bytes to each stream.
 		for i := 0; i < 10; i++ {
-			stream.Stdout().Write([]byte{'O'})
-			stream.Stderr().Write([]byte{'E'})
+			_, err := stream.Stdout().Write([]byte{'O'})
+			g.Expect(err).To(BeNil())
+
+			_, err = stream.Stderr().Write([]byte{'E'})
+			g.Expect(err).To(BeNil())
 		}
 
 		// The Writer should not have been affected in any way.

--- a/testutils/mock_agent/mock_agent_server.go
+++ b/testutils/mock_agent/mock_agent_server.go
@@ -46,7 +46,7 @@ func NewMockAgentServer() (*MockAgentServer, hub.Dialer, int) {
 	idl.RegisterAgentServer(mockServer.grpcServer, mockServer)
 
 	go func() {
-		mockServer.grpcServer.Serve(lis)
+		_ = mockServer.grpcServer.Serve(lis)
 	}()
 
 	// Target this running server during dial.


### PR DESCRIPTION
This pulls in @berlin-ab linter work to 1) remove dead code, and 2) address unhandled errors exposed by golangci-lint.

We are breaking the linter work into digestible chunks ideally grouping similar issues together into a single commit. This will keep the PRs short and specific to make it easy to review, and to get this merged before the code gets stale and drifts. Further PR's to follow.

[Test Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fix_linter_issues_part1)