### PR TITLE
go.mod: use context from the official go repo, not from net

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1 // indirect
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
-	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	golang.org/x/sys v0.0.0-20191010194322-b09406accb47
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 	google.golang.org/grpc v1.24.0

--- a/hub/config.go
+++ b/hub/config.go
@@ -4,12 +4,12 @@
 package hub
 
 import (
+	"context"
+
 	"github.com/greenplum-db/gpupgrade/idl"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"golang.org/x/net/context"
 )
 
 func (s *Server) GetConfig(ctx context.Context, in *idl.GetConfigRequest) (*idl.GetConfigReply, error) {

--- a/hub/delete_data_directories.go
+++ b/hub/delete_data_directories.go
@@ -4,10 +4,10 @@
 package hub
 
 import (
+	"context"
 	"sync"
 
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/net/context"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/idl"

--- a/hub/hub_start_services_test.go
+++ b/hub/hub_start_services_test.go
@@ -4,6 +4,7 @@
 package hub_test
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
@@ -16,7 +17,6 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/net/context"
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"


### PR DESCRIPTION
Co-authored-by: Jacob Champion <pchampion@vmware.com>