### PR TITLE
update version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,12 @@ MODULE_NAME=gpupgrade
 #   note git hash for that version(might have been rebased, etc); call it GIT_HASH
 #   YOUR_BRANCH> git tag -a TAGNAME -m "version 0.1.1: add version" GIT_HASH
 #   YOUR_BRANCH> git push origin TAGNAME
-VERSION := $(shell git describe --tags --long| perl -pe 's/(.*)-([0-9]*)-(g[0-9a-f]*)/\1+dev.\2.\3/')
-VERSION_LD_STR="-X github.com/greenplum-db/$(MODULE_NAME)/cli/commands.Version=$(VERSION)"
+VERSION := $(shell git describe --tags --abbrev=0)
+COMMIT := $(shell git rev-parse --short --verify HEAD)
+RELEASE=Dev Build
+VERSION_LD_STR := -X 'github.com/greenplum-db/$(MODULE_NAME)/cli/commands.Version=$(VERSION)'
+VERSION_LD_STR += -X 'github.com/greenplum-db/$(MODULE_NAME)/cli/commands.Commit=$(COMMIT)'
+VERSION_LD_STR += -X 'github.com/greenplum-db/$(MODULE_NAME)/cli/commands.Release=$(RELEASE)'
 
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 LINUX_ENV := env GOOS=linux GOARCH=amd64
@@ -93,7 +97,7 @@ build_mac: OS := MAC
 build_linux build_mac: build
 
 BUILD_FLAGS = -gcflags="all=-N -l"
-override BUILD_FLAGS += -ldflags $(VERSION_LD_STR)
+override BUILD_FLAGS += -ldflags "$(VERSION_LD_STR)"
 
 install:
 	go install $(BUILD_FLAGS) github.com/greenplum-db/gpupgrade/cmd/gpupgrade

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ MODULE_NAME=gpupgrade
 #   note git hash for that version(might have been rebased, etc); call it GIT_HASH
 #   YOUR_BRANCH> git tag -a TAGNAME -m "version 0.1.1: add version" GIT_HASH
 #   YOUR_BRANCH> git push origin TAGNAME
-GIT_VERSION := $(shell git describe --tags --long| perl -pe 's/(.*)-([0-9]*)-(g[0-9a-f]*)/\1+dev.\2.\3/')
-VERSION_LD_STR="-X github.com/greenplum-db/$(MODULE_NAME)/cli/commands.UpgradeVersion=$(GIT_VERSION)"
+VERSION := $(shell git describe --tags --long| perl -pe 's/(.*)-([0-9]*)-(g[0-9a-f]*)/\1+dev.\2.\3/')
+VERSION_LD_STR="-X github.com/greenplum-db/$(MODULE_NAME)/cli/commands.Version=$(VERSION)"
 
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 LINUX_ENV := env GOOS=linux GOARCH=amd64

--- a/cli/commands/version.go
+++ b/cli/commands/version.go
@@ -5,15 +5,17 @@ package commands
 
 import "fmt"
 
