### PR TITLE
Run revert.bats on CCP

### DIFF
--- a/ci/generated/pipeline.yml
+++ b/ci/generated/pipeline.yml
@@ -1481,6 +1481,330 @@ jobs:
     <<: *ccp_destroy
   on_failure:
     <<: *slack_alert
+
+- name: 6-to-6-multihost-bats-centos-6
+  serial_groups: [6-to-6-multihost-bats]
+  # Specifying serial groups so that only one platform runs at a time. For
+  # example, 5-to-6-centos7 will only run after 5-to-6-centos6 completes. This
+  # will prevent concourse from becoming overloaded.
+  plan:
+    - in_parallel:
+        - get: bin_gpupgrade
+          trigger: true
+          passed: [ build ]
+        - get: gpupgrade_src
+          passed: [ build ]
+        - get: rpm_gpdb_source
+          resource: rpm_gpdb6_centos6
+          trigger: true
+        - get: ccp_src
+        - get: bats
+    - put: terraform
+      params:
+        <<: *ccp_default_params
+        vars:
+          standby_master: true
+          instance_type: n1-standard-2
+          number_of_nodes: 4
+          PLATFORM: centos6
+          # Decrease the reap time from the default of 8 hours now that there are
+          # both centos6 and centos7 jobs in order to not overload concourse.
+          ccp_reap_minutes: 180
+    - task: gen_source_cluster
+      file: ccp_src/ci/tasks/gen_cluster.yml
+      params:
+        <<: *ccp_gen_cluster_default_params
+        PLATFORM: centos6
+        GPDB_RPM: true
+      input_mapping:
+        gpdb_rpm: rpm_gpdb_source
+    - task: gpinitsystem_source_cluster
+      file: ccp_src/ci/tasks/gpinitsystem.yml
+    - task: prepare_source_and_target_installations
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: alpine
+            tag: latest
+        inputs:
+          - name: gpupgrade_src
+          - name: cluster_env_files
+        run:
+          path: gpupgrade_src/ci/scripts/prepare-source-and-target-installations.sh
+          args:
+            - greenplum-db-6
+            - greenplum-db-6
+    - task: run_bats
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: pivotaldata/centos-gpdb-dev
+            tag: "6-gcc6.2-llvm3.7"
+        inputs:
+          - name: terraform
+          - name: ccp_src
+          - name: cluster_env_files
+          - name: gpupgrade_src
+          - name: bin_gpupgrade
+          - name: bats
+        run:
+          path: gpupgrade_src/ci/scripts/bats-on-cluster.bash
+      params:
+  ensure:
+    <<: *set_failed
+  on_success:
+    <<: *ccp_destroy
+  on_failure:
+    <<: *slack_alert
+
+- name: 6-to-6-multihost-bats-centos-7
+  serial_groups: [6-to-6-multihost-bats]
+  # Specifying serial groups so that only one platform runs at a time. For
+  # example, 5-to-6-centos7 will only run after 5-to-6-centos6 completes. This
+  # will prevent concourse from becoming overloaded.
+  plan:
+    - in_parallel:
+        - get: bin_gpupgrade
+          trigger: true
+          passed: [ build ]
+        - get: gpupgrade_src
+          passed: [ build ]
+        - get: rpm_gpdb_source
+          resource: rpm_gpdb6_centos7
+          trigger: true
+        - get: ccp_src
+        - get: bats
+    - put: terraform
+      params:
+        <<: *ccp_default_params
+        vars:
+          standby_master: true
+          instance_type: n1-standard-2
+          number_of_nodes: 4
+          PLATFORM: centos7
+          # Decrease the reap time from the default of 8 hours now that there are
+          # both centos6 and centos7 jobs in order to not overload concourse.
+          ccp_reap_minutes: 180
+    - task: gen_source_cluster
+      file: ccp_src/ci/tasks/gen_cluster.yml
+      params:
+        <<: *ccp_gen_cluster_default_params
+        PLATFORM: centos7
+        GPDB_RPM: true
+      input_mapping:
+        gpdb_rpm: rpm_gpdb_source
+    - task: gpinitsystem_source_cluster
+      file: ccp_src/ci/tasks/gpinitsystem.yml
+    - task: prepare_source_and_target_installations
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: alpine
+            tag: latest
+        inputs:
+          - name: gpupgrade_src
+          - name: cluster_env_files
+        run:
+          path: gpupgrade_src/ci/scripts/prepare-source-and-target-installations.sh
+          args:
+            - greenplum-db-6
+            - greenplum-db-6
+    - task: run_bats
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: pivotaldata/centos-gpdb-dev
+            tag: "6-gcc6.2-llvm3.7"
+        inputs:
+          - name: terraform
+          - name: ccp_src
+          - name: cluster_env_files
+          - name: gpupgrade_src
+          - name: bin_gpupgrade
+          - name: bats
+        run:
+          path: gpupgrade_src/ci/scripts/bats-on-cluster.bash
+      params:
+  ensure:
+    <<: *set_failed
+  on_success:
+    <<: *ccp_destroy
+  on_failure:
+    <<: *slack_alert
+
+- name: 5-to-6-multihost-bats-centos-6
+  serial_groups: [5-to-6-multihost-bats]
+  # Specifying serial groups so that only one platform runs at a time. For
+  # example, 5-to-6-centos7 will only run after 5-to-6-centos6 completes. This
+  # will prevent concourse from becoming overloaded.
+  plan:
+    - in_parallel:
+        - get: bin_gpupgrade
+          trigger: true
+          passed: [ build ]
+        - get: gpupgrade_src
+          passed: [ build ]
+        - get: rpm_gpdb_source
+          resource: rpm_gpdb5_centos6
+          trigger: true
+        - get: rpm_gpdb_target
+          resource: rpm_gpdb6_centos6
+          trigger: true
+        - get: ccp_src
+        - get: bats
+    - put: terraform
+      params:
+        <<: *ccp_default_params
+        vars:
+          standby_master: true
+          instance_type: n1-standard-2
+          number_of_nodes: 4
+          PLATFORM: centos6
+          # Decrease the reap time from the default of 8 hours now that there are
+          # both centos6 and centos7 jobs in order to not overload concourse.
+          ccp_reap_minutes: 180
+    - task: gen_source_cluster
+      file: ccp_src/ci/tasks/gen_cluster.yml
+      params:
+        <<: *ccp_gen_cluster_default_params
+        PLATFORM: centos6
+        GPDB_RPM: true
+      input_mapping:
+        gpdb_rpm: rpm_gpdb_source
+    - task: gpinitsystem_source_cluster
+      file: ccp_src/ci/tasks/gpinitsystem.yml
+    - task: prepare_source_and_target_installations
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: alpine
+            tag: latest
+        inputs:
+          - name: gpupgrade_src
+          - name: cluster_env_files
+          - name: rpm_gpdb_target
+        run:
+          path: gpupgrade_src/ci/scripts/prepare-source-and-target-installations.sh
+          args:
+            - greenplum-db-5
+            - greenplum-db-6
+    - task: run_bats
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: pivotaldata/centos-gpdb-dev
+            tag: "6-gcc6.2-llvm3.7"
+        inputs:
+          - name: terraform
+          - name: ccp_src
+          - name: cluster_env_files
+          - name: gpupgrade_src
+          - name: bin_gpupgrade
+          - name: bats
+        run:
+          path: gpupgrade_src/ci/scripts/bats-on-cluster.bash
+      params:
+  ensure:
+    <<: *set_failed
+  on_success:
+    <<: *ccp_destroy
+  on_failure:
+    <<: *slack_alert
+
+- name: 5-to-6-multihost-bats-centos-7
+  serial_groups: [5-to-6-multihost-bats]
+  # Specifying serial groups so that only one platform runs at a time. For
+  # example, 5-to-6-centos7 will only run after 5-to-6-centos6 completes. This
+  # will prevent concourse from becoming overloaded.
+  plan:
+    - in_parallel:
+        - get: bin_gpupgrade
+          trigger: true
+          passed: [ build ]
+        - get: gpupgrade_src
+          passed: [ build ]
+        - get: rpm_gpdb_source
+          resource: rpm_gpdb5_centos7
+          trigger: true
+        - get: rpm_gpdb_target
+          resource: rpm_gpdb6_centos7
+          trigger: true
+        - get: ccp_src
+        - get: bats
+    - put: terraform
+      params:
+        <<: *ccp_default_params
+        vars:
+          standby_master: true
+          instance_type: n1-standard-2
+          number_of_nodes: 4
+          PLATFORM: centos7
+          # Decrease the reap time from the default of 8 hours now that there are
+          # both centos6 and centos7 jobs in order to not overload concourse.
+          ccp_reap_minutes: 180
+    - task: gen_source_cluster
+      file: ccp_src/ci/tasks/gen_cluster.yml
+      params:
+        <<: *ccp_gen_cluster_default_params
+        PLATFORM: centos7
+        GPDB_RPM: true
+      input_mapping:
+        gpdb_rpm: rpm_gpdb_source
+    - task: gpinitsystem_source_cluster
+      file: ccp_src/ci/tasks/gpinitsystem.yml
+    - task: prepare_source_and_target_installations
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: alpine
+            tag: latest
+        inputs:
+          - name: gpupgrade_src
+          - name: cluster_env_files
+          - name: rpm_gpdb_target
+        run:
+          path: gpupgrade_src/ci/scripts/prepare-source-and-target-installations.sh
+          args:
+            - greenplum-db-5
+            - greenplum-db-6
+    - task: run_bats
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: pivotaldata/centos-gpdb-dev
+            tag: "6-gcc6.2-llvm3.7"
+        inputs:
+          - name: terraform
+          - name: ccp_src
+          - name: cluster_env_files
+          - name: gpupgrade_src
+          - name: bin_gpupgrade
+          - name: bats
+        run:
+          path: gpupgrade_src/ci/scripts/bats-on-cluster.bash
+      params:
+  ensure:
+    <<: *set_failed
+  on_success:
+    <<: *ccp_destroy
+  on_failure:
+    <<: *slack_alert
 - name: publish-release-candidate
   plan:
     - in_parallel:
