### PR TITLE
upgrade: don't pass through LD_LIBRARY_PATH

### DIFF
--- a/upgrade/run.go
+++ b/upgrade/run.go
@@ -4,9 +4,7 @@
 package upgrade
 
 import (
-	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -86,13 +84,6 @@ func Run(p SegmentPair, options ...Option) error {
 	// Explicitly clear the child environment. pg_upgrade shouldn't need things
 	// like PATH, and PGPORT et al are explicitly forbidden to be set.
 	cmd.Env = []string{}
-
-	// XXX ...but we make a single exception for now, for LD_LIBRARY_PATH, to
-	// work around pervasive problems with RPATH settings in our Postgres
-	// extension modules.
-	if path, ok := os.LookupEnv("LD_LIBRARY_PATH"); ok {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("LD_LIBRARY_PATH=%s", path))
-	}
 
 	gplog.Info(cmd.String())
 


### PR DESCRIPTION
pg_upgrade should no longer need `LD_LIBRARY_PATH` to function after the 5.28 and 6.9 GPDB releases. Remove the hack so that 5->6 upgrades no longer cross-link 6X binaries with 5X's version of libxml2.