### PR TITLE
greenplum_test: make use of MustCreateCluster

### DIFF
--- a/greenplum/cluster_test.go
+++ b/greenplum/cluster_test.go
@@ -79,11 +79,7 @@ func TestCluster(t *testing.T) {
 		t.Run(fmt.Sprintf("%s cluster", c.name), func(t *testing.T) {
 			segments := append(c.primaries, c.mirrors...)
 
-			actualCluster, err := greenplum.NewCluster(segments)
-			if err != nil {
-				t.Fatalf("returned error %+v", err)
-			}
-
+			actualCluster := greenplum.MustCreateCluster(t, segments)
 			actualContents := actualCluster.GetContentList()
 
 			var expectedContents []int
@@ -340,10 +336,7 @@ func TestSelectSegments(t *testing.T) {
 		{ContentID: 3, Role: "p"},
 		{ContentID: 3, Role: "m"},
 	}
-	cluster, err := greenplum.NewCluster(segs)
-	if err != nil {
-		t.Fatalf("creating test cluster: %+v", err)
-	}
+	cluster := greenplum.MustCreateCluster(t, segs)
 
 	// Ensure all segments are visited correctly.
 	selectAll := func(_ *greenplum.SegConfig) bool { return true }
@@ -376,10 +369,7 @@ func TestHasAllMirrorsAndStandby(t *testing.T) {
 			{ContentID: 2, Role: "p"},
 			{ContentID: 2, Role: "m"},
 		}
-		cluster, err := greenplum.NewCluster(segs)
-		if err != nil {
-			t.Fatalf("NewCluster returned error: %+v", err)
-		}
+		cluster := greenplum.MustCreateCluster(t, segs)
 
 		if !cluster.HasAllMirrorsAndStandby() {
 			t.Errorf("expected a cluster that has all mirrors and a standby")
@@ -434,15 +424,11 @@ func TestHasAllMirrorsAndStandby(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			cluster, err := greenplum.NewCluster(c.segs)
-			if err != nil {
-				t.Fatalf("NewCluster returned error: %+v", err)
-			}
+			cluster := greenplum.MustCreateCluster(t, c.segs)
 
 			if cluster.HasAllMirrorsAndStandby() {
 				t.Errorf("expected a cluster missing at least one mirror or its standby")
 			}
 		})
 	}
-
 }

--- a/greenplum/common_test.go
+++ b/greenplum/common_test.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package greenplum
+
+import "testing"
+
+// MustCreateCluster creates a utils.Cluster and calls t.Fatalf() if there is
+// any error.
+//
+// TODO: Consolidate with the same function in common_test.go in the hub
+// package. This is tricky due to cycle imports and other issues.
+func MustCreateCluster(t *testing.T, segs []SegConfig) *Cluster {
+	t.Helper()
+
+	cluster, err := NewCluster(segs)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	return cluster
+}

--- a/greenplum/start_or_stop_cluster_test.go
+++ b/greenplum/start_or_stop_cluster_test.go
@@ -44,21 +44,6 @@ func init() {
 	)
 }
 
-// TODO: Consolidate with the same function in common_test.go in the
-//  hub package. This is tricky due to cycle imports and other issues.
-// MustCreateCluster creates a utils.Cluster and calls t.Fatalf() if there is
-// any error.
-func MustCreateCluster(t *testing.T, segs []SegConfig) *Cluster {
-	t.Helper()
-
-	cluster, err := NewCluster(segs)
-	if err != nil {
-		t.Fatalf("%+v", err)
-	}
-
-	return cluster
-}
-
 func TestStartOrStopCluster(t *testing.T) {
 	testhelper.SetupTestLogger() // initialize gplog
 


### PR DESCRIPTION
Move `MustCreateCluster()` to `greenplum/common_test.go` and use it consistently.

This is just a small cleanup that made some other refactoring easier for me.