### PR TITLE
Add initial infrastructure and scripts to complement pg_upgrade check failures

### DIFF
--- a/migration_scripts/pre-upgrade/execute_preupgrade_sql.bash
+++ b/migration_scripts/pre-upgrade/execute_preupgrade_sql.bash
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+if [ "$#" -ne 3 ]; then
+    echo "Illegal number of parameters"
+    echo "Usage: $(basename $0) <GPHOME> <PGPORT> <INPUT_DIR>"
+    exit 1
+fi
+
+GPHOME=$1
+PGPORT=$2
+INPUT_DIR=$3
+
+main(){
+    local log_file="${INPUT_DIR}/migration_sql.log"
+
+    rm -f "$log_file"
+
+    cmd="find ${INPUT_DIR} -type f -name *.sql"
+    local files="$(eval "$cmd")"
+    if [ -z "$files" ]; then
+        echo "Executing command \"${cmd}\" returned no sql files. Exiting!" | tee -a "$log_file"
+        exit 1
+    fi
+
+    for file in ${files[*]}; do
+        local cmd="${GPHOME}/bin/psql -d postgres -p ${PGPORT} -f ${file}"
+        echo "Executing command: ${cmd}" | tee -a "$log_file"
+        ${cmd} | tee -a "$log_file"
+    done
+
+    echo "Check log file for execution details: $log_file"
+}
+
+main

--- a/migration_scripts/pre-upgrade/gen_alter_gphdfs_roles.sql
+++ b/migration_scripts/pre-upgrade/gen_alter_gphdfs_roles.sql
@@ -1,0 +1,11 @@
+-- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- generates a sql script to drop gphdfs roles in the cluster
+SELECT 'ALTER ROLE '|| rolname || $$ NOCREATEEXTTABLE(protocol='gphdfs',type='readable'); $$
+FROM pg_roles
+WHERE rolcreaterexthdfs='t'
+UNION ALL
+SELECT 'ALTER ROLE ' || rolname || $$ NOCREATEEXTTABLE(protocol='gphdfs',type='writable'); $$
+FROM pg_roles
+WHERE rolcreatewexthdfs='t';

--- a/migration_scripts/pre-upgrade/gen_drop_constraint_step_1.sql
+++ b/migration_scripts/pre-upgrade/gen_drop_constraint_step_1.sql
@@ -1,0 +1,16 @@
+-- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Step 1 of 3
+-- generates a script to Drop foreign/unique/primary key constraints from partitioned tables.
+--    Order is significant. Remove constraints on root partition table before
+--    non-partition tables so that we can cascade deleting constraints from
+--    child partition tables.
+SELECT 'ALTER TABLE ' || nspname || '.' || relname || ' DROP CONSTRAINT ' || conname || ' CASCADE;'
+FROM pg_constraint cc
+    JOIN
+    (SELECT DISTINCT c.oid, n.nspname, c.relname
+     FROM pg_catalog.pg_partition p
+        JOIN pg_catalog.pg_class c ON (p.parrelid = c.oid)
+        JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)) as sub ON sub.oid=cc.conrelid
+WHERE cc.contype IN ('f', 'u', 'p');

--- a/migration_scripts/pre-upgrade/gen_drop_constraint_step_2.sql
+++ b/migration_scripts/pre-upgrade/gen_drop_constraint_step_2.sql
@@ -1,0 +1,15 @@
+-- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Step 2 of 3
+-- Generate a script to to DROP unique/primary key constraints
+SELECT 'ALTER TABLE '||n.nspname||'.'||cc.relname||' DROP CONSTRAINT '||conname||' CASCADE;'
+FROM pg_constraint con
+    JOIN pg_depend dep ON (refclassid, classid, objsubid) = ('pg_constraint'::regclass, 'pg_class'::regclass, 0) AND
+                          refobjid = con.oid AND
+                          deptype = 'i' AND
+                          contype IN ('u', 'p')
+    JOIN pg_class c ON objid = c.oid AND relkind = 'i'
+    JOIN pg_class cc ON cc.oid = con.conrelid
+    JOIN pg_namespace n ON (n.oid = cc.relnamespace)
+WHERE conname <> c.relname;

--- a/migration_scripts/pre-upgrade/gen_drop_constraint_step_3.sql
+++ b/migration_scripts/pre-upgrade/gen_drop_constraint_step_3.sql
@@ -1,0 +1,20 @@
+-- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Step 3 or 3
+-- generates a script to DROP partition indexes
+WITH partitions AS (
+    SELECT DISTINCT n.nspname, c.relname
+    FROM pg_catalog.pg_partition p
+        JOIN pg_catalog.pg_class c ON (p.parrelid = c.oid)
+        JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
+    UNION
+    SELECT n.nspname,
+           partitiontablename AS relname
+    FROM pg_catalog.pg_partitions p
+        JOIN pg_catalog.pg_class c ON (p.partitiontablename = c.relname)
+        JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
+)
+SELECT 'DROP INDEX '|| nspname ||'.'||indexname||';'
+FROM partitions
+    JOIN pg_catalog.pg_indexes ON (relname = tablename AND nspname = schemaname);

