### PR TITLE
introduce CLI-only substep framework

### DIFF
--- a/cli/commanders/steps.go
+++ b/cli/commanders/steps.go
@@ -36,43 +36,43 @@ type receiver interface {
 	Recv() (*idl.Message, error)
 }
 
-type substepText struct {
+type SubstepText struct {
 	OutputText string
 	HelpText   string
 }
 
-var SubstepDescriptions = map[idl.Substep]substepText{
-	idl.Substep_CREATING_DIRECTORIES:                     substepText{"Creating directories...", "Create directories"},
-	idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG:             substepText{"Saving source cluster configuration...", "Save source cluster configuration"},
-	idl.Substep_START_HUB:                                substepText{"Starting gpupgrade hub process...", "Start gpupgrade hub process"},
-	idl.Substep_START_AGENTS:                             substepText{"Starting gpupgrade agent processes...", "Start gpupgrade agent processes"},
-	idl.Substep_CHECK_DISK_SPACE:                         substepText{"Checking disk space...", "Check disk space"},
-	idl.Substep_CREATE_TARGET_CONFIG:                     substepText{"Generating target cluster configuration...", "Generate target cluster configuration"},
-	idl.Substep_INIT_TARGET_CLUSTER:                      substepText{"Creating target cluster...", "Create target cluster"},
-	idl.Substep_SHUTDOWN_TARGET_CLUSTER:                  substepText{"Stopping target cluster...", "Stop target cluster"},
-	idl.Substep_BACKUP_TARGET_MASTER:                     substepText{"Backing up target master...", "Back up target master"},
-	idl.Substep_CHECK_UPGRADE:                            substepText{"Running pg_upgrade checks...", "Run pg_upgrade checks"},
-	idl.Substep_SHUTDOWN_SOURCE_CLUSTER:                  substepText{"Stopping source cluster...", "Stop source cluster"},
-	idl.Substep_UPGRADE_MASTER:                           substepText{"Upgrading master...", "Upgrade master"},
-	idl.Substep_COPY_MASTER:                              substepText{"Copying master catalog to primary segments...", "Copy master catalog to primary segments"},
-	idl.Substep_UPGRADE_PRIMARIES:                        substepText{"Upgrading primary segments...", "Upgrade primary segments"},
-	idl.Substep_START_TARGET_CLUSTER:                     substepText{"Starting target cluster...", "Start target cluster"},
-	idl.Substep_UPDATE_TARGET_CATALOG_AND_CLUSTER_CONFIG: substepText{"Updating target master catalog...", "Update target master catalog"},
-	idl.Substep_UPDATE_DATA_DIRECTORIES:                  substepText{"Updating data directories...", "Update data directories"},
-	idl.Substep_UPDATE_TARGET_CONF_FILES:                 substepText{"Updating target master configuration files...", "Update target master configuration files"},
-	idl.Substep_UPGRADE_STANDBY:                          substepText{"Upgrading standby master...", "Upgrade standby master"},
-	idl.Substep_UPGRADE_MIRRORS:                          substepText{"Upgrading mirror segments...", "Upgrade mirror segments"},
-	idl.Substep_DELETE_TABLESPACES:                       substepText{"Deleting target tablespace directories...", "Delete target tablespace directories"},
-	idl.Substep_DELETE_PRIMARY_DATADIRS:                  substepText{"Deleting primary segment data directories...", "Delete primary segment data directories"},
-	idl.Substep_DELETE_MASTER_DATADIR:                    substepText{"Deleting master data directory...", "Delete master data directory"},
-	idl.Substep_DELETE_SEGMENT_STATEDIRS:                 substepText{"Deleting state directories on the segments...", "Delete state directories on the segments"},
-	idl.Substep_STOP_HUB_AND_AGENTS:                      substepText{"Stopping hub and agents...", "Stop hub and agents"},
-	idl.Substep_DELETE_MASTER_STATEDIR:                   substepText{"Deleting master state directory...", "Delete master state directory"},
-	idl.Substep_ARCHIVE_LOG_DIRECTORIES:                  substepText{"Archiving log directories...", "Archive log directories"},
-	idl.Substep_RESTORE_SOURCE_CLUSTER:                   substepText{"Restoring source cluster...", "Restore source cluster"},
-	idl.Substep_START_SOURCE_CLUSTER:                     substepText{"Starting source cluster...", "Start source cluster"},
-	idl.Substep_RESTORE_PGCONTROL:                        substepText{"Re-enabling source cluster...", "Re-enable source cluster"},
-	idl.Substep_RECOVERSEG_SOURCE_CLUSTER:                substepText{"Recovering source cluster mirrors...", "Recover source cluster mirrors"},
+var SubstepDescriptions = map[idl.Substep]SubstepText{
+	idl.Substep_CREATING_DIRECTORIES:                     SubstepText{"Creating directories...", "Create directories"},
+	idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG:             SubstepText{"Saving source cluster configuration...", "Save source cluster configuration"},
+	idl.Substep_START_HUB:                                SubstepText{"Starting gpupgrade hub process...", "Start gpupgrade hub process"},
+	idl.Substep_START_AGENTS:                             SubstepText{"Starting gpupgrade agent processes...", "Start gpupgrade agent processes"},
+	idl.Substep_CHECK_DISK_SPACE:                         SubstepText{"Checking disk space...", "Check disk space"},
+	idl.Substep_CREATE_TARGET_CONFIG:                     SubstepText{"Generating target cluster configuration...", "Generate target cluster configuration"},
+	idl.Substep_INIT_TARGET_CLUSTER:                      SubstepText{"Creating target cluster...", "Create target cluster"},
+	idl.Substep_SHUTDOWN_TARGET_CLUSTER:                  SubstepText{"Stopping target cluster...", "Stop target cluster"},
+	idl.Substep_BACKUP_TARGET_MASTER:                     SubstepText{"Backing up target master...", "Back up target master"},
+	idl.Substep_CHECK_UPGRADE:                            SubstepText{"Running pg_upgrade checks...", "Run pg_upgrade checks"},
+	idl.Substep_SHUTDOWN_SOURCE_CLUSTER:                  SubstepText{"Stopping source cluster...", "Stop source cluster"},
+	idl.Substep_UPGRADE_MASTER:                           SubstepText{"Upgrading master...", "Upgrade master"},
+	idl.Substep_COPY_MASTER:                              SubstepText{"Copying master catalog to primary segments...", "Copy master catalog to primary segments"},
+	idl.Substep_UPGRADE_PRIMARIES:                        SubstepText{"Upgrading primary segments...", "Upgrade primary segments"},
+	idl.Substep_START_TARGET_CLUSTER:                     SubstepText{"Starting target cluster...", "Start target cluster"},
+	idl.Substep_UPDATE_TARGET_CATALOG_AND_CLUSTER_CONFIG: SubstepText{"Updating target master catalog...", "Update target master catalog"},
+	idl.Substep_UPDATE_DATA_DIRECTORIES:                  SubstepText{"Updating data directories...", "Update data directories"},
+	idl.Substep_UPDATE_TARGET_CONF_FILES:                 SubstepText{"Updating target master configuration files...", "Update target master configuration files"},
+	idl.Substep_UPGRADE_STANDBY:                          SubstepText{"Upgrading standby master...", "Upgrade standby master"},
+	idl.Substep_UPGRADE_MIRRORS:                          SubstepText{"Upgrading mirror segments...", "Upgrade mirror segments"},
+	idl.Substep_DELETE_TABLESPACES:                       SubstepText{"Deleting target tablespace directories...", "Delete target tablespace directories"},
+	idl.Substep_DELETE_PRIMARY_DATADIRS:                  SubstepText{"Deleting primary segment data directories...", "Delete primary segment data directories"},
+	idl.Substep_DELETE_MASTER_DATADIR:                    SubstepText{"Deleting master data directory...", "Delete master data directory"},
+	idl.Substep_DELETE_SEGMENT_STATEDIRS:                 SubstepText{"Deleting state directories on the segments...", "Delete state directories on the segments"},
+	idl.Substep_STOP_HUB_AND_AGENTS:                      SubstepText{"Stopping hub and agents...", "Stop hub and agents"},
+	idl.Substep_DELETE_MASTER_STATEDIR:                   SubstepText{"Deleting master state directory...", "Delete master state directory"},
+	idl.Substep_ARCHIVE_LOG_DIRECTORIES:                  SubstepText{"Archiving log directories...", "Archive log directories"},
+	idl.Substep_RESTORE_SOURCE_CLUSTER:                   SubstepText{"Restoring source cluster...", "Restore source cluster"},
+	idl.Substep_START_SOURCE_CLUSTER:                     SubstepText{"Starting source cluster...", "Start source cluster"},
+	idl.Substep_RESTORE_PGCONTROL:                        SubstepText{"Re-enabling source cluster...", "Re-enable source cluster"},
+	idl.Substep_RECOVERSEG_SOURCE_CLUSTER:                SubstepText{"Recovering source cluster mirrors...", "Recover source cluster mirrors"},
 }
 
 var indicators = map[idl.Status]string{
@@ -276,7 +276,7 @@ func Format(description string, status idl.Status) string {
 // Substep prints out an "in progress" marker for the given substep description,
 // and returns a struct that can be .Finish()d (in a defer statement) to print
 // the final complete/failed state.
-func Substep(step idl.Substep) *substepText {
+func Substep(step idl.Substep) *SubstepText {
 	substepText := SubstepDescriptions[step]
 	fmt.Printf("%s\r", Format(substepText.OutputText, idl.Status_RUNNING))
 	return &substepText
@@ -293,7 +293,7 @@ func Substep(step idl.Substep) *substepText {
 //        ...
 //    }
 //
-func (s *substepText) Finish(err *error) {
+func (s *SubstepText) Finish(err *error) {
 	status := idl.Status_COMPLETE
 	if *err != nil {
 		status = idl.Status_FAILED

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -51,6 +51,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/cli"
 	"github.com/greenplum-db/gpupgrade/cli/commanders"
+	"github.com/greenplum-db/gpupgrade/cli/substep"
 	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/step"

--- a/cli/substep/substep.go
+++ b/cli/substep/substep.go
@@ -1,0 +1,71 @@
+//  Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+//  SPDX-License-Identifier: Apache-2.0
+
+package substep
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"golang.org/x/xerrors"
+
+	"github.com/greenplum-db/gpupgrade/cli/commanders"
+	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/step"
+)
+
+// CLISubstep are substeps that are only run on the CLI
+type CLISubstep struct {
+	streams *step.BufferedStreams // writes stdout/err
+	verbose bool
+}
+
+func New(streams *step.BufferedStreams, verbose bool) *CLISubstep {
+	return &CLISubstep{
+		streams: streams,
+		verbose: verbose,
+	}
+}
+
+// Run prints out the corresponding status marker such as running, completed, or
+// failed.
+func (s *CLISubstep) Run(name idl.Substep, f func(streams step.OutStreams) error) {
+	text := commanders.SubstepDescriptions[name]
+	var err error
+	defer func() {
+		if err != nil {
+			err = xerrors.Errorf(`substep "%s": %w`, name, err)
+		}
+
+		s.finish(&err, name, text, 0)
+	}()
+
+	fmt.Printf("%s\r", commanders.Format(text.OutputText, idl.Status_RUNNING))
+
+	err = f(s.streams)
+	if s.verbose {
+		os.Stdout.Write(s.streams.StdoutBuf.Bytes())
+		os.Stdout.Write(s.streams.StderrBuf.Bytes())
+	}
+}
+
+// finish prints out the final status of the substep; either COMPLETE or FAILED
+// depending on whether or not there is an error. The method takes a pointer to
+// error rather than error to make it possible to defer:
+func (s *CLISubstep) finish(err *error, name idl.Substep, text commanders.SubstepText, duration time.Duration) {
+	status := idl.Status_COMPLETE
+	if *err != nil {
+		status = idl.Status_FAILED
+	}
+
+	fmt.Printf("%s\n", commanders.Format(text.OutputText, status))
+
+	durationMsg := fmt.Sprintf("\n%s took %s\n\n", name, duration)
+	if s.verbose {
+		fmt.Print(durationMsg)
+	}
+
+	gplog.Debug(durationMsg)
+}

--- a/cli/substep/substep_test.go
+++ b/cli/substep/substep_test.go
@@ -1,0 +1,159 @@
+//  Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+//  SPDX-License-Identifier: Apache-2.0
+
+package substep_test
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"sync"
+	"testing"
+
+	"golang.org/x/xerrors"
+
+	"github.com/greenplum-db/gpupgrade/cli/commanders"
+	"github.com/greenplum-db/gpupgrade/cli/substep"
+	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/step"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
+)
+
+func TestSubstep(t *testing.T) {
+	testlog.SetupLogger()
+
+	d := BufferStandardDescriptors(t)
+	defer d.Close()
+
+	s := substep.New(&step.BufferedStreams{}, false)
+
+	s.Run(idl.Substep_CREATING_DIRECTORIES, func(streams step.OutStreams) error {
+		return nil
+	})
+
+	err := errors.New("error")
+	s.Run(idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG, func(streams step.OutStreams) error {
+		return err
+	})
+
+	stdout, stderr := d.Collect()
+
+	if len(stderr) != 0 {
+		t.Errorf("unexpected stderr %#v", string(stderr))
+	}
+
+	expected := commanders.Format(commanders.SubstepDescriptions[idl.Substep_CREATING_DIRECTORIES].OutputText, idl.Status_RUNNING) + "\r"
+	expected += commanders.Format(commanders.SubstepDescriptions[idl.Substep_CREATING_DIRECTORIES].OutputText, idl.Status_COMPLETE) + "\n"
+	expected += commanders.Format(commanders.SubstepDescriptions[idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG].OutputText, idl.Status_RUNNING) + "\r"
+	expected += commanders.Format(commanders.SubstepDescriptions[idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG].OutputText, idl.Status_FAILED) + "\n"
+
+	actual := string(stdout)
+	if actual != expected {
+		t.Errorf("output %#v want %#v", actual, expected)
+	}
+}
+
+// descriptors is a helper to redirect os.Stdout and os.Stderr and buffer the
+// bytes that are written to them.
+//
+//    d := BufferStandardDescriptors(t)
+//    defer d.Close()
+//
+//    // write to os.Stdout and os.Stderr
+//
+//    bytesOut, bytesErr := d.Collect()
+//
+// All errors are handled through a t.Fatalf().
+type descriptors struct {
+	t                  *testing.T
+	wg                 sync.WaitGroup
+	stdout, stderr     *os.File
+	saveOut, saveErr   *os.File
+	outBytes, errBytes []byte
+}
+
+func BufferStandardDescriptors(t *testing.T) *descriptors {
+	d := &descriptors{t: t}
+
+	var err error
+	var rOut, rErr *os.File
+
+	rOut, d.stdout, err = os.Pipe()
+	if err != nil {
+		d.t.Fatalf("opening stdout pipe: %+v", err)
+	}
+
+	rErr, d.stderr, err = os.Pipe()
+	if err != nil {
+		d.t.Fatalf("opening stderr pipe: %+v", err)
+	}
+
+	// Switch out the streams; they are replaced by d.Close().
+	d.saveOut, d.saveErr = os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = d.stdout, d.stderr
+
+	// Each stream must be read separately to avoid deadlock.
+	errChan := make(chan error, 2)
+	d.wg.Add(2)
+	go func() {
+		defer d.wg.Done()
+
+		d.outBytes, err = ioutil.ReadAll(rOut)
+		if err != nil {
+			errChan <- xerrors.Errorf("reading from stdout pipe: %w", err)
+		}
+	}()
+	go func() {
+		defer d.wg.Done()
+
+		d.errBytes, err = ioutil.ReadAll(rErr)
+		if err != nil {
+			errChan <- xerrors.Errorf("reading from stderr pipe: %w", err)
+		}
+	}()
+
+	close(errChan)
+	for err := range errChan {
+		d.t.Fatal(err)
+	}
+
+	return d
+}
+
+// Collect drains the pipes and returns the contents of stdout and stderr. It's
+// safe to call more than once.
+func (d *descriptors) Collect() ([]byte, []byte) {
+	// Close the write sides of the pipe so our goroutines will finish.
+	if d.stdout != nil {
+		err := d.stdout.Close()
+		if err != nil {
+			d.t.Fatalf("closing stdout pipe: %+v", err)
+		}
+
+		d.stdout = nil
+	}
+
+	if d.stderr != nil {
+		err := d.stderr.Close()
+		if err != nil {
+			d.t.Fatalf("closing stderr pipe: %+v", err)
+		}
+
+		d.stderr = nil
+	}
+
+	d.wg.Wait()
+
+	return d.outBytes, d.errBytes
+}
+
+// Close puts os.Stdout and os.Stderr back the way they were, after draining the
+// redirected pipes if necessary.
+func (d *descriptors) Close() {
+	// Always make sure we've waited on the pipe contents before closing.
+	// Collect() is safe to call more than once.
+	d.Collect()
+
+	os.Stdout = d.saveOut
+	os.Stderr = d.saveErr
+}


### PR DESCRIPTION
Some substeps are only run on the CLI and thus do not easily tie into the exisiting step framework. The following issues are presenting themselves.

1) Inconsistent ways of invoking and using the commanders substep framework. There is a mix of substep calls outside and inside the function.
```go
s := commanders.Substep(idl.Substep_STOP_HUB_AND_AGENTS)
err = stopHubAndAgents(false)
s.Finish(&err)
if err != nil {
    return err
}
```
And
```go
func CreateStateDir() (err error) {
	s := Substep(idl.Substep_CREATING_DIRECTORIES)
	defer s.Finish(&err)
        // create directories
}
```

2) Decentralized place to stream function output, and have full control over verbose mode.
```go
s = commanders.Substep(idl.Substep_DELETE_MASTER_STATEDIR)
streams := &step.BufferedStreams{}
err = upgrade.DeleteDirectories([]string{utils.GetStateDir()}, upgrade.StateDirectoryFiles, streams)
if verbose {
    os.Stdout.Write(streams.StdoutBuf.Bytes())
    os.Stdout.Write(streams.StderrBuf.Bytes())
}
```


This PR hopes to address some of these and gather the substep logic into one place. It is intended to replace `commanders.Substep`. So far only revert has been migrated leaving initialize for the actual PR. This is a draft PR looking for general and some specific feedback. To see a possible full implementation check out the [refactorSubstepWIP branch](https://github.com/kalensk/gpupgrade/tree/refactorSubstepWIP).