### PR TITLE
Linter: fix govet and gosimple issues from golangci-lint

### DIFF
--- a/agent/rsync_test.go
+++ b/agent/rsync_test.go
@@ -56,7 +56,7 @@ func TestRsync(t *testing.T) {
 
 		targetContents, _ := ioutil.ReadFile(filepath.Join(targetDir, "/hi"))
 
-		if bytes.Compare(targetContents, []byte("hi")) != 0 {
+		if !bytes.Equal(targetContents, []byte("hi")) {
 			t.Errorf("target directory file 'hi' contained %v, wanted %v",
 				targetContents,
 				"hi")

--- a/agent/server_test.go
+++ b/agent/server_test.go
@@ -93,8 +93,5 @@ func doesPathEventuallyExist(path string) (bool, error) {
 
 func pathExists(path string) bool {
 	_, err := os.Stat(path)
-	if os.IsNotExist(err) {
-		return false
-	}
-	return true
+	return !os.IsNotExist(err)
 }

--- a/agent/upgrade_primary.go
+++ b/agent/upgrade_primary.go
@@ -31,8 +31,8 @@ func upgradeSegment(segment Segment, request *idl.UpgradePrimariesRequest, host 
 func performUpgrade(segment Segment, request *idl.UpgradePrimariesRequest) error {
 	dbid := int(segment.DBID)
 	segmentPair := upgrade.SegmentPair{
-		Source: &upgrade.Segment{request.SourceBinDir, segment.SourceDataDir, dbid, int(segment.SourcePort)},
-		Target: &upgrade.Segment{request.TargetBinDir, segment.TargetDataDir, dbid, int(segment.TargetPort)},
+		Source: &upgrade.Segment{BinDir: request.SourceBinDir, DataDir: segment.SourceDataDir, DBID: dbid, Port: int(segment.SourcePort)},
+		Target: &upgrade.Segment{BinDir: request.TargetBinDir, DataDir: segment.TargetDataDir, DBID: dbid, Port: int(segment.TargetPort)},
 	}
 
 	options := []upgrade.Option{

--- a/cli/commanders/steps_test.go
+++ b/cli/commanders/steps_test.go
@@ -40,15 +40,15 @@ func (m *errStream) Recv() (*idl.Message, error) {
 func TestUILoop(t *testing.T) {
 	t.Run("writes STDOUT and STDERR chunks in the order they are received", func(t *testing.T) {
 		msgs := msgStream{
-			{Contents: &idl.Message_Chunk{&idl.Chunk{
+			{Contents: &idl.Message_Chunk{Chunk: &idl.Chunk{
 				Buffer: []byte("my string1"),
 				Type:   idl.Chunk_STDOUT,
 			}}},
-			{Contents: &idl.Message_Chunk{&idl.Chunk{
+			{Contents: &idl.Message_Chunk{Chunk: &idl.Chunk{
 				Buffer: []byte("my error"),
 				Type:   idl.Chunk_STDERR,
 			}}},
-			{Contents: &idl.Message_Chunk{&idl.Chunk{
+			{Contents: &idl.Message_Chunk{Chunk: &idl.Chunk{
 				Buffer: []byte("my string2"),
 				Type:   idl.Chunk_STDOUT,
 			}}},
@@ -86,19 +86,19 @@ func TestUILoop(t *testing.T) {
 
 	t.Run("writes status and stdout chunks serially in verbose mode", func(t *testing.T) {
 		msgs := msgStream{
-			{Contents: &idl.Message_Status{&idl.SubstepStatus{
+			{Contents: &idl.Message_Status{Status: &idl.SubstepStatus{
 				Step:   idl.Substep_INIT_TARGET_CLUSTER,
 				Status: idl.Status_RUNNING,
 			}}},
-			{Contents: &idl.Message_Chunk{&idl.Chunk{
+			{Contents: &idl.Message_Chunk{Chunk: &idl.Chunk{
 				Buffer: []byte("my string\n"),
 				Type:   idl.Chunk_STDOUT,
 			}}},
-			{Contents: &idl.Message_Status{&idl.SubstepStatus{
+			{Contents: &idl.Message_Status{Status: &idl.SubstepStatus{
 				Step:   idl.Substep_INIT_TARGET_CLUSTER,
 				Status: idl.Status_COMPLETE,
 			}}},
-			{Contents: &idl.Message_Status{&idl.SubstepStatus{
+			{Contents: &idl.Message_Status{Status: &idl.SubstepStatus{
 				Step:   idl.Substep_UPGRADE_MASTER,
 				Status: idl.Status_FAILED,
 			}}},
@@ -131,23 +131,23 @@ func TestUILoop(t *testing.T) {
 
 	t.Run("overwrites status lines and ignores chunks in non-verbose mode", func(t *testing.T) {
 		msgs := msgStream{
-			{Contents: &idl.Message_Status{&idl.SubstepStatus{
+			{Contents: &idl.Message_Status{Status: &idl.SubstepStatus{
 				Step:   idl.Substep_INIT_TARGET_CLUSTER,
 				Status: idl.Status_RUNNING,
 			}}},
-			{Contents: &idl.Message_Chunk{&idl.Chunk{
+			{Contents: &idl.Message_Chunk{Chunk: &idl.Chunk{
 				Buffer: []byte("output ignored"),
 				Type:   idl.Chunk_STDOUT,
 			}}},
-			{Contents: &idl.Message_Status{&idl.SubstepStatus{
+			{Contents: &idl.Message_Status{Status: &idl.SubstepStatus{
 				Step:   idl.Substep_INIT_TARGET_CLUSTER,
 				Status: idl.Status_COMPLETE,
 			}}},
-			{Contents: &idl.Message_Chunk{&idl.Chunk{
+			{Contents: &idl.Message_Chunk{Chunk: &idl.Chunk{
 				Buffer: []byte("error ignored"),
 				Type:   idl.Chunk_STDERR,
 			}}},
-			{Contents: &idl.Message_Status{&idl.SubstepStatus{
+			{Contents: &idl.Message_Status{Status: &idl.SubstepStatus{
 				Step:   idl.Substep_UPGRADE_MASTER,
 				Status: idl.Status_FAILED,
 			}}},
@@ -218,13 +218,13 @@ func TestUILoop(t *testing.T) {
 			msg  *idl.Message
 		}{{
 			"bad step",
-			&idl.Message{Contents: &idl.Message_Status{&idl.SubstepStatus{
+			&idl.Message{Contents: &idl.Message_Status{Status: &idl.SubstepStatus{
 				Step:   idl.Substep_UNKNOWN_SUBSTEP,
 				Status: idl.Status_COMPLETE,
 			}}},
 		}, {
 			"bad status",
-			&idl.Message{Contents: &idl.Message_Status{&idl.SubstepStatus{
+			&idl.Message{Contents: &idl.Message_Status{Status: &idl.SubstepStatus{
 				Step:   idl.Substep_COPY_MASTER,
 				Status: idl.Status_UNKNOWN_STATUS,
 			}}},

--- a/greenplum/cluster.go
+++ b/greenplum/cluster.go
@@ -98,7 +98,7 @@ func (c *Cluster) HasMirrors() bool {
 
 // XXX This does not provide mirror hostnames yet.
 func (c *Cluster) GetHostnames() []string {
-	hostnameMap := make(map[string]bool, 0)
+	hostnameMap := make(map[string]bool)
 	for _, seg := range c.Primaries {
 		hostnameMap[seg.Hostname] = true
 	}
@@ -110,7 +110,7 @@ func (c *Cluster) GetHostnames() []string {
 }
 
 func (c *Cluster) PrimaryHostnames() []string {
-	hostnames := make(map[string]bool, 0)
+	hostnames := make(map[string]bool)
 	for _, seg := range c.Primaries {
 		// Ignore the master.
 		if seg.ContentID >= 0 {

--- a/hub/check_disk_space.go
+++ b/hub/check_disk_space.go
@@ -59,7 +59,7 @@ func checkDiskSpace(ctx context.Context, cluster *greenplum.Cluster, agents []*C
 
 			segments := cluster.SelectSegments(excludingMaster)
 			if len(segments) == 0 {
-				errs <- greenplum.UnknownHostError{agent.Hostname}
+				errs <- greenplum.UnknownHostError{Hostname: agent.Hostname}
 				return
 			}
 

--- a/hub/check_upgrade_test.go
+++ b/hub/check_upgrade_test.go
@@ -1,7 +1,6 @@
 package hub
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -69,46 +68,46 @@ func TestMasterIsCheckedLinkModeTrue(t *testing.T) {
 
 func UpgradeMasterMock(result UpgradeMasterArgs, expected *Server) error {
 	if !reflect.DeepEqual(result.Source, expected.Source) {
-		return errors.New(fmt.Sprintf("got %#v, expected %#v", result.Source, expected.Source))
+		return fmt.Errorf("got %#v, expected %#v", result.Source, expected.Source)
 	}
 	if !reflect.DeepEqual(result.Target, expected.Target) {
-		return errors.New(fmt.Sprintf("got %#v, expected %#v", result.Target, expected.Target))
+		return fmt.Errorf("got %#v, expected %#v", result.Target, expected.Target)
 	}
 	if result.StateDir != expected.StateDir {
-		return errors.New(fmt.Sprintf("got %#v expected %#v", result.StateDir, expected.StateDir))
+		return fmt.Errorf("got %#v expected %#v", result.StateDir, expected.StateDir)
 	}
 	// does not seem worth testing stream right now
 	if result.CheckOnly != true {
-		return errors.New(fmt.Sprintf("got %#v expected %#v", result.CheckOnly, true))
+		return fmt.Errorf("got %#v expected %#v", result.CheckOnly, true)
 	}
 	if result.UseLinkMode != expected.UseLinkMode {
-		return errors.New(fmt.Sprintf("got %#v expected %#v", result.UseLinkMode, expected.UseLinkMode))
+		return fmt.Errorf("got %#v expected %#v", result.UseLinkMode, expected.UseLinkMode)
 	}
 	return nil
 }
 
 func UpgradePrimariesMock(result UpgradePrimaryArgs, expected *Server) error {
 	if result.CheckOnly != true {
-		return errors.New(fmt.Sprintf("got %#v expected %#v", result.CheckOnly, true))
+		return fmt.Errorf("got %#v expected %#v", result.CheckOnly, true)
 	}
 	if result.MasterBackupDir != "" {
-		return errors.New(fmt.Sprintf("got %#v expected %#v", result.MasterBackupDir, ""))
+		return fmt.Errorf("got %#v expected %#v", result.MasterBackupDir, "")
 	}
 	if !reflect.DeepEqual(result.AgentConns, connections) {
-		return errors.New(fmt.Sprintf("got %#v expected %#v", result.AgentConns, connections))
+		return fmt.Errorf("got %#v expected %#v", result.AgentConns, connections)
 	}
 	expectedDataDirs, _ := expected.GetDataDirPairs()
 	if !reflect.DeepEqual(result.DataDirPairMap, expectedDataDirs) {
-		return errors.New(fmt.Sprintf("got %#v expected %#v", result.DataDirPairMap, expectedDataDirs))
+		return fmt.Errorf("got %#v expected %#v", result.DataDirPairMap, expectedDataDirs)
 	}
 	if !reflect.DeepEqual(result.Source, expected.Source) {
-		return errors.New(fmt.Sprintf("got %#v, expected %#v", result.Source, expected.Source))
+		return fmt.Errorf("got %#v, expected %#v", result.Source, expected.Source)
 	}
 	if !reflect.DeepEqual(result.Target, expected.Target) {
-		return errors.New(fmt.Sprintf("got %#v, expected %#v", result.Target, expected.Target))
+		return fmt.Errorf("got %#v, expected %#v", result.Target, expected.Target)
 	}
 	if result.UseLinkMode != expected.UseLinkMode {
-		return errors.New(fmt.Sprintf("got %#v expected %#v", result.UseLinkMode, expected.UseLinkMode))
+		return fmt.Errorf("got %#v expected %#v", result.UseLinkMode, expected.UseLinkMode)
 	}
 	return nil
 }

--- a/hub/server.go
+++ b/hub/server.go
@@ -153,8 +153,9 @@ func (s *Server) StopAgents() error {
 	errs := make(chan error, len(s.agentConns))
 
 	for _, conn := range s.agentConns {
-		wg.Add(1)
+		conn := conn
 
+		wg.Add(1)
 		go func() {
 			defer wg.Done()
 

--- a/step/step.go
+++ b/step/step.go
@@ -166,7 +166,7 @@ func (s *Step) sendStatus(substep idl.Substep, status idl.Status) {
 	// A stream is not guaranteed to remain connected during execution, so
 	// errors are explicitly ignored.
 	_ = s.sender.Send(&idl.Message{
-		Contents: &idl.Message_Status{&idl.SubstepStatus{
+		Contents: &idl.Message_Status{Status: &idl.SubstepStatus{
 			Step:   substep,
 			Status: status,
 		}},

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -23,12 +23,12 @@ func TestStepRun(t *testing.T) {
 
 		server := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
 		server.EXPECT().
-			Send(&idl.Message{Contents: &idl.Message_Status{&idl.SubstepStatus{
+			Send(&idl.Message{Contents: &idl.Message_Status{Status: &idl.SubstepStatus{
 				Step:   idl.Substep_GENERATING_CONFIG,
 				Status: idl.Status_RUNNING,
 			}}})
 		server.EXPECT().
-			Send(&idl.Message{Contents: &idl.Message_Status{&idl.SubstepStatus{
+			Send(&idl.Message{Contents: &idl.Message_Status{Status: &idl.SubstepStatus{
 				Step:   idl.Substep_GENERATING_CONFIG,
 				Status: idl.Status_COMPLETE,
 			}}})
@@ -52,12 +52,12 @@ func TestStepRun(t *testing.T) {
 
 		server := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
 		server.EXPECT().
-			Send(&idl.Message{Contents: &idl.Message_Status{&idl.SubstepStatus{
+			Send(&idl.Message{Contents: &idl.Message_Status{Status: &idl.SubstepStatus{
 				Step:   idl.Substep_GENERATING_CONFIG,
 				Status: idl.Status_RUNNING,
 			}}})
 		server.EXPECT().
-			Send(&idl.Message{Contents: &idl.Message_Status{&idl.SubstepStatus{
+			Send(&idl.Message{Contents: &idl.Message_Status{Status: &idl.SubstepStatus{
 				Step:   idl.Substep_GENERATING_CONFIG,
 				Status: idl.Status_COMPLETE,
 			}}})
@@ -89,12 +89,12 @@ func TestStepRun(t *testing.T) {
 
 		server := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
 		server.EXPECT().
-			Send(&idl.Message{Contents: &idl.Message_Status{&idl.SubstepStatus{
+			Send(&idl.Message{Contents: &idl.Message_Status{Status: &idl.SubstepStatus{
 				Step:   idl.Substep_CHECK_UPGRADE,
 				Status: idl.Status_RUNNING,
 			}}})
 		server.EXPECT().
-			Send(&idl.Message{Contents: &idl.Message_Status{&idl.SubstepStatus{
+			Send(&idl.Message{Contents: &idl.Message_Status{Status: &idl.SubstepStatus{
 				Step:   idl.Substep_CHECK_UPGRADE,
 				Status: idl.Status_COMPLETE,
 			}}})
@@ -119,12 +119,12 @@ func TestStepRun(t *testing.T) {
 
 		server := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
 		server.EXPECT().
-			Send(&idl.Message{Contents: &idl.Message_Status{&idl.SubstepStatus{
+			Send(&idl.Message{Contents: &idl.Message_Status{Status: &idl.SubstepStatus{
 				Step:   idl.Substep_GENERATING_CONFIG,
 				Status: idl.Status_RUNNING,
 			}}})
 		server.EXPECT().
-			Send(&idl.Message{Contents: &idl.Message_Status{&idl.SubstepStatus{
+			Send(&idl.Message{Contents: &idl.Message_Status{Status: &idl.SubstepStatus{
 				Step:   idl.Substep_GENERATING_CONFIG,
 				Status: idl.Status_FAILED,
 			}}})
@@ -172,7 +172,7 @@ func TestStepRun(t *testing.T) {
 
 		server := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
 		server.EXPECT().
-			Send(&idl.Message{Contents: &idl.Message_Status{&idl.SubstepStatus{
+			Send(&idl.Message{Contents: &idl.Message_Status{Status: &idl.SubstepStatus{
 				Step:   idl.Substep_CHECK_UPGRADE,
 				Status: idl.Status_COMPLETE,
 			}}})

--- a/step/stream.go
+++ b/step/stream.go
@@ -93,7 +93,7 @@ func (w *streamWriter) Write(p []byte) (int, error) {
 		}
 
 		err = w.stream.Send(&idl.Message{
-			Contents: &idl.Message_Chunk{chunk},
+			Contents: &idl.Message_Chunk{Chunk: chunk},
 		})
 
 		if err != nil {

--- a/step/stream_test.go
+++ b/step/stream_test.go
@@ -32,12 +32,12 @@ func TestMultiplexedStream(t *testing.T) {
 
 		mockStream := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
 		mockStream.EXPECT().
-			Send(&idl.Message{Contents: &idl.Message_Chunk{&idl.Chunk{
+			Send(&idl.Message{Contents: &idl.Message_Chunk{Chunk: &idl.Chunk{
 				Buffer: []byte(expectedStdout),
 				Type:   idl.Chunk_STDOUT,
 			}}})
 		mockStream.EXPECT().
-			Send(&idl.Message{Contents: &idl.Message_Chunk{&idl.Chunk{
+			Send(&idl.Message{Contents: &idl.Message_Chunk{Chunk: &idl.Chunk{
 				Buffer: []byte(expectedStderr),
 				Type:   idl.Chunk_STDERR,
 			}}})

--- a/upgrade/id_test.go
+++ b/upgrade/id_test.go
@@ -22,11 +22,9 @@ func TestID(t *testing.T) {
 	t.Run("String gives a base64 representation of the ID", func(t *testing.T) {
 		var id upgrade.ID
 
-		actual := fmt.Sprintf("%s", id)
 		expected := "AAAAAAAAAAA" // all zeroes in base64. 8 bytes decoded -> 11 bytes encoded
-
-		if actual != expected {
-			t.Errorf("String() returned %q, want %q", actual, expected)
+		if id.String() != expected {
+			t.Errorf("String() returned %q, want %q", id.String(), expected)
 		}
 	})
 }


### PR DESCRIPTION
Continuing from https://github.com/greenplum-db/gpupgrade/pull/298 this pulls in @berlin-ab linter work to address the govet and gosimple issues exposed by golangci-lint. Take a look a commit at at a time.

To reiterate, we are breaking the linter work into digestible chunks ideally grouping similar issues together into a single commit. This will keep the PRs short and specific to make it easy to review, and to get this merged before the code gets stale and drifts. Further PR's to follow.

[Test Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fix_linter_issues_part2)