### PR TITLE
test/migration_scripts: prevent rsyncs to/from root

### DIFF
--- a/test/migration_scripts.bats
+++ b/test/migration_scripts.bats
@@ -65,7 +65,10 @@ backup_source_cluster() {
     datadir_root="$(realpath "$MASTER_DATA_DIRECTORY"/../..)"
 
     gpstop -af
-    rsync --archive "$datadir_root"/ "$backup_dir"/
+    # TODO: Find out why in some cases the variables used in rsync are empty/not-set
+    # which causes deletion of the the root directory. Once we have identified,
+    # do the necessary refactoring
+    rsync --archive "${datadir_root:?}"/ "${backup_dir:?}"/
     gpstart -a
 }
 
@@ -82,7 +85,10 @@ restore_source_cluster() {
     datadir_root="$(realpath "$MASTER_DATA_DIRECTORY"/../..)"
 
     stop_any_cluster
-    rsync --archive -I --delete "$backup_dir"/ "$datadir_root"/
+    # TODO: Find out why in some cases the variables used in rsync are empty/not-set
+    # which causes deletion of the the root directory. Once we have identified,
+    # do the necessary refactoring
+    rsync --archive -I --delete "${backup_dir:?}"/ "${datadir_root:?}"/
     gpstart -a
 }
 


### PR DESCRIPTION
We're hitting intermittent issues where `$datadir_root` is blank, which is causing `rsync` to destroy data. Although it's not yet clear why the existing checks aren't good enough -- perhaps `realpath` is failing intermittently -- add code to bail out, at point of call, if either variable is blank.