### PR TITLE
kill-services: try hub default port if configFile cannot be accessed

### DIFF
--- a/cli/commands/commands_test.go
+++ b/cli/commands/commands_test.go
@@ -6,6 +6,10 @@ package commands
 import (
 	"reflect"
 	"testing"
+
+	"github.com/greenplum-db/gpupgrade/hub"
+	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/upgrade"
 )
 
 func TestParsePorts(t *testing.T) {
@@ -128,4 +132,46 @@ func TestIsLinkMode(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetHubPort(t *testing.T) {
+	t.Run("correctly pulls the port from the stored config", func(t *testing.T) {
+		stateDir := testutils.GetTempDir(t, "")
+		defer testutils.MustRemoveAll(t, stateDir)
+
+		// set GPUPGRADE_HOME to the stateDir to provide a home for the config file
+		resetEnv := testutils.SetEnv(t, "GPUPGRADE_HOME", stateDir)
+		defer resetEnv()
+
+		// save the expected port value to the conf file
+		expected := 12345
+		server := hub.New(&hub.Config{Port: expected}, nil, stateDir)
+		err := server.SaveConfig()
+		if err != nil {
+			t.Errorf("got unexpected error %#v", err)
+		}
+
+		// looks up port from config file
+		port := getHubPort(false)
+		if port != expected {
+			t.Errorf("got %d expected %d", port, expected)
+		}
+
+		// still looks up port from config file whn default port is allowed
+		port = getHubPort(true)
+		if port != expected {
+			t.Errorf("got %d expected %d", port, expected)
+		}
+
+	})
+
+	t.Run("uses default port if the config file does not exist", func(t *testing.T) {
+		expected := upgrade.DefaultHubPort
+
+		port := getHubPort(true)
+		if port != expected {
+			t.Errorf("got %d expected %d", port, expected)
+		}
+	})
+
 }

--- a/test/services.bats
+++ b/test/services.bats
@@ -26,6 +26,10 @@ teardown() {
 
     gpupgrade kill-services
     rm -r "$STATE_DIR"
+
+    if [ -n "${TMP_DIR}" ]; then
+        rm -r "${TMP_DIR}"
+    fi
 }
 
 @test "kill-services actually stops hub and agents" {
@@ -39,6 +43,27 @@ teardown() {
     # make sure that they are down
     ! process_is_running "[g]pupgrade hub"
     ! process_is_running "[g]pupgrade agent"
+}
+
+@test "kill-services stops hub and agents on default port if config file does not exist" {
+    # check that hub and agent are up
+    process_is_running "[g]pupgrade hub"
+    process_is_running "[g]pupgrade agent"
+
+    # move the gpupgrade dir so that kill-services will use the default port
+    TMP_DIR=`mktemp -d`
+    mv "${STATE_DIR}/gpupgrade" "${TMP_DIR}"
+
+    # stop them
+    gpupgrade kill-services
+
+    # make sure that they are down
+    ! process_is_running "[g]pupgrade hub"
+    ! process_is_running "[g]pupgrade agent"
+
+    # move the gpupgrade back so that teardown() will work
+    mv "${TMP_DIR}/gpupgrade" "${STATE_DIR}"
+
 }
 
 @test "kill-services can be run multiple times without issue " {


### PR DESCRIPTION
** the first commit and the fixup_fixup contain different implementations.  I intend you to review the last one **

kill-services is used internally for testing only.  Typically, a bats
test will call kill-services in both the setup() and teardown().
However, in setup() where kill-services is called, the configFile for
the current run is not set.  But if the hub is already running(say,
from a previous failed test or the developer has been running it),
kill-services will fail.  It should pass.

This fixes this case.  It is typically not currently seen because
kill-services exits quickly if the hub is not running.

Several possible fixes were considered:
- adding a flag `--default-port` to kill-services. 
    - this was dismissed as kill-services is supposed to kill all running hubs
    - in the future, we might need to support multiple upgrades per host, but that's for later
- doing nothing(force the developer to manually kill the hub)
    - this is extra work that frustrated me(which is why I filed this PR)