### PR TITLE
use centos7 rpm's for install-tests

### DIFF
--- a/ci/generated/pipeline.yml
+++ b/ci/generated/pipeline.yml
@@ -247,10 +247,10 @@ jobs:
       resource: gpdb6_src
     - get: bats
     - get: rpm_gpdb_source
-      resource: rpm_gpdb6_centos6
+      resource: rpm_gpdb6_centos7
       trigger: true
     - get: rpm_gpdb_target
-      resource: rpm_gpdb6_centos6
+      resource: rpm_gpdb6_centos7
       trigger: true
   - task: install-tests
     file: gpupgrade_src/ci/tasks/install-tests.yml
@@ -269,10 +269,10 @@ jobs:
       resource: gpdb5_src
     - get: bats
     - get: rpm_gpdb_source
-      resource: rpm_gpdb5_centos6
+      resource: rpm_gpdb5_centos7
       trigger: true
     - get: rpm_gpdb_target
-      resource: rpm_gpdb6_centos6
+      resource: rpm_gpdb6_centos7
       trigger: true
   - task: install-tests
     file: gpupgrade_src/ci/tasks/install-tests.yml

--- a/ci/template.yml
+++ b/ci/template.yml
@@ -220,10 +220,10 @@ jobs:
       resource: gpdb{{.Source}}_src
     - get: bats
     - get: rpm_gpdb_source
-      resource: rpm_gpdb{{.Source}}_centos6
+      resource: rpm_gpdb{{.Source}}_centos7
       trigger: true
     - get: rpm_gpdb_target
-      resource: rpm_gpdb{{.Target}}_centos6
+      resource: rpm_gpdb{{.Target}}_centos7
       trigger: true
   - task: install-tests
     file: gpupgrade_src/ci/tasks/install-tests.yml


### PR DESCRIPTION
@bradfordb-vmware noticed that we are using the RHEL6 binaries on a RHEL7 container. That is, the [install-test.yml specifies centos 7](https://github.com/greenplum-db/gpupgrade/blob/9a9ad0c9fd46ead878a52f47613013cf15071795/ci/tasks/install-tests.yml#L10), yet the pipeline was using centos 6.

[Test pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:install_tests_fix_gpdb_version)