### PR TITLE
add new stream methods for general use

### DIFF
--- a/agent/delete_directories.go
+++ b/agent/delete_directories.go
@@ -9,6 +9,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 
 	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 	"github.com/greenplum-db/gpupgrade/utils"
 )
@@ -23,7 +24,7 @@ func (s *Server) DeleteStateDirectory(ctx context.Context, in *idl.DeleteStateDi
 		return &idl.DeleteStateDirectoryReply{}, err
 	}
 
-	err = deleteDirectories([]string{s.conf.StateDir}, upgrade.StateDirectoryFiles, hostname, utils.DevNull)
+	err = deleteDirectories([]string{s.conf.StateDir}, upgrade.StateDirectoryFiles, hostname, step.DevNullStream)
 	return &idl.DeleteStateDirectoryReply{}, err
 }
 
@@ -35,6 +36,6 @@ func (s *Server) DeleteDataDirectories(ctx context.Context, in *idl.DeleteDataDi
 		return &idl.DeleteDataDirectoriesReply{}, err
 	}
 
-	err = deleteDirectories(in.Datadirs, upgrade.PostgresFiles, hostname, utils.DevNull)
+	err = deleteDirectories(in.Datadirs, upgrade.PostgresFiles, hostname, step.DevNullStream)
 	return &idl.DeleteDataDirectoriesReply{}, err
 }

--- a/agent/delete_directories_test.go
+++ b/agent/delete_directories_test.go
@@ -65,8 +65,8 @@ func TestDeleteDataDirectories(t *testing.T) {
 			t.Errorf("got hostname %q want %q", actualHostname, expectedHostname)
 		}
 
-		if actualStreams != utils.DevNull {
-			t.Errorf("got streams %#v want %#v", actualStreams, utils.DevNull)
+		if actualStreams != step.DevNullStream {
+			t.Errorf("got streams %#v want %#v", actualStreams, step.DevNullStream)
 		}
 	})
 
@@ -135,8 +135,8 @@ func TestDeleteStateDirectory(t *testing.T) {
 			t.Errorf("got hostname %q want %q", actualHostname, expectedHostname)
 		}
 
-		if actualStreams != utils.DevNull {
-			t.Errorf("got streams %#v want %#v", actualStreams, utils.DevNull)
+		if actualStreams != step.DevNullStream {
+			t.Errorf("got streams %#v want %#v", actualStreams, step.DevNullStream)
 		}
 	})
 

--- a/greenplum/start_or_stop_cluster_test.go
+++ b/greenplum/start_or_stop_cluster_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"golang.org/x/xerrors"
 
+	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
 	"github.com/greenplum-db/gpupgrade/utils"
 )
@@ -107,7 +108,7 @@ func TestStartOrStopCluster(t *testing.T) {
 				}
 			})
 
-		running, err := source.IsMasterRunning(utils.DevNull)
+		running, err := source.IsMasterRunning(step.DevNullStream)
 		if err != nil {
 			t.Errorf("IsMasterRunning returned error: %+v", err)
 		}
@@ -120,7 +121,7 @@ func TestStartOrStopCluster(t *testing.T) {
 	t.Run("IsMasterRunning fails", func(t *testing.T) {
 		isPostmasterRunningCmd = exectest.NewCommand(IsPostmasterRunningCmd_Errors)
 
-		running, err := source.IsMasterRunning(utils.DevNull)
+		running, err := source.IsMasterRunning(step.DevNullStream)
 		var expected *exec.ExitError
 		if !xerrors.As(err, &expected) {
 			t.Errorf("expected error to contain type %T", expected)
@@ -135,7 +136,7 @@ func TestStartOrStopCluster(t *testing.T) {
 		source := MustCreateCluster(t, []SegConfig{
 			{ContentID: -1, DbID: 1, Port: 15432, Hostname: "localhost", DataDir: "/does/not/exist", Role: "p"},
 		})
-		running, err := source.IsMasterRunning(utils.DevNull)
+		running, err := source.IsMasterRunning(step.DevNullStream)
 		if err != nil {
 			t.Errorf("IsMasterRunning returned error: %+v", err)
 		}
@@ -148,7 +149,7 @@ func TestStartOrStopCluster(t *testing.T) {
 	t.Run("returns false with no error when no processes were matched", func(t *testing.T) {
 		isPostmasterRunningCmd = exectest.NewCommand(IsPostmasterRunningCmd_MatchesNoProcesses)
 
-		running, err := source.IsMasterRunning(utils.DevNull)
+		running, err := source.IsMasterRunning(step.DevNullStream)
 		if err != nil {
 			t.Errorf("IsMasterRunning returned error: %+v", err)
 		}
@@ -184,7 +185,7 @@ func TestStartOrStopCluster(t *testing.T) {
 				}
 			})
 
-		err := source.Stop(utils.DevNull)
+		err := source.Stop(step.DevNullStream)
 		if err != nil {
 			t.Errorf("unexpected error %#v", err)
 		}
@@ -199,7 +200,7 @@ func TestStartOrStopCluster(t *testing.T) {
 				skippedStopClusterCommand = false
 			})
 
-		err := source.Stop(utils.DevNull)
+		err := source.Stop(step.DevNullStream)
 		if err == nil {
 			t.Errorf("expected error %#v got nil", err)
 		}
@@ -223,7 +224,7 @@ func TestStartOrStopCluster(t *testing.T) {
 				}
 			})
 
-		err := source.Start(utils.DevNull)
+		err := source.Start(step.DevNullStream)
 		if err != nil {
 			t.Errorf("unexpected error %#v", err)
 		}
@@ -243,7 +244,7 @@ func TestStartOrStopCluster(t *testing.T) {
 				}
 			})
 
-		err := source.StartMasterOnly(utils.DevNull)
+		err := source.StartMasterOnly(step.DevNullStream)
 		if err != nil {
 			t.Errorf("unexpected error %#v", err)
 		}
@@ -275,7 +276,7 @@ func TestStartOrStopCluster(t *testing.T) {
 				}
 			})
 
