### PR TITLE
add ExecuteRPC helper function

### DIFF
--- a/hub/archive_log_directory.go
+++ b/hub/archive_log_directory.go
@@ -5,46 +5,21 @@ package hub
 
 import (
 	"context"
-	"sync"
-
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/idl"
 )
 
 func ArchiveSegmentLogDirectories(agentConns []*Connection, excludeHostname, newDir string) error {
-	wg := sync.WaitGroup{}
-	errChan := make(chan error, len(agentConns))
-
-	for _, conn := range agentConns {
-		conn := conn
-
-		// Skip the state directory that is on the master host, which we delete
-		// later from the hub.
+	request := func(conn *Connection) error {
 		if conn.Hostname == excludeHostname {
-			continue
+			return nil
 		}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			_, err := conn.AgentClient.ArchiveLogDirectory(context.Background(), &idl.ArchiveLogDirectoryRequest{
-				NewDir: newDir,
-			})
-			if err != nil {
-				errChan <- err
-			}
-		}()
+		_, err := conn.AgentClient.ArchiveLogDirectory(context.Background(), &idl.ArchiveLogDirectoryRequest{
+			NewDir: newDir,
+		})
+		return err
 	}
 
-	wg.Wait()
-	close(errChan)
-
-	var mErr *multierror.Error
-	for err := range errChan {
-		mErr = multierror.Append(mErr, err)
-	}
-
-	return mErr.ErrorOrNil()
+	return ExecuteRPC(agentConns, request)
 }

--- a/hub/delete_state_directories.go
+++ b/hub/delete_state_directories.go
@@ -5,47 +5,19 @@ package hub
 
 import (
 	"context"
-	"sync"
-
-	"github.com/greenplum-db/gp-common-go-libs/gplog"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/idl"
 )
 
 func DeleteStateDirectories(agentConns []*Connection, excludeHostname string) error {
-	wg := sync.WaitGroup{}
-	errChan := make(chan error, len(agentConns))
-
-	for _, conn := range agentConns {
-		conn := conn
-
-		// Skip the state directory that is on the master host, which we delete
-		// later from the hub.
+	request := func(conn *Connection) error {
 		if conn.Hostname == excludeHostname {
-			continue
+			return nil
 		}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			_, err := conn.AgentClient.DeleteStateDirectory(context.Background(), &idl.DeleteStateDirectoryRequest{})
-			if err != nil {
-				gplog.Error("Error deleting state directory on host %s: %s",
-					conn.Hostname, err.Error())
-				errChan <- err
-			}
-		}()
+		_, err := conn.AgentClient.DeleteStateDirectory(context.Background(), &idl.DeleteStateDirectoryRequest{})
+		return err
 	}
 
-	wg.Wait()
-	close(errChan)
-
-	var mErr *multierror.Error
-	for err := range errChan {
-		mErr = multierror.Append(mErr, err)
-	}
-
-	return mErr.ErrorOrNil()
+	return ExecuteRPC(agentConns, request)
 }

--- a/hub/rpc.go
+++ b/hub/rpc.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package hub
+
+import (
+	"sync"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+func ExecuteRPC(agentConns []*Connection, executeRequest func(conn *Connection) error) error {
+	var wg sync.WaitGroup
+	errs := make(chan error, len(agentConns))
+
+	for _, conn := range agentConns {
+		conn := conn
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			err := executeRequest(conn)
+			errs <- err
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	var mErr *multierror.Error
+	for err := range errs {
+		mErr = multierror.Append(mErr, err)
+	}
+
+	return mErr.ErrorOrNil()
+}

--- a/hub/rpc_test.go
+++ b/hub/rpc_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package hub_test
+
+import (
+	"errors"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/hashicorp/go-multierror"
+	"golang.org/x/xerrors"
+
+	"github.com/greenplum-db/gpupgrade/hub"
+)
+
+func TestExecuteRPC(t *testing.T) {
+	t.Run("executes multiple requests", func(t *testing.T) {
+		agentConns := []*hub.Connection{
+			{nil, nil, "mdw", nil},
+			{nil, nil, "sdw", nil},
+		}
+
+		var hosts []string
+		request := func(conn *hub.Connection) error {
+			hosts = append(hosts, conn.Hostname)
+			return nil
+		}
+
+		err := hub.ExecuteRPC(agentConns, request)
+		if err != nil {
+			t.Errorf("ExecuteRPC returned error %+v", err)
+		}
+
+		expected := []string{"mdw", "sdw"}
+		sort.Strings(hosts)
+		if !reflect.DeepEqual(hosts, expected) {
+			t.Errorf("got %v want %v", hosts, expected)
+		}
+	})
+
+	t.Run("bubbles up errors", func(t *testing.T) {
+		agentConns := []*hub.Connection{
+			{nil, nil, "mdw", nil},
+			{nil, nil, "sdw", nil},
+		}
+
+		expected := errors.New("permission denied")
+		request := func(conn *hub.Connection) error {
+			if conn.Hostname == "mdw" {
+				return expected
+			}
+
+			return nil
+		}
+
+		err := hub.ExecuteRPC(agentConns, request)
+		var multiErr *multierror.Error
+		if !xerrors.As(err, &multiErr) {
+			t.Fatalf("got error %#v, want type %T", err, multiErr)
+		}
+
+		if len(multiErr.Errors) != 1 {
+			t.Errorf("received %d errors, want %d", len(multiErr.Errors), 1)
+		}
+
+		for _, err := range multiErr.Errors {
+			if !xerrors.Is(err, expected) {
+				t.Errorf("got error %#v, want %#v", expected, err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
This extracts the common loop that executes gRPC requests from the hub to the agent.

This is a small step forward and hopefully will allow easier iteration. Future work may include simplifying existing tests.

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:rpc)