-// This global var Version should have a value set at build time.
-// see Makefile for -ldflags "-X etc"
-var Version = ""
+// These variables are set during build time as specified in the Makefile.
+var Version string
+var Commit string
+var Release string
 
 func VersionString(executableName string) string {
 	if Version == "" {
 		return executableName + " unknown version"
 	}
-	return executableName + " version " + Version
+
+	return fmt.Sprintf("Version: %s\nCommit: %s\nRelease: %s", Version, Commit, Release)
 }
 
 func printVersion() {

--- a/cli/commands/version.go
+++ b/cli/commands/version.go
@@ -5,15 +5,15 @@ package commands
 
 import "fmt"
 
-// This global var UpgradeVersion should have a value set at build time.
+// This global var Version should have a value set at build time.
 // see Makefile for -ldflags "-X etc"
-var UpgradeVersion = ""
+var Version = ""
 
 func VersionString(executableName string) string {
-	if UpgradeVersion == "" {
+	if Version == "" {
 		return executableName + " unknown version"
 	}
-	return executableName + " version " + UpgradeVersion
+	return executableName + " version " + Version
 }
 
 func printVersion() {

--- a/cli/commands/version.go
+++ b/cli/commands/version.go
@@ -10,14 +10,10 @@ var Version string
 var Commit string
 var Release string
 
-func VersionString(executableName string) string {
-	if Version == "" {
-		return executableName + " unknown version"
-	}
-
+func VersionString() string {
 	return fmt.Sprintf("Version: %s\nCommit: %s\nRelease: %s", Version, Commit, Release)
 }
 
 func printVersion() {
-	fmt.Println(VersionString("gpupgrade"))
+	fmt.Println(VersionString())
 }

--- a/cli/commands/version_test.go
+++ b/cli/commands/version_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestVersionString(t *testing.T) {
 	t.Run("returns unknown version when version is not set", func(t *testing.T) {
-		commands.UpgradeVersion = ""
+		commands.Version = ""
 
 		actual := commands.VersionString("gpupgrade")
 		expected := "gpupgrade unknown version"
@@ -21,7 +21,7 @@ func TestVersionString(t *testing.T) {
 	})
 
 	t.Run("returns version", func(t *testing.T) {
-		commands.UpgradeVersion = "1.2.3"
+		commands.Version = "1.2.3"
 
 		actual := commands.VersionString("gpupgrade")
 		expected := "gpupgrade version 1.2.3"

--- a/cli/commands/version_test.go
+++ b/cli/commands/version_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 func TestVersionString(t *testing.T) {
-	t.Run("returns unknown version when version is not set", func(t *testing.T) {
-		commands.Version = ""
-
-		actual := commands.VersionString("gpupgrade")
-		expected := "gpupgrade unknown version"
+	t.Run("returns empty values when version fields are not set", func(t *testing.T) {
+		actual := commands.VersionString()
+		expected := `Version: 
+Commit: 
+Release: `
 		if actual != expected {
 			t.Errorf("got version %q want %q", actual, expected)
 		}
@@ -25,7 +25,7 @@ func TestVersionString(t *testing.T) {
 		commands.Commit = "5889c19"
 		commands.Release = "Enterprise"
 
-		actual := commands.VersionString("gpupgrade")
+		actual := commands.VersionString()
 		expected := `Version: 1.2.3
 Commit: 5889c19
 Release: Enterprise`

--- a/cli/commands/version_test.go
+++ b/cli/commands/version_test.go
@@ -22,9 +22,13 @@ func TestVersionString(t *testing.T) {
 
 	t.Run("returns version", func(t *testing.T) {
 		commands.Version = "1.2.3"
+		commands.Commit = "5889c19"
+		commands.Release = "Enterprise"
 
 		actual := commands.VersionString("gpupgrade")
-		expected := "gpupgrade version 1.2.3"
+		expected := `Version: 1.2.3
+Commit: 5889c19
+Release: Enterprise`
 		if actual != expected {
 			t.Errorf("got version %q want %q", actual, expected)
 		}

--- a/test/version.bats
+++ b/test/version.bats
@@ -22,5 +22,7 @@
 
 check_version() {
     [ "$status" -eq 0 ]
-    [[ "${lines[0]}" =~ ^gpupgrade[[:space:]]version[[:space:]][[:digit:]]\.[[:digit:]]\.[[:digit:]] ]]
+    [[ "${lines[0]}" =~ "Version:"[[:space:]][[:digit:]]\.[[:digit:]]\.[[:digit:]] ]]
+    [[ "${lines[1]}" =~ "Commit:"[[:space:]][[:alnum:]] ]]
+    [[ "${lines[2]}" = "Release: Dev Build" ]]
 }


### PR DESCRIPTION
Overall this includes:
- Renaming UpgradeVersion to Version for clarity
- Update the version output to include the commit sha and release type
- Return empty values when version fields are not set. This has been approved by the PM since the designer happened to be out that day.

Soon we will have to finalize our overall release process, but for now we can run make with the RELEASE variable set.

[Test pipelines](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:dev:version)

