### PR TITLE
revert: add idempotence regression tests

### DIFF
--- a/hub/idempotence.go
+++ b/hub/idempotence.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package hub
+
+import (
+	"fmt"
+
+	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/step"
+)
+
+// idempotenceRunner is a SubstepRunner that always fails the first run of each
+// substep after it completes. It uses the wrapped Step for actual substep
+// execution.
+//
+// The purpose of this implementation is to assist regression testing
+// frameworks; it's not intended to be used in production.
+type idempotenceRunner struct {
+	st *step.Step // used to Run() substeps
+}
+
+func (i idempotenceRunner) Run(substep idl.Substep, f func(step.OutStreams) error) {
+	i.st.Run(substep, i.wrap(substep, f))
+}
+
+func (i idempotenceRunner) AlwaysRun(substep idl.Substep, f func(step.OutStreams) error) {
+	i.st.AlwaysRun(substep, i.wrap(substep, f))
+}
+
+func (i idempotenceRunner) wrap(substep idl.Substep, f func(step.OutStreams) error) func(step.OutStreams) error {
+	alreadyRun, err := step.HasRun(i.st.Name(), substep)
+	if err != nil {
+		// This is a test-only implementation; no need to be clever.
+		panic(fmt.Sprintf("couldn't retrieve substep status: %v", err))
+	}
+
+	if alreadyRun {
+		// For subsequent runs, just run the substep as intended.
+		return f
+	}
+
+	// For the first run, force a failure no matter what.
+	return func(streams step.OutStreams) error {
+		if err := f(streams); err != nil {
+			return err
+		}
+
+		return DebugIdempotenceError{}
+	}
+}
+
+// DebugIdempotenceError is a sentinel error injected by idempotenceRunner on
+// the first run of any substep.
+type DebugIdempotenceError struct{}
+
+func (d DebugIdempotenceError) Error() string {
+	return "forced error for idempotence testing"
+}

--- a/hub/revert.go
+++ b/hub/revert.go
@@ -49,6 +49,25 @@ func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) 
 		return xerrors.Errorf("connect to gpupgrade agent: %w", err)
 	}
 
+	archiveDir, err := s.revert(st)
+	if err != nil {
+		return err
+	}
+
+	message := &idl.Message{Contents: &idl.Message_Response{Response: &idl.Response{Data: map[string]string{
+		idl.ResponseKey_source_port.String():                  strconv.Itoa(s.Source.MasterPort()),
+		idl.ResponseKey_source_master_data_directory.String(): s.Source.MasterDataDir(),
+		idl.ResponseKey_source_version.String():               s.Source.Version.VersionString,
+		idl.ResponseKey_revert_log_archive_directory.String(): archiveDir,
+	}}}}
+	if err := stream.Send(message); err != nil {
+		return xerrors.Errorf("sending response message: %w", err)
+	}
+
+	return st.Err()
+}
+
+func (s *Server) revert(st *step.Step) (string, error) {
 	// If the target cluster is started, it must be stopped.
 	if s.Target != nil {
 		st.AlwaysRun(idl.Substep_SHUTDOWN_TARGET_CLUSTER, func(streams step.OutStreams) error {
@@ -104,7 +123,7 @@ func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) 
 		// cluster as its files could have been modified.
 		targetStarted, err := step.HasRun(idl.Step_EXECUTE, idl.Substep_START_TARGET_CLUSTER)
 		if err != nil {
-			return err
+			return "", err
 		}
 
 		if targetStarted {
@@ -120,7 +139,7 @@ func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) 
 
 	handleMirrorStartupFailure, err := s.expectMirrorFailure()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// If the source cluster is not running, it must be started.
@@ -183,17 +202,7 @@ func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) 
 		return DeleteStateDirectories(s.agentConns, s.Source.MasterHostname())
 	})
 
-	message := &idl.Message{Contents: &idl.Message_Response{Response: &idl.Response{Data: map[string]string{
-		idl.ResponseKey_source_port.String():                  strconv.Itoa(s.Source.MasterPort()),
-		idl.ResponseKey_source_master_data_directory.String(): s.Source.MasterDataDir(),
-		idl.ResponseKey_source_version.String():               s.Source.Version.VersionString,
-		idl.ResponseKey_revert_log_archive_directory.String(): archiveDir,
-	}}}}
-	if err := stream.Send(message); err != nil {
-		return xerrors.Errorf("sending response message: %w", err)
-	}
-
-	return st.Err()
+	return archiveDir, nil
 }
 
 // In 5X, running pg_upgrade on the primaries can cause the mirrors to receive an invalid

--- a/hub/server.go
+++ b/hub/server.go
@@ -374,6 +374,9 @@ type Config struct {
 	Tablespaces                greenplum.Tablespaces
 	TablespacesMappingFilePath string
 	TargetCatalogVersion       string
+
+	// Debugging Features
+	DebugIdempotence bool
 }
 
 func (c *Config) Load(r io.Reader) error {

--- a/hub/server_internal_test.go
+++ b/hub/server_internal_test.go
@@ -39,6 +39,7 @@ func TestConfig(t *testing.T) {
 				}}}, // Tablespaces
 			greenplum.TablespacesMappingFile, // TablespacesMappingFilePath
 			"301908232",                      // TargetCatalogVersion
+			false,                            // DebugIdempotence
 		}
 
 		buf := new(bytes.Buffer)

--- a/step/step.go
+++ b/step/step.go
@@ -109,6 +109,10 @@ func HasRun(step idl.Step, substep idl.Substep) (bool, error) {
 	return false, nil
 }
 
+func (s *Step) Name() idl.Step {
+	return s.name
+}
+
 func (s *Step) Streams() OutStreams {
 	return s.streams
 }

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -377,6 +377,18 @@ func TestStepFinish(t *testing.T) {
 	})
 }
 
+func TestStep(t *testing.T) {
+	t.Run("Name() returns the underlying step code", func(t *testing.T) {
+		name := idl.Step_INITIALIZE
+		s := step.New(name, nil, nil, nil)
+
+		actual := s.Name()
+		if actual != name {
+			t.Errorf("Name() = %q, want %q", actual, name)
+		}
+	})
+}
+
 func TestStatusFile(t *testing.T) {
 	stateDir, err := ioutil.TempDir("", "")
 	if err != nil {


### PR DESCRIPTION
_This is a draft because the log directory archival step is not yet idempotent and causes a legitimate failure in the multihost pipeline._

Setting the DebugIdempotence flag in the hub configuration will cause the hub to fail every revert substep exactly once. The corresponding end-to-end test simply loops in a call to revert, checking that any errors are due to the idempotence framework, until the step succeeds.

This tests only a subset of idempotence -- namely, that each individual substep (and all of its `AlwaysRun` predecessors) can be re-run after completion -- but in practice this catches a number of common bugs.