### PR TITLE
remove gomega as a dependency

### DIFF
--- a/agent/archive_log_directory_test.go
+++ b/agent/archive_log_directory_test.go
@@ -13,8 +13,7 @@ import (
 	"testing"
 
 	"github.com/greenplum-db/gpupgrade/testutils"
-
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 
 	"github.com/greenplum-db/gpupgrade/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -22,7 +21,7 @@ import (
 )
 
 func TestArchiveLogDirectories(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 	server := agent.NewServer(agent.Config{})
 
 	t.Run("bubbles up errors", func(t *testing.T) {

--- a/agent/delete_directories_test.go
+++ b/agent/delete_directories_test.go
@@ -9,17 +9,16 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-
 	"github.com/greenplum-db/gpupgrade/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/step"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 	"github.com/greenplum-db/gpupgrade/utils"
 )
 
 func TestDeleteDataDirectories(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	t.Run("deletes data directories", func(t *testing.T) {
 		utils.System.Hostname = func() (string, error) {
@@ -67,7 +66,7 @@ func TestDeleteDataDirectories(t *testing.T) {
 }
 
 func TestDeleteStateDirectory(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	t.Run("deletes the state directory", func(t *testing.T) {
 		utils.System.Hostname = func() (string, error) {

--- a/agent/rename_directories_test.go
+++ b/agent/rename_directories_test.go
@@ -8,15 +8,15 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 )
 
 func TestRenameDirectories(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 	server := agent.NewServer(agent.Config{})
 
 	t.Run("bubbles up errors", func(t *testing.T) {

--- a/agent/rsync_test.go
+++ b/agent/rsync_test.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/agent"
@@ -21,12 +20,13 @@ import (
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 	"github.com/greenplum-db/gpupgrade/utils/rsync"
 )
 
 func TestRsync(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 	server := agent.NewServer(agent.Config{})
 
 	source := testutils.GetTempDir(t, "")
@@ -177,7 +177,7 @@ func TestRsync(t *testing.T) {
 }
 
 func TestRsyncTablespaceDirectories(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 	server := agent.NewServer(agent.Config{})
 
 	_, sourceTsLocationDir := testutils.MustMake5XTablespaceDir(t, 0)

--- a/agent/server_test.go
+++ b/agent/server_test.go
@@ -9,15 +9,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/agent"
 	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 )
 
 func TestServerStart(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	t.Run("successfully starts and creates state directory if it does not exist", func(t *testing.T) {
 		tempDir := testutils.GetTempDir(t, "")

--- a/agent/upgrade_primaries_test.go
+++ b/agent/upgrade_primaries_test.go
@@ -12,12 +12,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/greenplum-db/gpupgrade/utils/rsync"
 )
@@ -28,7 +28,7 @@ func ResetCommands() {
 }
 
 func TestUpgradePrimary(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	// Disable exec.Command. This way, if a test forgets to mock it out, we
 	// crash the test instead of executing code on a dev system.

--- a/cli/commanders/commanders_suite_test.go
+++ b/cli/commanders/commanders_suite_test.go
@@ -7,12 +7,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 )
 
 func TestMain(m *testing.M) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 	os.Exit(exectest.Run(m))
 }

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/jackc/pgx v3.2.0+incompatible
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/lib/pq v1.8.0
-	github.com/onsi/gomega v1.7.1
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/DATA-DOG/go-sqlmock v1.4.0 h1:yxQ63CFIA8Sxkh0vqIofuNrsXl/LZ42TpeTLV4Nb5HM=
-github.com/DATA-DOG/go-sqlmock v1.4.0/go.mod h1:3TucWNLPFOLcHhha1CPp7Kis1UG2h/AqGROPyOeZzsM=
 github.com/DATA-DOG/go-sqlmock v1.4.1 h1:ThlnYciV1iM/V0OSF/dtkqWb6xo5qITT1TJBG1MRDJM=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -48,8 +46,6 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekf
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
-github.com/golang/mock v1.3.1-0.20190508161146-9fa652df1129 h1:tT8iWCYw4uOem71yYA3htfH+LNopJvcqZQshm56G5L4=
-github.com/golang/mock v1.3.1-0.20190508161146-9fa652df1129/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -61,8 +57,6 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/renameio v0.1.0 h1:GOZbcHa3HfsPKPlmyPyN2KEohoMXOhdMbHrvbpl2QaA=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/greenplum-db/gp-common-go-libs v1.0.2 h1:0fR0YG7fQdt6TQro+VVa+FYQvb+lPf8vyTKA1qhccnQ=
-github.com/greenplum-db/gp-common-go-libs v1.0.2/go.mod h1:+l4POQul2akeeSutWY9CtvIq9lkLiSkvt4iypuNmD9o=
 github.com/greenplum-db/gp-common-go-libs v1.0.4 h1:/xVTB4n8VH0QSo/UOxKwchv6dn7dQ82nYmil2CBAff4=
 github.com/greenplum-db/gp-common-go-libs v1.0.4/go.mod h1:9c/YHmHTWUmFPAOuIrXElDrNF7U0Du3bz2BFnABXD4k=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -70,8 +64,6 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
-github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
@@ -113,12 +105,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.11.0 h1:JAKSXpt1YjtLA7YpPiqO9ss6sNXEsPfSGdwN0UHqzrw=
-github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0 h1:Iw5WCbBcaAAd0fpRb1c9r5YCylv4XDoCSigm1zLevwU=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
-github.com/onsi/gomega v1.4.0 h1:p/ZBjQI9G/VwoPrslo/sqS6R5vHU9Od60+axIiP6WuQ=
-github.com/onsi/gomega v1.4.0/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.1 h1:K0jcRCwNQM3vFGh1ppMtDh/+7ApJrjldlX8fA0jDTLQ=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -158,6 +146,7 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
@@ -185,8 +174,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
-golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
-golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -201,8 +188,6 @@ golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/ntt0swNk5oYBziWeTCvY=
-golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e h1:N7DeIrjYszNmSW409R3frPPwglRwMkXSBzwVbkOjLLA=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200806125547-5acd03effb82 h1:6cBnXxYO+CiRVrChvCosSv7magqTPbyAgz1M8iOv5wM=
@@ -218,8 +203,6 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 h1:5Beo0mZN8dRzgrMMkDp0jc8YXQKx9DiJ2k1dkvGsn5A=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
-golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
-golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/greenplum/cluster_test.go
+++ b/greenplum/cluster_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 )
 
 func TestCluster(t *testing.T) {
@@ -164,7 +165,7 @@ func TestCluster(t *testing.T) {
 }
 
 func TestGetSegmentConfiguration(t *testing.T) {
-	testhelper.SetupTestLogger() // init gplog
+	testlog.SetupLogger()
 
 	cases := []struct {
 		name     string
@@ -238,7 +239,7 @@ func TestPrimaryHostnames(t *testing.T) {
 	expectedCluster := testutils.CreateMultinodeSampleCluster("/tmp")
 	expectedCluster.GPHome = "/fake/path"
 	expectedCluster.Version = dbconn.NewVersion("6.0.0")
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	defer func() {
 		os.RemoveAll(testStateDir)
@@ -261,7 +262,7 @@ func TestClusterFromDB(t *testing.T) {
 		t.Errorf("got error when creating tempdir: %+v", err)
 	}
 
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	defer func() {
 		os.RemoveAll(testStateDir)

--- a/greenplum/start_or_stop_cluster_test.go
+++ b/greenplum/start_or_stop_cluster_test.go
@@ -12,10 +12,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/utils"
 )
 
@@ -45,7 +44,7 @@ func init() {
 }
 
 func TestStartOrStopCluster(t *testing.T) {
-	testhelper.SetupTestLogger() // initialize gplog
+	testlog.SetupLogger()
 
 	masterDataDir, err := ioutil.TempDir("", "")
 	if err != nil {

--- a/hub/archive_log_directory_test.go
+++ b/hub/archive_log_directory_test.go
@@ -8,18 +8,18 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 )
 
 const newDir = "NewDirectory"
 
 func TestArchiveLogDirectories(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	t.Run("archive segment log directories", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/hub/check_disk_space_test.go
+++ b/hub/check_disk_space_test.go
@@ -13,13 +13,13 @@ import (
 
 	sigar "github.com/cloudfoundry/gosigar"
 	"github.com/golang/mock/gomock"
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	multierror "github.com/hashicorp/go-multierror"
 	"golang.org/x/sys/unix"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/utils/disk"
 )
 
@@ -30,7 +30,7 @@ func TestCheckDiskSpace(t *testing.T) {
 	var req *idl.CheckDiskSpaceRequest
 	ctx := context.Background()
 
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	// This helper performs the boring test work. Set the above variables as
 	// part of your more interesting test setup.

--- a/hub/copy_master_test.go
+++ b/hub/copy_master_test.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
 	"google.golang.org/grpc"
 
@@ -21,6 +20,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/utils/rsync"
 )
 
@@ -44,7 +44,7 @@ func init() {
 }
 
 func TestCopy(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	t.Run("copies the directory only once per host", func(t *testing.T) {
 

--- a/hub/delete_data_directories_test.go
+++ b/hub/delete_data_directories_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
@@ -22,6 +21,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 )
 
@@ -49,7 +49,7 @@ func TestDeleteSegmentDataDirs(t *testing.T) {
 
 	c := hub.MustCreateCluster(t, segConfigs)
 
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	t.Run("DeleteMirrorAndStandbyDataDirectories", func(t *testing.T) {
 		t.Run("deletes standby and mirror data directories", func(t *testing.T) {

--- a/hub/delete_state_directories_test.go
+++ b/hub/delete_state_directories_test.go
@@ -8,16 +8,16 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 )
 
 func TestDeleteStateDirectories(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	t.Run("DeleteStateDirectories", func(t *testing.T) {
 		t.Run("deletes state directories on all hosts except for the host that gets passed in", func(t *testing.T) {

--- a/hub/hub_start_services_test.go
+++ b/hub/hub_start_services_test.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
@@ -25,6 +24,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 )
 
 func gpupgrade_agent() {
@@ -43,7 +43,7 @@ func init() {
 }
 
 func TestRestartAgent(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 	listener := bufconn.Listen(1024 * 1024)
 	agentServer := grpc.NewServer()
 	defer agentServer.Stop()

--- a/hub/init_target_cluster_test.go
+++ b/hub/init_target_cluster_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/utils"
 )
 
@@ -278,7 +279,7 @@ func TestGetMasterSegPrefix(t *testing.T) {
 }
 
 func TestGetCatalogVersion(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	gphome := "/usr/local/target"
 	datadir := "/data/qddir_upgrade/seg-1"

--- a/hub/rename_data_directories_test.go
+++ b/hub/rename_data_directories_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
@@ -16,11 +15,12 @@ import (
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 )
 
 func TestRenameSegmentDataDirs(t *testing.T) {
-	testhelper.SetupTestLogger() // initialize gplog
+	testlog.SetupLogger()
 
 	m := hub.RenameMap{
 		"sdw1": {

--- a/hub/restore_source_cluster_test.go
+++ b/hub/restore_source_cluster_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
@@ -23,6 +22,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/utils/rsync"
 )
 
@@ -31,7 +31,7 @@ func ResetRecoversegCmd() {
 }
 
 func TestRsyncMasterAndPrimaries(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	cluster := hub.MustCreateCluster(t, []greenplum.SegConfig{
 		{DbID: 1, ContentID: -1, Hostname: "master", DataDir: "/data/qddir", Role: greenplum.PrimaryRole},

--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -24,6 +23,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/testutils/mock_agent"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 )
 
@@ -180,7 +180,7 @@ func TestAgentConns(t *testing.T) {
 		UpgradeID:              0,
 	}
 
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	t.Run("closes open connections when shutting down", func(t *testing.T) {
 		h := hub.New(conf, dialer, "")

--- a/hub/upgrade_master_test.go
+++ b/hub/upgrade_master_test.go
@@ -16,12 +16,12 @@ import (
 	"testing"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/greenplum-db/gpupgrade/utils/rsync"
@@ -113,7 +113,7 @@ func init() {
 }
 
 func TestUpgradeMaster(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	source := MustCreateCluster(t, []greenplum.SegConfig{
 		{ContentID: -1, Port: 5432, DataDir: "/data/old", DbID: 1, Role: "p"},

--- a/hub/upgrade_standby_test.go
+++ b/hub/upgrade_standby_test.go
@@ -6,13 +6,12 @@ package hub_test
 import (
 	"testing"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-
 	"github.com/greenplum-db/gpupgrade/hub"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 )
 
 func TestUpgradeStandby(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	t.Run("it upgrades the standby through gpinitstandby", func(t *testing.T) {
 		config := hub.StandbyConfig{

--- a/step/stream_test.go
+++ b/step/stream_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 )
 
 // Since we have no good way to test devNullStream, we instead
@@ -52,8 +52,7 @@ func TestBufStream(t *testing.T) {
 }
 
 func TestMultiplexedStream(t *testing.T) {
-	// Store gplog output.
-	_, _, log := testhelper.SetupTestLogger()
+	_, _, log := testlog.SetupLogger()
 
 	t.Run("forwards stdout and stderr to the stream", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -144,7 +143,7 @@ func TestMultiplexedStream(t *testing.T) {
 		}
 
 		expected := "halting client stream: error during send"
-		contents := string(log.Contents())
+		contents := string(log.Bytes())
 		if !strings.Contains(contents, expected) {
 			t.Errorf("log file %q does not contain %q", contents, expected)
 		}

--- a/testutils/test_utils.go
+++ b/testutils/test_utils.go
@@ -9,11 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
-	"github.com/onsi/gomega/gbytes"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/upgrade"
@@ -184,30 +182,6 @@ func SetEnv(t *testing.T, envar, value string) func() {
 				t.Fatalf("unsetting %s environment variable: %#v", envar, err)
 			}
 		}
-	}
-}
-
-func VerifyLogContains(t *testing.T, testlog *gbytes.Buffer, expected string) {
-	t.Helper()
-	verifyLog(t, testlog, expected, true)
-}
-
-func VerifyLogDoesNotContain(t *testing.T, testlog *gbytes.Buffer, expected string) {
-	t.Helper()
-	verifyLog(t, testlog, expected, false)
-}
-
-func verifyLog(t *testing.T, testlog *gbytes.Buffer, expected string, shouldContain bool) {
-	t.Helper()
-
-	text := "to not contain"
-	if shouldContain {
-		text = "to contain"
-	}
-
-	contents := string(testlog.Contents())
-	if shouldContain && !strings.Contains(contents, expected) {
-		t.Errorf("\nexpected log: %q\n%s:   %q", contents, text, expected)
 	}
 }
 

--- a/testutils/testlog/log.go
+++ b/testutils/testlog/log.go
@@ -1,0 +1,43 @@
+package testlog
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/greenplum-db/gpupgrade/utils/syncbuf"
+)
+
+// TODO: if no callers use testSdtout and testStderr we can simplify this interface.
+func SetupLogger() (*syncbuf.Syncbuf, *syncbuf.Syncbuf, *syncbuf.Syncbuf) {
+	testStdout := syncbuf.New()
+	testStderr := syncbuf.New()
+	testLogfile := syncbuf.New()
+	testLogger := gplog.NewLogger(testStdout, testStderr, testLogfile, "sync.SyncBuf", gplog.LOGINFO, "testProgram")
+	gplog.SetLogger(testLogger)
+	return testStdout, testStderr, testLogfile
+}
+
+func VerifyLogContains(t *testing.T, testlog *syncbuf.Syncbuf, expected string) {
+	t.Helper()
+	verifyLog(t, testlog, expected, true)
+}
+
+func VerifyLogDoesNotContain(t *testing.T, testlog *syncbuf.Syncbuf, expected string) {
+	t.Helper()
+	verifyLog(t, testlog, expected, false)
+}
+
+func verifyLog(t *testing.T, testlog *syncbuf.Syncbuf, expected string, shouldContain bool) {
+	t.Helper()
+
+	contents := string(testlog.Bytes())
+	contains := strings.Contains(contents, expected)
+	if shouldContain && !contains {
+		t.Errorf("\nexpected log: %q\nto contain:   %q", contents, expected)
+	}
+
+	if !shouldContain && contains {
+		t.Errorf("\nexpected log: %q\nto not contain:   %q", contents, expected)
+	}
+}

--- a/upgrade/directories_test.go
+++ b/upgrade/directories_test.go
@@ -14,11 +14,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 	"github.com/greenplum-db/gpupgrade/utils"
 )
@@ -80,7 +80,7 @@ func TestGetArchiveDirectoryName(t *testing.T) {
 }
 
 func TestArchiveSource(t *testing.T) {
-	_, _, testlog := testhelper.SetupTestLogger()
+	_, _, log := testlog.SetupLogger()
 
 	t.Run("successfully renames source to archive, and target to source", func(t *testing.T) {
 		source, target, cleanup := testutils.MustCreateDataDirs(t)
@@ -225,7 +225,7 @@ func TestArchiveSource(t *testing.T) {
 
 		testutils.VerifyRename(t, source, target)
 
-		testutils.VerifyLogDoesNotContain(t, testlog, "Source directory does not exist")
+		testlog.VerifyLogDoesNotContain(t, log, "Source directory does not exist")
 	})
 
 	t.Run("when renaming the source fails then a re-run succeeds", func(t *testing.T) {
@@ -267,7 +267,7 @@ func TestArchiveSource(t *testing.T) {
 
 		testutils.VerifyRename(t, source, target)
 
-		testutils.VerifyLogDoesNotContain(t, testlog, "Source directory does not exist")
+		testlog.VerifyLogDoesNotContain(t, log, "Source directory does not exist")
 	})
 
 	t.Run("when renaming the target fails then a re-run succeeds", func(t *testing.T) {
@@ -309,7 +309,7 @@ func TestArchiveSource(t *testing.T) {
 
 		testutils.VerifyRename(t, source, target)
 
-		testutils.VerifyLogContains(t, testlog, "Source directory not found")
+		testlog.VerifyLogContains(t, log, "Source directory not found")
 	})
 }
 
@@ -328,7 +328,7 @@ func setup(t *testing.T) (teardown func(), directories []string, requiredPaths [
 }
 
 func TestDeleteDirectories(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	utils.System.Hostname = func() (string, error) {
 		return "localhost.local", nil
@@ -481,7 +481,7 @@ func TestTablespacePath(t *testing.T) {
 const userRWX = 0700
 
 func TestDeleteNewTablespaceDirectories(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 	utils.System.Hostname = func() (s string, err error) {
 		return "", nil
 	}

--- a/upgrade/run_test.go
+++ b/upgrade/run_test.go
@@ -15,9 +15,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 )
 
@@ -59,7 +58,7 @@ func init() {
 }
 
 func TestRun(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	pair := upgrade.SegmentPair{
 		Source: &upgrade.Segment{

--- a/utils/disk/disk_test.go
+++ b/utils/disk/disk_test.go
@@ -11,15 +11,15 @@ import (
 	"testing"
 
 	sigar "github.com/cloudfoundry/gosigar"
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"golang.org/x/sys/unix"
 
 	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/utils/disk"
 )
 
 func TestCheckUsage(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	// This test disk has two mount points:
 	//  - /, at 25% utilization

--- a/utils/log/panic_test.go
+++ b/utils/log/panic_test.go
@@ -7,19 +7,18 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/utils/log"
 )
 
 func TestWritePanics(t *testing.T) {
 	t.Run("writes panics to the log file", func(t *testing.T) {
-		_, _, buffer := testhelper.SetupTestLogger()
+		_, _, buffer := testlog.SetupLogger()
 
 		expected := "ahhh"
 		defer func() {
 			if e := recover(); e != nil {
-				contents := string(buffer.Contents())
+				contents := string(buffer.Bytes())
 				if !strings.Contains(contents, expected) {
 					t.Errorf("expected %q in log file: %q", expected, contents)
 				}

--- a/utils/rsync/rsync_test.go
+++ b/utils/rsync/rsync_test.go
@@ -11,11 +11,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/greenplum-db/gpupgrade/utils/rsync"
 )
@@ -34,7 +33,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestRsync(t *testing.T) {
-	testhelper.SetupTestLogger()
+	testlog.SetupLogger()
 
 	if _, err := exec.LookPath("rsync"); err != nil {
 		t.Fatalf("tests require rsync (%v)", err)

--- a/utils/syncbuf/syncbuf.go
+++ b/utils/syncbuf/syncbuf.go
@@ -1,0 +1,46 @@
+//  Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+//  SPDX-License-Identifier: Apache-2.0
+
+package syncbuf
+
+import (
+	"bytes"
+	"sync"
+)
+
+// Syncbuf implements a go-routine safe unbounded buffer
+type Syncbuf struct {
+	buf bytes.Buffer
+	sync.Mutex
+}
+
+func New() *Syncbuf {
+	return &Syncbuf{}
+}
+
+func (s *Syncbuf) Write(p []byte) (n int, err error) {
+	s.Lock()
+	defer s.Unlock()
+
+	return s.buf.Write(p)
+}
+
+func (s *Syncbuf) Read(b []byte) (n int, err error) {
+	s.Lock()
+	defer s.Unlock()
+
+	return s.buf.Read(b)
+}
+
+// Bytes() returns the current contents of the Syncbuf, without
+// modifying it.
+func (s *Syncbuf) Bytes() []byte {
+	s.Lock()
+	defer s.Unlock()
+
+	// copy contents into a buffer that does not expose our internals
+	var buf bytes.Buffer
+	buf.Write(s.buf.Bytes())
+
+	return buf.Bytes()
+}

--- a/utils/syncbuf/syncbuf_test.go
+++ b/utils/syncbuf/syncbuf_test.go
@@ -1,0 +1,75 @@
+//  Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+//  SPDX-License-Identifier: Apache-2.0
+
+package syncbuf_test
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/greenplum-db/gpupgrade/utils/syncbuf"
+)
+
+func TestSyncbuf(t *testing.T) {
+	t.Run("writes to a buffer", func(t *testing.T) {
+		s := syncbuf.New()
+
+		expected := []byte("hello")
+		_, err := s.Write(expected)
+		if err != nil {
+			t.Fatalf("Write returned error %+v", err)
+		}
+
+		actual := s.Bytes()
+		if !bytes.Equal(actual, expected) {
+			t.Errorf("got %#v expected %#v", actual, expected)
+		}
+	})
+
+	t.Run("make sure Write is atomic", func(t *testing.T) {
+		seq1 := []byte("01234")
+		seq2 := []byte("56789")
+
+		var wg sync.WaitGroup
+		s := syncbuf.New()
+
+		// 10 runs always fails when we remove synchronization from s.Write()
+		runs := 10
+		for run := 0; run < runs; run++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := s.Write(seq1)
+				if err != nil {
+					t.Errorf("Write failed %+v", err)
+				}
+				_, err = s.Write(seq2)
+				if err != nil {
+					t.Errorf("Write failed %+v", err)
+				}
+			}()
+		}
+
+		wg.Wait()
+
+		// Check that seq1 or seq2 are written in any order the correct number of times.
+		expectedLength := (len(seq1) + len(seq2)) * runs
+		actual := make([]byte, expectedLength)
+		_, err := s.Read(actual)
+		if err != nil {
+			t.Fatalf("Read returned error %+v", err)
+		}
+
+		numSeq1 := strings.Count(string(actual), string(seq1))
+		if numSeq1 != runs {
+			t.Errorf("found seq1 %d times want %d in %q", numSeq1, runs, actual)
+		}
+
+		numSeq2 := strings.Count(string(actual), string(seq2))
+		if numSeq2 != runs {
+			t.Errorf("found seq2 %d times want %d in %q", numSeq2, runs, actual)
+		}
+	})
+}


### PR DESCRIPTION
We remove gomega as a dependency. 

The only use was for the testlogger comparison routines.  So we replace it by:

1). defining our own synchronized buffer.
2). implementing our own test logger setup that uses that buffer.
3). using that test logger everywhere
4). removing the dependency.

Ideally, the SyncBuf would be in testutils directly, but due to pre-existing dependency cycles(testutils includes greenplum and upgrade, and greenplum includes upgrade) it is simplest for now to place the log code into its own package.