### PR TITLE
Initialize step logs in gpAdminLogs subdirectory

### DIFF
--- a/cli/commands/agent.go
+++ b/cli/commands/agent.go
@@ -24,7 +24,11 @@ func Agent() *cobra.Command {
 		Hidden: true,
 		Args:   cobra.MaximumNArgs(0), //no positional args allowed
 		RunE: func(cmd *cobra.Command, args []string) error {
-			gplog.InitializeLogging("gpupgrade agent", "")
+			logdir, err := utils.GetLogDir()
+			if err != nil {
+				return err
+			}
+			gplog.InitializeLogging("gpupgrade_agent", logdir)
 			defer log.WritePanics()
 
 			conf := agent.Config{

--- a/cli/commands/hub.go
+++ b/cli/commands/hub.go
@@ -32,7 +32,11 @@ func Hub() *cobra.Command {
 		Hidden: true,
 		Args:   cobra.MaximumNArgs(0), //no positional args allowed
 		RunE: func(cmd *cobra.Command, args []string) error {
-			gplog.InitializeLogging("gpupgrade hub", "")
+			logdir, err := utils.GetLogDir()
+			if err != nil {
+				return err
+			}
+			gplog.InitializeLogging("gpupgrade_hub", logdir)
 			debug.SetTraceback("all")
 			defer log.WritePanics()
 

--- a/cmd/gpupgrade/main.go
+++ b/cmd/gpupgrade/main.go
@@ -12,25 +12,26 @@ import (
 	_ "github.com/lib/pq"
 
 	"github.com/greenplum-db/gpupgrade/cli/commands"
+	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/greenplum-db/gpupgrade/utils/daemon"
 )
 
 func main() {
-	setUpLogging()
+	debug.SetTraceback("all")
+	logdir, err := utils.GetLogDir()
+	if err != nil {
+		fmt.Printf("\n%+v\n", err)
+		os.Exit(1)
+	}
+	gplog.InitializeLogging("gpupgrade_cli", logdir)
 
 	root := commands.BuildRootCommand()
 	root.SilenceErrors = true // we'll print these ourselves
 
-	err := root.Execute()
+	err = root.Execute()
 	if err != nil && err != daemon.ErrSuccessfullyDaemonized {
 		// Use v to print the stack trace of an object errors.
 		fmt.Printf("\n%+v\n", err)
 		os.Exit(1)
 	}
-}
-
-func setUpLogging() {
-	debug.SetTraceback("all")
-	//empty logdir defaults to ~/gpAdminLogs
-	gplog.InitializeLogging("gpupgrade_cli", "")
 }

--- a/step/step.go
+++ b/step/step.go
@@ -9,10 +9,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/greenplum-db/gp-common-go-libs/operating"
 	multierror "github.com/hashicorp/go-multierror"
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/utils"
 )
 
 type Step struct {
@@ -33,7 +35,12 @@ func New(name string, sender idl.MessageSender, store Store, streams OutStreamsC
 }
 
 func Begin(stateDir string, name string, sender idl.MessageSender) (*Step, error) {
-	path := filepath.Join(stateDir, fmt.Sprintf("%s.log", name))
+	logdir, err := utils.GetLogDir()
+	if err != nil {
+		return nil, err
+	}
+
+	path := filepath.Join(logdir, fmt.Sprintf("%s_%s.log", name, operating.System.Now().Format("20060102")))
 	log, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
 	if err != nil {
 		return nil, xerrors.Errorf(`step "%s": %w`, name, err)

--- a/test/pg_upgrade.bats
+++ b/test/pg_upgrade.bats
@@ -10,6 +10,7 @@ setup() {
 
     STATE_DIR=`mktemp -d /tmp/gpupgrade.XXXXXX`
     export GPUPGRADE_HOME="${STATE_DIR}/gpupgrade"
+    export GPUPGRADE_LOGDIR=~/gpAdminLogs/gpupgrade
     gpupgrade kill-services
 
     # If this variable is set (to a master data directory), teardown() will call
@@ -61,7 +62,7 @@ teardown() {
 
     NEW_CLUSTER="$(gpupgrade config show --target-datadir)"
 
-    grep "Checking for indexes on partitioned tables                  fatal" "$GPUPGRADE_HOME"/initialize.log
+    grep "Checking for indexes on partitioned tables                  fatal" "$GPUPGRADE_LOGDIR"/initialize_*.log
 
     # revert added index
     $PSQL -d postgres -p $PGPORT -c "DROP TABLE test_pg_upgrade CASCADE;"
@@ -81,7 +82,7 @@ teardown() {
 
     NEW_CLUSTER="$(gpupgrade config show --target-datadir)"
 
-    grep "Clusters are compatible" "$GPUPGRADE_HOME"/initialize.log
+    grep "Clusters are compatible" "$GPUPGRADE_LOGDIR"/initialize_*.log
 
     [ -e "$GPUPGRADE_HOME"/pg_upgrade/seg-1/pg_upgrade_internal.log ]
     [ -e "$GPUPGRADE_HOME"/pg_upgrade/seg0/pg_upgrade_internal.log ]

--- a/utils/sys_utils.go
+++ b/utils/sys_utils.go
@@ -106,6 +106,16 @@ func GetStateDir() string {
 	return stateDir
 }
 
+func GetLogDir() (string, error) {
+	currentUser, err := System.CurrentUser()
+	if err != nil {
+		return "", err
+	}
+
+	logDir := filepath.Join(currentUser.HomeDir, "gpAdminLogs", "gpupgrade")
+	return logDir, nil
+}
+
 func CreateDataDirectory(dataDir string) error {
 	file := filepath.Join(dataDir, markerFile)
 	_, err := System.Stat(file)


### PR DESCRIPTION
Logs created in ~/gpAdminLogs/gpupgrade directory with same file pattern
as gpupgrade_cli_[timestamp]. Unfortunately for us, gplog is currently a
singleton, so we cannot easily reuse that library to create multiple log
files.