### PR TITLE
Extract substep logic from steps.go to substeps.go

### DIFF
--- a/cli/commanders/common_test.go
+++ b/cli/commanders/common_test.go
@@ -1,0 +1,118 @@
+//  Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+//  SPDX-License-Identifier: Apache-2.0
+
+package commanders
+
+import (
+	"io/ioutil"
+	"os"
+	"sync"
+	"testing"
+
+	"golang.org/x/xerrors"
+)
+
+// descriptors is a helper to redirect os.Stdout and os.Stderr and buffer the
+// bytes that are written to them.
+//
+//    d := BufferStandardDescriptors(t)
+//    defer d.Close()
+//
+//    // write to os.Stdout and os.Stderr
+//
+//    bytesOut, bytesErr := d.Collect()
+//
+// All errors are handled through a t.Fatalf().
+type descriptors struct {
+	t                  *testing.T
+	wg                 sync.WaitGroup
+	stdout, stderr     *os.File
+	saveOut, saveErr   *os.File
+	outBytes, errBytes []byte
+}
+
+func BufferStandardDescriptors(t *testing.T) *descriptors {
+	d := &descriptors{t: t}
+
+	var err error
+	var rOut, rErr *os.File
+
+	rOut, d.stdout, err = os.Pipe()
+	if err != nil {
+		d.t.Fatalf("opening stdout pipe: %+v", err)
+	}
+
+	rErr, d.stderr, err = os.Pipe()
+	if err != nil {
+		d.t.Fatalf("opening stderr pipe: %+v", err)
+	}
+
+	// Switch out the streams; they are replaced by d.Close().
+	d.saveOut, d.saveErr = os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = d.stdout, d.stderr
+
+	// Each stream must be read separately to avoid deadlock.
+	errChan := make(chan error, 2)
+	d.wg.Add(2)
+	go func() {
+		defer d.wg.Done()
+
+		d.outBytes, err = ioutil.ReadAll(rOut)
+		if err != nil {
+			errChan <- xerrors.Errorf("reading from stdout pipe: %w", err)
+		}
+	}()
+	go func() {
+		defer d.wg.Done()
+
+		d.errBytes, err = ioutil.ReadAll(rErr)
+		if err != nil {
+			errChan <- xerrors.Errorf("reading from stderr pipe: %w", err)
+		}
+	}()
+
+	close(errChan)
+	for err := range errChan {
+		d.t.Fatal(err)
+	}
+
+	return d
+}
+
+// Collect drains the pipes and returns the contents of stdout and stderr. It's
+// safe to call more than once.
+func (d *descriptors) Collect() ([]byte, []byte) {
+	// Close the write sides of the pipe so our goroutines will finish.
+	if d.stdout != nil {
+		err := d.stdout.Close()
+		if err != nil {
+			d.t.Fatalf("closing stdout pipe: %+v", err)
+		}
+
+		d.stdout = nil
+	}
+
+	if d.stderr != nil {
+		err := d.stderr.Close()
+		if err != nil {
+			d.t.Fatalf("closing stderr pipe: %+v", err)
+		}
+
+		d.stderr = nil
+	}
+
+	d.wg.Wait()
+
+	return d.outBytes, d.errBytes
+}
+
+// Close puts os.Stdout and os.Stderr back the way they were, after draining the
+// redirected pipes if necessary.
+func (d *descriptors) Close() {
+	// Always make sure we've waited on the pipe contents before closing.
+	// Collect() is safe to call more than once.
+	d.Collect()
+
+	os.Stdout = d.saveOut
+	os.Stderr = d.saveErr
+}

--- a/cli/commanders/steps.go
+++ b/cli/commanders/steps.go
@@ -37,52 +37,6 @@ type receiver interface {
 	Recv() (*idl.Message, error)
 }
 
