### PR TITLE
exectest: add standard success/failure Main implementations

### DIFF
--- a/testutils/exectest/mains.go
+++ b/testutils/exectest/mains.go
@@ -1,0 +1,19 @@
+package exectest
+
+import "os"
+
+// These are built-in Main implementations that seem to be common/useful to many
+// tests.
+
+// Success is a Main implementation that exits with a zero exit code.
+func Success() {}
+
+// Failure is a Main implementation that exits with an exit code of 1.
+func Failure() { os.Exit(1) }
+
+func init() {
+	RegisterMains(
+		Success,
+		Failure,
+	)
+}

--- a/testutils/exectest/mains_test.go
+++ b/testutils/exectest/mains_test.go
@@ -1,0 +1,40 @@
+package exectest_test
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+
+	. "github.com/greenplum-db/gpupgrade/testutils/exectest"
+)
+
+func TestBuiltinMains(t *testing.T) {
+	t.Run("Success()", func(t *testing.T) {
+		success := NewCommand(Success)("/unused/path")
+		err := success.Run()
+		if err != nil {
+			t.Errorf("exited with error %v", err)
+
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				t.Logf("subprocess stderr follows:\n%s", string(exitErr.Stderr))
+			}
+		}
+	})
+
+	t.Run("Failure()", func(t *testing.T) {
+		failure := NewCommand(Failure)("/unused/path")
+		err := failure.Run()
+		if err == nil {
+			t.Fatal("exited without an error")
+		}
+
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("got error %#v, want type %T", err, exitErr)
+		}
+		if exitErr.ExitCode() != 1 {
+			t.Errorf("exit code is %d, want %d", exitErr.ExitCode(), 1)
+		}
+	})
+}


### PR DESCRIPTION
Many of the current tests using `exectest` create just two `Main` implementations: one for success and one for failure. Since this pattern seems to be in wide use, pull it up into the `exectest` package itself, which now supplies two precreated `Main` implementations:

- `exectest.Success` exits with code 0
- `exectest.Failure` exits with code 1