### PR TITLE
remove greenplum.OutStreams in favor of steps.OutStreams

### DIFF
--- a/greenplum/cluster.go
+++ b/greenplum/cluster.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/xerrors"
 
+	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 )
 
@@ -276,11 +277,11 @@ func (c *Cluster) GetDirForContent(contentID int) string {
 	return c.Primaries[contentID].DataDir
 }
 
-func (c *Cluster) Start(stream OutStreams) error {
+func (c *Cluster) Start(stream step.OutStreams) error {
 	return runStartStopCmd(stream, c.BinDir, fmt.Sprintf("gpstart -a -d %[1]s", c.MasterDataDir()))
 }
 
-func (c *Cluster) Stop(stream OutStreams) error {
+func (c *Cluster) Stop(stream step.OutStreams) error {
 	// TODO: why can't we call IsMasterRunning for the !stop case?  If we do, we get this on the pipeline:
 	// Usage: pgrep [-flvx] [-d DELIM] [-n|-o] [-P PPIDLIST] [-g PGRPLIST] [-s SIDLIST]
 	// [-u EUIDLIST] [-U UIDLIST] [-G GIDLIST] [-t TERMLIST] [PATTERN]
@@ -297,11 +298,11 @@ func (c *Cluster) Stop(stream OutStreams) error {
 	return runStartStopCmd(stream, c.BinDir, fmt.Sprintf("gpstop -a -d %[1]s", c.MasterDataDir()))
 }
 
-func (c *Cluster) StartMasterOnly(stream OutStreams) error {
+func (c *Cluster) StartMasterOnly(stream step.OutStreams) error {
 	return runStartStopCmd(stream, c.BinDir, fmt.Sprintf("gpstart -m -a -d %[1]s", c.MasterDataDir()))
 }
 
-func (c *Cluster) StopMasterOnly(stream OutStreams) error {
+func (c *Cluster) StopMasterOnly(stream step.OutStreams) error {
 	// TODO: why can't we call IsMasterRunning for the !stop case?  If we do, we get this on the pipeline:
 	// Usage: pgrep [-flvx] [-d DELIM] [-n|-o] [-P PPIDLIST] [-g PGRPLIST] [-s SIDLIST]
 	// [-u EUIDLIST] [-U UIDLIST] [-G GIDLIST] [-t TERMLIST] [PATTERN]
@@ -318,7 +319,7 @@ func (c *Cluster) StopMasterOnly(stream OutStreams) error {
 	return runStartStopCmd(stream, c.BinDir, fmt.Sprintf("gpstop -m -a -d %[1]s", c.MasterDataDir()))
 }
 
-func runStartStopCmd(stream OutStreams, binDir, command string) error {
+func runStartStopCmd(stream step.OutStreams, binDir, command string) error {
 	commandWithEnv := fmt.Sprintf("source %[1]s/../greenplum_path.sh && %[1]s/%[2]s",
 		binDir,
 		command)
@@ -331,7 +332,7 @@ func runStartStopCmd(stream OutStreams, binDir, command string) error {
 }
 
 // IsMasterRunning returns whether the cluster's master process is running.
-func (c *Cluster) IsMasterRunning(stream OutStreams) (bool, error) {
+func (c *Cluster) IsMasterRunning(stream step.OutStreams) (bool, error) {
 	path := filepath.Join(c.MasterDataDir(), "postmaster.pid")
 	if !upgrade.PathExists(path) {
 		return false, nil

--- a/greenplum/runner.go
+++ b/greenplum/runner.go
@@ -5,24 +5,20 @@ package greenplum
 
 import (
 	"fmt"
-	"io"
 	"os/exec"
 	"path/filepath"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/kballard/go-shellquote"
+
+	"github.com/greenplum-db/gpupgrade/step"
 )
 
 type Runner interface {
 	Run(utilityName string, arguments ...string) error
 }
 
-type OutStreams interface {
-	Stdout() io.Writer
-	Stderr() io.Writer
-}
-
-func NewRunner(c *Cluster, streams OutStreams) Runner {
+func NewRunner(c *Cluster, streams step.OutStreams) Runner {
 	return &runner{
 		masterPort:          c.MasterPort(),
 		masterDataDirectory: c.MasterDataDir(),
@@ -54,6 +50,5 @@ type runner struct {
 	binDir              string
 	masterDataDirectory string
 	masterPort          int
-
-	streams OutStreams
+	streams             step.OutStreams
 }


### PR DESCRIPTION
There were two identical OutStream types which caused some confusion and
issues. For example, using a function pointer to pass a step.OutStreams
into a function that accepted a greenplum.OutStreams.

[Test pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:outstreams)