### PR TITLE
Move tablespace info to cluster

### DIFF
--- a/greenplum/cluster.go
+++ b/greenplum/cluster.go
@@ -40,6 +40,8 @@ type Cluster struct {
 	GPHome  string
 	Version dbconn.GPDBVersion
 
+	// Tablespaces contains the tablespace in the database keyed by
+	// dbid and tablespace oid
 	Tablespaces                Tablespaces
 	TablespacesMappingFilePath string
 }

--- a/greenplum/cluster.go
+++ b/greenplum/cluster.go
@@ -39,6 +39,9 @@ type Cluster struct {
 
 	GPHome  string
 	Version dbconn.GPDBVersion
+
+	Tablespaces                Tablespaces
+	TablespacesMappingFilePath string
 }
 
 // ClusterFromDB will create a Cluster by querying the passed DBConn for

--- a/hub/copy_master.go
+++ b/hub/copy_master.go
@@ -86,7 +86,7 @@ func (s *Server) CopyMasterDataDir(streams step.OutStreams, destination string) 
 }
 
 func (s *Server) CopyMasterTablespaces(streams step.OutStreams, destinationDir string) error {
-	if s.Tablespaces == nil {
+	if s.Source == nil || s.Source.Tablespaces == nil {
 		return nil
 	}
 
@@ -94,7 +94,7 @@ func (s *Server) CopyMasterTablespaces(streams step.OutStreams, destinationDir s
 	sourcePaths := []string{s.Source.TablespacesMappingFilePath}
 
 	// include all the master tablespace directories
-	for _, tablespace := range s.Tablespaces.GetMasterTablespaces() {
+	for _, tablespace := range s.Source.Tablespaces.GetMasterTablespaces() {
 		if !tablespace.IsUserDefined() {
 			continue
 		}

--- a/hub/copy_master.go
+++ b/hub/copy_master.go
@@ -91,7 +91,7 @@ func (s *Server) CopyMasterTablespaces(streams step.OutStreams, destinationDir s
 	}
 
 	// include tablespace mapping file which is used as a parameter to pg_upgrade
-	sourcePaths := []string{s.TablespacesMappingFilePath}
+	sourcePaths := []string{s.Source.TablespacesMappingFilePath}
 
 	// include all the master tablespace directories
 	for _, tablespace := range s.Tablespaces.GetMasterTablespaces() {

--- a/hub/copy_master_test.go
+++ b/hub/copy_master_test.go
@@ -211,35 +211,35 @@ func TestCopyMasterTablespaces(t *testing.T) {
 
 	t.Run("copies tablespace mapping file and master tablespace directory to each primary host", func(t *testing.T) {
 		sourceCluster.TablespacesMappingFilePath = "/tmp/mapping.txt"
+		sourceCluster.Tablespaces = greenplum.Tablespaces{
+			1: greenplum.SegmentTablespaces{
+				1663: greenplum.TablespaceInfo{
+					Location:    "/tmp/tblspc1",
+					UserDefined: 0},
+				1664: greenplum.TablespaceInfo{
+					Location:    "/tmp/tblspc2",
+					UserDefined: 1},
+			},
+			2: greenplum.SegmentTablespaces{
+				1663: greenplum.TablespaceInfo{
+					Location:    "/tmp/primary1/tblspc1",
+					UserDefined: 0},
+				1664: greenplum.TablespaceInfo{
+					Location:    "/tmp/primary1/tblspc2",
+					UserDefined: 1},
+			},
+			3: greenplum.SegmentTablespaces{
+				1663: greenplum.TablespaceInfo{
+					Location:    "/tmp/primary2/tblspc1",
+					UserDefined: 0},
+				1664: greenplum.TablespaceInfo{
+					Location:    "/tmp/primary2/tblspc2",
+					UserDefined: 1},
+			},
+		}
 		conf := &Config{
 			Source: sourceCluster,
 			Target: targetCluster,
-			Tablespaces: greenplum.Tablespaces{
-				1: greenplum.SegmentTablespaces{
-					1663: greenplum.TablespaceInfo{
-						Location:    "/tmp/tblspc1",
-						UserDefined: 0},
-					1664: greenplum.TablespaceInfo{
-						Location:    "/tmp/tblspc2",
-						UserDefined: 1},
-				},
-				2: greenplum.SegmentTablespaces{
-					1663: greenplum.TablespaceInfo{
-						Location:    "/tmp/primary1/tblspc1",
-						UserDefined: 0},
-					1664: greenplum.TablespaceInfo{
-						Location:    "/tmp/primary1/tblspc2",
-						UserDefined: 1},
-				},
-				3: greenplum.SegmentTablespaces{
-					1663: greenplum.TablespaceInfo{
-						Location:    "/tmp/primary2/tblspc1",
-						UserDefined: 0},
-					1664: greenplum.TablespaceInfo{
-						Location:    "/tmp/primary2/tblspc2",
-						UserDefined: 1},
-				},
-			},
 		}
 		hub := New(conf, grpc.DialContext, ".gpupgrade")
 
@@ -265,7 +265,13 @@ func TestCopyMasterTablespaces(t *testing.T) {
 	})
 
 	t.Run("CopyMasterTablespaces returns nil if there is no tablespaces", func(t *testing.T) {
+		sourceCluster := MustCreateCluster(t, []greenplum.SegConfig{
+			{ContentID: -1, DbID: 1, Port: 15432, Hostname: "localhost", DataDir: "/data/qddir/seg-1", Role: "p"},
+			{ContentID: 0, DbID: 2, Port: 25432, Hostname: "host1", DataDir: "/data/dbfast1/seg1", Role: "p"},
+			{ContentID: 1, DbID: 3, Port: 25433, Hostname: "host2", DataDir: "/data/dbfast2/seg2", Role: "p"},
+		})
 		conf := &Config{
+			Source: sourceCluster,
 			Target: targetCluster,
 		}
 		hub := New(conf, grpc.DialContext, ".gpupgrade")

--- a/hub/copy_master_test.go
+++ b/hub/copy_master_test.go
@@ -198,6 +198,11 @@ func TestCopyMasterDataDir(t *testing.T) {
 }
 
 func TestCopyMasterTablespaces(t *testing.T) {
+	sourceCluster := MustCreateCluster(t, []greenplum.SegConfig{
+		{ContentID: -1, DbID: 1, Port: 15432, Hostname: "localhost", DataDir: "/data/qddir/seg-1", Role: "p"},
+		{ContentID: 0, DbID: 2, Port: 25432, Hostname: "host1", DataDir: "/data/dbfast1/seg1", Role: "p"},
+		{ContentID: 1, DbID: 3, Port: 25433, Hostname: "host2", DataDir: "/data/dbfast2/seg2", Role: "p"},
+	})
 	targetCluster := MustCreateCluster(t, []greenplum.SegConfig{
 		{ContentID: -1, DbID: 1, Port: 15432, Hostname: "localhost", DataDir: "/data/qddir/seg-1", Role: "p"},
 		{ContentID: 0, DbID: 2, Port: 25432, Hostname: "host1", DataDir: "/data/dbfast1/seg1", Role: "p"},
@@ -205,7 +210,9 @@ func TestCopyMasterTablespaces(t *testing.T) {
 	})
 
 	t.Run("copies tablespace mapping file and master tablespace directory to each primary host", func(t *testing.T) {
+		sourceCluster.TablespacesMappingFilePath = "/tmp/mapping.txt"
 		conf := &Config{
+			Source: sourceCluster,
 			Target: targetCluster,
 			Tablespaces: greenplum.Tablespaces{
 				1: greenplum.SegmentTablespaces{
@@ -233,7 +240,6 @@ func TestCopyMasterTablespaces(t *testing.T) {
 						UserDefined: 1},
 				},
 			},
-			TablespacesMappingFilePath: "/tmp/mapping.txt",
 		}
 		hub := New(conf, grpc.DialContext, ".gpupgrade")
 

--- a/hub/execute.go
+++ b/hub/execute.go
@@ -95,7 +95,7 @@ func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_Execut
 			Source:                 s.Source,
 			Target:                 s.Target,
 			UseLinkMode:            s.UseLinkMode,
-			TablespacesMappingFile: s.TablespacesMappingFilePath,
+			TablespacesMappingFile: s.Source.TablespacesMappingFilePath,
 		})
 	})
 

--- a/hub/fill_cluster_configs.go
+++ b/hub/fill_cluster_configs.go
@@ -60,8 +60,8 @@ func FillConfiguration(config *Config, conn *sql.DB, _ step.OutStreams, request 
 		if err := utils.System.MkdirAll(utils.GetTablespaceDir(), 0700); err != nil {
 			return xerrors.Errorf("create tablespace directory %q: %w", utils.GetTablespaceDir(), err)
 		}
-		config.TablespacesMappingFilePath = filepath.Join(utils.GetTablespaceDir(), greenplum.TablespacesMappingFile)
-		config.Tablespaces, err = greenplum.TablespacesFromDB(dbconn, config.TablespacesMappingFilePath)
+		config.Source.TablespacesMappingFilePath = filepath.Join(utils.GetTablespaceDir(), greenplum.TablespacesMappingFile)
+		config.Tablespaces, err = greenplum.TablespacesFromDB(dbconn, config.Source.TablespacesMappingFilePath)
 		if err != nil {
 			return xerrors.Errorf("extract tablespace information: %w", err)
 		}

--- a/hub/fill_cluster_configs.go
+++ b/hub/fill_cluster_configs.go
@@ -61,7 +61,7 @@ func FillConfiguration(config *Config, conn *sql.DB, _ step.OutStreams, request 
 			return xerrors.Errorf("create tablespace directory %q: %w", utils.GetTablespaceDir(), err)
 		}
 		config.Source.TablespacesMappingFilePath = filepath.Join(utils.GetTablespaceDir(), greenplum.TablespacesMappingFile)
-		config.Tablespaces, err = greenplum.TablespacesFromDB(dbconn, config.Source.TablespacesMappingFilePath)
+		config.Source.Tablespaces, err = greenplum.TablespacesFromDB(dbconn, config.Source.TablespacesMappingFilePath)
 		if err != nil {
 			return xerrors.Errorf("extract tablespace information: %w", err)
 		}

--- a/hub/revert.go
+++ b/hub/revert.go
@@ -83,7 +83,7 @@ func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) 
 				return err
 			}
 
-			return RsyncMasterAndPrimariesTablespaces(stream, s.agentConns, s.Source, s.Tablespaces)
+			return RsyncMasterAndPrimariesTablespaces(stream, s.agentConns, s.Source, s.Source.Tablespaces)
 		})
 	}
 
@@ -100,7 +100,7 @@ func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) 
 		})
 
 		st.Run(idl.Substep_DELETE_TABLESPACES, func(streams step.OutStreams) error {
-			return DeleteTargetTablespaces(streams, s.agentConns, s.Config.Target, s.TargetCatalogVersion, s.Tablespaces)
+			return DeleteTargetTablespaces(streams, s.agentConns, s.Config.Target, s.TargetCatalogVersion, s.Source.Tablespaces)
 		})
 	}
 

--- a/hub/server.go
+++ b/hub/server.go
@@ -369,9 +369,6 @@ type Config struct {
 	TargetGPHome string
 	UpgradeID    upgrade.ID
 
-	// Tablespaces contains the tablespace in the database keyed by
-	// dbid and tablespace oid
-	Tablespaces          greenplum.Tablespaces
 	TargetCatalogVersion string
 }
 

--- a/hub/server.go
+++ b/hub/server.go
@@ -371,9 +371,8 @@ type Config struct {
 
 	// Tablespaces contains the tablespace in the database keyed by
 	// dbid and tablespace oid
-	Tablespaces                greenplum.Tablespaces
-	TablespacesMappingFilePath string
-	TargetCatalogVersion       string
+	Tablespaces          greenplum.Tablespaces
+	TargetCatalogVersion string
 }
 
 func (c *Config) Load(r io.Reader) error {

--- a/hub/server_internal_test.go
+++ b/hub/server_internal_test.go
@@ -18,6 +18,13 @@ func TestConfig(t *testing.T) {
 	t.Run("saves itself to the provided stream", func(t *testing.T) {
 		source, target := testutils.CreateMultinodeSampleClusterPair("/tmp")
 		source.TablespacesMappingFilePath = greenplum.TablespacesMappingFile
+		source.Tablespaces = map[int]greenplum.SegmentTablespaces{
+			1: {1663: {
+				Location:    "/tmp/master/my_tablespace/1663",
+				UserDefined: 1,
+			}},
+		}
+
 		targetInitializeConfig := InitializeConfig{Master: greenplum.SegConfig{Hostname: "mdw"}}
 
 		// NOTE: we explicitly do not name the struct members here, to ensure
@@ -33,12 +40,7 @@ func TestConfig(t *testing.T) {
 			false,           // UseLinkMode
 			target.GPHome,   // TargetGPHome
 			upgrade.NewID(), // UpgradeID
-			map[int]greenplum.SegmentTablespaces{
-				1: {1663: {
-					Location:    "/tmp/master/my_tablespace/1663",
-					UserDefined: 1,
-				}}}, // Tablespaces
-			"301908232", // TargetCatalogVersion
+			"301908232",     // TargetCatalogVersion
 		}
 
 		buf := new(bytes.Buffer)

--- a/hub/server_internal_test.go
+++ b/hub/server_internal_test.go
@@ -17,6 +17,7 @@ func TestConfig(t *testing.T) {
 	// "stream" refers to the io.Writer/Reader interfaces.
 	t.Run("saves itself to the provided stream", func(t *testing.T) {
 		source, target := testutils.CreateMultinodeSampleClusterPair("/tmp")
+		source.TablespacesMappingFilePath = greenplum.TablespacesMappingFile
 		targetInitializeConfig := InitializeConfig{Master: greenplum.SegConfig{Hostname: "mdw"}}
 
 		// NOTE: we explicitly do not name the struct members here, to ensure
@@ -37,8 +38,7 @@ func TestConfig(t *testing.T) {
 					Location:    "/tmp/master/my_tablespace/1663",
 					UserDefined: 1,
 				}}}, // Tablespaces
-			greenplum.TablespacesMappingFile, // TablespacesMappingFilePath
-			"301908232",                      // TargetCatalogVersion
+			"301908232", // TargetCatalogVersion
 		}
 
 		buf := new(bytes.Buffer)

--- a/hub/upgrade_primaries.go
+++ b/hub/upgrade_primaries.go
@@ -89,7 +89,7 @@ func (s *Server) GetDataDirPairs() (map[string][]*idl.DataDirPair, error) {
 			TargetPort:    int32(targetSeg.Port),
 			Content:       int32(contentID),
 			DBID:          int32(sourceSeg.DbID),
-			Tablespaces:   getProtoTablespaceMap(s.Tablespaces, targetSeg.DbID),
+			Tablespaces:   getProtoTablespaceMap(s.Source.Tablespaces, targetSeg.DbID),
 		}
 
 		dataDirPairMap[sourceSeg.Hostname] = append(dataDirPairMap[sourceSeg.Hostname], dataPair)


### PR DESCRIPTION
Currently, the tablespace information is in the Config struct, but it is semantically attached to the source cluster.  So this PR moves that information into the greenplum.Cluster struct.

This is a DRAFT PR, as I am not sure of the history of keeping that information where it currently is.







[test pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:move_tablespace_info_to_cluster)