-type substepText struct {
-	OutputText string
-	HelpText   string
-}
-
-type substep struct {
-	name    idl.Substep
-	text    substepText
-	verbose bool
-	timer   *stopwatch.Stopwatch
-}
-
-var SubstepDescriptions = map[idl.Substep]substepText{
-	idl.Substep_CREATING_DIRECTORIES:                     substepText{"Creating directories...", "Create directories"},
-	idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG:             substepText{"Saving source cluster configuration...", "Save source cluster configuration"},
-	idl.Substep_START_HUB:                                substepText{"Starting gpupgrade hub process...", "Start gpupgrade hub process"},
-	idl.Substep_START_AGENTS:                             substepText{"Starting gpupgrade agent processes...", "Start gpupgrade agent processes"},
-	idl.Substep_CHECK_DISK_SPACE:                         substepText{"Checking disk space...", "Check disk space"},
-	idl.Substep_CREATE_TARGET_CONFIG:                     substepText{"Generating target cluster configuration...", "Generate target cluster configuration"},
-	idl.Substep_INIT_TARGET_CLUSTER:                      substepText{"Creating target cluster...", "Create target cluster"},
-	idl.Substep_SHUTDOWN_TARGET_CLUSTER:                  substepText{"Stopping target cluster...", "Stop target cluster"},
-	idl.Substep_BACKUP_TARGET_MASTER:                     substepText{"Backing up target master...", "Back up target master"},
-	idl.Substep_CHECK_UPGRADE:                            substepText{"Running pg_upgrade checks...", "Run pg_upgrade checks"},
-	idl.Substep_SHUTDOWN_SOURCE_CLUSTER:                  substepText{"Stopping source cluster...", "Stop source cluster"},
-	idl.Substep_UPGRADE_MASTER:                           substepText{"Upgrading master...", "Upgrade master"},
-	idl.Substep_COPY_MASTER:                              substepText{"Copying master catalog to primary segments...", "Copy master catalog to primary segments"},
-	idl.Substep_UPGRADE_PRIMARIES:                        substepText{"Upgrading primary segments...", "Upgrade primary segments"},
-	idl.Substep_START_TARGET_CLUSTER:                     substepText{"Starting target cluster...", "Start target cluster"},
-	idl.Substep_UPDATE_TARGET_CATALOG_AND_CLUSTER_CONFIG: substepText{"Updating target master catalog...", "Update target master catalog"},
-	idl.Substep_UPDATE_DATA_DIRECTORIES:                  substepText{"Updating data directories...", "Update data directories"},
-	idl.Substep_UPDATE_TARGET_CONF_FILES:                 substepText{"Updating target master configuration files...", "Update target master configuration files"},
-	idl.Substep_UPGRADE_STANDBY:                          substepText{"Upgrading standby master...", "Upgrade standby master"},
-	idl.Substep_UPGRADE_MIRRORS:                          substepText{"Upgrading mirror segments...", "Upgrade mirror segments"},
-	idl.Substep_DELETE_TABLESPACES:                       substepText{"Deleting target tablespace directories...", "Delete target tablespace directories"},
-	idl.Substep_DELETE_PRIMARY_DATADIRS:                  substepText{"Deleting primary segment data directories...", "Delete primary segment data directories"},
-	idl.Substep_DELETE_MASTER_DATADIR:                    substepText{"Deleting master data directory...", "Delete master data directory"},
-	idl.Substep_DELETE_SEGMENT_STATEDIRS:                 substepText{"Deleting state directories on the segments...", "Delete state directories on the segments"},
-	idl.Substep_STOP_HUB_AND_AGENTS:                      substepText{"Stopping hub and agents...", "Stop hub and agents"},
-	idl.Substep_DELETE_MASTER_STATEDIR:                   substepText{"Deleting master state directory...", "Delete master state directory"},
-	idl.Substep_ARCHIVE_LOG_DIRECTORIES:                  substepText{"Archiving log directories...", "Archive log directories"},
-	idl.Substep_RESTORE_SOURCE_CLUSTER:                   substepText{"Restoring source cluster...", "Restore source cluster"},
-	idl.Substep_START_SOURCE_CLUSTER:                     substepText{"Starting source cluster...", "Start source cluster"},
-	idl.Substep_RESTORE_PGCONTROL:                        substepText{"Re-enabling source cluster...", "Re-enable source cluster"},
-	idl.Substep_RECOVERSEG_SOURCE_CLUSTER:                substepText{"Recovering source cluster mirrors...", "Recover source cluster mirrors"},
-}
-
 var indicators = map[idl.Status]string{
 	idl.Status_RUNNING:  "[IN PROGRESS]",
 	idl.Status_COMPLETE: "[COMPLETE]",
@@ -279,43 +233,6 @@ func Format(description string, status idl.Status) string {
 	}
 
 	return fmt.Sprintf("%-67s%-13s", description, indicator)
-}
-
-// NewSubstep prints out an "in progress" marker for the given substep description,
-// and returns a struct that can be .Finish()d (in a defer statement) to print
-// the final complete/failed state.
-func NewSubstep(step idl.Substep, verbose bool) *substep {
-	substepText := SubstepDescriptions[step]
-	fmt.Printf("%s\r", Format(substepText.OutputText, idl.Status_RUNNING))
-
-	return &substep{
-		name:    step,
-		text:    substepText,
-		verbose: verbose,
-		timer:   stopwatch.Start(),
-	}
-}
-
-// Finish prints out the final status of the substep; either COMPLETE or FAILED
-// depending on whether or not there is an error. The method takes a pointer to
-// error rather than error to make it possible to defer:
-//
-//    func runSubstep() (err error) {
-//        s := NewSubstep("Doing something...")
-//        defer s.Finish(&err)
-//
-//        ...
-//    }
-//
-func (s *substep) Finish(err *error) {
-	status := idl.Status_COMPLETE
-	if *err != nil {
-		status = idl.Status_FAILED
-	}
-
-	fmt.Printf("%s\n", Format(s.text.OutputText, status))
-
-	LogDuration(s.name.String(), s.verbose, s.timer.Stop())
 }
 
 func LogDuration(operation string, verbose bool, timer *stopwatch.Stopwatch) {

--- a/cli/commanders/steps_test.go
+++ b/cli/commanders/steps_test.go
@@ -261,32 +261,3 @@ func TestFormatStatus(t *testing.T) {
 		}
 	})
 }
