### PR TITLE
recoverseg : pass master data directory

### DIFF
--- a/hub/restore_source_cluster.go
+++ b/hub/restore_source_cluster.go
@@ -65,7 +65,7 @@ func Recoverseg(stream step.OutStreams, cluster *greenplum.Cluster) error {
 		return nil
 	}
 
-	script := fmt.Sprintf("source %[1]s/greenplum_path.sh && %[1]s/bin/gprecoverseg -a", cluster.GPHome)
+	script := fmt.Sprintf("source %[1]s/greenplum_path.sh && MASTER_DATA_DIRECTORY=%[2]s %[1]s/bin/gprecoverseg -a", cluster.GPHome, cluster.MasterDataDir())
 	cmd := RecoversegCmd("bash", "-c", script)
 
 	cmd.Stdout = stream.Stdout()

--- a/hub/restore_source_cluster_test.go
+++ b/hub/restore_source_cluster_test.go
@@ -5,6 +5,7 @@ package hub_test
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"reflect"
@@ -88,7 +89,7 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 				t.Errorf("got %q want bash", utility)
 			}
 
-			expected := []string{"-c", "source /usr/local/greenplum-db/greenplum_path.sh && /usr/local/greenplum-db/bin/gprecoverseg -a"}
+			expected := []string{"-c", fmt.Sprintf("source /usr/local/greenplum-db/greenplum_path.sh && MASTER_DATA_DIRECTORY=%s /usr/local/greenplum-db/bin/gprecoverseg -a", cluster.MasterDataDir())}
 			if !reflect.DeepEqual(args, expected) {
 				t.Errorf("got %q want %q", args, expected)
 			}


### PR DESCRIPTION
Recoverseg fails if MASTER_DATA_DIRECTORY is not set
```
Starting RESTORE_SOURCE_CLUSTER...

Traceback (most recent call last):
  File "/usr/local/gpdb5/bin/gprecoverseg", line 19, in <module>
    GpRecoverSegmentProgram.mainOptions())
  File "/usr/local/gpdb5/lib/python/gppylib/mainUtils.py", line 187, in simple_main
    simple_main_internal(createOptionParserFn, createCommandFn, mainOptions)
  File "/usr/local/gpdb5/lib/python/gppylib/mainUtils.py", line 199, in simple_main_internal
    sml = SimpleMainLock(mainOptions)
  File "/usr/local/gpdb5/lib/python/gppylib/mainUtils.py", line 71, in __init__
    self.ppath = os.path.join(gp.get_masterdatadir(), self.pidfilename)
  File "/usr/local/gpdb5/lib/python/gppylib/commands/gp.py", line 1347, in get_masterdatadir
    raise GpError("Environment Variable MASTER_DATA_DIRECTORY not set!")
gppylib.commands.gp.GpError: Environment Variable MASTER_DATA_DIRECTORY not set!
```