### PR TITLE
testutils: only restore env variable if it was previously set

### DIFF
--- a/testutils/test_utils.go
+++ b/testutils/test_utils.go
@@ -135,17 +135,24 @@ func VerifyRename(t *testing.T, source, target string) {
 func SetEnv(t *testing.T, envar, value string) func() {
 	t.Helper()
 
-	old := os.Getenv(envar)
+	old, reset := os.LookupEnv(envar)
 
 	err := os.Setenv(envar, value)
 	if err != nil {
-		t.Fatalf("setting %s environment variable to %s", envar, value)
+		t.Fatalf("setting %s environment variable to %s: %#v", envar, value, err)
 	}
 
 	return func() {
-		err := os.Setenv(envar, old)
-		if err != nil {
-			t.Fatalf("setting %s environment variable to %s", envar, old)
+		if reset {
+			err := os.Setenv(envar, old)
+			if err != nil {
+				t.Fatalf("resetting %s environment variable to %s: %#v", envar, old, err)
+			}
+		} else {
+			err := os.Unsetenv(envar)
+			if err != nil {
+				t.Fatalf("unsetting %s environment variable: %#v", envar, err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This fixes a bug in testutils.SetEnv(envar).

Previously, if envar is unset prior to this call, the resulting
returned function will leave envar set to "" after this call.

The correct behavior of this function is to have no side-effects, and
to leave envar unset in this case.

See https://gist.github.com/dkrieger-pvtl/97ee7158970283213b5cf9debfc6a219 for an example of how it can matter.