### PR TITLE
consolidate all test streams to testutils/stream.go

### DIFF
--- a/hub/common_test.go
+++ b/hub/common_test.go
@@ -32,15 +32,6 @@ func ResetRsyncExecCommand() {
 	execCommandRsync = nil
 }
 
-// failingWriter is an io.Writer for which all calls to Write() return an error.
-type failingWriter struct {
-	err error
-}
-
-func (f *failingWriter) Write(_ []byte) (int, error) {
-	return 0, f.err
-}
-
 // MustCreateCluster creates a utils.Cluster and calls t.Fatalf() if there is
 // any error.
 func MustCreateCluster(t *testing.T, segs []greenplum.SegConfig) *greenplum.Cluster {

--- a/hub/copy_master_test.go
+++ b/hub/copy_master_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/step"
+	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
 )
 
@@ -104,7 +105,7 @@ func TestCopy(t *testing.T) {
 
 	t.Run("returns errors when writing stdout and stderr buffers to the stream", func(t *testing.T) {
 		execCommand = exectest.NewCommand(StreamingMain)
-		streams := failingStreams{errors.New("e")}
+		streams := testutils.FailingStreams{Err: errors.New("e")}
 
 		err := Copy(streams, "", nil, []string{"localhost"})
 
@@ -114,8 +115,8 @@ func TestCopy(t *testing.T) {
 			t.Fatalf("returned %#v, want error type %T", err, merr)
 		}
 		for _, err := range merr.Errors {
-			if !xerrors.Is(err, streams.err) {
-				t.Errorf("returned error %#v, want %#v", err, streams.err)
+			if !xerrors.Is(err, streams.Err) {
+				t.Errorf("returned error %#v, want %#v", err, streams.Err)
 			}
 		}
 	})

--- a/hub/upgrade_master_test.go
+++ b/hub/upgrade_master_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/signal"
@@ -217,7 +216,7 @@ func TestUpgradeMaster(t *testing.T) {
 			Source:      source,
 			Target:      target,
 			StateDir:    tempDir,
-			Stream:      failingStreams{expectedErr},
+			Stream:      testutils.FailingStreams{Err: expectedErr},
 			CheckOnly:   false,
 			UseLinkMode: false,
 		})
@@ -273,18 +272,4 @@ func TestRsyncMasterDir(t *testing.T) {
 		}
 	})
 
-}
-
-// failingStreams is an implementation of OutStreams for which every call to a
-// stream's Write() method will fail with the given error.
-type failingStreams struct {
-	err error
-}
-
-func (f failingStreams) Stdout() io.Writer {
-	return &testutils.FailingWriter{f.err}
-}
-
-func (f failingStreams) Stderr() io.Writer {
-	return &testutils.FailingWriter{f.err}
 }

--- a/hub/upgrade_master_test.go
+++ b/hub/upgrade_master_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/step"
+	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 	"github.com/greenplum-db/gpupgrade/utils"
@@ -281,9 +282,9 @@ type failingStreams struct {
 }
 
 func (f failingStreams) Stdout() io.Writer {
-	return &failingWriter{f.err}
+	return &testutils.FailingWriter{f.err}
 }
 
 func (f failingStreams) Stderr() io.Writer {
-	return &failingWriter{f.err}
+	return &testutils.FailingWriter{f.err}
 }

--- a/hub/upgrade_mirrors_test.go
+++ b/hub/upgrade_mirrors_test.go
@@ -76,11 +76,11 @@ func TestWriteGpAddmirrorsConfig(t *testing.T) {
 			{DbID: 3, ContentID: 0, Port: 234, Hostname: "localhost", DataDir: "/data/mirrors/seg0", Role: "m"},
 		}
 
-		writer := &failingWriter{errors.New("ahhh")}
+		writer := &testutils.FailingWriter{Err: errors.New("ahhh")}
 
 		err := writeGpAddmirrorsConfig(mirrors, writer)
-		if !xerrors.Is(err, writer.err) {
-			t.Errorf("returned error %#v, want %#v", err, writer.err)
+		if !xerrors.Is(err, writer.Err) {
+			t.Errorf("returned error %#v, want %#v", err, writer.Err)
 		}
 	})
 }

--- a/testutils/stream.go
+++ b/testutils/stream.go
@@ -1,0 +1,53 @@
+package testutils
+
+import (
+	"io"
+	"io/ioutil"
+)
+
+// DevNullWithClose implements step.OutStreams
+type DevNullSpy struct {
+	OutStream io.Writer
+}
+
+func (s DevNullSpy) Stdout() io.Writer {
+	return s.OutStream
+}
+
+func (s DevNullSpy) Stderr() io.Writer {
+	return ioutil.Discard
+}
+
+// FailingStreams is an implementation of OutStreams for which every call to a
+// stream's Write() method will fail with the given error.
+type FailingStreams struct {
+	Err error
+}
+
+func (f FailingStreams) Stdout() io.Writer {
+	return &FailingWriter{f.Err}
+}
+
+func (f FailingStreams) Stderr() io.Writer {
+	return &FailingWriter{f.Err}
+}
+
+// DevNullWithClose implements step.OutStreamsCloser as a no-op. It also tracks calls to
+// Close().
+type DevNullWithClose struct {
+	Closed   bool
+	CloseErr error
+}
+
+func (DevNullWithClose) Stdout() io.Writer {
+	return ioutil.Discard
+}
+
+func (DevNullWithClose) Stderr() io.Writer {
+	return ioutil.Discard
+}
+
+func (d *DevNullWithClose) Close() error {
+	d.Closed = true
+	return d.CloseErr
+}

--- a/testutils/test_utils.go
+++ b/testutils/test_utils.go
@@ -18,6 +18,15 @@ import (
 	"github.com/greenplum-db/gpupgrade/upgrade"
 )
 
+// FailingWriter is an io.Writer for which all calls to Write() return an error.
+type FailingWriter struct {
+	Err error
+}
+
+func (f *FailingWriter) Write(_ []byte) (int, error) {
+	return 0, f.Err
+}
+
 // TODO remove in favor of MustCreateCluster
 func CreateMultinodeSampleCluster(baseDir string) *greenplum.Cluster {
 	return &greenplum.Cluster{

--- a/upgrade/directories_test.go
+++ b/upgrade/directories_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -314,25 +313,13 @@ func setup(t *testing.T) (teardown func(), directories []string, requiredPaths [
 	return teardown, directories, requiredPaths
 }
 
-type devNullSpy struct {
-	outStream io.Writer
-}
-
-func (s devNullSpy) Stdout() io.Writer {
-	return s.outStream
-}
-
-func (_ devNullSpy) Stderr() io.Writer {
-	return ioutil.Discard
-}
-
 func TestDeleteDirectories(t *testing.T) {
 	testhelper.SetupTestLogger()
 
 	t.Run("successfully deletes the directories if all required paths exist in that directory", func(t *testing.T) {
 		var buf bytes.Buffer
-		devNull := devNullSpy{
-			outStream: &buf,
+		devNull := testutils.DevNullSpy{
+			OutStream: &buf,
 		}
 		hostname := "localhost.local"
 		teardown, directories, requiredPaths := setup(t)


### PR DESCRIPTION
Riffing off https://github.com/greenplum-db/gpupgrade/pull/354 this consolidates all test streams into `testutils/stream.go`.

[Test pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:test_streams)