@@ -1503,6 +1827,10 @@ jobs:
           - 5-to-6-primaries-only-centos-7
           - 5-to-6-no-standby-centos-7
           - 5-to-6-retail-demo-centos-7
+          - 6-to-6-multihost-bats-centos-6
+          - 6-to-6-multihost-bats-centos-7
+          - 5-to-6-multihost-bats-centos-6
+          - 5-to-6-multihost-bats-centos-7
       - get: bin_gpupgrade
         passed:
           - build
@@ -1518,6 +1846,10 @@ jobs:
           - 5-to-6-primaries-only-centos-7
           - 5-to-6-no-standby-centos-7
           - 5-to-6-retail-demo-centos-7
+          - 6-to-6-multihost-bats-centos-6
+          - 6-to-6-multihost-bats-centos-7
+          - 5-to-6-multihost-bats-centos-6
+          - 5-to-6-multihost-bats-centos-7
     - task: version-rc
       config:
         platform: linux

--- a/ci/scripts/bats-on-cluster.bash
+++ b/ci/scripts/bats-on-cluster.bash
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux -o pipefail
+
+is_GPDB5() {
+    local gphome=$1
+    version=$(ssh mdw "$gphome"/bin/postgres --gp-version)
+    [[ $version =~ ^"postgres (Greenplum Database) 5." ]]
+}
+
+drop_gphdfs_roles() {
+  echo 'Dropping gphdfs role...'
+  ssh mdw "
+      set -x
+
+      source /usr/local/greenplum-db-source/greenplum_path.sh
+      export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1
+
+      psql -d postgres <<SQL_EOF
+          CREATE OR REPLACE FUNCTION drop_gphdfs() RETURNS VOID AS \\\$\\\$
+          DECLARE
+            rolerow RECORD;
+          BEGIN
+            RAISE NOTICE 'Dropping gphdfs users...';
+            FOR rolerow IN SELECT * FROM pg_catalog.pg_roles LOOP
+              EXECUTE 'alter role '
+                || quote_ident(rolerow.rolname) || ' '
+                || 'NOCREATEEXTTABLE(protocol=''gphdfs'',type=''readable'')';
+              EXECUTE 'alter role '
+                || quote_ident(rolerow.rolname) || ' '
+                || 'NOCREATEEXTTABLE(protocol=''gphdfs'',type=''writable'')';
+              RAISE NOTICE 'dropping gphdfs from role % ...', quote_ident(rolerow.rolname);
+            END LOOP;
+          END;
+          \\\$\\\$ LANGUAGE plpgsql;
+
+          SELECT drop_gphdfs();
+
+          DROP FUNCTION drop_gphdfs();
+SQL_EOF
+  "
+}
+
+#
+# MAIN
+#
+
+# TODO: combine this or at least pull out common functions with upgrade-cluster.bash?
+
+# This port is selected by our CI pipeline
+MASTER_PORT=5432
+
+# We'll need this to transfer our built binaries over to the cluster hosts.
+./ccp_src/scripts/setup_ssh_to_cluster.sh
+
+# Cache our list of hosts to loop over below.
+mapfile -t hosts < cluster_env_files/hostfile_all
+
+# Install gpupgrade binary onto the cluster machines.
+chmod +x bin_gpupgrade/gpupgrade
+for host in "${hosts[@]}"; do
+    scp bin_gpupgrade/gpupgrade "gpadmin@$host:/tmp"
+    ssh centos@$host "sudo mv /tmp/gpupgrade /usr/local/bin"
+done
+
+# Install gpupgrade_src on mdw
+scp -rpq gpupgrade_src gpadmin@mdw:/home/gpadmin
+
+# Install bats on mdw
+scp -rpq bats centos@mdw:~
+ssh centos@mdw sudo ./bats/install.sh /usr/local
+
+if is_GPDB5 /usr/local/greenplum-db-source; then
+  drop_gphdfs_roles
+fi
+
+time ssh mdw bash <<EOF
+    set -eux -o pipefail
+
+    source /usr/local/greenplum-db-source/greenplum_path.sh
+    export GPHOME_TARGET=/usr/local/greenplum-db-target
+    export PGPORT="$MASTER_PORT"
+    export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1
+
+    ./gpupgrade_src/test/revert.bats
+EOF
+
+echo 'bats test successful.'

