### PR TITLE
revert: shut down target if it's up

### DIFF
--- a/greenplum/common.go
+++ b/greenplum/common.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package greenplum
+
+import "os/exec"
+
+// execCommand should be used instead of exec.Command in all package code, so
+// that the test framework can intercept external command invocations.
+var execCommand = exec.Command

--- a/greenplum/common_test.go
+++ b/greenplum/common_test.go
@@ -3,7 +3,24 @@
 
 package greenplum
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/greenplum-db/gpupgrade/testutils/exectest"
+)
+
+func init() {
+	// Make sure all tests explicitly set execCommand.
+	ResetExecCommand()
+}
+
+func SetExecCommand(cmdFunc exectest.Command) {
+	execCommand = cmdFunc
+}
+
+func ResetExecCommand() {
+	execCommand = nil
+}
 
 // MustCreateCluster creates a utils.Cluster and calls t.Fatalf() if there is
 // any error.

--- a/greenplum/version.go
+++ b/greenplum/version.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package greenplum
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/blang/semver"
+	"github.com/pkg/errors"
+)
+
+var ErrUnknownVersion = errors.New("unknown GPDB version")
+
+// GPHomeVersion returns the semantic version of a GPDB installation located at
+// the given GPHOME.
+func GPHomeVersion(gphome string) (semver.Version, error) {
+	postgres := filepath.Join(gphome, "bin", "postgres")
+	cmd := execCommand(postgres, "--gp-version")
+
+	cmd.Env = []string{} // explicitly clear the environment
+
+	stdout, err := cmd.Output()
+	if err != nil {
+		return semver.Version{}, err
+	}
+
+	version := string(stdout)
+	return parseGPVersion(version)
+}
+
+// parseGPVersion takes the output from `postgres --gp-version` and returns the
+// parsed dotted-triple semantic version.
+func parseGPVersion(gpversion string) (semver.Version, error) {
+	// XXX The following logic is based on dbconn.InitializeVersion, in an
+	// attempt to minimize implementation differences between this and the
+	// version that is parsed from a live cluster. We can't use that logic
+	// as-is, unfortunately, because the version string formats aren't the same
+	// for the two cases:
+	//
+	//     postgres=# select version();
+	//
+	//                               version
+	//     -----------------------------------------------------------
+	//      PostgreSQL 8.3.23 (Greenplum Database 5.0.0 build dev) ...
+	//     (1 row)
+	//
+	// versus
+	//
+	//     $ ${GPHOME}/bin/postgres --gp-version
+	//     postgres (Greenplum Database) 5.0.0 build dev
+	//
+	// Consolidate once the dependency on dbconn is removed from the codebase.
+	const marker = "(Greenplum Database)"
+
+	// Remove everything up to and including the marker.
+	markerStart := strings.Index(gpversion, marker)
+	if markerStart < 0 {
+		return semver.Version{}, &unknownVersionError{gpversion}
+	}
+
+	versionStart := markerStart + len(marker)
+	version := gpversion[versionStart:]
+
+	// Find the dotted triple.
+	pattern := regexp.MustCompile(`\d+\.\d+\.\d+`)
+	matches := pattern.FindStringSubmatch(version)
+
+	if len(matches) < 1 {
+		return semver.Version{}, &unknownVersionError{gpversion}
+	}
+
+	return semver.Parse(matches[0])
+}
+
+// unknownVersionError is returned when parseGPVersion fails. It's an instance
+// of ErrUnknownVersion.
+type unknownVersionError struct {
+	input string
+}
+
+func (u *unknownVersionError) Error() string {
+	return fmt.Sprintf("could not find GPDB version in %q", u.input)
+}
+
+func (u *unknownVersionError) Is(err error) bool {
+	return err == ErrUnknownVersion
+}