--- a/migration_scripts/pre-upgrade/gen_drop_external_tables.sql
+++ b/migration_scripts/pre-upgrade/gen_drop_external_tables.sql
@@ -1,0 +1,11 @@
+-- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- generates a sql script to drop external tables in the cluster
+SELECT 'DROP EXTERNAL TABLE ' || d.objid::regclass || ';'
+FROM pg_catalog.pg_depend d
+       JOIN pg_catalog.pg_exttable x ON ( d.objid = x.reloid )
+       JOIN pg_catalog.pg_extprotocol p ON ( p.oid = d.refobjid )
+       JOIN pg_catalog.pg_class c ON ( c.oid = d.objid )
+WHERE d.refclassid = 'pg_extprotocol'::regclass
+    AND p.ptcname = 'gphdfs';

--- a/migration_scripts/pre-upgrade/generate_preupgrade_sql.bash
+++ b/migration_scripts/pre-upgrade/generate_preupgrade_sql.bash
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+if [ "$#" -ne 3 ]; then
+    echo "Illegal number of parameters"
+    echo "Usage: $(basename $0) <GPHOME> <PGPORT> <OUTPUT_DIR>"
+    exit 1
+fi
+
+GPHOME=$1
+PGPORT=$2
+OUTPUT_DIR=$3
+APPLY_ONCE_FILES=("gen_alter_gphdfs_roles.sql")
+
+get_databases(){
+    databases=$("$GPHOME"/bin/psql -d postgres -p "$PGPORT" -Atc "SELECT datname FROM pg_database WHERE datname != 'template0';")
+    echo "$databases"
+}
+
+exec_sql_file(){
+    local database=$1
+    local path=$2
+    local file=$3
+    local output_file=migration_${database}_${file}
+
+    records=$("$GPHOME"/bin/psql -d "$database" -p "$PGPORT" -Atf "$path")
+    if [[ -n "$records" ]]; then
+        echo "\c $database" > "${OUTPUT_DIR}/${output_file}"
+        echo "$records" >> "${OUTPUT_DIR}/${output_file}"
+    fi
+}
+
+should_apply_once(){
+    local file=$1
+    [[ " ${APPLY_ONCE_FILES[*]} " =~ ${file} ]]
+}
+
+main(){
+    mkdir -p "$OUTPUT_DIR"
+    rm -rf "$OUTPUT_DIR"/*.sql
+
+    local databases=($(get_databases))
+    local paths=($(find $(dirname "$0") -type f -name "*.sql"))
+
+    for database in "${databases[@]}"; do
+        for path in "${paths[@]}"; do
+            local file=$(basename "$path")
+            # generate sql modifying shared objects only for default database
+            if ! should_apply_once "$file" || [ "$database" == "postgres" ]; then
+                exec_sql_file "$database" "$path" "$file"
+            fi
+        done
+    done
+
+    echo "Output files are located in: $OUTPUT_DIR"
+}
+
+main

--- a/migration_scripts/test/create_nonupgradable_objects.sql
+++ b/migration_scripts/test/create_nonupgradable_objects.sql
@@ -1,0 +1,39 @@
+-- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+DROP TABLE IF EXISTS regular CASCADE;
+CREATE TABLE regular (a int unique);
+
+-- create partitioned table with foreign, unique and primary key constraints
+DROP TABLE IF EXISTS pt_with_index CASCADE;
+CREATE TABLE pt_with_index (a int references regular(a), b int, c int, d int)
+    PARTITION BY RANGE(b)
+        (
+        PARTITION pt1 START(1),
+        PARTITION pt2 START(2) END (3)
+        );
+
+CREATE INDEX ptidxc on pt_with_index(c);
+CREATE INDEX ptidxb_prt_2 on pt_with_index_1_prt_pt2(b);
+CREATE INDEX ptidxc_prt_2 on pt_with_index_1_prt_pt2(c);
+INSERT INTO pt_with_index SELECT i, i%2+1, i, i FROM generate_series(1,10)i;
+
+-- create tables where the index relation name is not equal primary/unique key constraint name
+CREATE TYPE table_with_unique_constraint_author_key AS (dummy int);
+CREATE TYPE table_with_unique_constraint_author_key1 AS (dummy int);
+CREATE TABLE table_with_unique_constraint (author int, title int, CONSTRAINT table_with_unique_constraint_uniq_au_ti UNIQUE (author, title)) DISTRIBUTED BY (author);
+DROP TYPE table_with_unique_constraint_author_key, table_with_unique_constraint_author_key1;
+ALTER TABLE table_with_unique_constraint ADD PRIMARY KEY (author, title);
+INSERT INTO table_with_unique_constraint VALUES(1, 1);
+INSERT INTO table_with_unique_constraint VALUES(2, 2);
+
+CREATE TYPE table_with_primary_constraint_pkey AS (dummy int);
+CREATE TYPE table_with_primary_constraint_pkey1 AS (dummy int);
+CREATE TABLE table_with_primary_constraint (author int, title int, CONSTRAINT table_with_primary_constraint_au_ti PRIMARY KEY (author, title)) DISTRIBUTED BY (author);
+DROP TYPE table_with_primary_constraint_pkey, table_with_primary_constraint_pkey1;
+ALTER TABLE table_with_primary_constraint ADD UNIQUE (author, title);
+INSERT INTO table_with_primary_constraint VALUES(1, 1);
+INSERT INTO table_with_primary_constraint VALUES(2, 2);
+
+-- create role with gphdfs readable and writable privileges
+CREATE ROLE gphdfs_user CREATEEXTTABLE(protocol='gphdfs', type='writable') CREATEEXTTABLE(protocol='gphdfs', type='readable');

--- a/test/migration_scripts.bats
+++ b/test/migration_scripts.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+load helpers
+
+PREUPGRADE_SCRIPTS_DIR=$BATS_TEST_DIRNAME/../migration_scripts/pre-upgrade
+
+setup() {
+    skip_if_no_gpdb
+
+    PSQL="$GPHOME_SOURCE/bin/psql -X --no-align --tuples-only"
+
+    TEST_DBNAME=testdb
+    DEFAULT_DBNAME=postgres
+    GPHDFS_USER=gphdfs_user
+
+    $PSQL -c "DROP DATABASE IF EXISTS $TEST_DBNAME;" -d $DEFAULT_DBNAME
+    $PSQL -c "DROP ROLE IF EXISTS $GPHDFS_USER;" -d $DEFAULT_DBNAME
+
+    STATE_DIR=`mktemp -d /tmp/gpupgrade.XXXXXX`
+    export GPUPGRADE_HOME="${STATE_DIR}/gpupgrade"
+
+    gpupgrade kill-services
+}
+
+teardown() {
+    skip_if_no_gpdb
+
+    if [ -n "$NEW_CLUSTER" ]; then
+        delete_finalized_cluster $GPHOME_TARGET $NEW_CLUSTER
+    fi
+
+    gpupgrade kill-services
+
+    restore_cluster
+
+    start_source_cluster
+
+    $GPHOME_SOURCE/bin/psql -c "DROP ROLE IF EXISTS ${GPHDFS_USER}" -d $DEFAULT_DBNAME
+    $GPHOME_SOURCE/bin/psql -c "DROP DATABASE IF EXISTS ${TEST_DBNAME}" -d $DEFAULT_DBNAME
+}
+
+@test "migration scripts generate sql to modify non-upgradeable objects and fix pg_upgrade check errors" {
+    setup_restore_cluster "--mode=copy"
+
+    $PSQL -c "CREATE DATABASE $TEST_DBNAME;" -d $DEFAULT_DBNAME
+    $PSQL -f $BATS_TEST_DIRNAME/../migration_scripts/test/create_nonupgradable_objects.sql -d $TEST_DBNAME
+
+    run gpupgrade initialize \
+            --source-bindir="$GPHOME_SOURCE/bin" \
+            --target-bindir="$GPHOME_TARGET/bin" \
+            --source-master-port="${PGPORT}" \
+            --temp-port-range 6020-6040 \
+            --disk-free-ratio 0 \
+            --verbose
+    [ "$status" -ne 0 ] || fail "expected initialize to fail due to pg_upgrade check: $output"
+
+    egrep "\"CHECK_UPGRADE\": \"FAILED\"" $GPUPGRADE_HOME/status.json
+    egrep "^Checking.*fatal$" $GPUPGRADE_HOME/pg_upgrade/seg-1/pg_upgrade_internal.log
+
+    PREUPGRADE_DIR=`mktemp -d /tmp/migration.XXXXXX`
+    $PREUPGRADE_SCRIPTS_DIR/generate_preupgrade_sql.bash $GPHOME_SOURCE $PGPORT $PREUPGRADE_DIR
+    $PREUPGRADE_SCRIPTS_DIR/execute_preupgrade_sql.bash $GPHOME_SOURCE $PGPORT $PREUPGRADE_DIR
+
+    gpupgrade initialize \
+            --source-bindir="$GPHOME_SOURCE/bin" \
+            --target-bindir="$GPHOME_TARGET/bin" \
+            --source-master-port="${PGPORT}" \
+            --temp-port-range 6020-6040 \
+            --disk-free-ratio 0 \
+            --verbose
+    gpupgrade execute --verbose
+    gpupgrade finalize --verbose
+
+    NEW_CLUSTER="$MASTER_DATA_DIRECTORY"
+}


### PR DESCRIPTION
This commit adds the following
1. SQL statements to generate DDL to modify Database objects which
   cannot be upgraded
2. Wrapper scripts to generate and execute the sql scripts.
3. Bats test to test if the scripts fixed the issues identified by
   pg_ugprade --checks