### PR TITLE
Remove the access to s.agentConns

### DIFF
--- a/hub/finalize.go
+++ b/hub/finalize.go
@@ -47,7 +47,11 @@ func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeSe
 	})
 
 	st.Run(idl.Substep_UPDATE_DATA_DIRECTORIES, func(_ step.OutStreams) error {
-		return s.UpdateDataDirectories()
+		conns, err := s.AgentConns()
+		if err != nil {
+			return err
+		}
+		return s.UpdateDataDirectories(conns)
 	})
 
 	st.Run(idl.Substep_UPDATE_TARGET_CONF_FILES, func(streams step.OutStreams) error {

--- a/hub/rename_data_directories.go
+++ b/hub/rename_data_directories.go
@@ -17,8 +17,8 @@ var ArchiveSource = upgrade.ArchiveSource
 
 type RenameMap = map[string][]*idl.RenameDirectories
 
-func (s *Server) UpdateDataDirectories() error {
-	return UpdateDataDirectories(s.Config, s.agentConns)
+func (s *Server) UpdateDataDirectories(agentConns []*Connection) error {
+	return UpdateDataDirectories(s.Config, agentConns)
 }
 
 func UpdateDataDirectories(conf *Config, agentConns []*Connection) error {


### PR DESCRIPTION
From the API perspective, the developer should only call s.AgentConns()
to get the agent connections. The access to s.agentConns makes it
confusing to chose, so remove the member agentConns from the struct
Server.