### PR TITLE
test/teardown_helpers: increase test coverage

### DIFF
--- a/test/teardown_helpers.bats
+++ b/test/teardown_helpers.bats
@@ -56,3 +56,14 @@ EOF
     run_teardowns || status=$?
     [ "$status" -eq 1 ] || fail "status was $status; expected 1"
 }
+
+@test "teardown failures fail fast even without set -e" {
+    local was_run=0
+
+    register_teardown eval was_run=1  # runs last
+    register_teardown false           # runs first
+
+    run_teardowns || true # disable set -e
+
+    (( ! was_run )) || fail "second teardown was run unexpectedly"
+}


### PR DESCRIPTION
Ensure that teardowns stop running on the first failure, even without `set -e` in use. This was guaranteed by the current implementation, but it wasn't pinned behavior.