### PR TITLE
Linter: fix structcheck, ineffassign, staticcheck, and errcheck issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,21 @@ installcheck:
 		@echo "# FIXME: Make, if run in parallel, hangs after test completes."
 		./installcheck.bats
 
+# To lint, you must install golangci-lint via one of the supported methods
+# listed at
+#
+#     https://github.com/golangci/golangci-lint#install
+#
+# DO NOT add the linter to the project dependencies in Gopkg.toml, as much as
+# you may want to streamline this installation process, because
+# 1. `go get` is an explicitly unsupported installation method for this utility,
+#    much like it is for gpupgrade itself, and
+# 2. adding it as a project dependency opens up the possibility of accidentally
+#    vendoring GPL'd code.
+.PHONY: lint
+lint:
+	golangci-lint run
+
 clean:
 		# Build artifacts
 		rm -f gpupgrade

--- a/ci/generated/dev-pipeline.yml
+++ b/ci/generated/dev-pipeline.yml
@@ -177,6 +177,15 @@ jobs:
   on_failure:
     <<: *slack_alert
 
+- name: lint
+  plan:
+  - get: gpupgrade_src
+    trigger: true
+  - task: lint
+    file: gpupgrade_src/ci/tasks/lint.yml
+  on_failure:
+    <<: *slack_alert
+
 - name: noinstall-tests
   plan:
   - in_parallel:

--- a/ci/scripts/filter/filter.go
+++ b/ci/scripts/filter/filter.go
@@ -107,10 +107,9 @@ nextline:
 		log.Fatalf("scanning stdin: %+v", scanner.Err())
 	}
 
-	// Flush and empty our buffer.
+	// Flush our buffer.
 	if len(buf) > 0 {
 		write(out, buf...)
-		buf = buf[:0]
 	}
 }
 

--- a/ci/tasks/lint.yml
+++ b/ci/tasks/lint.yml
@@ -1,0 +1,23 @@
+PLATFORM: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: golangci/golangci-lint
+    tag: 'latest'
+
+inputs:
+- name: gpupgrade_src
+  path: ../../../go/src/github.com/greenplum-db/gpupgrade
+
+run:
+  path: bash
+  args:
+  - -c
+  - |
+    set -ex
+
+    cd $GOPATH/src/github.com/greenplum-db/gpupgrade
+    make depend # to pull in dependencies for analysis
+
+    golangci-lint run

--- a/ci/template.yml
+++ b/ci/template.yml
@@ -186,6 +186,15 @@ jobs:
   on_failure:
     <<: *slack_alert
 
+- name: lint
+  plan:
+  - get: gpupgrade_src
+    trigger: true
+  - task: lint
+    file: gpupgrade_src/ci/tasks/lint.yml
+  on_failure:
+    <<: *slack_alert
+
 - name: noinstall-tests
   plan:
   - in_parallel:

--- a/cli/bash/generate.go
+++ b/cli/bash/generate.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"log"
 	"os"
 
 	"github.com/greenplum-db/gpupgrade/cli/commands"
