### PR TITLE
migrate errors.Wrap to xerrors.Errorf

### DIFF
--- a/agent/upgrade_primaries_test.go
+++ b/agent/upgrade_primaries_test.go
@@ -97,7 +97,7 @@ func TestUpgradePrimary(t *testing.T) {
 		// XXX it'd be nice if we didn't couple against a hardcoded string here,
 		// but it's difficult to unwrap multierror with the new xerrors
 		// interface.
-		if !strings.Contains(err.Error(), "failed to check primary on host") ||
+		if !strings.Contains(err.Error(), "check primary on host") ||
 			!strings.Contains(err.Error(), "with content 1") {
 			t.Errorf("error %q did not contain expected contents 'check primary on host' and 'content 1'",
 				err.Error())
@@ -123,7 +123,7 @@ func TestUpgradePrimary(t *testing.T) {
 		// XXX it'd be nice if we didn't couple against a hardcoded string here,
 		// but it's difficult to unwrap multierror with the new xerrors
 		// interface.
-		if !strings.Contains(err.Error(), "failed to upgrade primary on host") ||
+		if !strings.Contains(err.Error(), "upgrade primary on host") ||
 			!strings.Contains(err.Error(), "with content 1") {
 			t.Errorf("error %q did not contain expected contents 'upgrade primary on host' and 'content 1'",
 				err.Error())

--- a/agent/upgrade_primary_test.go
+++ b/agent/upgrade_primary_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -64,8 +65,8 @@ func TestRestoreTablespaces(t *testing.T) {
 
 		// all the args for multiple invocations of rsync
 		expectedRsyncArgs := []string{
-				"--archive", "--delete",
-				"/tmp/tablespaces/1663/1/", "/tmp/default/1663/2",
+			"--archive", "--delete",
+			"/tmp/tablespaces/1663/1/", "/tmp/default/1663/2",
 		}
 
 		var actualArgs []string
@@ -179,7 +180,7 @@ func TestRestoreTablespaces(t *testing.T) {
 			t.Error("expected ReCreateSymLink() to fail")
 		}
 
-		expectedErrorStr := "failed to recreate symbolic link"
+		expectedErrorStr := "recreate symbolic link"
 		if !strings.Contains(err.Error(), expectedErrorStr) {
 			t.Errorf("got %+v, want %+v", err, expectedErrorStr)
 		}
@@ -200,8 +201,8 @@ func TestReCreateSymLink(t *testing.T) {
 			t.Errorf("got nil, want %+v", os.ErrPermission)
 		}
 
-		if os.ErrPermission != errors.Cause(err) {
-			t.Errorf("got %#v, want %#v", err, os.ErrPermission)
+		if !xerrors.Is(err, os.ErrPermission) {
+			t.Errorf("expected error %#v to contain %#v", err, os.ErrPermission)
 		}
 	})
 
@@ -225,11 +226,11 @@ func TestReCreateSymLink(t *testing.T) {
 			t.Errorf("expected Lstat() to be called")
 		}
 
-		if os.ErrPermission != errors.Cause(err) {
+		if os.ErrPermission != xerrors.Unwrap(err) {
 			t.Errorf("got %q, want %q", err.Error(), os.ErrPermission)
 		}
 
-		expectedErrStr := "failed to unlink"
+		expectedErrStr := "unlink"
 		if !strings.Contains(err.Error(), expectedErrStr) {
 			t.Errorf("got %q, want %q", err.Error(), expectedErrStr)
 		}

--- a/cli/commanders/steps.go
+++ b/cli/commanders/steps.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
-	"github.com/pkg/errors"
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -65,7 +64,7 @@ var indicators = map[idl.Status]string{
 func Initialize(client idl.CliToHubClient, request *idl.InitializeRequest, verbose bool) (err error) {
 	stream, err := client.Initialize(context.Background(), request)
 	if err != nil {
-		return errors.Wrap(err, "initializing hub")
+		return xerrors.Errorf("initialize hub: %w", err)
 	}
 
 	_, err = UILoop(stream, verbose)
@@ -81,7 +80,7 @@ func InitializeCreateCluster(client idl.CliToHubClient, verbose bool) (err error
 		&idl.InitializeCreateClusterRequest{},
 	)
 	if err != nil {
-		return errors.Wrap(err, "initializing hub2")
+		return xerrors.Errorf("initialize create cluster: %w", err)
 	}
 
 	_, err = UILoop(stream, verbose)

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -356,17 +356,17 @@ func initialize() *cobra.Command {
 
 			err = commanders.CreateStateDir()
 			if err != nil {
-				return errors.Wrap(err, "creating state directory")
+				return xerrors.Errorf("create state directory: %w", err)
 			}
 
 			err = commanders.CreateInitialClusterConfigs()
 			if err != nil {
-				return errors.Wrap(err, "creating initial cluster configs")
+				return xerrors.Errorf("create initial cluster configs: %w", err)
 			}
 
 			err = commanders.StartHub()
 			if err != nil {
-				return errors.Wrap(err, "starting hub")
+				return xerrors.Errorf("start hub: %w", err)
 			}
 
 			client := connectToHub()
@@ -381,7 +381,7 @@ func initialize() *cobra.Command {
 			}
 			err = commanders.Initialize(client, request, verbose)
 			if err != nil {
-				return errors.Wrap(err, "initializing hub")
+				return xerrors.Errorf("initialize hub: %w", err)
 			}
 
 			err = commanders.RunChecks(client, diskFreeRatio)
@@ -395,7 +395,7 @@ func initialize() *cobra.Command {
 
 			err = commanders.InitializeCreateCluster(client, verbose)
 			if err != nil {
-				return errors.Wrap(err, "initializing cluster")
+				return xerrors.Errorf("initialize create cluster: %w", err)
 			}
 
 			fmt.Println(`

--- a/greenplum/cluster.go
+++ b/greenplum/cluster.go
@@ -14,6 +14,7 @@ import (
 
 var isPostmasterRunningCmd = exec.Command
 var startStopCmd = exec.Command
+
 const MasterDbid = 1
 
 type Cluster struct {
@@ -41,13 +42,13 @@ type Cluster struct {
 func ClusterFromDB(conn *dbconn.DBConn, binDir string) (*Cluster, error) {
 	err := conn.Connect(1)
 	if err != nil {
-		return nil, errors.Wrap(err, "couldn't connect to cluster")
+		return nil, xerrors.Errorf("connect to cluster: %w", err)
 	}
 	defer conn.Close()
 
 	segments, err := GetSegmentConfiguration(conn)
 	if err != nil {
-		return nil, errors.Wrap(err, "couldn't retrieve segment configuration")
+		return nil, xerrors.Errorf("retrieve segment configuration: %w", err)
 	}
 
 	c, err := NewCluster(segments)

--- a/greenplum/tablespace_test.go
+++ b/greenplum/tablespace_test.go
@@ -66,7 +66,7 @@ func TestGetTablespaces(t *testing.T) {
 			rows:           nil,
 			versionStr:     "",
 			expectedTuples: nil,
-			error:          errors.New("querying tablespaces"),
+			error:          errors.New("tablespace query"),
 		},
 	}
 

--- a/hub/check_upgrade.go
+++ b/hub/check_upgrade.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/step"
 )
@@ -52,7 +52,7 @@ func (s *Server) CheckUpgrade(stream step.OutStreams, conns []*Connection) error
 
 		dataDirPairMap, dataDirPairsErr := s.GetDataDirPairs()
 		if dataDirPairsErr != nil {
-			checkErrs <- errors.Wrap(dataDirPairsErr, "failed to get source and target primary data directories")
+			checkErrs <- xerrors.Errorf("get source and target primary data directories: %w", dataDirPairsErr)
 			return
 		}
 

--- a/hub/execute.go
+++ b/hub/execute.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -66,7 +65,7 @@ func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_Execut
 			return err
 		}
 
-		err = s.CopyMasterTablespaces(streams, utils.GetTablespaceDir() + string(os.PathSeparator))
+		err = s.CopyMasterTablespaces(streams, utils.GetTablespaceDir()+string(os.PathSeparator))
 		if err != nil {
 			return err
 		}
@@ -78,13 +77,13 @@ func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_Execut
 		agentConns, err := s.AgentConns()
 
 		if err != nil {
-			return errors.Wrap(err, "failed to connect to gpupgrade agent")
+			return xerrors.Errorf("connect to gpupgrade agent: %w", err)
 		}
 
 		dataDirPair, err := s.GetDataDirPairs()
 
 		if err != nil {
-			return errors.Wrap(err, "failed to get source and target primary data directories")
+			return xerrors.Errorf("get source and target primary data directories: %w", err)
 		}
 
 		return UpgradePrimaries(UpgradePrimaryArgs{

--- a/hub/fill_cluster_configs.go
+++ b/hub/fill_cluster_configs.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 
 	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/db"
 	"github.com/greenplum-db/gpupgrade/greenplum"
@@ -35,7 +36,7 @@ func FillClusterConfigsSubStep(config *Config, conn *sql.DB, _ step.OutStreams, 
 	dbconn := db.NewDBConn("localhost", int(request.SourcePort), "template1")
 	source, err := greenplum.ClusterFromDB(dbconn, request.SourceBinDir)
 	if err != nil {
-		return errors.Wrap(err, "could not retrieve source configuration")
+		return xerrors.Errorf("retrieve source configuration: %w", err)
 	}
 
 	config.Source = source
@@ -55,12 +56,12 @@ func FillClusterConfigsSubStep(config *Config, conn *sql.DB, _ step.OutStreams, 
 	// major version upgrade requires upgrading tablespaces
 	if dbconn.Version.Is("5") {
 		if err := utils.System.MkdirAll(utils.GetTablespaceDir(), 0700); err != nil {
-			return errors.Wrapf(err, "creating tablespace directory %q", utils.GetTablespaceDir())
+			return xerrors.Errorf("create tablespace directory %q: %w", utils.GetTablespaceDir(), err)
 		}
 		config.TablespacesMappingFilePath = filepath.Join(utils.GetTablespaceDir(), greenplum.TablespacesMappingFile)
 		config.Tablespaces, err = greenplum.TablespacesFromDB(dbconn, config.TablespacesMappingFilePath)
 		if err != nil {
-			return errors.Wrap(err, "extracting tablespace information")
+			return xerrors.Errorf("extract tablespace information: %w", err)
 		}
 	}
 

--- a/hub/server.go
+++ b/hub/server.go
@@ -92,7 +92,7 @@ func (s *Server) MakeDaemon() {
 func (s *Server) Start() error {
 	lis, err := net.Listen("tcp", ":"+strconv.Itoa(s.Port))
 	if err != nil {
-		return errors.Wrap(err, "failed to listen")
+		return xerrors.Errorf("listen on port %d: %w", s.Port, err)
 	}
 
 	// Set up an interceptor function to log any panics we get from request
@@ -123,7 +123,7 @@ func (s *Server) Start() error {
 
 	err = server.Serve(lis)
 	if err != nil {
-		err = errors.Wrap(err, "failed to serve")
+		err = xerrors.Errorf("serve: %w", err)
 	}
 
 	// inform Stop() that is it is OK to stop now

--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -85,7 +85,7 @@ func TestHubStart(t *testing.T) {
 
 		select {
 		case err := <-errChan:
-			expected := "failed to listen"
+			expected := "listen"
 			if err != nil && !strings.Contains(err.Error(), expected) {
 				t.Errorf("got error %#v want %#v", err, expected)
 			}

--- a/hub/upgrade_primaries.go
+++ b/hub/upgrade_primaries.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -49,7 +50,7 @@ func UpgradePrimaries(args UpgradePrimaryArgs) error {
 			})
 
 			if err != nil {
-				agentErrs <- errors.Wrapf(err, "failed to upgrade primary segment on host %s", conn.Hostname)
+				agentErrs <- xerrors.Errorf("upgrade primary segment on host %s: %w", conn.Hostname, err)
 			}
 		}(conn)
 	}

--- a/hub/upgrade_primaries_test.go
+++ b/hub/upgrade_primaries_test.go
@@ -175,7 +175,7 @@ func TestUpgradePrimaries(t *testing.T) {
 
 		// XXX it'd be nice if we didn't couple against a hardcoded string here,
 		// but it's difficult to unwrap multierror with the new xerrors interface.
-		if !strings.Contains(err.Error(), "failed to upgrade primary segment on host sdw2") ||
+		if !strings.Contains(err.Error(), "upgrade primary segment on host sdw2") ||
 			!strings.Contains(err.Error(), expected.Error()) {
 			t.Errorf("error %q did not contain expected contents '%q'", err.Error(), expected.Error())
 		}


### PR DESCRIPTION
The xerrors backport package gives stack frames in our error values compared to the old errors.Wrap style. This also consolidates all error messages to use a single consistent idiom to avoid confusion.

Error context was also minimized with "failed to" type prefixes such that the return context is easier to read. For example avoiding

`failed to x: failed to y: failed to create new store: the error`

Compared to:
`x: y: new store: the error`

This example is from:
https://github.com/uber-go/guide/blob/master/style.md#error-wrapping

[Test pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:xerrors)