### PR TITLE
Use Initalize config to identify what directories to delete

### DIFF
--- a/greenplum/segconfig.go
+++ b/greenplum/segconfig.go
@@ -17,6 +17,8 @@ type SegConfig struct {
 	Role      string
 }
 
+type SegConfigs []SegConfig
+
 const (
 	PrimaryRole = "p"
 	MirrorRole  = "m"
@@ -83,4 +85,19 @@ func MustGetSegmentConfiguration(connection *dbconn.DBConn) []SegConfig {
 	segConfigs, err := GetSegmentConfiguration(connection)
 	gplog.FatalOnError(err)
 	return segConfigs
+}
+
+// SelectSegmentConfigs returns a list of all segments that match the given selector
+// function. Segments are visited in order of ascending content ID (primaries
+// before mirrors).
+func (s SegConfigs) Select(selector func(*SegConfig) bool) SegConfigs {
+	var matches SegConfigs
+
+	for _, seg := range s {
+		if selector(&seg) {
+			matches = append(matches, seg)
+		}
+	}
+
+	return matches
 }

--- a/greenplum/segconfig_test.go
+++ b/greenplum/segconfig_test.go
@@ -1,0 +1,35 @@
+package greenplum_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/greenplum-db/gpupgrade/greenplum"
+)
+
+func TestSelect(t *testing.T) {
+	segs := greenplum.SegConfigs{
+		{ContentID: 1, Role: "p"},
+		{ContentID: 2, Role: "p"},
+		{ContentID: 3, Role: "p"},
+		{ContentID: 3, Role: "m"},
+	}
+
+	// Ensure all segments are visited correctly.
+	selectAll := func(_ *greenplum.SegConfig) bool { return true }
+	results := segs.Select(selectAll)
+
+	if !reflect.DeepEqual(results, segs) {
+		t.Errorf("SelectSegments(*) = %+v, want %+v", results, segs)
+	}
+
+	// Test a simple selector.
+	moreThanOne := func(c *greenplum.SegConfig) bool { return c.ContentID > 1 }
+	results = segs.Select(moreThanOne)
+
+	expected := greenplum.SegConfigs{segs[1], segs[2], segs[3]}
+	if !reflect.DeepEqual(results, expected) {
+		t.Errorf("SelectSegments(ContentID > 1) = %+v, want %+v", results, expected)
+	}
+
+}

--- a/hub/revert.go
+++ b/hub/revert.go
@@ -73,13 +73,15 @@ func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) 
 		})
 	}
 
-	if len(s.Config.Target.Primaries) > 0 {
+	if s.TargetInitializeConfig.Primaries != nil {
 		st.Run(idl.Substep_DELETE_PRIMARY_DATADIRS, func(_ step.OutStreams) error {
-			return DeletePrimaryDataDirectories(s.agentConns, s.Config.Target)
+			return DeletePrimaryDataDirectories(s.agentConns, s.TargetInitializeConfig.Primaries)
 		})
+	}
 
+	if s.TargetInitializeConfig.Master.DataDir != "" {
 		st.Run(idl.Substep_DELETE_MASTER_DATADIR, func(streams step.OutStreams) error {
-			datadir := s.Config.Target.MasterDataDir()
+			datadir := s.TargetInitializeConfig.Master.DataDir
 			return upgrade.DeleteDirectories([]string{datadir}, upgrade.PostgresFiles, streams)
 		})
 	}


### PR DESCRIPTION
Revert may be executed even before the target cluster is created, so
it's better to rely on Initialize Config. This allows for cleanup of the
target cluster directories which could be a left over from a failed init
cluster during initialize