### PR TITLE
test: correctly return from run_teardowns

### DIFF
--- a/test/teardown_helpers.bash
+++ b/test/teardown_helpers.bash
@@ -23,7 +23,7 @@ register_teardown() {
 # Runs all teardown commands (registered via register_teardown) in LIFO order
 # and clears the list of teardowns.
 run_teardowns() {
-    _run "${TEARDOWN_FUNCTIONS[@]}"
+    _run "${TEARDOWN_FUNCTIONS[@]}" || return $?
 
     TEARDOWN_FUNCTIONS=()
 }
@@ -46,6 +46,6 @@ _run() {
         printf '\n'
 
         # Run.
-        "${cmd[@]}"
+        "${cmd[@]}" || return $?
     done
 }

--- a/test/teardown_helpers.bats
+++ b/test/teardown_helpers.bats
@@ -46,3 +46,13 @@ EOF
     run_teardowns
     (( ! was_run )) || fail "teardown was re-run incorrectly"
 }
+
+@test "teardown failures are reported even without set -e" {
+    local status=0
+
+    register_teardown false
+
+    # Chaining commands with || will disable set -e.
+    run_teardowns || status=$?
+    [ "$status" -eq 1 ] || fail "status was $status; expected 1"
+}


### PR DESCRIPTION
The teardown function in BATS runs without `set -e` protection. Explicitly return on failures.