### PR TITLE
Add contributing and update Readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-We warmly welcome and appreciate contributions from the community! By participating you agree to the [code of conduct](https://github.com/greenplum-db/gpupgrade/CODE-OF-CONDUCT.md). To contribute:
+We warmly welcome and appreciate contributions from the community! By participating you agree to the [code of conduct](https://github.com/greenplum-db/gpupgrade/blob/master/CODE-OF-CONDUCT.md). To contribute:
 
 - Sign our [Contributor License Agreement](https://cla.pivotal.io/sign/greenplum).
 
@@ -22,7 +22,7 @@ We warmly welcome and appreciate contributions from the community! By participat
 
     - Add appropriate tests and view coverage with `make coverage`.
 
-    - Ensure a well written commit message as explained [here](https://chris.beams.io/posts/git-commit/) and [here](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+    - Ensure a well written commit message as explained [here](https://chris.beams.io/posts/git-commit/) and [here](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 
     - Format code with `make format`.
      

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing
+
+We warmly welcome and appreciate contributions from the community! By participating you agree to the [code of conduct](https://github.com/greenplum-db/gpupgrade/CODE-OF-CONDUCT.md). To contribute:
+
+- Sign our [Contributor License Agreement](https://cla.pivotal.io/sign/greenplum).
+
+- Fork the gpupgrade repository on GitHub.
+
+- Clone the repository.
+
+- Follow the README to set up your environment and run the tests.
+
+- Create a change
+
+    - Create a topic branch.
+
+    - Make commits as logical units for ease of reviewing.
+
+    - Try and follow similar coding styles as found throughout the code base.
+
+    - Rebase with master often to stay in sync with upstream.
+
+    - Add appropriate tests and view coverage with `make coverage`.
+
+    - Ensure a well written commit message as explained [here](https://chris.beams.io/posts/git-commit/) and [here](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+
+    - Format code with `make format`.
+     
+    - Address any linter issues with `make lint`.
+
+- Submit a pull request (PR).
+
+    - Create a [pull request from your fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/.creating-a-pull-request-from-a-fork).
+
+    - We will create a test pipeline which runs additional acceptance tests based on your branch.
+
+    - Address PR feedback with fixup and/or squash commits.
+        ```
+        git add .
+        git commit --fixup <commit SHA> 
+            Or
+        git commit --squash <commit SHA>
+        ```    
+
+    - Once approved, before merging into master squash your fixups with:
+        ```
+        git rebase -i --autosquash origin/master
+        git push --force-with-lease $USER <my-feature-branch>
+        ```
+
+
+# Community
+
+Connect with Greenplum on:
+- [Slack](https://greenplum.slack.com/)
+- [Dev Google Group mailing list](https://groups.google.com/a/greenplum.org/forum/#!forum/gpdb-dev/join)
+


### PR DESCRIPTION
Adds contributing.md and update Readme.md. To see a rendered version try looking at the [branch](https://github.com/kalensk/gpupgrade/tree/contributing.md).

Ideally I think it would be useful to keep the README generic enough to not get out dated too quickly, but useful enough for new people. I believe the source of truth should be the actual source code such as the Makefile, rather than duplicated in the README.

To keep things clean and clear commands like `make lint` and `make format` are now referenced in contributing.md rather than the README.
