### PR TITLE
Update to Go 1.14

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -394,6 +394,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/DATA-DOG/go-sqlmock",
+    "github.com/blang/semver",
     "github.com/cloudfoundry/gosigar",
     "github.com/golang/mock/gomock",
     "github.com/golang/mock/mockgen",

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ any feedback you have!
 
 ### Prerequisites
 
-- Golang. We currently develop against latest stable Golang, which was v1.10 as of May 2018.
+- Golang. We currently develop against latest stable Golang, which was v1.14 as of April 2020.
 - protoc. This is the compiler for the [gRPC protobuffer](https://grpc.io/) system.
 On macOS, one way to install this is via `brew install protobuf`
 

--- a/ci/generated/prod-pipeline.yml
+++ b/ci/generated/prod-pipeline.yml
@@ -663,7 +663,7 @@ jobs:
           type: docker-image
           source:
             repository: golang
-            tag: '1.12.7'
+            tag: '1.14'
         inputs:
           - name: gpupgrade_src
             path: go/src/github.com/greenplum-db/gpupgrade

--- a/ci/tasks/build.yml
+++ b/ci/tasks/build.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: '1.12.7'
+    tag: '1.14'
 
 inputs:
 - name: gpupgrade_src

--- a/ci/tasks/noinstall-tests.yml
+++ b/ci/tasks/noinstall-tests.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: '1.12.7'
+    tag: '1.14'
 
 inputs:
 - name: gpupgrade_src

--- a/ci/template.yml
+++ b/ci/template.yml
@@ -367,7 +367,7 @@ jobs:
           type: docker-image
           source:
             repository: golang
-            tag: '1.12.7'
+            tag: '1.14'
         inputs:
           - name: gpupgrade_src
             path: go/src/github.com/greenplum-db/gpupgrade


### PR DESCRIPTION
(and fix up `Gopkg.lock` while we're at it)

Note that this is only a first step; because the X-to-Y test jobs build on CCP images, they will be using whatever version of Go is installed there (1.12 at last check). That will need to be fixed by having those jobs consume output from the build job.

[Test pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:dev:1.14) to make sure nothing goes terribly wrong.