### PR TITLE
Migration scripts name columns

### DIFF
--- a/migration_scripts/execute_migration_sql.bash
+++ b/migration_scripts/execute_migration_sql.bash
@@ -26,9 +26,9 @@ main(){
     fi
 
     for file in ${files[*]}; do
-        local cmd="${GPHOME}/bin/psql -d postgres -p ${PGPORT} -f ${file}"
+        local cmd="${GPHOME}/bin/psql -d postgres -p ${PGPORT} -f ${file} --echo-queries --quiet"
         echo "Executing command: ${cmd}" | tee -a "$log_file"
-        ${cmd} | tee -a "$log_file"
+        ${cmd} 2>&1 | tee -a "$log_file"
     done
 
     echo "Check log file for execution details: $log_file"

--- a/migration_scripts/generate_migration_sql.bash
+++ b/migration_scripts/generate_migration_sql.bash
@@ -38,11 +38,12 @@ exec_script(){
     fi
 
     if [[ -n "$records" ]]; then
+        # change database before header, to allow header to define SQL functions
+        echo "\c $database" >> "${output_dir}/${output_file}"
         header_file=$(echo "${path/.sql/.header}")
         if [[ -f $header_file ]]; then
             cat $header_file >> "${output_dir}/${output_file}"
         fi
-        echo "\c $database" >> "${output_dir}/${output_file}"
         echo "$records" >> "${output_dir}/${output_file}"
     fi
 }

--- a/migration_scripts/post-revert/recreate_gphdfs_external_tables.sh
+++ b/migration_scripts/post-revert/recreate_gphdfs_external_tables.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 #
 # Copyright (c) 2017-2020 VMware, Inc. or its affiliates
 # SPDX-License-Identifier: Apache-2.0

--- a/migration_scripts/pre-upgrade/gen_alter_name_type_columns.header
+++ b/migration_scripts/pre-upgrade/gen_alter_name_type_columns.header
@@ -1,0 +1,19 @@
+-- The below SQL alters, where possible, the name data type to varchar(63)
+-- in columns other than the first.  For a partition table, SQL is only generated
+-- for root partitions as that cascades to the child partitions. Where not possible,
+-- a message is logged, and such tables must be manually modified to remove the name
+-- data type prior to running gpugprade.
+
+\set VERBOSITY terse
+
+\unset ECHO
+CREATE OR REPLACE FUNCTION pg_temp.notsupported(text) RETURNS VOID AS $$
+BEGIN
+    RAISE WARNING '---------------------------------------------------------------------------------';
+    RAISE WARNING 'Removing the name datatype column failed on table ''%''.  You must resolve it manually.',$1;
+    RAISE WARNING '---------------------------------------------------------------------------------';
+END
+$$ LANGUAGE plpgsql;
+\set ECHO queries
+
+

--- a/migration_scripts/pre-upgrade/gen_alter_name_type_columns.sql
+++ b/migration_scripts/pre-upgrade/gen_alter_name_type_columns.sql
@@ -1,0 +1,48 @@
+-- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Portions Copyright © 1996-2020, The PostgreSQL Global Development Group
+--
+-- Portions Copyright © 1994, The Regents of the University of California
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice
+-- and this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+-- BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+-- A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS,
+-- AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE,
+-- SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+-- generate ALTER TABLE ALTER COLUMN commands for tables with name datatype attributes
+-- The DDL command to alter the name datatype is executed on root partitions and
+-- non-partitioned tables. The ALTER command executed on root partitions cascades
+-- to child partitions, and thus are excluded here.
+SELECT 'DO $$ BEGIN ALTER TABLE ' || c.oid::pg_catalog.regclass ||
+       ' ALTER COLUMN ' || pg_catalog.quote_ident(a.attname) ||
+       ' TYPE VARCHAR(63); EXCEPTION WHEN feature_not_supported THEN PERFORM pg_temp.notsupported(''' || c.oid::pg_catalog.regclass || '''); END $$;'
+FROM pg_catalog.pg_class c,
+     pg_catalog.pg_namespace n,
+     pg_catalog.pg_attribute a
+WHERE c.oid = a.attrelid
+  AND a.attnum > 1
+  AND NOT a.attisdropped
+  AND a.atttypid = 'pg_catalog.name'::pg_catalog.regtype
+  AND c.relnamespace = n.oid
+  AND -- exclude possible orphaned temp tables
+        n.nspname !~ '^pg_temp_'
+  AND n.nspname !~ '^pg_toast_temp_'
+  AND n.nspname NOT IN ('pg_catalog',
+                        'information_schema',
+                        'gp_toolkit')
+  AND c.oid NOT IN
+      (SELECT DISTINCT parchildrelid
+       FROM pg_catalog.pg_partition_rule);

--- a/migration_scripts/test/create_nonupgradable_objects.sql
+++ b/migration_scripts/test/create_nonupgradable_objects.sql
@@ -101,3 +101,16 @@ CREATE EXTERNAL TABLE ext_gphdfs (name text)
 CREATE EXTERNAL TABLE "ext gphdfs" (name text) -- whitespace in the name
 	LOCATION ('gphdfs://example.com/data/filename.txt')
 	FORMAT 'TEXT' (DELIMITER '|');
+
+-- create name datatype attributes as the not-first column
+DROP TABLE IF EXISTS table_with_name_as_second_column;
+CREATE TABLE table_with_name_as_second_column (a int, "first last" name);
+INSERT INTO table_with_name_as_second_column VALUES(1, 'George Washington');
+INSERT INTO table_with_name_as_second_column VALUES(1, 'Henry Ford');
+-- create partition table with name datatype attribute as the not-first column as the partition key
+DROP TABLE IF EXISTS partition_table_partitioned_by_name_type;
+CREATE TABLE partition_table_partitioned_by_name_type(a int, b name) PARTITION BY RANGE (b) (START('a') END('z'));
+-- create table with name datatype attribute as the not-first column as the distribution key
+DROP TABLE IF EXISTS table_distributed_by_name_type;
+CREATE TABLE table_distributed_by_name_type(a int, b name) DISTRIBUTED BY (b);
+INSERT INTO table_distributed_by_name_type VALUES (1,'z'),(2,'x');


### PR DESCRIPTION
migration_scripts: handle name type columns

We need to handle name type columns that are not in the first column.

Our solution runs this in pre-upgrade:

ALTER TABLE table ALTER COLUMN col TYPE varchar(63)

on all non-(child partition) tables for which col is originally of
name type.

Unfortunately, there are documented and undocumented cases where this
ALTER COLUMN fails.  So we print out to the executing log to inform
the user that they must manually update those tables.

For post-revert, we do nothing now as we do not want to track which
tables the user might have manually migrated.

For post-upgrade, we do nothing now as the name type should not be
used in user tables.

Example:
If you run our test code, you will see this in the log output:

```
DO $$ BEGIN ALTER TABLE partition_table_partitioned_by_name_type ALTER COLUMN b TYPE VARCHAR(63); EXCEPTION WHEN feature_not_supported THEN PERFORM pg_temp.notsupported('partition_table_partitioned_by_name_type'); END $$;
psql:erase/pre-upgrade/migration_postgres_gen_alter_name_type_columns.sql:21: WARNING:  ---------------------------------------------------------------------------------
psql:erase/pre-upgrade/migration_postgres_gen_alter_name_type_columns.sql:21: WARNING:  Removing the name-type column failed on table 'partition_table_partitioned_by_name_type'.  You must resolve it manually.
psql:erase/pre-upgrade/migration_postgres_gen_alter_name_type_columns.sql:21: WARNING:  ---------------------------------------------------------------------------------
DO $$ BEGIN ALTER TABLE table_distributed_by_name_type ALTER COLUMN b TYPE VARCHAR(63); EXCEPTION WHEN feature_not_supported THEN PERFORM pg_temp.notsupported('table_distributed_by_name_type'); END $$;
psql:erase/pre-upgrade/migration_postgres_gen_alter_name_type_columns.sql:22: WARNING:  ---------------------------------------------------------------------------------
psql:erase/pre-upgrade/migration_postgres_gen_alter_name_type_columns.sql:22: WARNING:  Removing the name-type column failed on table 'table_distributed_by_name_type'.  You must resolve it manually.
psql:erase/pre-upgrade/migration_postgres_gen_alter_name_type_columns.sql:22: WARNING:  --------
```