### PR TITLE
CI: switch X-to-Y tests to ports 6020-6040

### DIFF
--- a/ci/scripts/upgrade-cluster.bash
+++ b/ci/scripts/upgrade-cluster.bash
@@ -87,7 +87,10 @@ time ssh mdw bash <<EOF
               $LINK_MODE \
               --target-bindir ${GPHOME_NEW}/bin \
               --source-bindir ${GPHOME_OLD}/bin \
-              --source-master-port $MASTER_PORT
+              --source-master-port $MASTER_PORT \
+              --temp-port-range 6020-6040
+    # TODO: rather than setting a temp port range, consider carving out an
+    # ip_local_reserved_ports range during/after CCP provisioning.
 
     gpupgrade execute
     gpupgrade finalize


### PR DESCRIPTION
Some intermittent failures appear to be related to port collisions in the ephemeral range, so switch to the same port range used by the install-tests fix in ff9e6406f.

Eventually, we can probably reserve the default 50432-* range on the VMs instead (unlike install-tests, which is using containers), but while we're trying to debug and reason about these intermittent failures, consistency seems more helpful.