### PR TITLE
copy-mode revert now syncs the standby properly

### DIFF
--- a/upgrade/run.go
+++ b/upgrade/run.go
@@ -69,6 +69,10 @@ func Run(p SegmentPair, options ...Option) error {
 		args = append(args, "--old-tablespaces-file", opts.TablespaceFilePath)
 	}
 
+	if opts.OldOptions != "" {
+		args = append(args, "--old-options", opts.OldOptions)
+	}
+
 	// If the caller specified an explicit Command implementation to use, get
 	// our exec.Cmd using that. Otherwise use our internal execCommand.
 	cmdFunc := execCommand
@@ -153,6 +157,14 @@ func WithTablespaceFile(filePath string) Option {
 	}
 }
 
+// WithOldOptions allows the "--old-options" flag to pg_upgrade to be set by the caller,
+// to set extra options on the pg_ctl used for the source cluster.
+func WithOldOptions(opts string) Option {
+	return func(o *optionList) {
+		o.OldOptions = opts
+	}
+}
+
 // optionList holds the combined result of all possible Options. Zero values
 // represent the default settings.
 type optionList struct {
@@ -164,6 +176,7 @@ type optionList struct {
 	SegmentMode        bool
 	Stdout, Stderr     io.Writer
 	TablespaceFilePath string
+	OldOptions         string
 }
 
 // newOptionList returns an optionList with all of the provided Options applied.

--- a/upgrade/run_test.go
+++ b/upgrade/run_test.go
@@ -241,6 +241,7 @@ func TestRun(t *testing.T) {
 				fs.Bool("retain", false, "")
 				fs.Bool("link", false, "")
 				fs.String("old-tablespaces-file", "", "")
+				fs.String("old-options", "", "")
 
 				err := fs.Parse(args)
 				if err != nil {
@@ -261,6 +262,7 @@ func TestRun(t *testing.T) {
 					"retain":               true,
 					"link":                 options.UseLinkMode,
 					"old-tablespaces-file": options.TablespaceFilePath,
+					"old-options":          options.OldOptions,
 				}
 
 				fs.VisitAll(func(f *flag.Flag) {
@@ -291,6 +293,7 @@ func TestRun(t *testing.T) {
 			{"--link mode on master", []upgrade.Option{upgrade.WithLinkMode()}},
 			{"--link mode on segments", []upgrade.Option{upgrade.WithSegmentMode(), upgrade.WithLinkMode()}},
 			{"--old-tablespaces-file flag on segments", []upgrade.Option{upgrade.WithTablespaceFile("tablespaceMappingFile.txt"), upgrade.WithSegmentMode()}},
+			{"--old-options on master", []upgrade.Option{upgrade.WithOldOptions("option value")}},
 		}
 
 		for _, c := range cases {


### PR DESCRIPTION
upgrade: add the dbid of the standby to the master in UpgradeMaster

When executing a 5-6 pg_upgrade, the source master should know the dbid of its
standby.  This is in general the correct semantic.

Furthermore, depending on how we do revert after execute, the standby may
never sync its WAL with the master and exit abruptly:

1). rsync based revert (currently done for link-mode)
    Setting the standby-dbid isn't strictly necessary but is still corret.
2). gprecoverseg based revert (currently done for copy-mode)
    Setting the standby-dbib is needed to sync the standby to the master.

For context, see:
https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/RunORQtf0X4/reX311xIAwAJ

revert.bats tests have been modified to validate that the standby is in sync with the master after an execute revert.

NOTE: This solution sets the master's standby dbid using `gpupgrade`.  We could instead do this in `pg_upgrade`...the master could query `gp_segment_configuration` and pass the `-o -x <standby_dbid>` directly in `start_postmaster`.  This is the "correct solution" in that the fix is really a property of pg_upgrade, not gpupgrade.  However, since this fix is only needed in gpdb-5 and apparently its only use is gpupgrade, we deem it sufficient to fix in `gpugprade`.   It is also a specialized use: it is only needed if one "reverts" after a pg_upgrade.  That said, placing the fix into `pg_upgrade` is straightforward enough.  This also introduces a merge conflict with upstream; the fix would also need to be placed into master for the 5to7 gpupgrade, likely.