### PR TITLE
go.mod: make use of pgx explicit

### DIFF
--- a/cmd/gpupgrade/main.go
+++ b/cmd/gpupgrade/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	_ "github.com/jackc/pgx" // pgx is used directly in the hub via its global state
 	_ "github.com/lib/pq"
 
 	"github.com/greenplum-db/gpupgrade/cli"

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/renameio v0.1.0
 	github.com/greenplum-db/gp-common-go-libs v1.0.4
 	github.com/hashicorp/go-multierror v1.0.0
-	github.com/jackc/pgx v3.2.0+incompatible // indirect
+	github.com/jackc/pgx v3.2.0+incompatible
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/lib/pq v1.3.0
 	github.com/onsi/gomega v1.7.1


### PR DESCRIPTION
We use the pgx module directly in our code as well as indirectly via
go-common-libs(as told by "go mod why github.com/jackc/pgx").  However
the current go.mod file lists pgx as an indirect dependency.

Include a direct import of pgx in the correct place, which for us is
the main function of the hub.

Co-authored-by: Jacob Champion <pchampion@vmware.com>