### PR TITLE
upgrade: eliminate all `--` in upgradeID generated ids

### DIFF
--- a/upgrade/id_test.go
+++ b/upgrade/id_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/greenplum-db/gpupgrade/upgrade"
@@ -70,4 +71,16 @@ func TestIDCommand(_ *testing.T) {
 
 	fmt.Printf("%d", upgrade.NewID())
 	os.Exit(0)
+}
+
+// Make sure we are filtering out "--".  Empirical testing shows about 300 iterations
+//  are required to hit a "--", so we choose 10000 to ensure we'd catch an erroneous
+//  implementation.  This test takes 10ms on my laptop.
+func TestNoDoubleDash(t *testing.T) {
+	for i := 0; i < 10000; i++ {
+		id := upgrade.NewID()
+		if strings.Contains(id.String(), "--") {
+			t.Fatalf("id %s contains --", id)
+		}
+	}
 }


### PR DESCRIPTION
GPDB has a bug that doesn't handle "--" in directory names in some
cases.  But gpupgrade generates a base-64 encoded string that goes into our target cluster's data directory names during execute, that can contain `--`.  It is easier to fix here right now, than in GPDB.  

We have two options:
1). replace `--` in a generated ID with some string, like `dd`.  This can work, and doesn't materially increase the chance of a collision.  The problem is that the String() and the underlying ID bytes are then not related by the simple base-64 scheme any more.

2). keep generating an ID until it has no `--`.  This works as long as there is enough entropy in a users random number generator.  I think it is pathological if not.  

3). I suppose a third option is to replace any `--` in the string and re-encode the value.

I choose option 2).