### PR TITLE
deleteStateDirectory: don't check contents before deleting state directory

### DIFF
--- a/agent/delete_directories.go
+++ b/agent/delete_directories.go
@@ -24,7 +24,9 @@ func (s *Server) DeleteStateDirectory(ctx context.Context, in *idl.DeleteStateDi
 		return &idl.DeleteStateDirectoryReply{}, err
 	}
 
-	err = deleteDirectories([]string{s.conf.StateDir}, upgrade.StateDirectoryFiles, hostname, step.DevNullStream)
+	// pass an empty []string to avoid check for any pre-existing files,
+	// this call might come in before any stateDir files are created
+	err = deleteDirectories([]string{s.conf.StateDir}, []string{}, hostname, step.DevNullStream)
 	return &idl.DeleteStateDirectoryReply{}, err
 }
 

--- a/agent/delete_directories_test.go
+++ b/agent/delete_directories_test.go
@@ -127,8 +127,8 @@ func TestDeleteStateDirectory(t *testing.T) {
 			t.Errorf("got directories: %s want: %s", actualDirectories, expectedDirectories)
 		}
 
-		if !reflect.DeepEqual(actualRequiredPaths, upgrade.StateDirectoryFiles) {
-			t.Errorf("got required paths: %s want: %s", actualRequiredPaths, upgrade.StateDirectoryFiles)
+		if len(actualRequiredPaths) != 0 {
+			t.Errorf("unexpected required paths: %s", actualRequiredPaths)
 		}
 
 		if actualHostname != expectedHostname {


### PR DESCRIPTION
State directory on the agents does not contain any content until
pg_upgrade check is run in initialize, but we support revert both after
initialize and execute. If initialize failed before pg_upgrade check,
there will be no contents in the state directory, so there is currently
no marker file which validates the state directory.

Also, before this commit, the check used to verify the config.json and
status.json files on the agent before deleting the state directory, but
these files don't exist on agents.