### PR TITLE
Don't print stack traces on errors 

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -57,6 +57,7 @@ import (
 )
 
 var (
+	Help           map[string]string
 	InitializeHelp string
 	ExecuteHelp    string
 	FinalizeHelp   string
@@ -102,6 +103,12 @@ func init() {
 		idl.Substep_ARCHIVE_LOG_DIRECTORIES,
 		idl.Substep_START_SOURCE_CLUSTER,
 	})
+	Help = map[string]string{
+		"initialize": InitializeHelp,
+		"execute":    ExecuteHelp,
+		"finalize":   FinalizeHelp,
+		"revert":     RevertHelp,
+	}
 }
 
 func BuildRootCommand() *cobra.Command {

--- a/cmd/gpupgrade/main.go
+++ b/cmd/gpupgrade/main.go
@@ -26,12 +26,12 @@ func main() {
 	gplog.InitializeLogging("gpupgrade_cli", logdir)
 
 	root := commands.BuildRootCommand()
-	root.SilenceErrors = true // we'll print these ourselves
 
 	err = root.Execute()
 	if err != nil && err != daemon.ErrSuccessfullyDaemonized {
-		// Use v to print the stack trace of an object errors.
-		fmt.Printf("\n%+v\n", err)
+		// We use gplog.Debug instead of Error so the error is not displayed
+		// twice to the user in the terminal.
+		gplog.Debug("%+v", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Only print stack traces on panics, and simply return errors. Since stack traces for errors (rather than panics) are not very helpful and can overwhelm the user.

We also log errors to help with debugging. However, we do this at the debug level so that its not printed twice to stdout/stderr.

Also, only print usage for unknown flag errors.

[Test pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:errors)