### PR TITLE
ci: add concourse groups

### DIFF
--- a/ci/generated/pipeline.yml
+++ b/ci/generated/pipeline.yml
@@ -204,6 +204,58 @@ anchors:
           text: |
             Hey team, <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|gpupgrade/$BUILD_JOB_NAME> failed.
 
+groups:
+  - name: all
+    jobs:
+      - build
+      - lint
+      - noinstall-tests
+      - 6-to-6-install-tests
+      - 5-to-6-install-tests
+      - 6-to-6-multihost-bats-centos-6
+      - 6-to-6-multihost-bats-centos-7
+      - 5-to-6-multihost-bats-centos-6
+      - 5-to-6-multihost-bats-centos-7
+      - 6-to-6-centos-6
+      - 6-to-6-centos-7
+      - 5-to-6-centos-6
+      - 5-to-6-centos-7
+      - 5-to-6-link-mode-centos-6
+      - 5-to-6-primaries-only-centos-6
+      - 5-to-6-no-standby-centos-6
+      - 5-to-6-retail-demo-centos-6
+      - 5-to-6-link-mode-centos-7
+      - 5-to-6-primaries-only-centos-7
+      - 5-to-6-no-standby-centos-7
+      - 5-to-6-retail-demo-centos-7
+      - publish-release-candidate
+  - name: bats
+    jobs:
+      - 6-to-6-install-tests
+      - 5-to-6-install-tests
+      - 6-to-6-multihost-bats-centos-6
+      - 6-to-6-multihost-bats-centos-7
+      - 5-to-6-multihost-bats-centos-6
+      - 5-to-6-multihost-bats-centos-7
+  - name: upgrade
+    jobs:
+      - build
+      - 6-to-6-centos-6
+      - 6-to-6-centos-7
+      - 5-to-6-centos-6
+      - 5-to-6-centos-7
+      - 5-to-6-link-mode-centos-6
+      - 5-to-6-primaries-only-centos-6
+      - 5-to-6-no-standby-centos-6
+      - 5-to-6-link-mode-centos-7
+      - 5-to-6-primaries-only-centos-7
+      - 5-to-6-no-standby-centos-7
+  - name: functional
+    jobs:
+      - build
+      - 5-to-6-retail-demo-centos-6
+      - 5-to-6-retail-demo-centos-7
+
 jobs:
 - name: build
   plan:

--- a/ci/template.yml
+++ b/ci/template.yml
@@ -177,6 +177,47 @@ anchors:
           text: |
             Hey team, <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|gpupgrade/$BUILD_JOB_NAME> failed.
 
+groups:
+  - name: all
+    jobs:
+      - build
+      - lint
+      - noinstall-tests
+      {{- range .CheckJobs}}
+      - {{.Name}}
+      {{- end}}
+      {{- range .MultihostBatsJobs}}
+      - {{.Name}}
+      {{- end}}
+      {{- range .UpgradeJobs}}
+      - {{.Name}}
+      {{- end}}
+      - publish-release-candidate
+  - name: bats
+    jobs:
+      {{- range .CheckJobs}}
+      - {{.Name}}
+      {{- end}}
+      {{- range .MultihostBatsJobs}}
+      - {{.Name}}
+      {{- end}}
+  - name: upgrade
+    jobs:
+      - build
+      {{- range .UpgradeJobs}}
+      {{- if not .RetailDemo}}
+      - {{.Name}}
+      {{- end}}
+      {{- end}}
+  - name: functional
+    jobs:
+      - build
+      {{- range .UpgradeJobs}}
+      {{- if .RetailDemo}}
+      - {{.Name}}
+      {{- end}}
+      {{- end}}
+
 jobs:
 - name: build
   plan:


### PR DESCRIPTION
For ease of readability when looking at the pipeline on the web UI add Concourse groups.

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:groups)