--- a/greenplum/version_test.go
+++ b/greenplum/version_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package greenplum
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver"
+
+	"github.com/greenplum-db/gpupgrade/testutils/exectest"
+)
+
+func PostgresGPVersion_5_27_0_beta() {
+	fmt.Println("postgres (Greenplum Database) 5.27.0+beta.4 build commit:baef9b9ba885f2f4e4a87d5e201caae969ef4401")
+}
+
+func PostgresGPVersion_6_dev() {
+	fmt.Println("postgres (Greenplum Database) 6.0.0-beta.1 build dev")
+}
+
+func PostgresGPVersion_6_7_1() {
+	fmt.Println("postgres (Greenplum Database) 6.7.1 build commit:a21de286045072d8d1df64fa48752b7dfac8c1b7")
+}
+
+func PostgresGPVersion_11_341_31() {
+	fmt.Println("postgres (Greenplum Database) 11.341.31 build commit:a21de286045072d8d1df64fa48752b7dfac8c1b7")
+}
+
+func init() {
+	exectest.RegisterMains(
+		PostgresGPVersion_5_27_0_beta,
+		PostgresGPVersion_6_dev,
+		PostgresGPVersion_6_7_1,
+		PostgresGPVersion_11_341_31,
+	)
+}
+
+func TestGPHomeVersion(t *testing.T) {
+	const gphome = "/usr/local/my-gpdb-home"
+	postgresPath := filepath.Join(gphome, "bin", "postgres")
+
+	// Common verifier for all tests' calls to postgres.
+	verifier := func(t *testing.T) func(string, ...string) {
+		return func(executable string, args ...string) {
+			if executable != postgresPath {
+				t.Errorf("called %q, want %q", executable, postgresPath)
+			}
+
+			expected := []string{"--gp-version"}
+			if !reflect.DeepEqual(args, expected) {
+				t.Errorf("args were %q, want %q", args, expected)
+			}
+		}
+	}
+
+	cases := []struct {
+		name     string
+		execMain exectest.Main // the postgres Main implementation to run
+		expected string        // the expected semantic version; e.g. "5.1.14"
+	}{
+		{"handles development versions", PostgresGPVersion_6_dev, "6.0.0"},
+		{"handles beta versions", PostgresGPVersion_5_27_0_beta, "5.27.0"},
+		{"handles release versions", PostgresGPVersion_6_7_1, "6.7.1"},
+		{"handles large versions", PostgresGPVersion_11_341_31, "11.341.31"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			execCmd := exectest.NewCommandWithVerifier(c.execMain, verifier(t))
+
+			SetExecCommand(execCmd)
+			defer ResetExecCommand()
+
+			version, err := GPHomeVersion(gphome)
+			if err != nil {
+				t.Errorf("returned error: %+v", err)
+			}
+
+			expected := semver.MustParse(c.expected)
+			if !version.Equals(expected) {
+				t.Errorf("got version %v, want %v", version, expected)
+			}
+		})
+	}
+
+	formatErrorCases := []struct {
+		name    string
+		version string
+	}{
+		{"empty string", ""},
+		{"only a marker", "(Greenplum Database)"},
+	}
+
+	for _, c := range formatErrorCases {
+		t.Run(fmt.Sprintf("returns error with %s as input", c.name), func(t *testing.T) {
+			_, err := parseGPVersion(c.version)
+			if !errors.Is(err, ErrUnknownVersion) {
+				t.Fatalf("returned error %+v, want %+v", err, ErrUnknownVersion)
+			}
+
+			// The input should be reflected in any errors, for debugging.
+			if !strings.Contains(err.Error(), c.version) {
+				t.Errorf("Error() = %q, want it to contain %q", err.Error(), c.version)
+			}
+		})
+	}
+
+	t.Run("bubbles up postgres execution failures", func(t *testing.T) {
+		execCmd := exectest.NewCommandWithVerifier(exectest.Failure, verifier(t))
+
+		SetExecCommand(execCmd)
+		defer ResetExecCommand()
+
+		_, err := GPHomeVersion(gphome)
+
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Errorf("returned error %#v, want type %T", err, exitErr)
+		}
+	})
+}

