### PR TITLE
test/execute: sanitize directory removal

### DIFF
--- a/test/execute.bats
+++ b/test/execute.bats
@@ -133,7 +133,8 @@ ensure_hardlinks_for_relfilenode_on_master_and_segments() {
         --disk-free-ratio 0 \
         --verbose
 
-    local datadir="$(gpupgrade config show --target-datadir)"
+    local datadir
+    datadir="$(gpupgrade config show --target-datadir)"
     NEW_CLUSTER="${datadir}"
 
     # Initialize creates a backup of the target master data dir, during execute
@@ -141,7 +142,8 @@ ensure_hardlinks_for_relfilenode_on_master_and_segments() {
     # with the existing backup. Remove the target master data directory to
     # ensure that initialize created a backup and upgrade master refreshed the
     # target master data directory with the backup.
-    rm -rf "${datadir}"/*
+    abort_unless_target_master "${datadir}"
+    rm -rf "${datadir:?}"/*
 
     # create an extra file to ensure that its deleted during rsync as we pass
     # --delete flag

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -59,6 +59,17 @@ start_source_cluster() {
     isready || (source "$GPHOME_SOURCE"/greenplum_path.sh && "${GPHOME_SOURCE}"/bin/gpstart -a)
 }
 
+# Sanity check that the passed directory looks like a valid master data
+# directory for a target cluster. Intended to be called right before deleting
+# said directory.
+abort_unless_target_master() {
+    local dir=$1
+
+    local expected_suffix="*qddir/demoDataDir.*.-1"
+    [[ "$dir" == ${expected_suffix} ]] || \
+        abort "cowardly refusing to delete $dir which does not look like an upgraded demo data directory. Expected suffix ${expected_suffix}"
+}
+
 # delete_cluster takes an master data directory and calls gpdeletesystem, and
 # removes the associated data directories.
 delete_cluster() {
@@ -66,9 +77,7 @@ delete_cluster() {
     local masterdir="$2"
 
     # Perform a sanity check before deleting.
-    expected_suffix="*qddir/demoDataDir.*.-1"
-    [[ "$masterdir" == ${expected_suffix} ]] || \
-        abort "cowardly refusing to delete $masterdir which does not look like an upgraded demo data directory. Expected suffix ${expected_suffix}"
+    abort_unless_target_master "$masterdir"
 
     __gpdeletesystem "$gphome" "$masterdir"
 


### PR DESCRIPTION
Make sure the target master datadir really looks like a target master datadir before removal. Additionally apply some shellcheck recommended fixes to harden the implementation.