### PR TITLE
Cleanup Sysutils - Remove GetUser and GetHost and Move TryEnv

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -4,20 +4,32 @@
 package db
 
 import (
-	"github.com/greenplum-db/gpupgrade/utils"
+	"os/user"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	_ "github.com/lib/pq" //_ import for the side effect of having postgres driver available
+
+	"github.com/greenplum-db/gpupgrade/utils"
 )
 
 // TODO: do we need this code anymore?
 func NewDBConn(masterHost string, masterPort int, dbname string) *dbconn.DBConn {
-	currentUser, _, _ := utils.GetUser()
-	username := utils.TryEnv("PGUSER", currentUser)
+	currentUser, err := utils.System.CurrentUser()
+	if err != nil {
+		gplog.Error("Failed to look up current user: %s", err)
+		currentUser = &user.User{}
+	}
+	username := utils.TryEnv("PGUSER", currentUser.Username)
+
 	if dbname == "" {
 		dbname = utils.TryEnv("PGDATABASE", "")
 	}
-	hostname, _ := utils.GetHost()
+
+	hostname, err := utils.System.Hostname()
+	if err != nil {
+		gplog.Error("Failed to look up hostname: %s", err)
+	}
 	if masterHost == "" {
 		masterHost = utils.TryEnv("PGHOST", hostname)
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -4,6 +4,7 @@
 package db
 
 import (
+	"os"
 	"os/user"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
@@ -20,10 +21,10 @@ func NewDBConn(masterHost string, masterPort int, dbname string) *dbconn.DBConn 
 		gplog.Error("Failed to look up current user: %s", err)
 		currentUser = &user.User{}
 	}
-	username := utils.TryEnv("PGUSER", currentUser.Username)
+	username := tryEnv("PGUSER", currentUser.Username)
 
 	if dbname == "" {
-		dbname = utils.TryEnv("PGDATABASE", "")
+		dbname = tryEnv("PGDATABASE", "")
 	}
 
 	hostname, err := utils.System.Hostname()
@@ -31,7 +32,7 @@ func NewDBConn(masterHost string, masterPort int, dbname string) *dbconn.DBConn 
 		gplog.Error("Failed to look up hostname: %s", err)
 	}
 	if masterHost == "" {
-		masterHost = utils.TryEnv("PGHOST", hostname)
+		masterHost = tryEnv("PGHOST", hostname)
 	}
 
 	return &dbconn.DBConn{
@@ -45,4 +46,13 @@ func NewDBConn(masterHost string, masterPort int, dbname string) *dbconn.DBConn 
 		Tx:       nil,
 		Version:  dbconn.GPDBVersion{},
 	}
+}
+
+func tryEnv(key string, defaultValue string) string {
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		return defaultValue
+	}
+
+	return val
 }

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -4,6 +4,7 @@
 package db
 
 import (
+	"os"
 	"testing"
 
 	"github.com/greenplum-db/gpupgrade/testutils"
@@ -53,5 +54,32 @@ func TestNewDBConn(t *testing.T) {
 			t.Errorf("got host %q want %q", conn.DBName, expected)
 		}
 	})
+}
 
+func TestUserUtils(t *testing.T) {
+	t.Run("tryEnv returns environment variables", func(t *testing.T) {
+		expected := "val"
+
+		resetEnv := testutils.SetEnv(t, "VAR", expected)
+		defer resetEnv()
+
+		actual := tryEnv("VAR", "default")
+		if actual != expected {
+			t.Errorf("got %q want %q", actual, expected)
+		}
+	})
+
+	t.Run("tryEnv returns the default value when an environment variable does not exist", func(t *testing.T) {
+		// ensure the variable is not set
+		err := os.Unsetenv("VAR")
+		if err != nil {
+			t.Errorf("Unsetenv returend error %+v", err)
+		}
+
+		expected := "default"
+		actual := tryEnv("VAR", expected)
+		if actual != expected {
+			t.Errorf("got %q want %q", actual, expected)
+		}
+	})
 }

--- a/utils/sys_utils.go
+++ b/utils/sys_utils.go
@@ -88,19 +88,6 @@ func TryEnv(varname string, defval string) string {
 	return val
 }
 