--- a/hub/config.go
+++ b/hub/config.go
@@ -19,11 +19,15 @@ func (s *Server) GetConfig(ctx context.Context, in *idl.GetConfigRequest) (*idl.
 	case "id":
 		resp.Value = s.UpgradeID.String()
 	case "source-gphome":
-		resp.Value = s.Source.GPHome
+		if s.Source != nil {
+			resp.Value = s.Source.GPHome
+		}
 	case "target-gphome":
-		resp.Value = s.Target.GPHome
+		resp.Value = s.TargetGPHome
 	case "target-datadir":
-		resp.Value = s.Target.MasterDataDir()
+		if s.Target != nil {
+			resp.Value = s.Target.MasterDataDir()
+		}
 	default:
 		return nil, status.Errorf(codes.NotFound, "%s is not a valid configuration key", in.Name)
 	}

--- a/hub/fill_cluster_configs.go
+++ b/hub/fill_cluster_configs.go
@@ -20,8 +20,10 @@ import (
 	"github.com/greenplum-db/gpupgrade/utils"
 )
 
-// create source/target clusters, write to disk and re-read from disk to make sure it is "durable"
-func FillClusterConfigsSubStep(config *Config, conn *sql.DB, _ step.OutStreams, request *idl.InitializeRequest, saveConfig func() error) error {
+// FillConfiguration populates as much of the passed Config as possible, given a
+// connection to the source cluster and the settings contained in an
+// InitializeRequest from the client. The configuration is then saved to disk.
+func FillConfiguration(config *Config, conn *sql.DB, _ step.OutStreams, request *idl.InitializeRequest, saveConfig func() error) error {
 	config.AgentPort = int(request.AgentPort)
 
 	// Assign a new universal upgrade identifier.
@@ -40,7 +42,7 @@ func FillClusterConfigsSubStep(config *Config, conn *sql.DB, _ step.OutStreams, 
 	}
 
 	config.Source = source
-	config.Target = &greenplum.Cluster{GPHome: request.TargetGPHome}
+	config.TargetGPHome = request.TargetGPHome
 	config.UseLinkMode = request.UseLinkMode
 
 	var ports []int

--- a/hub/init_target_cluster_test.go
+++ b/hub/init_target_cluster_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
-	"github.com/greenplum-db/gp-common-go-libs/dbconn"
+	"github.com/blang/semver"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"golang.org/x/xerrors"
 
@@ -149,15 +149,11 @@ func TestWriteSegmentArray(t *testing.T) {
 }
 
 func TestRunInitsystemForTargetCluster(t *testing.T) {
-	cluster6X := &greenplum.Cluster{
-		GPHome:  "/usr/local/gpdb6",
-		Version: dbconn.NewVersion("6.0.0"),
-	}
+	gpHome6 := "/usr/local/gpdb6"
+	version6 := semver.MustParse("6.0.0")
 
-	cluster7X := &greenplum.Cluster{
-		GPHome:  "/usr/local/gpdb7",
-		Version: dbconn.NewVersion("7.0.0"),
-	}
+	gpHome7 := "/usr/local/gpdb7"
+	version7 := semver.MustParse("7.0.0")
 
 	gpinitsystemConfigPath := "/dir/.gpupgrade/gpinitsystem_config"
 
@@ -180,7 +176,7 @@ func TestRunInitsystemForTargetCluster(t *testing.T) {
 				}
 			})
 
-		err := RunInitsystemForTargetCluster(step.DevNullStream, cluster7X, gpinitsystemConfigPath)
+		err := RunInitsystemForTargetCluster(step.DevNullStream, gpHome7, gpinitsystemConfigPath, version7)
 		if err != nil {
 			t.Error("gpinitsystem failed")
 		}
@@ -200,7 +196,7 @@ func TestRunInitsystemForTargetCluster(t *testing.T) {
 				}
 			})
 
-		err := RunInitsystemForTargetCluster(step.DevNullStream, cluster6X, gpinitsystemConfigPath)
+		err := RunInitsystemForTargetCluster(step.DevNullStream, gpHome6, gpinitsystemConfigPath, version6)
 		if err != nil {
 			t.Error("gpinitsystem failed")
 		}
