### PR TITLE
Consolidate stdStreams to stream.go

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -51,6 +51,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/cli/commanders"
 	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 	"github.com/greenplum-db/gpupgrade/utils"
 )
@@ -573,7 +574,7 @@ func revert() *cobra.Command {
 				return err
 			}
 
-			err = upgrade.DeleteDirectories([]string{utils.GetStateDir()}, upgrade.StateDirectoryFiles, hostname, &utils.StdStream{})
+			err = upgrade.DeleteDirectories([]string{utils.GetStateDir()}, upgrade.StateDirectoryFiles, hostname, &step.StdStreams{})
 			s.Finish(&err)
 			if err != nil {
 				gplog.Error(err.Error())

--- a/step/stream.go
+++ b/step/stream.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
+	"os"
 	"sync"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
@@ -51,6 +52,17 @@ func (s *BufferedStreams) Stdout() io.Writer {
 
 func (s *BufferedStreams) Stderr() io.Writer {
 	return &s.StderrBuf
+}
+
+// StdStreams implements OutStreams that writes directly to stdout and stderr
+type StdStreams struct{}
+
+func (m *StdStreams) Stdout() io.Writer {
+	return os.Stdout
+}
+
+func (m *StdStreams) Stderr() io.Writer {
+	return os.Stderr
 }
 
 // multiplexedStream provides an implementation of OutStreams that safely

--- a/utils/sys_utils.go
+++ b/utils/sys_utils.go
@@ -5,7 +5,6 @@ package utils
 
 import (
 	"database/sql"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/user"
@@ -130,19 +129,6 @@ func CreateDataDirectory(dataDir string) error {
 		return xerrors.Errorf("create gpupgrade marker file %s: %w", mFile, err)
 	}
 	return nil
-}
-
-// StdStream can be passed into functions that are called
-// from the CLI.
-type StdStream struct {
-}
-
-func (m *StdStream) Stdout() io.Writer {
-	return os.Stdout
-}
-
-func (m *StdStream) Stderr() io.Writer {
-	return os.Stderr
 }
 
 func GetTablespaceDir() string {


### PR DESCRIPTION
Based off https://github.com/greenplum-db/gpupgrade/pull/353 this consolidate `stdStreams` to `stream.go`.

I am not sure if there is a good clean way to consolidate the other streams used in tests pointed out in this [comment](https://github.com/greenplum-db/gpupgrade/pull/353#issuecomment-644972124) as types exported in one package's `_test.go` file are not accessible to another packages `_test.go`. Putting them in the `testutils` package would work, but I am not sure if people would have backlash against that. ~Perhaps I can raise a draft PR.~ See https://github.com/greenplum-db/gpupgrade/pull/355

[Test pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:streams)