### PR TITLE
remove unused log-directory flag from hub and agent

### DIFF
--- a/cli/commands/agent.go
+++ b/cli/commands/agent.go
@@ -14,7 +14,7 @@ import (
 )
 
 func Agent() *cobra.Command {
-	var logdir, statedir string
+	var statedir string
 	var shouldDaemonize bool
 
 	var cmd = &cobra.Command{
@@ -24,7 +24,7 @@ func Agent() *cobra.Command {
 		Hidden: true,
 		Args:   cobra.MaximumNArgs(0), //no positional args allowed
 		RunE: func(cmd *cobra.Command, args []string) error {
-			gplog.InitializeLogging("gpupgrade agent", logdir)
+			gplog.InitializeLogging("gpupgrade agent", "")
 			defer log.WritePanics()
 
 			conf := agent.Config{
@@ -44,7 +44,6 @@ func Agent() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&logdir, "log-directory", "", "command_listener log directory")
 	cmd.Flags().StringVar(&statedir, "state-directory", utils.GetStateDir(), "Agent state directory")
 
 	daemon.MakeDaemonizable(cmd, &shouldDaemonize)

--- a/cli/commands/hub.go
+++ b/cli/commands/hub.go
@@ -23,7 +23,6 @@ import (
 // Minimal CLI command parsing to embrace that booting this binary to run the hub might have some flags like a log dir
 
 func Hub() *cobra.Command {
-	var logdir string
 	var shouldDaemonize bool
 
 	var cmd = &cobra.Command{
@@ -33,7 +32,7 @@ func Hub() *cobra.Command {
 		Hidden: true,
 		Args:   cobra.MaximumNArgs(0), //no positional args allowed
 		RunE: func(cmd *cobra.Command, args []string) error {
-			gplog.InitializeLogging("gpupgrade hub", logdir)
+			gplog.InitializeLogging("gpupgrade hub", "")
 			debug.SetTraceback("all")
 			defer log.WritePanics()
 
@@ -77,8 +76,6 @@ func Hub() *cobra.Command {
 			return nil
 		},
 	}
-
-	cmd.PersistentFlags().StringVar(&logdir, "log-directory", "", "gpupgrade hub log directory")
 
 	daemon.MakeDaemonizable(cmd, &shouldDaemonize)
 


### PR DESCRIPTION
This flag appears to be unused and thus dead code.

[Test pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:remove_logdir)