### PR TITLE
cluster: add an HasAllMirrorsAndStandby() check

### DIFF
--- a/greenplum/cluster.go
+++ b/greenplum/cluster.go
@@ -105,6 +105,16 @@ func (c *Cluster) HasMirrors() bool {
 	return false
 }
 
+func (c *Cluster) HasAllMirrorsAndStandby() bool {
+	for content := range c.Primaries {
+		if _, ok := c.Mirrors[content]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
 // XXX This does not provide mirror hostnames yet.
 func (c *Cluster) GetHostnames() []string {
 	hostnameMap := make(map[string]bool)


### PR DESCRIPTION
HasAllMirrorsAndStandby() on a cluster returns true if the master
has a standby and if each primary has a mirror.
It returns false otherwise.

This is a utility function that will be useful in upcoming features.