### PR TITLE
generate SQL scripts that drop non-upgradable objects

### DIFF
--- a/scripts/drop/README.md
+++ b/scripts/drop/README.md
@@ -1,0 +1,44 @@
+Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+
+SPDX-License-Identifier: Apache-2.0
+
+Background
+==========
+
+Iniitialize runs a "pg_upgrade --check", which can find various
+database objects that cannot be upgraded.  
+
+NOTE: right now, these scripts are to be run against a gpdb-5 database.
+
+Introduction
+============
+
+The scripts here generate SQL scripts that drop non-upgradable objects. 
+
+The scripts do not drop the objects directly, as a user might want
+to inspect the objects first.
+
+Notes
+======
+
+These generating scripts can be run in any order BUT THE RESULTING DROP SCRIPTS
+SHOULD BE RUN IN THIS ORDER:
+
+* script_to_drop_constraints_step_1.sql
+* script_to_drop_constraints_step_2.sql
+* script_to_drop_constraints_step_3.sql
+
+BEFORE DROPPING
+===============
+
+Run the script_to_recreate_partition_indexes.sql first and save off the
+results:
+
+    psql -d <database> -t -f script_to_recreate_partition_indexes.sql
+
+Running
+=======
+
+This will only output the tuple results(not the number of rows or column headers)
+
+    psql -d <database> -t -f script_to_drop_constraints_step_1.sql

--- a/scripts/drop/script_to_drop_constraints_step_1.sql
+++ b/scripts/drop/script_to_drop_constraints_step_1.sql
@@ -1,0 +1,16 @@
+-- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Step 1 of 3
+-- generates a script to Drop foreign/unique/primary key constraints from partitioned tables.
+--    Order is significant. Remove constraints on root partition table before
+--    non-partition tables so that we can cascade deleting constraints from
+--    child partition tables.
+SELECT 'ALTER TABLE ' || nspname || '.' || relname || ' DROP CONSTRAINT ' || conname || ' CASCADE;'
+FROM pg_constraint cc
+    JOIN
+    (SELECT DISTINCT c.oid, n.nspname, c.relname
+     FROM pg_catalog.pg_partition p
+        JOIN pg_catalog.pg_class c ON (p.parrelid = c.oid)
+        JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)) as sub ON sub.oid=cc.conrelid
+WHERE cc.contype IN ('f', 'u', 'p');

--- a/scripts/drop/script_to_drop_constraints_step_2.sql
+++ b/scripts/drop/script_to_drop_constraints_step_2.sql
@@ -1,0 +1,15 @@
+-- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Step 2 of 3
+-- Generate a script to to DROP unique/primary key constraints
+SELECT 'ALTER TABLE '||n.nspname||'.'||cc.relname||' DROP CONSTRAINT '||conname||' CASCADE;'
+FROM pg_constraint con
+    JOIN pg_depend dep ON (refclassid, classid, objsubid) = ('pg_constraint'::regclass, 'pg_class'::regclass, 0) AND
+                          refobjid = con.oid AND
+                          deptype = 'i' AND
+                          contype IN ('u', 'p')
+    JOIN pg_class c ON objid = c.oid AND relkind = 'i'
+    JOIN pg_class cc ON cc.oid = con.conrelid
+    JOIN pg_namespace n ON (n.oid = cc.relnamespace)
+WHERE conname <> c.relname;

--- a/scripts/drop/script_to_drop_constraints_step_3.sql
+++ b/scripts/drop/script_to_drop_constraints_step_3.sql
@@ -1,0 +1,20 @@
+-- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Step 3 or 3
+-- generates a script to DROP partition indexes
+WITH partitions AS (
+    SELECT DISTINCT n.nspname, c.relname
+    FROM pg_catalog.pg_partition p
+        JOIN pg_catalog.pg_class c ON (p.parrelid = c.oid)
+        JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
+    UNION
+    SELECT n.nspname,
+           partitiontablename AS relname
+    FROM pg_catalog.pg_partitions p
+        JOIN pg_catalog.pg_class c ON (p.partitiontablename = c.relname)
+        JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
+)
+SELECT 'DROP INDEX '|| nspname ||'.'||indexname||';'
+FROM partitions
+    JOIN pg_catalog.pg_indexes ON (relname = tablename AND nspname = schemaname);

--- a/scripts/drop/script_to_drop_external_tables.sql
+++ b/scripts/drop/script_to_drop_external_tables.sql
@@ -1,0 +1,11 @@
+-- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- generates a sql script to drop external tables in the cluster
+SELECT 'DROP EXTERNAL TABLE ' || d.objid::regclass || ';'
+FROM pg_catalog.pg_depend d
+       JOIN pg_catalog.pg_exttable x ON ( d.objid = x.reloid )
+       JOIN pg_catalog.pg_extprotocol p ON ( p.oid = d.refobjid )
+       JOIN pg_catalog.pg_class c ON ( c.oid = d.objid )
+WHERE d.refclassid = 'pg_extprotocol'::regclass
+    AND p.ptcname = 'gphdfs';

--- a/scripts/drop/script_to_drop_gphdfs_roles.sql
+++ b/scripts/drop/script_to_drop_gphdfs_roles.sql
@@ -1,0 +1,11 @@
+-- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- generates a sql script to drop gphdfs roles in the cluster
+SELECT 'ALTER ROLE '|| rolname || $$ NOCREATEEXTTABLE(protocol='gphdfs',type='readable'); $$
+FROM pg_roles
+WHERE rolcreaterexthdfs='t'
+UNION ALL
+SELECT 'ALTER ROLE ' || rolname || $$ NOCREATEEXTTABLE(protocol='gphdfs',type='writable'); $$
+FROM pg_roles
+WHERE rolcreatewexthdfs='t';

--- a/scripts/drop/script_to_recreate_partition_indexes.sql
+++ b/scripts/drop/script_to_recreate_partition_indexes.sql
@@ -1,0 +1,21 @@
+-- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+WITH partitions AS (
+    SELECT DISTINCT n.nspname,
+                    c.relname
+    FROM pg_catalog.pg_partition p
+        JOIN pg_catalog.pg_class c ON (p.parrelid = c.oid)
+        JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
+    UNION
+    SELECT n.nspname,
+           partitiontablename AS relname
+    FROM pg_catalog.pg_partitions p
+        JOIN pg_catalog.pg_class c ON (p.partitiontablename = c.relname)
+        JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
+    )
+SELECT indexdef
+FROM partitions
+    JOIN pg_catalog.pg_indexes ON (relname = tablename AND
+                                   nspname = schemaname);
+


### PR DESCRIPTION
Iniitialize runs a `pg_upgrade --check`, which can find various
database objects that cannot be upgraded.  These scripts generate
SQL scripts that can be used to drop different types of these
objects.

The scripts do not drop the objects directly, as a user might want
to inspect the objects first.

This is a hack, as ideally `pg_upgrade` would generate a script itself.  But this is expedient.