-func GetUser() (string, string, error) {
-	currentUser, err := System.CurrentUser()
-	if err != nil {
-		return "", "", err
-	}
-	return currentUser.Username, currentUser.HomeDir, err
-}
-
-func GetHost() (string, error) {
-	hostname, err := System.Hostname()
-	return hostname, err
-}
-
 func GetStateDir() string {
 	stateDir := os.Getenv("GPUPGRADE_HOME")
 	if stateDir == "" {

--- a/utils/sys_utils.go
+++ b/utils/sys_utils.go
@@ -80,14 +80,6 @@ func InitializeSystemFunctions() *SystemFunctions {
 	}
 }
 
-func TryEnv(varname string, defval string) string {
-	val := System.Getenv(varname)
-	if val == "" {
-		return defval
-	}
-	return val
-}
-
 func GetStateDir() string {
 	stateDir := os.Getenv("GPUPGRADE_HOME")
 	if stateDir == "" {

--- a/utils/sys_utils_test.go
+++ b/utils/sys_utils_test.go
@@ -18,36 +18,6 @@ func resetSystemFunctions() {
 	System = InitializeSystemFunctions()
 }
 
-func TestUserUtils(t *testing.T) {
-	t.Run("TryEnv returns environment variables", func(t *testing.T) {
-		defer resetSystemFunctions()
-
-		expected := "val"
-		System.Getenv = func(s string) string {
-			return expected
-		}
-
-		actual := TryEnv("VAR", "default")
-		if actual != expected {
-			t.Errorf("got %q want %q", actual, expected)
-		}
-	})
-
-	t.Run("TryEnv returns the default value when an environmental variable does not exist", func(t *testing.T) {
-		defer resetSystemFunctions()
-
-		System.Getenv = func(s string) string {
-			return ""
-		}
-
-		expected := "default"
-		actual := TryEnv("VAR", expected)
-		if actual != expected {
-			t.Errorf("got %q want %q", actual, expected)
-		}
-	})
-}
-
 func TestCreateAllDataDirectories(t *testing.T) {
 	testhelper.SetupTestLogger() // initialize gplog
 

--- a/utils/sys_utils_test.go
+++ b/utils/sys_utils_test.go
@@ -5,7 +5,6 @@ package utils
 
 import (
 	"os"
-	"os/user"
 	"strings"
 	"testing"
 	"time"
@@ -45,78 +44,6 @@ func TestUserUtils(t *testing.T) {
 		actual := TryEnv("VAR", expected)
 		if actual != expected {
 			t.Errorf("got %q want %q", actual, expected)
-		}
-	})
-
-	t.Run("GetUser returns current user and home directory", func(t *testing.T) {
-		defer resetSystemFunctions()
-
-		expectedUser := "Joe"
-		expectedDir := "my_home_dir"
-		System.CurrentUser = func() (*user.User, error) {
-			return &user.User{
-				Username: expectedUser,
-				HomeDir:  expectedDir,
-			}, nil
-		}
-
-		user, dir, err := GetUser()
-		if err != nil {
-			t.Errorf("unexpected error %#v", err)
-		}
-
-		if user != expectedUser {
-			t.Errorf("got user %q want %q", user, expectedUser)
-		}
-
-		if dir != expectedDir {
-			t.Errorf("got dir %q want %q", dir, expectedDir)
-		}
-	})
-
-	t.Run("GetUser bubbles up errors", func(t *testing.T) {
-		defer resetSystemFunctions()
-
-		expected := errors.New("oops!")
-		System.CurrentUser = func() (*user.User, error) {
-			return nil, expected
-		}
-
-		_, _, err := GetUser()
-		if !xerrors.Is(err, expected) {
-			t.Errorf("returned error %#v want %#v", err, expected)
-		}
-	})
-
-	t.Run("GetHost returns host", func(t *testing.T) {
-		defer resetSystemFunctions()
-
-		expected := "host"
-		System.Hostname = func() (string, error) {
-			return expected, nil
-		}
-
-		host, err := GetHost()
-		if err != nil {
-			t.Errorf("unexpected error %#v", err)
-		}
-
-		if host != expected {
-			t.Errorf("got %q want %q", host, expected)
-		}
-	})
-
-	t.Run("GetHost bubbles up errors", func(t *testing.T) {
-		defer resetSystemFunctions()
-
-		expected := errors.New("oops!")
-		System.Hostname = func() (string, error) {
-			return "", expected
-		}
-
-		_, err := GetHost()
-		if !xerrors.Is(err, expected) {
-			t.Errorf("returned error %#v want %#v", err, expected)
 		}
 	})
 }


### PR DESCRIPTION
`sys_utils.go` and `db.go` need some work, but this PR is hopefully a small step in the right direction.

This PR has two commits:
1) Removes `GetUser` and `GetHost` as they were not giving us much over the direct system calls.
2) Move `TryEnv` and its tests to db.go since it is only used in one place.

[Test Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:sysutils)