### PR TITLE
Refactor archive log dir

### DIFF
--- a/agent/archive_log_directory.go
+++ b/agent/archive_log_directory.go
@@ -19,11 +19,8 @@ func (s *Server) ArchiveLogDirectory(ctx context.Context, in *idl.ArchiveLogDire
 	if err != nil {
 		return &idl.ArchiveLogDirectoryReply{}, err
 	}
-	if err = utils.System.Rename(logdir, in.GetNewDir()); err != nil {
-		if utils.System.IsNotExist(err) {
-			gplog.Debug("log directory %s not archived, possibly due to multi-host environment. %+v", logdir, err)
-			err = nil
-		}
-	}
+
+	gplog.Debug("moving directory %q to %q", logdir, in.GetNewDir())
+	err = utils.Move(logdir, in.GetNewDir())
 	return &idl.ArchiveLogDirectoryReply{}, err
 }

--- a/hub/revert.go
+++ b/hub/revert.go
@@ -93,10 +93,10 @@ func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) 
 			return err
 		}
 		archiveDir = filepath.Join(filepath.Dir(oldDir), upgrade.GetArchiveDirectoryName(s.UpgradeID, time.Now()))
-		if err = utils.System.Rename(oldDir, archiveDir); err != nil {
-			if utils.System.IsNotExist(err) {
-				gplog.Debug("log directory %s not archived, possibly due to multi-host environment. %+v", archiveDir, err)
-			}
+
+		gplog.Debug("moving directory %q to %q", oldDir, archiveDir)
+		if err = utils.Move(oldDir, archiveDir); err != nil {
+			return err
 		}
 
 		return ArchiveSegmentLogDirectories(s.agentConns, s.Config.Target.MasterHostname(), archiveDir)

--- a/utils/sys_utils_test.go
+++ b/utils/sys_utils_test.go
@@ -1,0 +1,61 @@
+package utils_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/xerrors"
+
+	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/utils"
+)
+
+func TestMove(t *testing.T) {
+	t.Run("move run successfully", func(t *testing.T) {
+		src := testutils.GetTempDir(t, "")
+		defer os.RemoveAll(src)
+
+		file := "file.txt"
+		srcFile := filepath.Join(src, file)
+		_, err := os.Create(srcFile)
+		if err != nil {
+			t.Errorf("unexpected error %#v", err)
+		}
+
+		dst := src + "-aftermove"
+		err = utils.Move(src, dst)
+		if err != nil {
+			t.Errorf("unexpected error %#v", err)
+		}
+		defer os.RemoveAll(dst)
+
+		dstFile := filepath.Join(dst, file)
+		_, err = os.Stat(dstFile)
+		if err != nil {
+			t.Errorf("unexpected error %#v", err)
+		}
+
+		_, err = os.Stat(src)
+		if !os.IsNotExist(err) {
+			t.Errorf("expected source directory to not exist: %#v", err)
+		}
+	})
+
+	t.Run("move fails", func(t *testing.T) {
+		src := ""
+		dst := testutils.GetTempDir(t, "")
+		defer os.RemoveAll(dst)
+
+		err := utils.Move(src, dst)
+		if err == nil {
+			t.Errorf("expected error")
+		}
+
+		var exitError *exec.ExitError
+		if !xerrors.As(err, &exitError) {
+			t.Errorf("got %T, want %T", err, exitError)
+		}
+	})
+}


### PR DESCRIPTION
This PR contains 2 commit
1. Add the move utility
2. Use the move utility in archive log method in revert and related test cases.