### PR TITLE
pull commanders.Substep up into commands.go

### DIFF
--- a/cli/commanders/checks.go
+++ b/cli/commanders/checks.go
@@ -97,9 +97,6 @@ func (t tableRows) Swap(i, j int) {
 }
 
 func CheckDiskSpace(client idl.CliToHubClient, ratio float64) (err error) {
-	s := Substep(idl.Substep_CHECK_DISK_SPACE)
-	defer s.Finish(&err)
-
 	reply, err := client.CheckDiskSpace(context.Background(), &idl.CheckDiskSpaceRequest{Ratio: ratio})
 	if err != nil {
 		return xerrors.Errorf("check disk space: %w", err)

--- a/cli/commanders/checks_test.go
+++ b/cli/commanders/checks_test.go
@@ -6,7 +6,6 @@ package commanders_test
 import (
 	"errors"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/greenplum-db/gpupgrade/cli/commanders"
@@ -114,13 +113,8 @@ func TestDiskSpaceCheck(t *testing.T) {
 				&idl.CheckDiskSpaceRequest{Ratio: ratio},
 			).Return(&idl.CheckDiskSpaceReply{Failed: c.failed}, c.grpcErr)
 
-			d := bufferStandardDescriptors(t)
-			defer d.Close()
-
 			err := commanders.CheckDiskSpace(client, ratio)
-			actualOut, _ := d.Collect()
 
-			expectedStatus := idl.Status_FAILED
 			switch {
 			case c.grpcErr != nil:
 				if !errors.Is(err, c.grpcErr) {
@@ -136,15 +130,9 @@ func TestDiskSpaceCheck(t *testing.T) {
 				}
 
 			default:
-				expectedStatus = idl.Status_COMPLETE
 				if err != nil {
 					t.Errorf("returned error %#v, expected no error", err)
 				}
-			}
-
-			expected := commanders.Format("Checking disk space...", expectedStatus)
-			if !strings.Contains(string(actualOut), expected) {
-				t.Errorf("Expected string %q to contain %q", actualOut, expected)
 			}
 		})
 	}

--- a/cli/commanders/initialize.go
+++ b/cli/commanders/initialize.go
@@ -11,7 +11,6 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"golang.org/x/xerrors"
 
-	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 	"github.com/greenplum-db/gpupgrade/utils"
 )
@@ -23,9 +22,6 @@ var execCommandHubCount = exec.Command
 // we create the state directory in the cli to ensure that at most one gpupgrade is occurring
 // at the same time.
 func CreateStateDir() (err error) {
-	s := Substep(idl.Substep_CREATING_DIRECTORIES)
-	defer s.Finish(&err)
-
 	stateDir := utils.GetStateDir()
 	err = os.Mkdir(stateDir, 0700)
 	if os.IsExist(err) {
@@ -77,9 +73,6 @@ func CreateInitialClusterConfigs(hubPort int) (err error) {
 }
 
 func StartHub() (err error) {
-	s := Substep(idl.Substep_START_HUB)
-	defer s.Finish(&err)
-
 	running, err := IsHubRunning()
 	if err != nil {
 		gplog.Error("failed to determine if hub already running")

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -411,7 +411,9 @@ func initialize() *cobra.Command {
 			fmt.Println("Initialize in progress.")
 			fmt.Println()
 
+			s := commanders.Substep(idl.Substep_CREATING_DIRECTORIES)
 			err = commanders.CreateStateDir()
+			s.Finish(&err)
 			if err != nil {
 				return xerrors.Errorf("create state directory: %w", err)
 			}
@@ -421,7 +423,9 @@ func initialize() *cobra.Command {
 				return xerrors.Errorf("create initial cluster configs: %w", err)
 			}
 
+			s = commanders.Substep(idl.Substep_START_HUB)
 			err = commanders.StartHub()
+			s.Finish(&err)
 			if err != nil {
 				return xerrors.Errorf("start hub: %w", err)
 			}
@@ -444,7 +448,9 @@ func initialize() *cobra.Command {
 				return xerrors.Errorf("initialize hub: %w", err)
 			}
 
+			s = commanders.Substep(idl.Substep_CHECK_DISK_SPACE)
 			err = commanders.RunChecks(client, diskFreeRatio)
+			s.Finish(&err)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Unify the way we run CLI only substeps in commands.go. This will be useful when passing verbose into commanders.Substep.

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:commandSubsteps)