@@ -13,5 +14,8 @@ import (
 
 func main() {
 	root := commands.BuildRootCommand()
-	root.GenBashCompletionFile(os.Args[1])
+	err := root.GenBashCompletionFile(os.Args[1])
+	if err != nil {
+		log.Fatalf("generating bash-completion.sh: %+v", err)
+	}
 }

--- a/cli/commanders/steps.go
+++ b/cli/commanders/steps.go
@@ -216,7 +216,7 @@ func UILoop(stream receiver, verbose bool) (map[string]string, error) {
 			}
 			lastStep = x.Status.Step
 
-			fmt.Printf(FormatStatus(x.Status))
+			fmt.Print(FormatStatus(x.Status))
 			if verbose {
 				fmt.Println()
 			}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -390,13 +390,13 @@ After executing, you will need to finalize.`)
 	}
 
 	subInit.Flags().StringVar(&sourceBinDir, "source-bindir", "", "install directory for source gpdb version")
-	subInit.MarkFlagRequired("source-bindir")
+	subInit.MarkFlagRequired("source-bindir") //nolint
 	subInit.Flags().StringVar(&targetBinDir, "target-bindir", "", "install directory for target gpdb version")
-	subInit.MarkFlagRequired("target-bindir")
+	subInit.MarkFlagRequired("target-bindir") //nolint
 	subInit.Flags().IntVar(&sourcePort, "source-master-port", 0, "master port for source gpdb cluster")
-	subInit.MarkFlagRequired("source-master-port")
+	subInit.MarkFlagRequired("source-master-port") //nolint
 	subInit.Flags().BoolVar(&stopBeforeClusterCreation, "stop-before-cluster-creation", false, "only run up to pre-init")
-	subInit.Flags().MarkHidden("stop-before-cluster-creation")
+	subInit.Flags().MarkHidden("stop-before-cluster-creation") //nolint
 	subInit.Flags().Float64Var(&diskFreeRatio, "disk-free-ratio", 0.60, "percentage of disk space that must be available (from 0.0 - 1.0)")
 	subInit.Flags().BoolVarP(&verbose, "verbose", "v", false, "print the output stream from all substeps")
 	subInit.Flags().StringVar(&ports, "temp-port-range", "", "set of ports to use when initializing the target cluster")

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -695,7 +695,7 @@ func addHelpToCommand(cmd *cobra.Command, help string) *cobra.Command {
 		Short: "",
 		Long:  "",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Printf(help)
+			fmt.Print(help)
 			return nil
 		},
 	})
@@ -703,7 +703,7 @@ func addHelpToCommand(cmd *cobra.Command, help string) *cobra.Command {
 
 	// Override the built-in "-h" and "--help" flags
 	cmd.SetHelpFunc(func(cmd *cobra.Command, strs []string) {
-		fmt.Printf(help)
+		fmt.Print(help)
 	})
 
 	return cmd

--- a/hub/check_source_cluster_configuration.go
+++ b/hub/check_source_cluster_configuration.go
@@ -11,12 +11,12 @@ import (
 
 const (
 	Primary Role = "p"
-	Mirror       = "m"
+	Mirror  Role = "m"
 )
 
 const (
 	Up   Status = "u"
-	Down        = "d"
+	Down Status = "d"
 )
 
 type DBID int

--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -95,7 +95,8 @@ var _ = Describe("Hub", func() {
 		done := make(chan bool, 1)
 
 		go func() {
-			h.Start()
+			// This test is being ported to go-style testing so do a nolint for now.
+			h.Start() //nolint
 			done <- true
 		}()
 		h.Stop(true)
@@ -105,7 +106,8 @@ var _ = Describe("Hub", func() {
 
 	It("closes open connections when shutting down", func() {
 		h := hub.New(conf, mockDialer, "")
-		go h.Start()
+		// This test is being ported to go-style testing so do a nolint for now.
+		go h.Start() //nolint
 
 		By("creating connections")
 		conns, err := h.AgentConns()

--- a/hub/upgrade_master_test.go
+++ b/hub/upgrade_master_test.go
@@ -44,7 +44,7 @@ func StreamingMain() {
 func BlindlyWritingMain() {
 	// Ignore SIGPIPE. Note that the obvious signal.Ignore(syscall.SIGPIPE)
 	// doesn't work as expected; see https://github.com/golang/go/issues/32386.
-	signal.Notify(make(chan os.Signal), syscall.SIGPIPE)
+	signal.Notify(make(chan os.Signal, 1), syscall.SIGPIPE)
 
 	fmt.Println("blah blah blah blah")
 	fmt.Println("blah blah blah blah")

--- a/hub/upgrade_standby.go
+++ b/hub/upgrade_standby.go
@@ -23,7 +23,7 @@ type StandbyConfig struct {
 // standby for the cluster.
 //
 func UpgradeStandby(r greenplum.Runner, standbyConfig StandbyConfig) error {
-	gplog.Info(fmt.Sprintf("removing any existing standby master on target cluster"))
+	gplog.Info("removing any existing standby master on target cluster")
 
 	err := r.Run("gpinitstandby", "-r", "-a")
 

--- a/step/stream.go
+++ b/step/stream.go
@@ -74,8 +74,8 @@ type streamWriter struct {
 }
 
 func (w *streamWriter) Write(p []byte) (int, error) {
-	w.mutex.Lock()
-	defer w.mutex.Unlock()
+	w.multiplexedStream.mutex.Lock()
+	defer w.multiplexedStream.mutex.Unlock()
 
 	n, err := w.writer.Write(p)
 	if err != nil {

--- a/utils/daemon/daemon.go
+++ b/utils/daemon/daemon.go
@@ -340,7 +340,7 @@ func MakeDaemonizable(cmd *cobra.Command, shouldDaemonize *bool) {
 	var forkChild bool
 	cmd.Flags().BoolVar(&forkChild, "daemonize", false, "start hub in the background")
 	cmd.Flags().BoolVar(shouldDaemonize, "daemon", false, "disconnect standard streams (internal option; use --daemonize instead)")
-	cmd.Flags().MarkHidden("daemon")
+	cmd.Flags().MarkHidden("daemon") //nolint
 
 	// Don't destroy any prerun functions stored by the user. We'll call them
 	// after our prerun, if we don't daemonize.

--- a/utils/daemon/daemon_test.go
+++ b/utils/daemon/daemon_test.go
@@ -164,7 +164,8 @@ var _ = Describe("waitForDaemon", func() {
 		errput := []byte("this is an error\n")
 
 		cmd := MockDaemonizableCommand{StdoutBuf: output, StderrBuf: errput}
-		waitForDaemon(&cmd, outbuf, errbuf, 0)
+		err := waitForDaemon(&cmd, outbuf, errbuf, 0)
+		Expect(err).NotTo(HaveOccurred())
 
 		Expect(outbuf.Bytes()).To(Equal(output))
 		Expect(errbuf.Bytes()).To(Equal(errput))


### PR DESCRIPTION
**_Note_**: This PR needs to go in after PRs https://github.com/greenplum-db/gpupgrade/pull/298 and https://github.com/greenplum-db/gpupgrade/pull/300. Be sure to rebase and ensure the lint job on the test pipeline is green before merging.

Continuing from https://github.com/greenplum-db/gpupgrade/pull/298 and https://github.com/greenplum-db/gpupgrade/pull/300 this pulls in @berlin-ab linter work to address additional golangci-lint issues. Take a look a commit at at a time where the last commit adds a lint job to the CI.

To reiterate, we are breaking the linter work into digestible chunks ideally grouping similar issues together into a single commit. This will keep the PRs short and specific to make it easy to review, and to get this merged before the code gets stale and drifts. Further PR's to follow.

[Test Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fix_linter_issues_part3) (Note the lint job will fail until PRs https://github.com/greenplum-db/gpupgrade/pull/298 and https://github.com/greenplum-db/gpupgrade/pull/300 are merged, and this PR rebased with master.)
