### PR TITLE
linter: Silence false positives 

### DIFF
--- a/ci/tasks/lint.yml
+++ b/ci/tasks/lint.yml
@@ -20,4 +20,4 @@ run:
     cd $GOPATH/src/github.com/greenplum-db/gpupgrade
     make depend # to pull in dependencies for analysis
 
-    golangci-lint run
+    make lint

--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Hub", func() {
 	)
 
 	BeforeEach(func() {
-		agentA, mockDialer, hubToAgentPort = mock_agent.NewMockAgentServer()
+		agentA, mockDialer, hubToAgentPort = mock_agent.NewMockAgentServer() //nolint
 		source, target = testutils.CreateMultinodeSampleClusterPair("/tmp")
 		source.Mirrors = map[int]greenplum.SegConfig{
 			-1: {ContentID: -1, DbID: 1, Port: 15433, Hostname: "standby-host", DataDir: "/seg-1"},

--- a/hub/services_suite_test.go
+++ b/hub/services_suite_test.go
@@ -57,7 +57,7 @@ var _ = BeforeEach(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	source, target = testutils.CreateMultinodeSampleClusterPair(dir)
-	mockAgent, dialer, port = mock_agent.NewMockAgentServer()
+	mockAgent, dialer, port = mock_agent.NewMockAgentServer() //nolint
 	client = mock_idl.NewMockAgentClient(ctrl)
 
 	conf := &hub.Config{


### PR DESCRIPTION
After pushing the linter to the prod pipeline the following error was mysteriously being shown:

> ERRO Running error: assign: failed prerequisites: [inspect@github.com/greenplum-db/gpupgrade/hub_test [github.com/greenplum-db/gpupgrade/hub.test]: analysis skipped: errors in package: [/go/src/github.com/greenplum-db/gpupgrade/hub/server_test.go:42:40: cannot use mock_agent.NewMockAgentServer() (value of type hub.Dialer) as hub.Dialer value in assignment /go/src/github.com/greenplum-db/gpupgrade/hub/services_suite_test.go:60:28: cannot use mock_agent.NewMockAgentServer() (value of type hub.Dialer) as hub.Dialer value in assignment]] 


This fixed that and updates lint.yml to use `make lint` instead of `golangci-lint run`.

[Test pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fix_lint)