-		err := source.StopMasterOnly(utils.DevNull)
+		err := source.StopMasterOnly(step.DevNullStream)
 		if err != nil {
 			t.Errorf("unexpected error %#v", err)
 		}

--- a/hub/init_target_cluster_test.go
+++ b/hub/init_target_cluster_test.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
+	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
 	"github.com/greenplum-db/gpupgrade/utils"
 )
@@ -164,7 +165,7 @@ func TestRunInitsystemForTargetCluster(t *testing.T) {
 				}
 			})
 
-		err := RunInitsystemForTargetCluster(utils.DevNull, cluster7X, gpinitsystemConfigPath)
+		err := RunInitsystemForTargetCluster(step.DevNullStream, cluster7X, gpinitsystemConfigPath)
 		if err != nil {
 			t.Error("gpinitsystem failed")
 		}
@@ -184,7 +185,7 @@ func TestRunInitsystemForTargetCluster(t *testing.T) {
 				}
 			})
 
-		err := RunInitsystemForTargetCluster(utils.DevNull, cluster6X, gpinitsystemConfigPath)
+		err := RunInitsystemForTargetCluster(step.DevNullStream, cluster6X, gpinitsystemConfigPath)
 		if err != nil {
 			t.Error("gpinitsystem failed")
 		}
@@ -205,7 +206,7 @@ func TestRunInitsystemForTargetCluster(t *testing.T) {
 			})
 
 		cluster7X.BinDir += "/"
-		err := RunInitsystemForTargetCluster(utils.DevNull, cluster7X, gpinitsystemConfigPath)
+		err := RunInitsystemForTargetCluster(step.DevNullStream, cluster7X, gpinitsystemConfigPath)
 		if err != nil {
 			t.Error("gpinitsystem failed")
 		}