--- a/ci/template.yml
+++ b/ci/template.yml
@@ -402,6 +402,95 @@ jobs:
     <<: *slack_alert
 {{end -}}
 
+{{range .MultihostBatsJobs}}
+- name: {{ .Name }}
+  serial_groups: [{{ .BaseName }}]
+  # Specifying serial groups so that only one platform runs at a time. For
+  # example, 5-to-6-centos7 will only run after 5-to-6-centos6 completes. This
+  # will prevent concourse from becoming overloaded.
+  plan:
+    - in_parallel:
+        - get: bin_gpupgrade
+          trigger: true
+          passed: [ build ]
+        - get: gpupgrade_src
+          passed: [ build ]
+        - get: rpm_gpdb_source
+          resource: rpm_gpdb{{.Source}}_centos{{.CentosVersion}}
+          trigger: true
+        {{- if ne .Source .Target }}
+        - get: rpm_gpdb_target
+          resource: rpm_gpdb{{.Target}}_centos{{.CentosVersion}}
+          trigger: true
+        {{- end }}
+        - get: ccp_src
+        - get: bats
+    - put: terraform
+      params:
+        <<: *ccp_default_params
+        vars:
+          standby_master: true
+          instance_type: n1-standard-2
+          number_of_nodes: 4
+          PLATFORM: centos{{.CentosVersion}}
+          # Decrease the reap time from the default of 8 hours now that there are
+          # both centos6 and centos7 jobs in order to not overload concourse.
+          ccp_reap_minutes: 180
+    - task: gen_source_cluster
+      file: ccp_src/ci/tasks/gen_cluster.yml
+      params:
+        <<: *ccp_gen_cluster_default_params
+        PLATFORM: centos{{.CentosVersion}}
+        GPDB_RPM: true
+      input_mapping:
+        gpdb_rpm: rpm_gpdb_source
+    - task: gpinitsystem_source_cluster
+      file: ccp_src/ci/tasks/gpinitsystem.yml
+    - task: prepare_source_and_target_installations
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: alpine
+            tag: latest
+        inputs:
+          - name: gpupgrade_src
+          - name: cluster_env_files
+          {{- if ne .Source .Target }}
+          - name: rpm_gpdb_target
+          {{- end }}
+        run:
+          path: gpupgrade_src/ci/scripts/prepare-source-and-target-installations.sh
+          args:
+            - greenplum-db-{{majorVersion .Source}}
+            - greenplum-db-{{majorVersion .Target}}
+    - task: run_bats
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: pivotaldata/centos-gpdb-dev
+            tag: "6-gcc6.2-llvm3.7"
+        inputs:
+          - name: terraform
+          - name: ccp_src
+          - name: cluster_env_files
+          - name: gpupgrade_src
+          - name: bin_gpupgrade
+          - name: bats
+        run:
+          path: gpupgrade_src/ci/scripts/bats-on-cluster.bash
+      params:
+  ensure:
+    <<: *set_failed
+  on_success:
+    <<: *ccp_destroy
+  on_failure:
+    <<: *slack_alert
+{{end -}}
+
 - name: publish-release-candidate
   plan:
     - in_parallel:
@@ -416,10 +505,16 @@ jobs:
           {{- range .UpgradeJobs}}
           - {{ .Name }}
           {{- end}}
+          {{- range .MultihostBatsJobs}}
+          - {{ .Name }}
+          {{- end}}
       - get: bin_gpupgrade
         passed:
           - build
           {{- range .UpgradeJobs}}
+          - {{ .Name }}
+          {{- end}}
+          {{- range .MultihostBatsJobs}}
           - {{ .Name }}
           {{- end}}
     - task: version-rc


### PR DESCRIPTION
Add jobs to the pipeline to run BATS tests against a CCP cluster, and rewrite pieces of `revert.bats` to run against an arbitrary cluster.