### PR TITLE
linter: downgrade golanci-lint

### DIFF
--- a/ci/tasks/lint.yml
+++ b/ci/tasks/lint.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: golangci/golangci-lint
-    tag: 'latest'
+    tag: 'v1.23'
 
 inputs:
 - name: gpupgrade_src

--- a/ci/tasks/lint.yml
+++ b/ci/tasks/lint.yml
@@ -20,4 +20,4 @@ run:
     cd $GOPATH/src/github.com/greenplum-db/gpupgrade
     make depend # to pull in dependencies for analysis
 
-    golangci-lint run
+    make lint


### PR DESCRIPTION
The lint job on the CI is running into the following issue with the latest golangci-lint version 1.24:
```
ERRO Running error: assign: failed prerequisites:
[inspect@github.com/greenplum-db/gpupgrade/hub_test
[github.com/greenplum-db/gpupgrade/hub.test]: analysis skipped: errors
in package:
[/go/src/github.com/greenplum-db/gpupgrade/hub/server_test.go:42:40:
cannot use mock_agent.NewMockAgentServer() (value of type hub.Dialer) as
hub.Dialer value in assignment
/go/src/github.com/greenplum-db/gpupgrade/hub/services_suite_test.go:60:28:
cannot use mock_agent.NewMockAgentServer() (value of type hub.Dialer) as
hub.Dialer value in assignment]]
```

This appears to be a regression in golangci-lint:
golangci/golangci-lint#1014

Thus, downgrade to version 1.23 for now. Also use `make lint` in the lint task.

[Test Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:downgrade_golanci/jobs/lint/builds/2)