@@ -209,7 +205,7 @@ func TestRunInitsystemForTargetCluster(t *testing.T) {
 	t.Run("returns an error when gpinitsystem fails with --ignore-warnings when upgrading to GPDB6", func(t *testing.T) {
 		execCommand = exectest.NewCommand(gpinitsystem_Exits1)
 
-		err := RunInitsystemForTargetCluster(step.DevNullStream, cluster6X, gpinitsystemConfigPath)
+		err := RunInitsystemForTargetCluster(step.DevNullStream, gpHome6, gpinitsystemConfigPath, version6)
 
 		var actual *exec.ExitError
 		if !xerrors.As(err, &actual) {
@@ -224,7 +220,7 @@ func TestRunInitsystemForTargetCluster(t *testing.T) {
 	t.Run("returns an error when gpinitsystem errors when upgrading to GPDB7 or higher", func(t *testing.T) {
 		execCommand = exectest.NewCommand(gpinitsystem_Exits1)
 
-		err := RunInitsystemForTargetCluster(step.DevNullStream, cluster7X, gpinitsystemConfigPath)
+		err := RunInitsystemForTargetCluster(step.DevNullStream, gpHome7, gpinitsystemConfigPath, version7)
 
 		var actual *exec.ExitError
 		if !xerrors.As(err, &actual) {

--- a/hub/initialize.go
+++ b/hub/initialize.go
@@ -46,7 +46,7 @@ func (s *Server) Initialize(in *idl.InitializeRequest, stream idl.CliToHub_Initi
 			}
 		}()
 
-		return FillClusterConfigsSubStep(s.Config, conn, stream, in, s.SaveConfig)
+		return FillConfiguration(s.Config, conn, stream, in, s.SaveConfig)
 	})
 
 	st.Run(idl.Substep_START_AGENTS, func(_ step.OutStreams) error {

--- a/hub/server.go
+++ b/hub/server.go
@@ -350,17 +350,24 @@ type InitializeConfig struct {
 // Config contains all the information that will be persisted to/loaded from
 // from disk during calls to Save() and Load().
 type Config struct {
+	// Source is the GPDB cluster that is being upgraded. It is populated during
+	// the generation of the cluster config in the initialize step; before that,
+	// it is nil.
 	Source *greenplum.Cluster
+
+	// Target is the upgraded GPDB cluster. It is populated during the target
+	// gpinitsystem execution in the initialize step; before that, it is nil.
 	Target *greenplum.Cluster
 
 	// TargetInitializeConfig contains all the info needed to initialize the
 	// target cluster's master, standby, primaries and mirrors.
 	TargetInitializeConfig InitializeConfig
 
-	Port        int
-	AgentPort   int
-	UseLinkMode bool
-	UpgradeID   upgrade.ID
+	Port         int
+	AgentPort    int
+	UseLinkMode  bool
+	TargetGPHome string
+	UpgradeID    upgrade.ID
 
 	// Tablespaces contains the tablespace in the database keyed by
 	// dbid and tablespace oid

--- a/hub/server_internal_test.go
+++ b/hub/server_internal_test.go
@@ -30,6 +30,7 @@ func TestConfig(t *testing.T) {
 			12345,           // Port
 			54321,           // AgentPort
 			false,           // UseLinkMode
+			target.GPHome,   // TargetGPHome
 			upgrade.NewID(), // UpgradeID
 			map[int]greenplum.SegmentTablespaces{
 				1: {1663: {


### PR DESCRIPTION
~_This changeset is dependent on #414 (the first commit)._~ Merged and rebased.

This PR implements the first "revert fact":
> If the target cluster is started, it must be stopped.

The following TODO first had to be addressed, which takes up the first two commits in the patchset:

    // TODO: This will fail if the target does not exist which can occur when
    //  initialize fails part way through and does not create the target cluster.

`s.Target` is now non-`nil` only after the target cluster's gpinitsystem completes. Since previous code incorrectly made use of `s.Target` before it was valid, to get the cluster's version and `GPHOME`, a top-level config field has been added to store the value of `--target-gphome`, and a `greenplum` package helper has been added to retrieve the version of the cluster installed at `$GPHOME`.

Once that's out of the way, the final commit switches the shutdown logic to `step.AlwaysRun` as long as `s.Target != nil`.