### PR TITLE
migrate from xerrors to errors in tests

### DIFF
--- a/agent/archive_log_directory_test.go
+++ b/agent/archive_log_directory_test.go
@@ -5,6 +5,7 @@ package agent_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"os/user"
@@ -14,7 +15,6 @@ import (
 	"github.com/greenplum-db/gpupgrade/testutils"
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -33,7 +33,7 @@ func TestArchiveLogDirectories(t *testing.T) {
 			t.Errorf("expected error")
 		}
 		var exitError *exec.ExitError
-		if !xerrors.As(err, &exitError) {
+		if !errors.As(err, &exitError) {
 			t.Errorf("got %T, want %T", err, exitError)
 		}
 	})

--- a/agent/delete_directories_test.go
+++ b/agent/delete_directories_test.go
@@ -9,8 +9,6 @@ import (
 	"reflect"
 	"testing"
 
-	"golang.org/x/xerrors"
-
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 
 	"github.com/greenplum-db/gpupgrade/agent"
@@ -62,7 +60,7 @@ func TestDeleteDataDirectories(t *testing.T) {
 		server := agent.NewServer(agent.Config{})
 		req := &idl.DeleteDataDirectoriesRequest{}
 		_, err := server.DeleteDataDirectories(context.Background(), req)
-		if !xerrors.Is(err, expected) {
+		if !errors.Is(err, expected) {
 			t.Errorf("got error %#v, want %#v", expected, err)
 		}
 	})
@@ -110,7 +108,7 @@ func TestDeleteStateDirectory(t *testing.T) {
 		server := agent.NewServer(agent.Config{})
 		req := &idl.DeleteStateDirectoryRequest{}
 		_, err := server.DeleteStateDirectory(context.Background(), req)
-		if !xerrors.Is(err, expected) {
+		if !errors.Is(err, expected) {
 			t.Errorf("got error %#v, want %#v", expected, err)
 		}
 	})

--- a/agent/rename_directories_test.go
+++ b/agent/rename_directories_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -28,11 +27,11 @@ func TestRenameDirectories(t *testing.T) {
 
 		_, err := server.RenameDirectories(context.Background(), &idl.RenameDirectoriesRequest{Dirs: []*idl.RenameDirectories{{}}})
 		var merr *multierror.Error
-		if !xerrors.As(err, &merr) {
+		if !errors.As(err, &merr) {
 			t.Fatalf("returned %#v, want error type %T", err, merr)
 		}
 		for _, err := range merr.Errors {
-			if !xerrors.Is(err, expected) {
+			if !errors.Is(err, expected) {
 				t.Errorf("returned error %#v, want %#v", err, expected)
 			}
 		}

--- a/agent/upgrade_primaries_test.go
+++ b/agent/upgrade_primaries_test.go
@@ -4,14 +4,13 @@
 package agent_test
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"sort"
 	"strings"
 	"testing"
-
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
@@ -162,7 +161,7 @@ func TestUpgradePrimary(t *testing.T) {
 		// We expect each part of the request to return its own ExitError,
 		// containing the expected message from FailedRsync.
 		var multiErr *multierror.Error
-		if !xerrors.As(err, &multiErr) {
+		if !errors.As(err, &multiErr) {
 			t.Fatalf("got error %#v, want type %T", err, multiErr)
 		}
 

--- a/agent/upgrade_primary_test.go
+++ b/agent/upgrade_primary_test.go
@@ -4,13 +4,11 @@
 package agent_test
 
 import (
+	"errors"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/pkg/errors"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -202,7 +200,7 @@ func TestReCreateSymLink(t *testing.T) {
 			t.Errorf("got nil, want %+v", os.ErrPermission)
 		}
 
-		if !xerrors.Is(err, os.ErrPermission) {
+		if !errors.Is(err, os.ErrPermission) {
 			t.Errorf("expected error %#v to contain %#v", err, os.ErrPermission)
 		}
 	})
@@ -227,7 +225,7 @@ func TestReCreateSymLink(t *testing.T) {
 			t.Errorf("expected Lstat() to be called")
 		}
 
-		if os.ErrPermission != xerrors.Unwrap(err) {
+		if os.ErrPermission != errors.Unwrap(err) {
 			t.Errorf("got %q, want %q", err.Error(), os.ErrPermission)
 		}
 

--- a/cli/commanders/checks_test.go
+++ b/cli/commanders/checks_test.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/xerrors"
-
 	"github.com/greenplum-db/gpupgrade/cli/commanders"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
@@ -125,13 +123,13 @@ func TestDiskSpaceCheck(t *testing.T) {
 			expectedStatus := idl.Status_FAILED
 			switch {
 			case c.grpcErr != nil:
-				if !xerrors.Is(err, c.grpcErr) {
+				if !errors.Is(err, c.grpcErr) {
 					t.Errorf("returned error %#v, want %#v", err, c.grpcErr)
 				}
 
 			case len(c.failed) != 0:
 				var diskSpaceError commanders.DiskSpaceError
-				if !xerrors.As(err, &diskSpaceError) {
+				if !errors.As(err, &diskSpaceError) {
 					t.Errorf("returned error %#v, want a DiskSpaceError", err)
 				} else if !reflect.DeepEqual(diskSpaceError.Failed, c.failed) {
 					t.Errorf("error contents were %v, want %v", diskSpaceError.Failed, c.failed)

--- a/cli/commanders/initialize_test.go
+++ b/cli/commanders/initialize_test.go
@@ -4,6 +4,7 @@
 package commanders
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -11,8 +12,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
-
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
 	"github.com/greenplum-db/gpupgrade/upgrade"
@@ -101,7 +100,7 @@ func TestIsHubRunning_ErrorsWhenCheckFails(t *testing.T) {
 	execCommandHubCount = exectest.NewCommand(IsHubRunning_Error)
 	running, err := IsHubRunning()
 	var expected *exec.ExitError
-	if !xerrors.As(err, &expected) {
+	if !errors.As(err, &expected) {
 		t.Errorf("returned error %#v want %#v", err, expected)
 	}
 
@@ -130,7 +129,7 @@ func TestStartHub_FailsToStartWhenHubIsRunningErrors(t *testing.T) {
 	execCommandHubStart = exectest.NewCommand(GpupgradeHub_good_Main) // should not hit this, but fail it we do
 	err := StartHub()
 	var expected *exec.ExitError
-	if !xerrors.As(err, &expected) {
+	if !errors.As(err, &expected) {
 		t.Errorf("returned error %#v want %#v", err, expected)
 	}
 }

--- a/cli/commanders/steps_test.go
+++ b/cli/commanders/steps_test.go
@@ -4,6 +4,7 @@
 package commanders_test
 
 import (
+	"errors"
 	"io"
 	"io/ioutil"
 	"os"
@@ -79,7 +80,7 @@ func TestUILoop(t *testing.T) {
 	})
 
 	t.Run("returns an error when a non io.EOF error is encountered", func(t *testing.T) {
-		expected := xerrors.New("bengie")
+		expected := errors.New("bengie")
 
 		_, err := commanders.UILoop(&errStream{expected}, true)
 		if err != expected {
@@ -274,7 +275,7 @@ func TestSubstep(t *testing.T) {
 	s := commanders.Substep(idl.Substep_CREATING_DIRECTORIES)
 	s.Finish(&err)
 
-	err = xerrors.New("error")
+	err = errors.New("error")
 	s = commanders.Substep(idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG)
 	s.Finish(&err)
 

--- a/greenplum/cluster_test.go
+++ b/greenplum/cluster_test.go
@@ -17,7 +17,6 @@ import (
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/testutils"
@@ -157,7 +156,7 @@ func TestCluster(t *testing.T) {
 		t.Run(fmt.Sprintf("doesn't allow %s", c.name), func(t *testing.T) {
 			_, err := greenplum.NewCluster(c.segments)
 
-			if !xerrors.Is(err, greenplum.ErrInvalidSegments) {
+			if !errors.Is(err, greenplum.ErrInvalidSegments) {
 				t.Errorf("returned error %#v, want %#v", err, greenplum.ErrInvalidSegments)
 			}
 		})

--- a/greenplum/start_or_stop_cluster_test.go
+++ b/greenplum/start_or_stop_cluster_test.go
@@ -4,6 +4,7 @@
 package greenplum
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -12,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
@@ -108,7 +108,7 @@ func TestStartOrStopCluster(t *testing.T) {
 
 		running, err := source.IsMasterRunning(step.DevNullStream)
 		var expected *exec.ExitError
-		if !xerrors.As(err, &expected) {
+		if !errors.As(err, &expected) {
 			t.Errorf("expected error to contain type %T", expected)
 		}
 

--- a/hub/archive_log_directory_test.go
+++ b/hub/archive_log_directory_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -59,7 +58,7 @@ func TestArchiveLogDirectories(t *testing.T) {
 
 		err := hub.ArchiveSegmentLogDirectories(agentConns, "", newDir)
 		var multiErr *multierror.Error
-		if !xerrors.As(err, &multiErr) {
+		if !errors.As(err, &multiErr) {
 			t.Fatalf("got error %#v, want type %T", err, multiErr)
 		}
 
@@ -68,7 +67,7 @@ func TestArchiveLogDirectories(t *testing.T) {
 		}
 
 		for _, err := range multiErr.Errors {
-			if !xerrors.Is(err, expected) {
+			if !errors.Is(err, expected) {
 				t.Errorf("got error %#v, want %#v", expected, err)
 			}
 		}

--- a/hub/check_disk_space_test.go
+++ b/hub/check_disk_space_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	multierror "github.com/hashicorp/go-multierror"
 	"golang.org/x/sys/unix"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -237,7 +236,7 @@ func checkMultierrorContents(t *testing.T, err error, expected []error) {
 	t.Helper()
 
 	var multierr *multierror.Error
-	if !xerrors.As(err, &multierr) {
+	if !errors.As(err, &multierr) {
 		t.Errorf("error %#v does not contain type %T", err, multierr)
 		return
 	}
@@ -252,7 +251,7 @@ func checkMultierrorContents(t *testing.T, err error, expected []error) {
 		match := -1
 
 		for i, candidate := range expected {
-			if xerrors.Is(actual, candidate) {
+			if errors.Is(actual, candidate) {
 				match = i
 				break
 			}

--- a/hub/check_source_cluster_configuration_test.go
+++ b/hub/check_source_cluster_configuration_test.go
@@ -10,7 +10,6 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/testutils"
@@ -67,7 +66,7 @@ func TestSegmentStatusErrors(t *testing.T) {
 		var multiError *multierror.Error
 		var segmentStatusError hub.UnbalancedSegmentStatusError
 
-		if !xerrors.As(err, &multiError) || !xerrors.As(multiError.Errors[0], &segmentStatusError) {
+		if !errors.As(err, &multiError) || !errors.As(multiError.Errors[0], &segmentStatusError) {
 			t.Errorf("got an error that was not a segment status error: %v",
 				err.Error())
 		}
@@ -125,7 +124,7 @@ func TestSegmentStatusErrors(t *testing.T) {
 		var segmentStatusError hub.DownSegmentStatusError
 
 		var multiError *multierror.Error
-		if !xerrors.As(err, &multiError) || !xerrors.As(multiError.Errors[0], &segmentStatusError) {
+		if !errors.As(err, &multiError) || !errors.As(multiError.Errors[0], &segmentStatusError) {
 			t.Errorf("got an error that was not a segment status error: %v",
 				err.Error())
 		}
@@ -174,19 +173,19 @@ func TestSegmentStatusErrors(t *testing.T) {
 
 		var multiError *multierror.Error
 
-		if !xerrors.As(err, &multiError) {
+		if !errors.As(err, &multiError) {
 			t.Errorf("got an error that was not a multi error: %v",
 				err.Error())
 		}
 
 		var downSegmentStatusError hub.DownSegmentStatusError
-		if !xerrors.As(multiError.Errors[0], &downSegmentStatusError) {
+		if !errors.As(multiError.Errors[0], &downSegmentStatusError) {
 			t.Errorf("got an error that was not a down segment status error: %v",
 				err.Error())
 		}
 
 		var unbalancedSegmentStatusError hub.UnbalancedSegmentStatusError
-		if !xerrors.As(multiError.Errors[1], &unbalancedSegmentStatusError) {
+		if !errors.As(multiError.Errors[1], &unbalancedSegmentStatusError) {
 			t.Errorf("got an error that was not an unbalanced segment status error: %v",
 				err.Error())
 		}
@@ -243,7 +242,7 @@ func TestCheckSourceClusterConfiguration(t *testing.T) {
 		sqlmock.ExpectQuery(".*").WillReturnError(expected)
 
 		err = hub.CheckSourceClusterConfiguration(connection)
-		if !xerrors.Is(err, expected) {
+		if !errors.Is(err, expected) {
 			t.Errorf("got error %#v, want %#v", err, expected)
 		}
 	})
@@ -301,7 +300,7 @@ func TestGetSegmentStatuses(t *testing.T) {
 		sqlmock.ExpectQuery(".*").WillReturnError(expected)
 
 		_, err = hub.GetSegmentStatuses(connection)
-		if !xerrors.Is(err, expected) {
+		if !errors.Is(err, expected) {
 			t.Errorf("got error %#v, want %#v", err, expected)
 		}
 	})
@@ -347,7 +346,7 @@ func TestGetSegmentStatuses(t *testing.T) {
 		sqlmock.ExpectQuery(".*").WillReturnRows(rows)
 
 		_, err = hub.GetSegmentStatuses(connection)
-		if !xerrors.Is(err, expected) {
+		if !errors.Is(err, expected) {
 			t.Errorf("got error %#v, want %#v", err, expected)
 		}
 	})

--- a/hub/copy_master_test.go
+++ b/hub/copy_master_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
@@ -116,11 +115,11 @@ func TestCopy(t *testing.T) {
 
 		// Make sure the errors are correctly propagated up.
 		var merr *multierror.Error
-		if !xerrors.As(err, &merr) {
+		if !errors.As(err, &merr) {
 			t.Fatalf("returned %#v, want error type %T", err, merr)
 		}
 		for _, err := range merr.Errors {
-			if !xerrors.Is(err, streams.Err) {
+			if !errors.Is(err, streams.Err) {
 				t.Errorf("returned error %#v, want %#v", err, streams.Err)
 			}
 		}
@@ -135,12 +134,12 @@ func TestCopy(t *testing.T) {
 
 		// Make sure the errors are correctly propagated up.
 		var merr *multierror.Error
-		if !xerrors.As(err, &merr) {
+		if !errors.As(err, &merr) {
 			t.Fatalf("returned %#v, want error type %T", err, merr)
 		}
 		var exitErr *exec.ExitError
 		for _, err := range merr.Errors {
-			if !xerrors.As(err, &exitErr) || exitErr.ExitCode() != rsyncExitCode {
+			if !errors.As(err, &exitErr) || exitErr.ExitCode() != rsyncExitCode {
 				t.Errorf("returned error %#v, want exit code %d", err, rsyncExitCode)
 			}
 		}

--- a/hub/delete_data_directories_test.go
+++ b/hub/delete_data_directories_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/hub"
@@ -157,7 +156,7 @@ func TestDeleteSegmentDataDirs(t *testing.T) {
 			err := hub.DeletePrimaryDataDirectories(agentConns, primarySegConfigs)
 
 			var multiErr *multierror.Error
-			if !xerrors.As(err, &multiErr) {
+			if !errors.As(err, &multiErr) {
 				t.Fatalf("got error %#v, want type %T", err, multiErr)
 			}
 
@@ -166,7 +165,7 @@ func TestDeleteSegmentDataDirs(t *testing.T) {
 			}
 
 			for _, err := range multiErr.Errors {
-				if !xerrors.Is(err, expected) {
+				if !errors.Is(err, expected) {
 					t.Errorf("got error %#v, want %#v", expected, err)
 				}
 			}
@@ -350,7 +349,7 @@ func TestDeleteTablespaceDirectories(t *testing.T) {
 		err := hub.DeleteTargetTablespacesOnPrimaries(agentConns, target, nil, "")
 
 		var multiErr *multierror.Error
-		if !xerrors.As(err, &multiErr) {
+		if !errors.As(err, &multiErr) {
 			t.Fatalf("got error %#v, want type %T", err, multiErr)
 		}
 
@@ -359,7 +358,7 @@ func TestDeleteTablespaceDirectories(t *testing.T) {
 		}
 
 		for _, err := range multiErr.Errors {
-			if !xerrors.Is(err, expected) {
+			if !errors.Is(err, expected) {
 				t.Errorf("got error %#v, want %#v", expected, err)
 			}
 		}

--- a/hub/delete_state_directories_test.go
+++ b/hub/delete_state_directories_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -78,7 +77,7 @@ func TestDeleteStateDirectories(t *testing.T) {
 			err := hub.DeleteStateDirectories(agentConns, "")
 
 			var multiErr *multierror.Error
-			if !xerrors.As(err, &multiErr) {
+			if !errors.As(err, &multiErr) {
 				t.Fatalf("got error %#v, want type %T", err, multiErr)
 			}
 
@@ -87,7 +86,7 @@ func TestDeleteStateDirectories(t *testing.T) {
 			}
 
 			for _, err := range multiErr.Errors {
-				if !xerrors.Is(err, expected) {
+				if !errors.Is(err, expected) {
 					t.Errorf("got error %#v, want %#v", expected, err)
 				}
 			}

--- a/hub/hub_start_services_test.go
+++ b/hub/hub_start_services_test.go
@@ -5,6 +5,7 @@ package hub_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -17,7 +18,6 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 
@@ -123,7 +123,7 @@ func TestRestartAgent(t *testing.T) {
 
 			var exitErr *exec.ExitError
 			for _, err := range merr.WrappedErrors() {
-				if !xerrors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+				if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
 					t.Errorf("expected exit code: 1 but got: %#v", err)
 				}
 			}

--- a/hub/init_target_cluster_test.go
+++ b/hub/init_target_cluster_test.go
@@ -16,7 +16,6 @@ import (
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/blang/semver/v4"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/step"
@@ -208,7 +207,7 @@ func TestRunInitsystemForTargetCluster(t *testing.T) {
 		err := RunInitsystemForTargetCluster(step.DevNullStream, gpHome6, gpinitsystemConfigPath, version6)
 
 		var actual *exec.ExitError
-		if !xerrors.As(err, &actual) {
+		if !errors.As(err, &actual) {
 			t.Fatalf("got %#v, want ExitError", err)
 		}
 
@@ -223,7 +222,7 @@ func TestRunInitsystemForTargetCluster(t *testing.T) {
 		err := RunInitsystemForTargetCluster(step.DevNullStream, gpHome7, gpinitsystemConfigPath, version7)
 
 		var actual *exec.ExitError
-		if !xerrors.As(err, &actual) {
+		if !errors.As(err, &actual) {
 			t.Fatalf("got %#v, want ExitError", err)
 		}
 

--- a/hub/rename_data_directories_test.go
+++ b/hub/rename_data_directories_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/hub"
@@ -118,7 +117,7 @@ func TestRenameSegmentDataDirs(t *testing.T) {
 		err := hub.RenameSegmentDataDirs(agentConns, m)
 
 		var multiErr *multierror.Error
-		if !xerrors.As(err, &multiErr) {
+		if !errors.As(err, &multiErr) {
 			t.Fatalf("got error %#v, want type %T", err, multiErr)
 		}
 
@@ -127,7 +126,7 @@ func TestRenameSegmentDataDirs(t *testing.T) {
 		}
 
 		for _, err := range multiErr.Errors {
-			if !xerrors.Is(err, expected) {
+			if !errors.Is(err, expected) {
 				t.Errorf("got error %#v, want %#v", expected, err)
 			}
 		}
@@ -225,7 +224,7 @@ func TestUpdateDataDirectories(t *testing.T) {
 		}()
 
 		err := hub.UpdateDataDirectories(conf, nil)
-		if !xerrors.Is(err, expected) {
+		if !errors.Is(err, expected) {
 			t.Errorf("got %#v want %#v", err, expected)
 		}
 	})

--- a/hub/restore_source_cluster_test.go
+++ b/hub/restore_source_cluster_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/hub"
@@ -364,7 +363,7 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 
 		err := hub.Recoverseg(&testutils.DevNullWithClose{}, cluster)
 		var exitErr *exec.ExitError
-		if !xerrors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
 			t.Errorf("returned error %#v, want exit code %d", err, 1)
 		}
 	})
@@ -394,7 +393,7 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 		err := hub.RsyncPrimaries(agentConns, cluster)
 
 		var multiErr *multierror.Error
-		if !xerrors.As(err, &multiErr) {
+		if !errors.As(err, &multiErr) {
 			t.Fatalf("got error %#v, want type %T", err, multiErr)
 		}
 
@@ -403,7 +402,7 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 		}
 
 		for _, err := range multiErr.Errors {
-			if !xerrors.Is(err, expected) {
+			if !errors.Is(err, expected) {
 				t.Errorf("got error %#v, want %#v", expected, err)
 			}
 		}
@@ -434,7 +433,7 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 		err := hub.RsyncPrimariesTablespaces(agentConns, cluster, tablespaces)
 
 		var multiErr *multierror.Error
-		if !xerrors.As(err, &multiErr) {
+		if !errors.As(err, &multiErr) {
 			t.Fatalf("got error %#v, want type %T", err, multiErr)
 		}
 
@@ -443,7 +442,7 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 		}
 
 		for _, err := range multiErr.Errors {
-			if !xerrors.Is(err, expected) {
+			if !errors.Is(err, expected) {
 				t.Errorf("got error %#v, want %#v", expected, err)
 			}
 		}

--- a/hub/rpc_test.go
+++ b/hub/rpc_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/hub"
 )
@@ -64,7 +63,7 @@ func TestExecuteRPC(t *testing.T) {
 
 		err := hub.ExecuteRPC(agentConns, request)
 		var multiErr *multierror.Error
-		if !xerrors.As(err, &multiErr) {
+		if !errors.As(err, &multiErr) {
 			t.Fatalf("got error %#v, want type %T", err, multiErr)
 		}
 
@@ -73,7 +72,7 @@ func TestExecuteRPC(t *testing.T) {
 		}
 
 		for _, err := range multiErr.Errors {
-			if !xerrors.Is(err, expected) {
+			if !errors.Is(err, expected) {
 				t.Errorf("got error %#v, want %#v", expected, err)
 			}
 		}

--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -5,6 +5,7 @@ package hub_test
 
 import (
 	"context"
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -15,7 +16,6 @@ import (
 	"time"
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"github.com/pkg/errors"
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -63,7 +63,7 @@ func TestHubStart(t *testing.T) {
 
 		select {
 		case err := <-errChan:
-			if !xerrors.Is(err, hub.ErrHubStopped) {
+			if !errors.Is(err, hub.ErrHubStopped) {
 				t.Errorf("got error %#v want %#v", err, hub.ErrHubStopped)
 			}
 		case <-time.After(timeout): // use timeout to prevent test from hanging
@@ -279,7 +279,7 @@ func TestAgentConns(t *testing.T) {
 		h := hub.New(conf, errDialer, "")
 
 		_, err := h.AgentConns()
-		if !xerrors.Is(err, expected) {
+		if !errors.Is(err, expected) {
 			t.Errorf("returned error %#v want %#v", err, expected)
 		}
 	})

--- a/hub/update_catalog_test.go
+++ b/hub/update_catalog_test.go
@@ -4,6 +4,7 @@
 package hub_test
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	. "github.com/greenplum-db/gpupgrade/hub"
@@ -230,10 +230,10 @@ func TestUpdateCatalog(t *testing.T) {
 			if !ok {
 				t.Fatal("did not return a multierror")
 			}
-			if !xerrors.Is(multiErr.Errors[0], ErrSentinel) {
+			if !errors.Is(multiErr.Errors[0], ErrSentinel) {
 				t.Errorf("first error was %#v want %#v", err, ErrSentinel)
 			}
-			if !xerrors.Is(multiErr.Errors[1], ErrRollback) {
+			if !errors.Is(multiErr.Errors[1], ErrRollback) {
 				t.Errorf("second error was %#v want %#v", err, ErrRollback)
 			}
 		},
@@ -319,7 +319,7 @@ func TestUpdateCatalog(t *testing.T) {
 // through the testing.T if not.
 func expect(expected error) func(*testing.T, error) {
 	return func(t *testing.T, actual error) {
-		if !xerrors.Is(actual, expected) {
+		if !errors.Is(actual, expected) {
 			t.Errorf("returned %#v want %#v", actual, expected)
 		}
 	}

--- a/hub/upgrade_master_test.go
+++ b/hub/upgrade_master_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/step"
@@ -305,7 +304,7 @@ func TestUpgradeMaster(t *testing.T) {
 			CheckOnly:   false,
 			UseLinkMode: false,
 		})
-		if !xerrors.Is(err, expectedErr) {
+		if !errors.Is(err, expectedErr) {
 			t.Errorf("returned error %+v, want %+v", err, expectedErr)
 		}
 	})
@@ -355,7 +354,7 @@ func TestUpgradeMaster(t *testing.T) {
 		}
 
 		var upgradeErr UpgradeMasterError
-		if !xerrors.As(err, &upgradeErr) {
+		if !errors.As(err, &upgradeErr) {
 			t.Errorf("got type %T want %T", err, upgradeErr)
 		}
 

--- a/hub/upgrade_mirrors_test.go
+++ b/hub/upgrade_mirrors_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/testutils"
@@ -79,7 +78,7 @@ func TestWriteGpAddmirrorsConfig(t *testing.T) {
 		writer := &testutils.FailingWriter{Err: errors.New("ahhh")}
 
 		err := writeGpAddmirrorsConfig(mirrors, writer)
-		if !xerrors.Is(err, writer.Err) {
+		if !errors.Is(err, writer.Err) {
 			t.Errorf("returned error %#v, want %#v", err, writer.Err)
 		}
 	})
@@ -139,7 +138,7 @@ func TestRunAddMirrors(t *testing.T) {
 		}
 
 		actual := runAddMirrors(stub, "")
-		if !xerrors.Is(actual, expected) {
+		if !errors.Is(actual, expected) {
 			t.Errorf("returned error %#v, want %#v", actual, expected)
 		}
 	})
@@ -251,7 +250,7 @@ func TestDoUpgrade(t *testing.T) {
 		}
 
 		err = doUpgrade(db, "", []greenplum.SegConfig{}, &greenplumStub{})
-		if !xerrors.Is(err, expectedError) {
+		if !errors.Is(err, expectedError) {
 			t.Errorf("returned error %#v want %#v", err, expectedError)
 		}
 	})
@@ -276,7 +275,7 @@ func TestDoUpgrade(t *testing.T) {
 		err = doUpgrade(db, "/state/dir", mirrors, stub)
 
 		var merr *multierror.Error
-		if !xerrors.As(err, &merr) {
+		if !errors.As(err, &merr) {
 			t.Fatalf("returned error %#v, want error type %T", err, merr)
 		}
 
@@ -285,7 +284,7 @@ func TestDoUpgrade(t *testing.T) {
 		}
 
 		for _, err := range merr.Errors {
-			if !xerrors.Is(err, os.ErrInvalid) {
+			if !errors.Is(err, os.ErrInvalid) {
 				t.Errorf("returned error %#v want %#v", err, os.ErrInvalid)
 			}
 		}
@@ -303,7 +302,7 @@ func TestDoUpgrade(t *testing.T) {
 		}}
 
 		err = doUpgrade(db, "/state/dir", []greenplum.SegConfig{}, stub)
-		if !xerrors.Is(err, expected) {
+		if !errors.Is(err, expected) {
 			t.Errorf("returned error %#v want %#v", err, expected)
 		}
 	})
@@ -357,7 +356,7 @@ func TestUpgradeMirrors(t *testing.T) {
 		}
 
 		err := UpgradeMirrors("", 123, []greenplum.SegConfig{}, stub)
-		if !xerrors.Is(err, expected) {
+		if !errors.Is(err, expected) {
 			t.Errorf("got: %#v want: %#v", err, expected)
 		}
 	})

--- a/hub/upgrade_primaries_test.go
+++ b/hub/upgrade_primaries_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/hub"
@@ -201,7 +200,7 @@ func TestGetDataDirPairs(t *testing.T) {
 		server := hub.New(conf, nil, "")
 
 		_, err := server.GetDataDirPairs()
-		if !xerrors.Is(err, hub.ErrInvalidCluster) {
+		if !errors.Is(err, hub.ErrInvalidCluster) {
 			t.Errorf("returned error %#v got: %#v", err, hub.ErrInvalidCluster)
 		}
 	})
@@ -226,7 +225,7 @@ func TestGetDataDirPairs(t *testing.T) {
 		server := hub.New(conf, nil, "")
 
 		_, err := server.GetDataDirPairs()
-		if !xerrors.Is(err, hub.ErrInvalidCluster) {
+		if !errors.Is(err, hub.ErrInvalidCluster) {
 			t.Errorf("returned error %#v got: %#v", err, hub.ErrInvalidCluster)
 		}
 	})
@@ -251,7 +250,7 @@ func TestGetDataDirPairs(t *testing.T) {
 		server := hub.New(conf, nil, "")
 
 		_, err := server.GetDataDirPairs()
-		if !xerrors.Is(err, hub.ErrInvalidCluster) {
+		if !errors.Is(err, hub.ErrInvalidCluster) {
 			t.Errorf("returned error %#v got: %#v", err, hub.ErrInvalidCluster)
 		}
 	})

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
@@ -160,7 +159,7 @@ func TestStepRun(t *testing.T) {
 			return nil
 		})
 
-		if !xerrors.Is(s.Err(), failingStore.WriteErr) {
+		if !errors.Is(s.Err(), failingStore.WriteErr) {
 			t.Errorf("returned error %#v want %#v", s.Err(), failingStore.WriteErr)
 		}
 
@@ -218,7 +217,7 @@ func TestStepRun(t *testing.T) {
 			t.Error("expected substep to be skipped")
 		}
 
-		if !xerrors.Is(s.Err(), expected) {
+		if !errors.Is(s.Err(), expected) {
 			t.Errorf("got error %#v, want %#v", s.Err(), expected)
 		}
 	})
@@ -301,7 +300,7 @@ func TestHasRun(t *testing.T) {
 
 		hasRun, err := step.HasRun(idl.Step_INITIALIZE, idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG)
 		var expected *os.PathError
-		if !xerrors.As(err, &expected) {
+		if !errors.As(err, &expected) {
 			t.Errorf("returned error %#v want %#v", err, expected)
 		}
 
@@ -372,7 +371,7 @@ func TestStepFinish(t *testing.T) {
 		s := step.New(idl.Step_INITIALIZE, nil, nil, streams)
 
 		err := s.Finish()
-		if !xerrors.Is(err, expected) {
+		if !errors.Is(err, expected) {
 			t.Errorf("got error %#v, want %#v", err, expected)
 		}
 	})

--- a/step/stream_test.go
+++ b/step/stream_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
@@ -163,12 +162,12 @@ func TestMultiplexedStream(t *testing.T) {
 		stream := newMultiplexedStream(mockStream, &failingWriter{expected})
 
 		_, err := stream.Stdout().Write([]byte{'x'})
-		if !xerrors.Is(err, expected) {
+		if !errors.Is(err, expected) {
 			t.Errorf("Stdout().Write() returned %#v, want %#v", err, expected)
 		}
 
 		_, err = stream.Stderr().Write([]byte{'x'})
-		if !xerrors.Is(err, expected) {
+		if !errors.Is(err, expected) {
 			t.Errorf("Stderr().Write() returned %#v, want %#v", err, expected)
 		}
 	})

--- a/upgrade/directories_test.go
+++ b/upgrade/directories_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/testutils"
@@ -140,7 +139,7 @@ func TestArchiveSource(t *testing.T) {
 		}()
 
 		err := upgrade.ArchiveSource(source, target, true)
-		if !xerrors.Is(err, expected) {
+		if !errors.Is(err, expected) {
 			t.Errorf("got %#v want %#v", err, expected)
 		}
 	})
@@ -154,13 +153,13 @@ func TestArchiveSource(t *testing.T) {
 
 		err := upgrade.ArchiveSource(source, target, true)
 		var merr *multierror.Error
-		if !xerrors.As(err, &merr) {
+		if !errors.As(err, &merr) {
 			t.Fatalf("returned %#v want error type %T", err, merr)
 		}
 
 		for _, err := range merr.Errors {
 			expected := upgrade.ErrInvalidDataDirectory
-			if !xerrors.Is(err, expected) {
+			if !errors.Is(err, expected) {
 				t.Errorf("returned error %#v want %#v", err, expected)
 			}
 		}
@@ -242,7 +241,7 @@ func TestArchiveSource(t *testing.T) {
 		}
 
 		err := upgrade.ArchiveSource(source, target, true)
-		if !xerrors.Is(err, expected) {
+		if !errors.Is(err, expected) {
 			t.Errorf("got %#v want %#v", err, expected)
 		}
 
@@ -284,7 +283,7 @@ func TestArchiveSource(t *testing.T) {
 		}
 
 		err := upgrade.ArchiveSource(source, target, true)
-		if !xerrors.Is(err, expected) {
+		if !errors.Is(err, expected) {
 			t.Errorf("got %#v want %#v", err, expected)
 		}
 
@@ -373,7 +372,7 @@ func TestDeleteDirectories(t *testing.T) {
 		err := upgrade.DeleteDirectories(directories, []string{"a", "b"}, step.DevNullStream)
 
 		var multiErr *multierror.Error
-		if !xerrors.As(err, &multiErr) {
+		if !errors.As(err, &multiErr) {
 			t.Fatalf("got error %#v, want type %T", err, multiErr)
 		}
 
@@ -382,7 +381,7 @@ func TestDeleteDirectories(t *testing.T) {
 		}
 
 		for _, err := range multiErr.Errors {
-			if !xerrors.Is(err, os.ErrNotExist) {
+			if !errors.Is(err, os.ErrNotExist) {
 				t.Errorf("got error %#v, want %#v", err, os.ErrNotExist)
 			}
 		}
@@ -400,7 +399,7 @@ func TestDeleteDirectories(t *testing.T) {
 		err2 := upgrade.DeleteDirectories(directories, requiredPaths, step.DevNullStream)
 
 		var multiErr *multierror.Error
-		if !xerrors.As(err2, &multiErr) {
+		if !errors.As(err2, &multiErr) {
 			t.Fatalf("got error %#v, want type %T", err2, multiErr)
 		}
 
@@ -411,7 +410,7 @@ func TestDeleteDirectories(t *testing.T) {
 		var actualErr *os.PathError
 
 		for _, err := range multiErr.Errors {
-			if !xerrors.As(err, &actualErr) {
+			if !errors.As(err, &actualErr) {
 				t.Errorf("got error %#v, want %#v", err, "PathError")
 			}
 		}
@@ -438,7 +437,7 @@ func TestDeleteDirectories(t *testing.T) {
 		}()
 
 		err := upgrade.DeleteDirectories(directories, requiredPaths, step.DevNullStream)
-		if !xerrors.Is(err, expected) {
+		if !errors.Is(err, expected) {
 			t.Errorf("got error %#v want %#v", err, expected)
 		}
 	})

--- a/upgrade/run_test.go
+++ b/upgrade/run_test.go
@@ -6,6 +6,7 @@ package upgrade_test
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -15,7 +16,6 @@ import (
 	"testing"
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
 	"github.com/greenplum-db/gpupgrade/upgrade"
@@ -203,7 +203,7 @@ func TestRun(t *testing.T) {
 		err := upgrade.Run(pair)
 
 		var exitErr *exec.ExitError
-		if !xerrors.As(err, &exitErr) {
+		if !errors.As(err, &exitErr) {
 			t.Fatalf("got error %#v, want type *exec.ExitError", err)
 		}
 

--- a/utils/daemon/daemon_test.go
+++ b/utils/daemon/daemon_test.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"golang.org/x/xerrors"
 )
 
 // basicReadCloser is a helper struct for the implementation of NewReadCloser.
@@ -151,7 +149,7 @@ func TestWaitForDaemon(t *testing.T) {
 		cmd := MockDaemonizableCommand{StderrBuf: errput, WaitError: exitErr}
 
 		err := waitForDaemon(&cmd, outbuf, errbuf, 0)
-		if !xerrors.Is(err, exitErr) {
+		if !errors.Is(err, exitErr) {
 			t.Errorf("returned error %#v want %#v", err, exitErr)
 		}
 
@@ -171,7 +169,7 @@ func TestWaitForDaemon(t *testing.T) {
 
 		for _, cmd := range cmds {
 			err := waitForDaemon(&cmd, outbuf, errbuf, 0)
-			if !xerrors.Is(err, pipeErr) {
+			if !errors.Is(err, pipeErr) {
 				t.Errorf("returned error %#v want %#v", err, pipeErr)
 			}
 
@@ -188,7 +186,7 @@ func TestWaitForDaemon(t *testing.T) {
 		cmd := MockDaemonizableCommand{StartError: startErr}
 
 		err := waitForDaemon(&cmd, outbuf, errbuf, 0)
-		if !xerrors.Is(err, startErr) {
+		if !errors.Is(err, startErr) {
 			t.Errorf("returned error %#v want %#v", err, startErr)
 		}
 	})

--- a/utils/disk/disk_test.go
+++ b/utils/disk/disk_test.go
@@ -4,6 +4,7 @@
 package disk_test
 
 import (
+	"errors"
 	"os"
 	"reflect"
 	"strings"
@@ -11,9 +12,7 @@ import (
 
 	sigar "github.com/cloudfoundry/gosigar"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils/disk"
@@ -214,7 +213,7 @@ func TestCheckUsage(t *testing.T) {
 			t.Helper() // don't include this function in the stack trace
 
 			_, err := disk.CheckUsage(d, 0.5, "/test/path")
-			if !xerrors.Is(err, d.err) {
+			if !errors.Is(err, d.err) {
 				t.Errorf("returned %#v want %#v", err, d.err)
 			}
 		}

--- a/utils/rsync/rsync_test.go
+++ b/utils/rsync/rsync_test.go
@@ -4,6 +4,7 @@
 package rsync_test
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/testutils"
@@ -278,7 +278,7 @@ func TestRsync(t *testing.T) {
 		}
 
 		var rsyncError rsync.RsyncError
-		if !xerrors.As(err, &rsyncError) {
+		if !errors.As(err, &rsyncError) {
 			t.Errorf("got error %#v, wanted type %T", err, rsyncError)
 		}
 		expected := "exit status 1"
@@ -287,7 +287,7 @@ func TestRsync(t *testing.T) {
 		}
 
 		var exitError *exec.ExitError
-		if !xerrors.As(err, &exitError) {
+		if !errors.As(err, &exitError) {
 			t.Errorf("expected err to wrap ExitError")
 		}
 		if exitError.Error() != expected {
@@ -321,7 +321,7 @@ func TestRsync(t *testing.T) {
 		}
 
 		var rsyncError rsync.RsyncError
-		if !xerrors.As(err, &rsyncError) {
+		if !errors.As(err, &rsyncError) {
 			t.Errorf("got error %#v, wanted type %T", err, rsyncError)
 		}
 		expected := "rsync: --BOGUS: unknown option"
@@ -330,7 +330,7 @@ func TestRsync(t *testing.T) {
 		}
 
 		var exitError *exec.ExitError
-		if !xerrors.As(err, &exitError) {
+		if !errors.As(err, &exitError) {
 			t.Errorf("expected err to wrap ExitError")
 		}
 		if !strings.Contains(rsyncError.Error(), expected) {
@@ -391,7 +391,7 @@ func TestRsync(t *testing.T) {
 			t.Errorf("expected error '%#v', got nil", rsync.ErrInvalidRsyncSourcePath)
 		}
 
-		if !xerrors.Is(err, rsync.ErrInvalidRsyncSourcePath) {
+		if !errors.Is(err, rsync.ErrInvalidRsyncSourcePath) {
 			t.Errorf("got error '%#v' want '%#v'", err, rsync.ErrInvalidRsyncSourcePath)
 		}
 	})

--- a/utils/sys_utils_test.go
+++ b/utils/sys_utils_test.go
@@ -1,12 +1,11 @@
 package utils_test
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
-
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/upgrade"
@@ -55,7 +54,7 @@ func TestMove(t *testing.T) {
 		}
 
 		var exitError *exec.ExitError
-		if !xerrors.As(err, &exitError) {
+		if !errors.As(err, &exitError) {
 			t.Errorf("got %T, want %T", err, exitError)
 		}
 	})
@@ -84,7 +83,7 @@ func TestAtomicallyWrite(t *testing.T) {
 
 		err := utils.AtomicallyWrite(path, []byte{})
 		var expected *os.PathError
-		if !xerrors.As(err, &expected) {
+		if !errors.As(err, &expected) {
 			t.Errorf("returned error type %T want %T", err, expected)
 		}
 


### PR DESCRIPTION
This updates references to `xerrors.Is` and `xerrors.As` to the errors package.

Note: The `xerrors.Errorf` construct in production code is still useful as it produces stack traces whereas the `errors` package does not yet. This PR focuses on updating references in tests.

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:errors)