### PR TITLE
startstop: pass master data directory variable as environment

### DIFF
--- a/greenplum/cluster.go
+++ b/greenplum/cluster.go
@@ -297,7 +297,7 @@ func (c *Cluster) GetDirForContent(contentID int) string {
 }
 
 func (c *Cluster) Start(stream step.OutStreams) error {
-	return runStartStopCmd(stream, c.GPHome, fmt.Sprintf("gpstart -a -d %[1]s", c.MasterDataDir()))
+	return runStartStopCmd(stream, c.GPHome, fmt.Sprintf("gpstart -a -d %[1]s", c.MasterDataDir()), fmt.Sprintf("MASTER_DATA_DIRECTORY=%s", c.MasterDataDir()))
 }
 
 func (c *Cluster) Stop(stream step.OutStreams) error {
@@ -314,11 +314,11 @@ func (c *Cluster) Stop(stream step.OutStreams) error {
 		return errors.New("master is already stopped")
 	}
 
-	return runStartStopCmd(stream, c.GPHome, fmt.Sprintf("gpstop -a -d %[1]s", c.MasterDataDir()))
+	return runStartStopCmd(stream, c.GPHome, fmt.Sprintf("gpstop -a -d %[1]s", c.MasterDataDir()), fmt.Sprintf("MASTER_DATA_DIRECTORY=%s", c.MasterDataDir()))
 }
 
 func (c *Cluster) StartMasterOnly(stream step.OutStreams) error {
-	return runStartStopCmd(stream, c.GPHome, fmt.Sprintf("gpstart -m -a -d %[1]s", c.MasterDataDir()))
+	return runStartStopCmd(stream, c.GPHome, fmt.Sprintf("gpstart -m -a -d %[1]s", c.MasterDataDir()), fmt.Sprintf("MASTER_DATA_DIRECTORY=%s", c.MasterDataDir()))
 }
 
 func (c *Cluster) StopMasterOnly(stream step.OutStreams) error {
@@ -335,12 +335,13 @@ func (c *Cluster) StopMasterOnly(stream step.OutStreams) error {
 		return errors.New("master is already stopped")
 	}
 
-	return runStartStopCmd(stream, c.GPHome, fmt.Sprintf("gpstop -m -a -d %[1]s", c.MasterDataDir()))
+	return runStartStopCmd(stream, c.GPHome, fmt.Sprintf("gpstop -m -a -d %[1]s", c.MasterDataDir()), fmt.Sprintf("MASTER_DATA_DIRECTORY=%s", c.MasterDataDir()))
 }
 
-func runStartStopCmd(stream step.OutStreams, gphome, command string) error {
-	commandWithEnv := fmt.Sprintf("source %[1]s/greenplum_path.sh && %[1]s/bin/%[2]s",
+func runStartStopCmd(stream step.OutStreams, gphome, command string, env string) error {
+	commandWithEnv := fmt.Sprintf("source %[1]s/greenplum_path.sh && %[2]s %[1]s/bin/%[3]s",
 		gphome,
+		env,
 		command)
 
 	cmd := startStopCmd("bash", "-c", commandWithEnv)

--- a/greenplum/start_or_stop_cluster_test.go
+++ b/greenplum/start_or_stop_cluster_test.go
@@ -179,7 +179,7 @@ func TestStartOrStopCluster(t *testing.T) {
 				}
 
 				expected := []string{"-c", "source /usr/local/source/greenplum_path.sh " +
-					"&& /usr/local/source/bin/gpstop -a -d " + masterDataDir}
+					"&& MASTER_DATA_DIRECTORY=" + masterDataDir + " /usr/local/source/bin/gpstop -a -d " + masterDataDir}
 				if !reflect.DeepEqual(args, expected) {
 					t.Errorf("got %q want %q", args, expected)
 				}
@@ -218,7 +218,7 @@ func TestStartOrStopCluster(t *testing.T) {
 				}
 
 				expected := []string{"-c", "source /usr/local/source/greenplum_path.sh " +
-					"&& /usr/local/source/bin/gpstart -a -d " + masterDataDir}
+					"&& MASTER_DATA_DIRECTORY=" + masterDataDir + " /usr/local/source/bin/gpstart -a -d " + masterDataDir}
 				if !reflect.DeepEqual(args, expected) {
 					t.Errorf("got %q want %q", args, expected)
 				}
@@ -238,7 +238,7 @@ func TestStartOrStopCluster(t *testing.T) {
 				}
 
 				expected := []string{"-c", "source /usr/local/source/greenplum_path.sh " +
-					"&& /usr/local/source/bin/gpstart -m -a -d " + masterDataDir}
+					"&& MASTER_DATA_DIRECTORY=" + masterDataDir + " /usr/local/source/bin/gpstart -m -a -d " + masterDataDir}
 				if !reflect.DeepEqual(args, expected) {
 					t.Errorf("got %q want %q", args, expected)
 				}
@@ -270,7 +270,7 @@ func TestStartOrStopCluster(t *testing.T) {
 				}
 
 				expected := []string{"-c", "source /usr/local/source/greenplum_path.sh " +
-					"&& /usr/local/source/bin/gpstop -m -a -d " + masterDataDir}
+					"&& MASTER_DATA_DIRECTORY=" + masterDataDir + " /usr/local/source/bin/gpstop -m -a -d " + masterDataDir}
 				if !reflect.DeepEqual(args, expected) {
 					t.Errorf("got %q want %q", args, expected)
 				}


### PR DESCRIPTION
gpstart requires MASTER_DATA_DIRECTORY environment to be set prior to
invocation else it fails when it check if filespaces are configured in
GPDB 5. This should be fixed in GPDB too, but passing the environment
via gpupgrade for now allows to run gpstart successfully.