-
-func TestSubstep(t *testing.T) {
-	d := commanders.BufferStandardDescriptors(t)
-	defer d.Close()
-
-	var err error
-	s := commanders.NewSubstep(idl.Substep_CREATING_DIRECTORIES, false)
-	s.Finish(&err)
-
-	err = errors.New("error")
-	s = commanders.NewSubstep(idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG, false)
-	s.Finish(&err)
-
-	stdout, stderr := d.Collect()
-
-	if len(stderr) != 0 {
-		t.Errorf("unexpected stderr %#v", string(stderr))
-	}
-
-	expected := commanders.Format(commanders.SubstepDescriptions[idl.Substep_CREATING_DIRECTORIES].OutputText, idl.Status_RUNNING) + "\r"
-	expected += commanders.Format(commanders.SubstepDescriptions[idl.Substep_CREATING_DIRECTORIES].OutputText, idl.Status_COMPLETE) + "\n"
-	expected += commanders.Format(commanders.SubstepDescriptions[idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG].OutputText, idl.Status_RUNNING) + "\r"
-	expected += commanders.Format(commanders.SubstepDescriptions[idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG].OutputText, idl.Status_FAILED) + "\n"
-
-	actual := string(stdout)
-	if actual != expected {
-		t.Errorf("output %#v want %#v", actual, expected)
-	}
-}

--- a/cli/commanders/steps_test.go
+++ b/cli/commanders/steps_test.go
@@ -6,13 +6,8 @@ package commanders_test
 import (
 	"errors"
 	"io"
-	"io/ioutil"
-	"os"
 	"reflect"
-	"sync"
 	"testing"
-
-	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/cli/commanders"
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -58,7 +53,7 @@ func TestUILoop(t *testing.T) {
 			}}},
 		}
 
-		d := bufferStandardDescriptors(t)
+		d := commanders.BufferStandardDescriptors(t)
 		defer d.Close()
 
 		_, err := commanders.UILoop(&msgs, true)
