### PR TITLE
log step and substep timing

### DIFF
--- a/cli/commanders/steps_test.go
+++ b/cli/commanders/steps_test.go
@@ -272,11 +272,11 @@ func TestSubstep(t *testing.T) {
 	defer d.Close()
 
 	var err error
-	s := commanders.Substep(idl.Substep_CREATING_DIRECTORIES)
+	s := commanders.NewSubstep(idl.Substep_CREATING_DIRECTORIES, false)
 	s.Finish(&err)
 
 	err = errors.New("error")
-	s = commanders.Substep(idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG)
+	s = commanders.NewSubstep(idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG, false)
 	s.Finish(&err)
 
 	stdout, stderr := d.Collect()

--- a/utils/stopwatch/stopwatch.go
+++ b/utils/stopwatch/stopwatch.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package stopwatch
+
+import "time"
+
+type Stopwatch struct {
+	startTime   time.Time
+	elapsedTime time.Duration
+	stopped     bool
+}
+
+func Start() *Stopwatch {
+	return &Stopwatch{
+		startTime: time.Now(),
+	}
+}
+
+// NewTime is used for unit testing.
+func NewTime(start time.Time) *Stopwatch {
+	return &Stopwatch{
+		startTime: start,
+	}
+}
+
+func (s *Stopwatch) Stop() *Stopwatch {
+	if !s.stopped {
+		s.elapsedTime = time.Since(s.startTime)
+		s.stopped = true
+	}
+
+	return s
+}
+
+func (s *Stopwatch) String() string {
+	return round(s.elapsedTime).String()
+}
+
+// round returns a pretty-printable duration. This may omit precision and
+// rounding to the next lowest unit.
+func round(duration time.Duration) time.Duration {
+	switch {
+	case duration.Seconds() < 1:
+		return duration.Round(time.Millisecond)
+
+	case duration.Minutes() < 60:
+		return duration.Round(time.Second)
+
+	default:
+		return duration.Round(time.Minute)
+	}
+}

--- a/utils/stopwatch/stopwatch_test.go
+++ b/utils/stopwatch/stopwatch_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package stopwatch_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/greenplum-db/gpupgrade/utils/stopwatch"
+)
+
+// The internal implementation calls round to minimize test flakes. For
+// example, 3h26m8s rounds to 3h26m giving the test 8 seconds to complete.
+func TestStopwatch(t *testing.T) {
+	t.Run("outputs correctly formatted duration", func(t *testing.T) {
+		startTime := mustParseDuration(t, "-3h26m8s")
+		timer := stopwatch.NewTime(time.Now().Add(startTime))
+		timer.Stop()
+
+		expected := mustParseDuration(t, "3h26m")
+		if timer.String() != expected.String() {
+			t.Errorf("got %q want %q", timer.String(), expected)
+		}
+	})
+
+	t.Run("correctly rounds duration", func(t *testing.T) {
+		cases := []struct {
+			duration time.Duration
+			expected time.Duration
+		}{
+			{
+				duration: mustParseDuration(t, "-31.80526130h"),
+				expected: mustParseDuration(t, "31h48m"),
+			},
+			{
+				duration: mustParseDuration(t, "-31.80526130m"),
+				expected: mustParseDuration(t, "31m48s"),
+			},
+			{
+				duration: mustParseDuration(t, "-31.80526130s"),
+				expected: mustParseDuration(t, "32s"),
+			},
+			{
+				duration: mustParseDuration(t, "-31.80526130ms"),
+				expected: mustParseDuration(t, "32ms"),
+			},
+		}
+
+		now := time.Now()
+		for _, c := range cases {
+			timer := stopwatch.NewTime(now.Add(c.duration))
+			timer.Stop()
+
+			if timer.String() != c.expected.String() {
+				t.Errorf("got %s want %v", timer.String(), c.expected)
+			}
+		}
+	})
+}
+
+func mustParseDuration(t *testing.T, input string) time.Duration {
+	t.Helper()
+
+	duration, err := time.ParseDuration(input)
+	if err != nil {
+		t.Fatalf("parsing duration %q: %v", input, err)
+	}
+
+	return duration
+}


### PR DESCRIPTION
Log step and substep duration. Currently, for substeps that are run on the CLI timing is printed using gplog rather than the step log as is done for the other substeps.

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:timing)