@@ -214,7 +215,7 @@ func TestRunInitsystemForTargetCluster(t *testing.T) {
 	t.Run("returns an error when gpinitsystem fails with --ignore-warnings when upgrading to GPDB6", func(t *testing.T) {
 		execCommand = exectest.NewCommand(gpinitsystem_Exits1)
 
-		err := RunInitsystemForTargetCluster(utils.DevNull, cluster6X, gpinitsystemConfigPath)
+		err := RunInitsystemForTargetCluster(step.DevNullStream, cluster6X, gpinitsystemConfigPath)
 
 		var actual *exec.ExitError
 		if !xerrors.As(err, &actual) {
@@ -229,7 +230,7 @@ func TestRunInitsystemForTargetCluster(t *testing.T) {
 	t.Run("returns an error when gpinitsystem errors when upgrading to GPDB7 or higher", func(t *testing.T) {
 		execCommand = exectest.NewCommand(gpinitsystem_Exits1)
 
-		err := RunInitsystemForTargetCluster(utils.DevNull, cluster7X, gpinitsystemConfigPath)
+		err := RunInitsystemForTargetCluster(step.DevNullStream, cluster7X, gpinitsystemConfigPath)
 
 		var actual *exec.ExitError
 		if !xerrors.As(err, &actual) {

--- a/hub/update_conf_files_test.go
+++ b/hub/update_conf_files_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/greenplum-db/gpupgrade/hub"
-	"github.com/greenplum-db/gpupgrade/utils"
+	"github.com/greenplum-db/gpupgrade/step"
 )
 
 // TODO: this is an integration test; move it
@@ -43,7 +43,7 @@ other_log_location = /some/directory
 `)
 
 		// Perform the replacement.
-		err = hub.UpdateGpperfmonConf(utils.DevNull, dir)
+		err = hub.UpdateGpperfmonConf(step.DevNullStream, dir)
 		if err != nil {
 			t.Errorf("UpdateGpperfmonConf() returned error %+v", err)
 		}
@@ -76,7 +76,7 @@ port=50000
 `)
 
 		// Perform the replacement.
-		err = hub.UpdatePostgresqlConf(utils.DevNull, dir, 5000, 6000)
+		err = hub.UpdatePostgresqlConf(step.DevNullStream, dir, 5000, 6000)
 		if err != nil {
 			t.Errorf("UpdatePostgresqlConf() returned error %+v", err)
 		}

--- a/step/stream.go
+++ b/step/stream.go
@@ -4,7 +4,9 @@
 package step
 
 import (
+	"bytes"
 	"io"
+	"io/ioutil"
 	"sync"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
@@ -20,6 +22,35 @@ type OutStreams interface {
 type OutStreamsCloser interface {
 	OutStreams
 	Close() error
+}
+
+// DevNullStream provides an implementation of OutStreams that drops
+//   all writes to it.
+var DevNullStream = devNullStream{}
+
+type devNullStream struct{}
+
+func (_ devNullStream) Stdout() io.Writer {
+	return ioutil.Discard
+}
+
+func (_ devNullStream) Stderr() io.Writer {
+	return ioutil.Discard
+}
+
+// BufferedStreams provides an implementation of OutStreams that stores
+//   all writes to underlying bytes.Buffer objects.
+type BufferedStreams struct {
+	StdoutBuf bytes.Buffer
+	StderrBuf bytes.Buffer
+}
+
+func (s *BufferedStreams) Stdout() io.Writer {
+	return &s.StdoutBuf
+}
+
+func (s *BufferedStreams) Stderr() io.Writer {
+	return &s.StderrBuf
 }
 
 // multiplexedStream provides an implementation of OutStreams that safely

--- a/step/stream_test.go
+++ b/step/stream_test.go
@@ -19,6 +19,39 @@ import (
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
 )
 
+// Since we have no good way to test devNullStream, we instead
+//   provide an example.
+func ExampleDevNullStream() {
+	const (
+		stdout = "this command has progress..."
+		stderr = "there are some warnings..."
+	)
+	stream := DevNullStream
+	fmt.Fprintf(stream.Stdout(), "%s", stdout)
+	fmt.Fprintf(stream.Stderr(), "%s", stderr)
+	// Output:
+}
+
+func TestBufStream(t *testing.T) {
+	t.Run("records stdout and stderr to the stream", func(t *testing.T) {
+		const (
+			stdout = "this command has progress..."
+			stderr = "there are some warnings..."
+		)
+
+		stream := new(BufferedStreams)
+		fmt.Fprintf(stream.Stdout(), "%s", stdout)
+		fmt.Fprintf(stream.Stderr(), "%s", stderr)
+
+		if stdout != stream.StdoutBuf.String() {
+			t.Errorf("expected %s got %s", stdout, stream.StdoutBuf.String())
+		}
+		if stderr != stream.StderrBuf.String() {
+			t.Errorf("expected %s got %s", stderr, stream.StderrBuf.String())
+		}
+	})
+}
+
 func TestMultiplexedStream(t *testing.T) {
 	// Store gplog output.
 	_, _, log := testhelper.SetupTestLogger()

--- a/upgrade/directories_test.go
+++ b/upgrade/directories_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"golang.org/x/xerrors"
 
+	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 	"github.com/greenplum-db/gpupgrade/utils"
@@ -361,7 +362,7 @@ func TestDeleteDirectories(t *testing.T) {
 		teardown, directories, _ := setup(t)
 		defer teardown()
 
-		err := upgrade.DeleteDirectories(directories, []string{"a", "b"}, "", utils.DevNull)
+		err := upgrade.DeleteDirectories(directories, []string{"a", "b"}, "", step.DevNullStream)
 
 		var multiErr *multierror.Error
 		if !xerrors.As(err, &multiErr) {
@@ -388,7 +389,7 @@ func TestDeleteDirectories(t *testing.T) {
 			t.Errorf("unexpected error %+v", err)
 		}
 
-		err2 := upgrade.DeleteDirectories(directories, requiredPaths, "", utils.DevNull)
+		err2 := upgrade.DeleteDirectories(directories, requiredPaths, "", step.DevNullStream)
 
 		var multiErr *multierror.Error
 		if !xerrors.As(err2, &multiErr) {

--- a/utils/sys_utils.go
+++ b/utils/sys_utils.go
@@ -132,19 +132,6 @@ func CreateDataDirectory(dataDir string) error {
 	return nil
 }
 
-// DevNull implements OutStreams by just discarding all writes.
-var DevNull = devNull{}
-
-type devNull struct{}
-
-func (_ devNull) Stdout() io.Writer {
-	return ioutil.Discard
-}
-
-func (_ devNull) Stderr() io.Writer {
-	return ioutil.Discard
-}
-
 // StdStream can be passed into functions that are called
 // from the CLI.
 type StdStream struct {


### PR DESCRIPTION
This PR moves two stream types(DevNull and BufferedStreams) to a common
location so it is generally useful.

These will be useful in future work.