### PR TITLE
test/finalize: move to teardown infrastructure

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -59,6 +59,15 @@ start_source_cluster() {
     isready || (source "$GPHOME_SOURCE"/greenplum_path.sh && "${GPHOME_SOURCE}"/bin/gpstart -a)
 }
 
+# stop_any_cluster will attempt to stop the cluster defined by MASTER_DATA_DIRECTORY.
+stop_any_cluster() {
+    local gphome
+    gphome=$(awk '{ split($0, parts, "/bin/postgres"); print parts[1] }' "$MASTER_DATA_DIRECTORY"/postmaster.opts) \
+        || return $?
+
+    (source "$gphome"/greenplum_path.sh && gpstop -af) || return $?
+}
+
 # Sanity check that the passed directory looks like a valid master data
 # directory for a target cluster. Intended to be called right before deleting
 # said directory.

--- a/test/migration_scripts.bats
+++ b/test/migration_scripts.bats
@@ -92,14 +92,6 @@ restore_source_cluster() {
     gpstart -a
 }
 
-# stop_any_cluster will attempt to stop the cluster defined by MASTER_DATA_DIRECTORY.
-stop_any_cluster() {
-    local gphome
-    gphome=$(awk '{ split($0, parts, "/bin/postgres"); print parts[1] }' "$MASTER_DATA_DIRECTORY"/postmaster.opts)
-
-    (source "$gphome"/greenplum_path.sh && gpstop -af)
-}
-
 drop_unfixable_objects() {
     # the migration script should not remove primary / unique key constraints on partitioned tables, so
     # remove them manually by dropping the table as they can't be dropped.


### PR DESCRIPTION
The existing teardown logic was extremely difficult to follow. We already had the backup/restore pattern in use for `migration_scripts`, so co-opt it here (and improve it by moving to the new `teardown_helpers` API).