@@ -113,7 +108,7 @@ func TestUILoop(t *testing.T) {
 		expected += commanders.FormatStatus(msgs[2].GetStatus()) + "\n"
 		expected += commanders.FormatStatus(msgs[3].GetStatus()) + "\n"
 
-		d := bufferStandardDescriptors(t)
+		d := commanders.BufferStandardDescriptors(t)
 		defer d.Close()
 
 		_, err := commanders.UILoop(&msgs, true)
@@ -162,7 +157,7 @@ func TestUILoop(t *testing.T) {
 		expected += commanders.FormatStatus(msgs[2].GetStatus()) + "\n"
 		expected += commanders.FormatStatus(msgs[4].GetStatus()) + "\n"
 
-		d := bufferStandardDescriptors(t)
+		d := commanders.BufferStandardDescriptors(t)
 		defer d.Close()
 
 		_, err := commanders.UILoop(&msgs, false)
@@ -268,7 +263,7 @@ func TestFormatStatus(t *testing.T) {
 }
 
 func TestSubstep(t *testing.T) {
-	d := bufferStandardDescriptors(t)
+	d := commanders.BufferStandardDescriptors(t)
 	defer d.Close()
 
 	var err error
@@ -294,109 +289,4 @@ func TestSubstep(t *testing.T) {
 	if actual != expected {
 		t.Errorf("output %#v want %#v", actual, expected)
 	}
-}
-
-// descriptors is a helper to redirect os.Stdout and os.Stderr and buffer the
-// bytes that are written to them.
-//
-//    d := bufferStandardDescriptors(t)
-//    defer d.Close()
-//
-//    // write to os.Stdout and os.Stderr
-//
-//    bytesOut, bytesErr := d.Collect()
-//
-// All errors are handled through a t.Fatalf().
-type descriptors struct {
-	t                  *testing.T
-	wg                 sync.WaitGroup
-	stdout, stderr     *os.File
-	saveOut, saveErr   *os.File
-	outBytes, errBytes []byte
-}
-
-func bufferStandardDescriptors(t *testing.T) *descriptors {
-	d := &descriptors{t: t}
-
-	var err error
-	var rOut, rErr *os.File
-
-	rOut, d.stdout, err = os.Pipe()
-	if err != nil {
-		d.t.Fatalf("opening stdout pipe: %+v", err)
-	}
-
-	rErr, d.stderr, err = os.Pipe()
-	if err != nil {
-		d.t.Fatalf("opening stderr pipe: %+v", err)
-	}
-
-	// Switch out the streams; they are replaced by d.Close().
-	d.saveOut, d.saveErr = os.Stdout, os.Stderr
-	os.Stdout, os.Stderr = d.stdout, d.stderr
-
-	// Each stream must be read separately to avoid deadlock.
-	errChan := make(chan error, 2)
-	d.wg.Add(2)
-	go func() {
-		defer d.wg.Done()
-
-		d.outBytes, err = ioutil.ReadAll(rOut)
-		if err != nil {
-			errChan <- xerrors.Errorf("reading from stdout pipe: %w", err)
-		}
-	}()
-	go func() {
-		defer d.wg.Done()
-
-		d.errBytes, err = ioutil.ReadAll(rErr)
-		if err != nil {
-			errChan <- xerrors.Errorf("reading from stderr pipe: %w", err)
-		}
-	}()
-
-	close(errChan)
-	for err := range errChan {
-		d.t.Fatal(err)
-	}
-
-	return d
-}
-
-// Collect drains the pipes and returns the contents of stdout and stderr. It's
-// safe to call more than once.
-func (d *descriptors) Collect() ([]byte, []byte) {
-	// Close the write sides of the pipe so our goroutines will finish.
-	if d.stdout != nil {
-		err := d.stdout.Close()
-		if err != nil {
-			d.t.Fatalf("closing stdout pipe: %+v", err)
-		}
-
-		d.stdout = nil
-	}
-
-	if d.stderr != nil {
-		err := d.stderr.Close()
-		if err != nil {
-			d.t.Fatalf("closing stderr pipe: %+v", err)
-		}
-
-		d.stderr = nil
-	}
-
-	d.wg.Wait()
-
-	return d.outBytes, d.errBytes
-}
-
-// Close puts os.Stdout and os.Stderr back the way they were, after draining the
-// redirected pipes if necessary.
-func (d *descriptors) Close() {
-	// Always make sure we've waited on the pipe contents before closing.
-	// Collect() is safe to call more than once.
-	d.Collect()
-
-	os.Stdout = d.saveOut
-	os.Stderr = d.saveErr
 }

--- a/cli/commanders/substeps.go
+++ b/cli/commanders/substeps.go
@@ -1,0 +1,94 @@
+//  Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+//  SPDX-License-Identifier: Apache-2.0
+
+package commanders
+
+import (
+	"fmt"
+
+	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/utils/stopwatch"
+)
+
+type substep struct {
+	name    idl.Substep
+	text    substepText
+	verbose bool
+	timer   *stopwatch.Stopwatch
+}
+
+type substepText struct {
+	OutputText string
+	HelpText   string
+}
+
+var SubstepDescriptions = map[idl.Substep]substepText{
+	idl.Substep_CREATING_DIRECTORIES:                     substepText{"Creating directories...", "Create directories"},
+	idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG:             substepText{"Saving source cluster configuration...", "Save source cluster configuration"},
+	idl.Substep_START_HUB:                                substepText{"Starting gpupgrade hub process...", "Start gpupgrade hub process"},
+	idl.Substep_START_AGENTS:                             substepText{"Starting gpupgrade agent processes...", "Start gpupgrade agent processes"},
+	idl.Substep_CHECK_DISK_SPACE:                         substepText{"Checking disk space...", "Check disk space"},
+	idl.Substep_CREATE_TARGET_CONFIG:                     substepText{"Generating target cluster configuration...", "Generate target cluster configuration"},
+	idl.Substep_INIT_TARGET_CLUSTER:                      substepText{"Creating target cluster...", "Create target cluster"},
+	idl.Substep_SHUTDOWN_TARGET_CLUSTER:                  substepText{"Stopping target cluster...", "Stop target cluster"},
+	idl.Substep_BACKUP_TARGET_MASTER:                     substepText{"Backing up target master...", "Back up target master"},
+	idl.Substep_CHECK_UPGRADE:                            substepText{"Running pg_upgrade checks...", "Run pg_upgrade checks"},
+	idl.Substep_SHUTDOWN_SOURCE_CLUSTER:                  substepText{"Stopping source cluster...", "Stop source cluster"},
+	idl.Substep_UPGRADE_MASTER:                           substepText{"Upgrading master...", "Upgrade master"},
+	idl.Substep_COPY_MASTER:                              substepText{"Copying master catalog to primary segments...", "Copy master catalog to primary segments"},
+	idl.Substep_UPGRADE_PRIMARIES:                        substepText{"Upgrading primary segments...", "Upgrade primary segments"},
+	idl.Substep_START_TARGET_CLUSTER:                     substepText{"Starting target cluster...", "Start target cluster"},
+	idl.Substep_UPDATE_TARGET_CATALOG_AND_CLUSTER_CONFIG: substepText{"Updating target master catalog...", "Update target master catalog"},
+	idl.Substep_UPDATE_DATA_DIRECTORIES:                  substepText{"Updating data directories...", "Update data directories"},
+	idl.Substep_UPDATE_TARGET_CONF_FILES:                 substepText{"Updating target master configuration files...", "Update target master configuration files"},
+	idl.Substep_UPGRADE_STANDBY:                          substepText{"Upgrading standby master...", "Upgrade standby master"},
+	idl.Substep_UPGRADE_MIRRORS:                          substepText{"Upgrading mirror segments...", "Upgrade mirror segments"},
+	idl.Substep_DELETE_TABLESPACES:                       substepText{"Deleting target tablespace directories...", "Delete target tablespace directories"},
+	idl.Substep_DELETE_PRIMARY_DATADIRS:                  substepText{"Deleting primary segment data directories...", "Delete primary segment data directories"},
+	idl.Substep_DELETE_MASTER_DATADIR:                    substepText{"Deleting master data directory...", "Delete master data directory"},
+	idl.Substep_DELETE_SEGMENT_STATEDIRS:                 substepText{"Deleting state directories on the segments...", "Delete state directories on the segments"},
+	idl.Substep_STOP_HUB_AND_AGENTS:                      substepText{"Stopping hub and agents...", "Stop hub and agents"},
+	idl.Substep_DELETE_MASTER_STATEDIR:                   substepText{"Deleting master state directory...", "Delete master state directory"},
+	idl.Substep_ARCHIVE_LOG_DIRECTORIES:                  substepText{"Archiving log directories...", "Archive log directories"},
+	idl.Substep_RESTORE_SOURCE_CLUSTER:                   substepText{"Restoring source cluster...", "Restore source cluster"},
+	idl.Substep_START_SOURCE_CLUSTER:                     substepText{"Starting source cluster...", "Start source cluster"},
+	idl.Substep_RESTORE_PGCONTROL:                        substepText{"Re-enabling source cluster...", "Re-enable source cluster"},
+	idl.Substep_RECOVERSEG_SOURCE_CLUSTER:                substepText{"Recovering source cluster mirrors...", "Recover source cluster mirrors"},
+}
+
+// NewSubstep prints out an "in progress" marker for the given substep description,
+// and returns a struct that can be .Finish()d (in a defer statement) to print
+// the final complete/failed state.
+func NewSubstep(step idl.Substep, verbose bool) *substep {
+	substepText := SubstepDescriptions[step]
+	fmt.Printf("%s\r", Format(substepText.OutputText, idl.Status_RUNNING))
+
+	return &substep{
+		name:    step,
+		text:    substepText,
+		verbose: verbose,
+		timer:   stopwatch.Start(),
+	}
+}
+
+// Finish prints out the final status of the substep; either COMPLETE or FAILED
+// depending on whether or not there is an error. The method takes a pointer to
+// error rather than error to make it possible to defer:
+//
+//    func runSubstep() (err error) {
+//        s := NewSubstep("Doing something...")
+//        defer s.Finish(&err)
+//
+//        ...
+//    }
+//
+func (s *substep) Finish(err *error) {
+	status := idl.Status_COMPLETE
+	if *err != nil {
+		status = idl.Status_FAILED
+	}
+
+	fmt.Printf("%s\n", Format(s.text.OutputText, status))
+
+	LogDuration(s.name.String(), s.verbose, s.timer.Stop())
+}

--- a/cli/commanders/substeps_test.go
+++ b/cli/commanders/substeps_test.go
@@ -1,0 +1,41 @@
+//  Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+//  SPDX-License-Identifier: Apache-2.0
+
+package commanders_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/greenplum-db/gpupgrade/cli/commanders"
+	"github.com/greenplum-db/gpupgrade/idl"
+)
+
+func TestSubstep(t *testing.T) {
+	d := commanders.BufferStandardDescriptors(t)
+	defer d.Close()
+
+	var err error
+	s := commanders.NewSubstep(idl.Substep_CREATING_DIRECTORIES, false)
+	s.Finish(&err)
+
+	err = errors.New("error")
+	s = commanders.NewSubstep(idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG, false)
+	s.Finish(&err)
+
+	stdout, stderr := d.Collect()
+
+	if len(stderr) != 0 {
+		t.Errorf("unexpected stderr %#v", string(stderr))
+	}
+
+	expected := commanders.Format(commanders.SubstepDescriptions[idl.Substep_CREATING_DIRECTORIES].OutputText, idl.Status_RUNNING) + "\r"
+	expected += commanders.Format(commanders.SubstepDescriptions[idl.Substep_CREATING_DIRECTORIES].OutputText, idl.Status_COMPLETE) + "\n"
+	expected += commanders.Format(commanders.SubstepDescriptions[idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG].OutputText, idl.Status_RUNNING) + "\r"
+	expected += commanders.Format(commanders.SubstepDescriptions[idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG].OutputText, idl.Status_FAILED) + "\n"
+
+	actual := string(stdout)
+	if actual != expected {
+		t.Errorf("output %#v want %#v", actual, expected)
+	}
+}


### PR DESCRIPTION
Extract substep logic from `steps.go` to `substeps.go`. This requires moving `BufferStandardDescriptors` to a common location that can be used by both `substep_test.go` and `step_test.go`.

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:extractSubstep)