### PR TITLE
test/migration_scripts: use rsync's --archive rather than -r

### DIFF
--- a/test/migration_scripts.bats
+++ b/test/migration_scripts.bats
@@ -65,7 +65,7 @@ backup_source_cluster() {
     datadir_root="$(realpath "$MASTER_DATA_DIRECTORY"/../..)"
 
     gpstop -af
-    rsync -r "$datadir_root"/ "$backup_dir"/
+    rsync --archive "$datadir_root"/ "$backup_dir"/
     gpstart -a
 }
 
@@ -82,7 +82,7 @@ restore_source_cluster() {
     datadir_root="$(realpath "$MASTER_DATA_DIRECTORY"/../..)"
 
     stop_any_cluster
-    rsync -r -I --delete "$backup_dir"/ "$datadir_root"/
+    rsync --archive -I --delete "$backup_dir"/ "$datadir_root"/
     gpstart -a
 }
 


### PR DESCRIPTION
`--archive` matches what we really want: preserve everything we can about the original directory tree.