### PR TITLE
initialize: improve error handling and display

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -48,6 +48,7 @@ import (
 	"google.golang.org/grpc/codes"
 	grpcStatus "google.golang.org/grpc/status"
 
+	"github.com/greenplum-db/gpupgrade/cli"
 	"github.com/greenplum-db/gpupgrade/cli/commanders"
 	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -375,7 +376,7 @@ func initialize() *cobra.Command {
 
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if cmd.Flag("file").Changed {
 				configFile, err := os.Open(file)
 				if err != nil {
@@ -428,6 +429,14 @@ func initialize() *cobra.Command {
 			// If we got here, the args are okay and the user doesn't need a usage
 			// dump on failure.
 			cmd.SilenceUsage = true
+
+			// Past this point, we want any errors to be accompanied by helper
+			// text describing the next actions to take.
+			defer func() {
+				if err != nil {
+					err = cli.NewNextActions(err, "initialize")
+				}
+			}()
 
 			fmt.Println()
 			fmt.Println("Initialize in progress.")

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -434,6 +434,12 @@ func initialize() *cobra.Command {
 			// text describing the next actions to take.
 			defer func() {
 				if err != nil {
+					// XXX work around an annoying UI nit: the error message is
+					// smashed against the failing substep without any vertical
+					// space. Ideally this would be handled by the "UI" logic as
+					// opposed to pushed into business logic.
+					fmt.Println()
+
 					err = cli.NewNextActions(err, "initialize")
 				}
 			}()

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import "fmt"
+
+// NextActions attaches the PrintHelp method to an existing error. This is used
+// to tell the CLI's top level to print additional helper text AFTER the error
+// message is printed.
+type NextActions struct {
+	error
+	Subcommand string // the gpupgrade subcommand name to print
+}
+
+func NewNextActions(err error, subcommand string) NextActions {
+	return NextActions{
+		error:      err,
+		Subcommand: subcommand,
+	}
+}
+
+func (n NextActions) PrintHelp() {
+	// TODO: consider making the "revert" text optional, if we end up using this
+	// in contexts (such as finalize) where revert is not an option.
+	fmt.Printf(`
+NEXT ACTIONS
+------------
+Please address the above issue and run "gpupgrade %s" again.
+
+If you would like to return the cluster to its original state, please run "gpupgrade revert".
+`, n.Subcommand)
+}

--- a/cmd/gpupgrade/main.go
+++ b/cmd/gpupgrade/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"runtime/debug"
@@ -12,6 +13,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	_ "github.com/lib/pq"
 
+	"github.com/greenplum-db/gpupgrade/cli"
 	"github.com/greenplum-db/gpupgrade/cli/commands"
 	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/greenplum-db/gpupgrade/utils/daemon"
@@ -41,6 +43,13 @@ func main() {
 		// We use gplog.Debug instead of Error so the error is not displayed
 		// twice to the user in the terminal.
 		gplog.Debug("%+v", err)
+
+		// Print any additional actions that should be taken by the user.
+		var actions cli.NextActions
+		if errors.As(err, &actions) {
+			actions.PrintHelp()
+		}
+
 		os.Exit(1)
 	}
 }

--- a/test/checks.bats
+++ b/test/checks.bats
@@ -15,7 +15,10 @@ setup() {
 }
 
 teardown() {
-    skip_if_no_gpdb
+    # XXX Beware, BATS_TEST_SKIPPED is not a documented export.
+    if [ -n "${BATS_TEST_SKIPPED}" ]; then
+        return
+    fi
 
     gpupgrade kill-services
     rm -r "$STATE_DIR"
@@ -116,4 +119,8 @@ are_equivalent_within_tolerance() {
     if ! are_equivalent_within_tolerance $required_bytes $total_space 0.001; then
         fail "the required bytes ($required_bytes) are not within 0.1% of the total disk space ($total_space)"
     fi
+
+    # Make sure we print "next actions" too.
+    [[ $output == *'Please address the above issue and run "gpupgrade initialize" again.'* ]] \
+        || fail "failed to print expected next actions; actual output: $output"
 }


### PR DESCRIPTION
See commit messages. Here's the roadmap:
1. After `pg_upgrade --check` fails, error details from stdout are displayed in the top-level gpupgrade UI.
2. A `NEXT ACTIONS` block is printed after initialize failures.
3. cosmetic: the `[FAILED]` indicator and the error message are now separated by a newline.

-------
### Example output
```
$ gpupgrade initialize ... --disk-free-ratio=1

Initialize in progress.

Creating directories...                                            [COMPLETE]
Starting gpupgrade hub process...                                  [COMPLETE]
Saving source cluster configuration...                             [COMPLETE]
Starting gpupgrade agent processes...                              [COMPLETE]
Checking disk space...                                             [FAILED]

Error: You currently do not have enough disk space to run an upgrade.

Hostname   Filesystem  Shortfall  Available  Required
pchampion  /           239.4 GiB  222.5 GiB  462 GiB


NEXT ACTIONS
------------
Please address the above issue and run "gpupgrade initialize" again.

If you would like to return the cluster to its original state, please run "gpupgrade revert".
```
```
$ gpupgrade initialize ...

Initialize in progress.

Creating directories...                                            [COMPLETE]
Starting gpupgrade hub process...                                  [COMPLETE]
Saving source cluster configuration...                             [COMPLETE]
Starting gpupgrade agent processes...                              [COMPLETE]
Checking disk space...                                             [COMPLETE]
Generating target cluster configuration...                         [COMPLETE]
Creating target cluster...                                         [COMPLETE]
Stopping target cluster...                                         [COMPLETE]
Backing up target master...                                        [COMPLETE]
Running pg_upgrade checks...                                       [FAILED]

Error: initialize create cluster: InitializeCreateCluster: rpc error: code = Unknown desc = substep "CHECK_UPGRADE": 1 error occurred:
	* upgrading master: Checking for indexes on partitioned tables                  fatal

| Your installation contains partitioned tables with
| indexes defined on them.  Indexes on partition parents,
| as well as children, must be dropped before upgrade.
| A list of the problem tables is in the file:
| 	partitioned_tables_indexes.txt

Failure, exiting: exit status 1



NEXT ACTIONS
------------
Please address the above issue and run "gpupgrade initialize" again.

If you would like to return the cluster to its original state, please run "gpupgrade revert".
```