### PR TITLE
bats: add tablespaces to finalize.bats for testing coverage

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -289,7 +289,7 @@ get_segment_configuration() {
     local port=${2:-$PGPORT}
 
     if is_GPDB5 "$gphome"; then
-        $PSQL -AtF$'\t' -p "$port" postgres -c "
+        "$gphome"/bin/psql -AXtF$'\t' -p "$port" postgres -c "
             SELECT s.content, s.role, s.hostname, s.port, e.fselocation as datadir
             FROM gp_segment_configuration s
             JOIN pg_filespace_entry e ON s.dbid = e.fsedbid
@@ -298,7 +298,7 @@ get_segment_configuration() {
             ORDER BY s.content, s.role
         "
     else
-        $PSQL -AtF$'\t' -p "$port" postgres -c "
+        "$gphome"/bin/psql -AXtF$'\t' -p "$port" postgres -c "
             SELECT content, role, hostname, port, datadir
             FROM gp_segment_configuration
             ORDER BY content, role


### PR DESCRIPTION
Create a tablespace in a 5X cluster for upgrade. Note that, since pg_upgrade does fails to upgrade tablespaces in 6-6 mode, we only add a tablespace in GPDB5.

As a side effect of the changes made, we have a minor additional prefactor comment:  use correct psql binary in get_segment_configration.

The code change in this PR was straightforward, but much of the work was in realizing that the GPUPGRADE_TARGET rpm in our CI pipeline was outdated.  Hence, it did not contain a fix to 6X_STABLE that caused this addition to fail on the CI until the rpm version was updated.  Both prod and dev have been updated to use `greenplum-db-6.9.0-rhel7-x86_64.rpm` as their target cluster rpm.