### PR TITLE
Add migration scripts to create indexes in the target cluster

### DIFF
--- a/migration_scripts/execute_migration_sql.bash
+++ b/migration_scripts/execute_migration_sql.bash
@@ -18,7 +18,7 @@ main(){
 
     rm -f "$log_file"
 
-    cmd="find ${INPUT_DIR} -type f -name *.sql"
+    cmd="find ${INPUT_DIR} -type f -name *.sql | sort -n"
     local files="$(eval "$cmd")"
     if [ -z "$files" ]; then
         echo "Executing command \"${cmd}\" returned no sql files. Exiting!" | tee -a "$log_file"

--- a/migration_scripts/generate_migration_sql.bash
+++ b/migration_scripts/generate_migration_sql.bash
@@ -38,7 +38,11 @@ exec_script(){
     fi
 
     if [[ -n "$records" ]]; then
-        echo "\c $database" > "${output_dir}/${output_file}"
+        header_file=$(echo "${path/.sql/.header}")
+        if [[ -f $header_file ]]; then
+            cat $header_file >> "${output_dir}/${output_file}"
+        fi
+        echo "\c $database" >> "${output_dir}/${output_file}"
         echo "$records" >> "${output_dir}/${output_file}"
     fi
 }
@@ -53,7 +57,7 @@ execute_script_directory() {
     local dir=$1; shift
     local databases=( "$@" )
 
-    local paths=($(find "$(dirname "$0")/${dir}" -type f \( -name "*.sql" -o -name "*.sh" \) ))
+    local paths=($(find "$(dirname "$0")/${dir}" -type f \( -name "*.sql" -o -name "*.sh" \) | sort -n))
     local output_dir="${OUTPUT_DIR}/${dir}"
 
     mkdir -p "$output_dir"
@@ -73,7 +77,7 @@ execute_script_directory() {
 }
 
 main(){
-    local dirs=(pre-upgrade post-revert)
+    local dirs=(pre-upgrade post-revert post-upgrade)
     local databases=($(get_databases))
 
     for dir in "${dirs[@]}"; do

--- a/migration_scripts/post-upgrade/create_partition_indexes_step_1.header
+++ b/migration_scripts/post-upgrade/create_partition_indexes_step_1.header
@@ -1,0 +1,3 @@
+-- The below CREATE INDEX statement will create the indexes on the leaf
+-- partitions only. Indexes on the root partition will be created via a
+-- separate step which must be executed after these SQL statements.

--- a/migration_scripts/post-upgrade/create_partition_indexes_step_1.sql
+++ b/migration_scripts/post-upgrade/create_partition_indexes_step_1.sql
@@ -1,0 +1,104 @@
+-- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- generates SQL statement to create indexes on child partition tables that do
+-- not correspond to primary or unique constraints.
+
+WITH child_partitions (relid) AS
+(
+   SELECT DISTINCT
+      parchildrelid
+   FROM
+      pg_partition_rule
+)
+,
+part_constraints AS
+(
+   SELECT
+      conname,
+      c.relname conrel,
+      n.nspname relschema,
+      cc.relname rel
+   FROM
+      pg_constraint con
+      JOIN
+         pg_depend dep
+         ON (dep.refclassid, dep.classid, dep.objsubid) =
+         (
+            'pg_constraint'::regclass,
+            'pg_class'::regclass,
+            0
+         )
+         AND dep.refobjid = con.oid
+         AND dep.deptype = 'i'
+         AND con.contype IN
+         (
+            'u',
+            'p'
+         )
+      JOIN
+         pg_class c
+         ON dep.objid = c.oid
+         AND c.relkind = 'i'
+      JOIN
+         child_partitions
+         ON con.conrelid = child_partitions.relid
+      JOIN
+         pg_class cc
+         ON cc.oid = con.conrelid
+      JOIN
+         pg_namespace n
+         ON (n.oid = cc.relnamespace)
+)
+,
+indexes AS
+(
+   SELECT
+      n.nspname AS schemaname,
+      c.relname AS tablename,
+      i.relname AS indexname,
+      t.spcname AS tablespace,
+      pg_get_indexdef(i.oid) AS indexdef
+   FROM
+      pg_index x
+      JOIN
+         child_partitions np
+         on np.relid = x.indrelid
+      JOIN
+         pg_class c
+         ON c.oid = x.indrelid
+      JOIN
+         pg_class i
+         ON i.oid = x.indexrelid
+      LEFT JOIN
+         pg_namespace n
+         ON n.oid = c.relnamespace
+      LEFT JOIN
+         pg_tablespace t
+         ON t.oid = i.reltablespace
+   WHERE
+      c.relkind = 'r'::"char"
+      AND i.relkind = 'i'::"char"
+      AND c.relhassubclass = 'f'
+      AND x.indisunique = 'f'
+)
+SELECT
+$$SET SEARCH_PATH=$$ || schemaname || $$; $$ || indexdef || $$ ;$$
+FROM
+   indexes
+WHERE
+   (
+      indexname,
+      schemaname,
+      tablename
+   )
+   NOT IN
+   (
+      SELECT
+         conrel,
+         relschema,
+         rel
+      FROM
+         part_constraints
+   )
+;

--- a/migration_scripts/post-upgrade/create_partition_indexes_step_2.header
+++ b/migration_scripts/post-upgrade/create_partition_indexes_step_2.header
@@ -1,0 +1,18 @@
+-- The below CREATE INDEX statement will create the indexes on the root
+-- partitions, which get cascaded to the child partitions. Prior to execution of
+-- the CREATE INDEX statement on root, CREATE INDEX statement on the child
+-- partitions must be executed for non-unique indexes. When CREATE INDEX on
+-- root is created and cascaded, it will identify that an index on the child partition
+-- already exists on the desired column, so it will adopt it, instead of creating a new one.
+-- 
+-- Note:
+-- 1. There may be cases where an index was dropped on child partition in
+-- source cluster explicitly as it was allowed with Greenplum Database 5.x
+-- version, but with Greenplum Database 6.x since a CREATE INDEX will be executed
+-- on the root, indexes will be created on all the child partitions.
+--
+-- 2. If there were any indexes only on the mid-level partitions in source cluster,
+-- they will not be created, as they don't serve any functional purpose
+--
+-- 3. The name of the unique indexes on the child partitions created in target cluster
+-- may have a different name in source cluster.

--- a/migration_scripts/post-upgrade/create_partition_indexes_step_2.sql
+++ b/migration_scripts/post-upgrade/create_partition_indexes_step_2.sql
@@ -1,0 +1,103 @@
+-- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- generates SQL statement to create indexes on root partition tables
+-- that don't correspond to unique or primary key constraints
+
+-- cte to get all the unique and primary key constraints
+WITH root_partitions (relid) AS
+(
+   SELECT DISTINCT
+      parrelid
+   FROM
+      pg_partition
+)
+,
+root_constraints AS
+(
+   SELECT
+      conname,
+      c.relname conrel,
+      n.nspname relschema,
+      cc.relname rel
+   FROM
+      pg_constraint con
+      JOIN
+         pg_depend dep
+         ON (dep.refclassid, dep.classid, dep.objsubid) =
+         (
+            'pg_constraint'::regclass,
+            'pg_class'::regclass,
+            0
+         )
+         AND dep.refobjid = con.oid
+         AND dep.deptype = 'i'
+         AND con.contype IN
+         (
+            'u',
+            'p'
+         )
+      JOIN
+         pg_class c
+         ON dep.objid = c.oid
+         AND c.relkind = 'i'
+      JOIN
+         root_partitions
+         ON con.conrelid = root_partitions.relid
+      JOIN
+         pg_class cc
+         ON cc.oid = con.conrelid
+      JOIN
+         pg_namespace n
+         ON (n.oid = cc.relnamespace)
+)
+,
+indexes AS
+(
+   SELECT
+      n.nspname AS schemaname,
+      c.relname AS tablename,
+      i.relname AS indexname,
+      t.spcname AS tablespace,
+      pg_get_indexdef(i.oid) AS indexdef
+   FROM
+      pg_index x
+      JOIN
+         root_partitions rp
+         on rp.relid = x.indrelid
+      JOIN
+         pg_class c
+         ON c.oid = x.indrelid
+      JOIN
+         pg_class i
+         ON i.oid = x.indexrelid
+      LEFT JOIN
+         pg_namespace n
+         ON n.oid = c.relnamespace
+      LEFT JOIN
+         pg_tablespace t
+         ON t.oid = i.reltablespace
+   WHERE
+      c.relkind = 'r'::"char"
+      AND i.relkind = 'i'::"char"
+)
+SELECT
+$$SET SEARCH_PATH=$$ || schemaname || $$; $$ || indexdef || $$;$$
+FROM
+   indexes
+WHERE
+   (
+      indexname,
+      schemaname,
+      tablename
+   )
+   NOT IN
+   (
+      SELECT
+         conrel,
+         relschema,
+         rel
+      FROM
+         root_constraints
+   )
+;

--- a/migration_scripts/pre-upgrade/gen_drop_partition_indexes.sql
+++ b/migration_scripts/pre-upgrade/gen_drop_partition_indexes.sql
@@ -58,8 +58,7 @@ part_constraint AS
          ON (n.oid = cc.relnamespace)
 )
 SELECT
-   $$ DROP INDEX $$ || i.relname || $$ ;
- $$
+   $$ DROP INDEX $$ || i.relname || $$ ;$$
 FROM
    pg_index x
    JOIN


### PR DESCRIPTION
The PR contains of several commits which performs the below
1 - Initial Refactoring to allow creating scripts for pre-upgrade, post-upgrade, or post-revert stages
2- Functionality to add documentation to generated SQLs
3- SQL files to generate the create index statements to be executed after upgrade
4- Other minor cleanups
5- Adding the post-upgrade execution step to tests