### PR TITLE
test/initialize: codify TEARDOWN_FUNCTIONS for general use

### DIFF
--- a/test/teardown_helpers.bash
+++ b/test/teardown_helpers.bash
@@ -1,0 +1,51 @@
+# Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Helpers for performing more complex teardowns. Register a command to run with
+# register_teardown, and run all teardowns in reverse order of registration with
+# run_teardowns.
+#
+
+TEARDOWN_FUNCTIONS=()
+
+# Registers a command to be run during run_teardowns. Commands may have
+# arbitrary parameters; just keep in mind that Bash evaluates them during
+# register_teardown, not run_teardowns.
+register_teardown() {
+    # Bash doesn't have arrays of arrays. Fake them by length-prefixing each new
+    # "row" in the list. NOTE: there is probably a better way to do this in Bash
+    # 4, but many of us are running Bash 3 on macOS.
+    local len=${#@}
+    TEARDOWN_FUNCTIONS=( "$len" "$@" "${TEARDOWN_FUNCTIONS[@]}")
+}
+
+# Runs all teardown commands (registered via register_teardown) in LIFO order
+# and clears the list of teardowns.
+run_teardowns() {
+    _run "${TEARDOWN_FUNCTIONS[@]}"
+
+    TEARDOWN_FUNCTIONS=()
+}
+
+# Internal implementation for run_teardowns.
+_run() {
+    while (( ${#@} )); do
+        # Pop the length of the next command.
+        local len=$1; shift
+        local cmd=()
+
+        # Pop each element of the command into our list.
+        for (( i = 0; i < len; i++ )); do
+            cmd+=( "$1" ); shift
+        done
+
+        # Echo the teardown function, properly shell-quoted, to help debugging.
+        printf 'running teardown:'
+        printf ' %q' "${cmd[@]}"
+        printf '\n'
+
+        # Run.
+        "${cmd[@]}"
+    done
+}

--- a/test/teardown_helpers.bats
+++ b/test/teardown_helpers.bats
@@ -1,0 +1,48 @@
+#! /usr/bin/env bats
+#
+# Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+load helpers
+load teardown_helpers
+
+# Prints the number of arguments passed, and the arguments themselves, on
+# separate lines.
+print_args() {
+    echo ${#@}
+    for arg in "$@"; do
+        echo "$arg"
+    done
+}
+
+@test "run_teardowns runs all registered commands in reverse order" {
+    register_teardown echo first
+    register_teardown print_args one "two three" four
+    register_teardown echo last
+    
+    run run_teardowns
+
+    diff -U2 <(echo "$output") - <<'EOF' || fail "run_teardowns printed unexpected output (see diff)"
+running teardown: echo last
+last
+running teardown: print_args one two\ three four
+3
+one
+two three
+four
+running teardown: echo first
+first
+EOF
+}
+
+@test "run_teardowns clears the registered list" {
+    local was_run=0
+    register_teardown eval was_run=1
+
+    run_teardowns
+    (( was_run )) || fail "teardown was not run"
+
+    was_run=0
+    run_teardowns
+    (( ! was_run )) || fail "teardown was re-run incorrectly"
+}


### PR DESCRIPTION
The `TEARDOWN_FUNCTIONS` pattern is now pulled into `teardown_helpers.bash` for general use by tests. It's similar in use to Go's `defer` keyword:

    register_teardown some_teardown_function
    register_teardown echo hello

    run_teardowns # echoes 'hello', then runs some_teardown_function

Teardown functions are executed in LIFO order.

Changes from previous behavior:
- Teardowns are executed in reverse order of registration.
- Teardowns may have arguments: there's no need to create a single-line function wrapper if it's more convenient to register the teardown command inline.