### PR TITLE
Introduce errorlist.Append for concurrent errors 

### DIFF
--- a/agent/rename_directories.go
+++ b/agent/rename_directories.go
@@ -7,10 +7,10 @@ import (
 	"context"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/upgrade"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 var ArchiveSource = upgrade.ArchiveSource
@@ -18,13 +18,13 @@ var ArchiveSource = upgrade.ArchiveSource
 func (s *Server) RenameDirectories(ctx context.Context, in *idl.RenameDirectoriesRequest) (*idl.RenameDirectoriesReply, error) {
 	gplog.Info("agent received request to rename segment data directories")
 
-	var mErr *multierror.Error
+	var mErr error
 	for _, dir := range in.GetDirs() {
 		err := ArchiveSource(dir.GetSource(), dir.GetTarget(), dir.GetRenameTarget())
 		if err != nil {
-			mErr = multierror.Append(mErr, err)
+			mErr = errorlist.Append(mErr, err)
 		}
 	}
 
-	return &idl.RenameDirectoriesReply{}, mErr.ErrorOrNil()
+	return &idl.RenameDirectoriesReply{}, mErr
 }

--- a/agent/rename_directories_test.go
+++ b/agent/rename_directories_test.go
@@ -8,8 +8,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/hashicorp/go-multierror"
-
 	"github.com/greenplum-db/gpupgrade/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils/testlog"
@@ -26,14 +24,9 @@ func TestRenameDirectories(t *testing.T) {
 		}
 
 		_, err := server.RenameDirectories(context.Background(), &idl.RenameDirectoriesRequest{Dirs: []*idl.RenameDirectories{{}}})
-		var merr *multierror.Error
-		if !errors.As(err, &merr) {
-			t.Fatalf("returned %#v, want error type %T", err, merr)
-		}
-		for _, err := range merr.Errors {
-			if !errors.Is(err, expected) {
-				t.Errorf("returned error %#v, want %#v", err, expected)
-			}
+
+		if !errors.Is(err, expected) {
+			t.Errorf("returned error %#v, want %#v", err, expected)
 		}
 	})
 }

--- a/agent/restore_pg_control.go
+++ b/agent/restore_pg_control.go
@@ -6,21 +6,21 @@ package agent
 import (
 	"context"
 
-	"github.com/hashicorp/go-multierror"
-
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/upgrade"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 func (s *Server) RestorePrimariesPgControl(ctx context.Context, in *idl.RestorePgControlRequest) (*idl.RestorePgControlReply, error) {
-	var mErr *multierror.Error
+	var mErr error
+
 	for _, dir := range in.Datadirs {
 		err := upgrade.RestorePgControl(dir, step.DevNullStream)
 		if err != nil {
-			mErr = multierror.Append(mErr, err)
+			mErr = errorlist.Append(mErr, err)
 		}
 	}
 
-	return &idl.RestorePgControlReply{}, mErr.ErrorOrNil()
+	return &idl.RestorePgControlReply{}, mErr
 }

--- a/agent/restore_pg_control_test.go
+++ b/agent/restore_pg_control_test.go
@@ -11,13 +11,13 @@ import (
 	"testing"
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"github.com/hashicorp/go-multierror"
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/utils"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 func TestServer_RestorePrimariesPgControl(t *testing.T) {
@@ -27,16 +27,17 @@ func TestServer_RestorePrimariesPgControl(t *testing.T) {
 	t.Run("bubbles up errors when no pg_control files exist", func(t *testing.T) {
 		dirs := []string{"/tmp/test1", "/tmp/test2"}
 		_, err := server.RestorePrimariesPgControl(context.Background(), &idl.RestorePgControlRequest{Datadirs: dirs})
-		var mErr *multierror.Error
-		if !xerrors.As(err, &mErr) {
-			t.Fatalf("error %#v does not contain type %T", err, mErr)
+
+		var errs errorlist.Errors
+		if !xerrors.As(err, &errs) {
+			t.Fatalf("error %#v does not contain type %T", err, errs)
 		}
 
-		if len(dirs) != mErr.Len() {
-			t.Fatalf("got error count %d, want %d", mErr.Len(), len(dirs))
+		if len(errs) != len(dirs) {
+			t.Fatalf("got error count %d, want %d", len(errs), len(dirs))
 		}
 
-		for i, err := range mErr.Errors {
+		for i, err := range errs {
 			if !os.IsNotExist(err) {
 				t.Errorf("got error type %T, want %T", err, &os.LinkError{})
 			}

--- a/agent/upgrade_primaries.go
+++ b/agent/upgrade_primaries.go
@@ -9,12 +9,12 @@ import (
 	"os/exec"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
-	multierror "github.com/hashicorp/go-multierror"
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 	"github.com/greenplum-db/gpupgrade/utils"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 func (s *Server) UpgradePrimaries(ctx context.Context, request *idl.UpgradePrimariesRequest) (*idl.UpgradePrimariesReply, error) {
@@ -62,7 +62,7 @@ func UpgradePrimaries(stateDir string, request *idl.UpgradePrimariesRequest) err
 	for range segments {
 		response := <-upgradeResponse
 		if response != nil {
-			err = multierror.Append(err, response)
+			err = errorlist.Append(err, response)
 		}
 	}
 

--- a/agent/upgrade_primaries_test.go
+++ b/agent/upgrade_primaries_test.go
@@ -12,13 +12,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/go-multierror"
-
 	"github.com/greenplum-db/gpupgrade/agent"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
 	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/utils"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 	"github.com/greenplum-db/gpupgrade/utils/rsync"
 )
 
@@ -160,16 +159,16 @@ func TestUpgradePrimary(t *testing.T) {
 
 		// We expect each part of the request to return its own ExitError,
 		// containing the expected message from FailedRsync.
-		var multiErr *multierror.Error
-		if !errors.As(err, &multiErr) {
-			t.Fatalf("got error %#v, want type %T", err, multiErr)
+		var errs errorlist.Errors
+		if !errors.As(err, &errs) {
+			t.Fatalf("got error %#v, want type %T", err, errs)
 		}
 
-		if len(multiErr.Errors) != len(pairs) {
-			t.Errorf("received %d errors, want %d", len(multiErr.Errors), len(pairs))
+		if len(errs) != len(pairs) {
+			t.Errorf("received %d errors, want %d", len(errs), len(pairs))
 		}
 
-		for _, err := range multiErr.Errors {
+		for _, err := range errs {
 			if !strings.Contains(string(err.Error()), "rsync failed cause I said so") {
 				t.Errorf("wanted error message 'rsync failed cause I said so' from rsync, got %q",
 					string(err.Error()))

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -40,7 +40,6 @@ import (
 	"time"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
-	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -56,6 +55,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 	"github.com/greenplum-db/gpupgrade/utils"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 	"github.com/greenplum-db/gpupgrade/utils/stopwatch"
 )
 
@@ -347,7 +347,7 @@ func initialize() *cobra.Command {
 				}
 				defer func() {
 					if cErr := configFile.Close(); cErr != nil {
-						err = multierror.Append(err, cErr).ErrorOrNil()
+						err = errorlist.Append(err, cErr)
 					}
 				}()
 

--- a/hub/archive_log_directory_test.go
+++ b/hub/archive_log_directory_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -57,19 +56,8 @@ func TestArchiveLogDirectories(t *testing.T) {
 		}
 
 		err := hub.ArchiveSegmentLogDirectories(agentConns, "", newDir)
-		var multiErr *multierror.Error
-		if !errors.As(err, &multiErr) {
-			t.Fatalf("got error %#v, want type %T", err, multiErr)
-		}
-
-		if len(multiErr.Errors) != 1 {
-			t.Errorf("received %d errors, want %d", len(multiErr.Errors), 1)
-		}
-
-		for _, err := range multiErr.Errors {
-			if !errors.Is(err, expected) {
-				t.Errorf("got error %#v, want %#v", expected, err)
-			}
+		if !errors.Is(err, expected) {
+			t.Errorf("got error %#v, want %#v", err, expected)
 		}
 	})
 }

--- a/hub/check_disk_space.go
+++ b/hub/check_disk_space.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"sync"
 
-	multierror "github.com/hashicorp/go-multierror"
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils/disk"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 func (s *Server) CheckDiskSpace(ctx context.Context, in *idl.CheckDiskSpaceRequest) (*idl.CheckDiskSpaceReply, error) {
@@ -92,11 +92,11 @@ func checkDiskSpace(ctx context.Context, cluster *greenplum.Cluster, agents []*C
 	close(errs)
 	close(failures)
 
-	var multiErr *multierror.Error
-	for err := range errs {
-		multiErr = multierror.Append(multiErr, err)
+	var err error
+	for e := range errs {
+		err = errorlist.Append(err, e)
 	}
-	if err := multiErr.ErrorOrNil(); err != nil {
+	if err != nil {
 		return nil, err
 	}
 

--- a/hub/check_source_cluster_configuration.go
+++ b/hub/check_source_cluster_configuration.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 const (
@@ -71,17 +71,17 @@ func GetSegmentStatuses(connection *sql.DB) ([]SegmentStatus, error) {
 }
 
 func SegmentStatusErrors(statuses []SegmentStatus) error {
-	errors := &multierror.Error{}
+	var errs error
 
 	if err := checkForDownSegments(statuses); err != nil {
-		errors = multierror.Append(errors, err)
+		errs = errorlist.Append(errs, err)
 	}
 
 	if err := checkForUnbalancedSegments(statuses); err != nil {
-		errors = multierror.Append(errors, err)
+		errs = errorlist.Append(errs, err)
 	}
 
-	return errors.ErrorOrNil()
+	return errs
 }
 
 func checkForDownSegments(statuses []SegmentStatus) error {

--- a/hub/check_source_cluster_configuration_test.go
+++ b/hub/check_source_cluster_configuration_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 func TestSegmentStatusError_Error(t *testing.T) {
@@ -63,10 +63,9 @@ func TestSegmentStatusErrors(t *testing.T) {
 			t.Fatalf("got no errors for step, expected segment status error")
 		}
 
-		var multiError *multierror.Error
 		var segmentStatusError hub.UnbalancedSegmentStatusError
 
-		if !errors.As(err, &multiError) || !errors.As(multiError.Errors[0], &segmentStatusError) {
+		if !errors.As(err, &segmentStatusError) {
 			t.Errorf("got an error that was not a segment status error: %v",
 				err.Error())
 		}
@@ -122,9 +121,7 @@ func TestSegmentStatusErrors(t *testing.T) {
 		}
 
 		var segmentStatusError hub.DownSegmentStatusError
-
-		var multiError *multierror.Error
-		if !errors.As(err, &multiError) || !errors.As(multiError.Errors[0], &segmentStatusError) {
+		if !errors.As(err, &segmentStatusError) {
 			t.Errorf("got an error that was not a segment status error: %v",
 				err.Error())
 		}
@@ -171,21 +168,20 @@ func TestSegmentStatusErrors(t *testing.T) {
 			t.Fatalf("got no errors for step, expected segment status error")
 		}
 
-		var multiError *multierror.Error
+		var errs errorlist.Errors
 
-		if !errors.As(err, &multiError) {
-			t.Errorf("got an error that was not a multi error: %v",
-				err.Error())
+		if !errors.As(err, &errs) {
+			t.Fatalf("got error %#v, want type %T", err, errs)
 		}
 
 		var downSegmentStatusError hub.DownSegmentStatusError
-		if !errors.As(multiError.Errors[0], &downSegmentStatusError) {
+		if !errors.As(errs[0], &downSegmentStatusError) {
 			t.Errorf("got an error that was not a down segment status error: %v",
 				err.Error())
 		}
 
 		var unbalancedSegmentStatusError hub.UnbalancedSegmentStatusError
-		if !errors.As(multiError.Errors[1], &unbalancedSegmentStatusError) {
+		if !errors.As(errs[1], &unbalancedSegmentStatusError) {
 			t.Errorf("got an error that was not an unbalanced segment status error: %v",
 				err.Error())
 		}

--- a/hub/check_upgrade.go
+++ b/hub/check_upgrade.go
@@ -6,10 +6,10 @@ package hub
 import (
 	"sync"
 
-	"github.com/hashicorp/go-multierror"
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/step"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 type UpgradeChecker interface {
@@ -70,10 +70,10 @@ func (s *Server) CheckUpgrade(stream step.OutStreams, conns []*Connection) error
 	wg.Wait()
 	close(checkErrs)
 
-	var multiErr *multierror.Error
-	for err := range checkErrs {
-		multiErr = multierror.Append(multiErr, err)
+	var err error
+	for e := range checkErrs {
+		err = errorlist.Append(err, e)
 	}
 
-	return multiErr.ErrorOrNil()
+	return err
 }

--- a/hub/copy_master_test.go
+++ b/hub/copy_master_test.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/go-multierror"
 	"google.golang.org/grpc"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
@@ -21,6 +20,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
 	"github.com/greenplum-db/gpupgrade/testutils/testlog"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 	"github.com/greenplum-db/gpupgrade/utils/rsync"
 )
 
@@ -114,11 +114,11 @@ func TestCopy(t *testing.T) {
 		err := Copy(streams, "", nil, []string{"localhost"})
 
 		// Make sure the errors are correctly propagated up.
-		var merr *multierror.Error
-		if !errors.As(err, &merr) {
-			t.Fatalf("returned %#v, want error type %T", err, merr)
+		var errs errorlist.Errors
+		if !errors.As(err, &errs) {
+			t.Fatalf("returned %#v, want error type %T", err, errs)
 		}
-		for _, err := range merr.Errors {
+		for _, err := range errs {
 			if !errors.Is(err, streams.Err) {
 				t.Errorf("returned error %#v, want %#v", err, streams.Err)
 			}
@@ -133,12 +133,13 @@ func TestCopy(t *testing.T) {
 		err := Copy(buffer, "foobar/path", nil, hosts)
 
 		// Make sure the errors are correctly propagated up.
-		var merr *multierror.Error
-		if !errors.As(err, &merr) {
-			t.Fatalf("returned %#v, want error type %T", err, merr)
+		var errs errorlist.Errors
+		if !errors.As(err, &errs) {
+			t.Fatalf("returned %#v, want error type %T", err, errs)
 		}
+
 		var exitErr *exec.ExitError
-		for _, err := range merr.Errors {
+		for _, err := range errs {
 			if !errors.As(err, &exitErr) || exitErr.ExitCode() != rsyncExitCode {
 				t.Errorf("returned error %#v, want exit code %d", err, rsyncExitCode)
 			}

--- a/hub/delete_data_directories_test.go
+++ b/hub/delete_data_directories_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/hub"
@@ -165,19 +164,8 @@ func TestDeleteSegmentDataDirs(t *testing.T) {
 
 			err := hub.DeleteMasterAndPrimaryDataDirectories(step.DevNullStream, agentConns, source)
 
-			var multiErr *multierror.Error
-			if !errors.As(err, &multiErr) {
-				t.Fatalf("got error %#v, want type %T", err, multiErr)
-			}
-
-			if len(multiErr.Errors) != 1 {
-				t.Errorf("received %d errors, want %d", len(multiErr.Errors), 1)
-			}
-
-			for _, err := range multiErr.Errors {
-				if !errors.Is(err, expected) {
-					t.Errorf("got error %#v, want %#v", expected, err)
-				}
+			if !errors.Is(err, expected) {
+				t.Errorf("got error %#v, want %#v", err, expected)
 			}
 		})
 	})
@@ -358,19 +346,8 @@ func TestDeleteTablespaceDirectories(t *testing.T) {
 
 		err := hub.DeleteTargetTablespacesOnPrimaries(agentConns, target, nil, "")
 
-		var multiErr *multierror.Error
-		if !errors.As(err, &multiErr) {
-			t.Fatalf("got error %#v, want type %T", err, multiErr)
-		}
-
-		if len(multiErr.Errors) != 1 {
-			t.Errorf("received %d errors, want %d", len(multiErr.Errors), 1)
-		}
-
-		for _, err := range multiErr.Errors {
-			if !errors.Is(err, expected) {
-				t.Errorf("got error %#v, want %#v", expected, err)
-			}
+		if !errors.Is(err, expected) {
+			t.Errorf("got error %#v, want %#v", err, expected)
 		}
 	})
 }

--- a/hub/delete_state_directories_test.go
+++ b/hub/delete_state_directories_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -76,19 +75,8 @@ func TestDeleteStateDirectories(t *testing.T) {
 
 			err := hub.DeleteStateDirectories(agentConns, "")
 
-			var multiErr *multierror.Error
-			if !errors.As(err, &multiErr) {
-				t.Fatalf("got error %#v, want type %T", err, multiErr)
-			}
-
-			if len(multiErr.Errors) != 1 {
-				t.Errorf("received %d errors, want %d", len(multiErr.Errors), 1)
-			}
-
-			for _, err := range multiErr.Errors {
-				if !errors.Is(err, expected) {
-					t.Errorf("got error %#v, want %#v", expected, err)
-				}
+			if !errors.Is(err, expected) {
+				t.Errorf("got error %#v, want %#v", err, expected)
 			}
 		})
 	})

--- a/hub/execute.go
+++ b/hub/execute.go
@@ -10,12 +10,12 @@ import (
 	"strconv"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
-	"github.com/hashicorp/go-multierror"
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/utils"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 const executeMasterBackupName = "upgraded-master.bak"
@@ -30,7 +30,7 @@ func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_Execut
 
 	defer func() {
 		if ferr := st.Finish(); ferr != nil {
-			err = multierror.Append(err, ferr).ErrorOrNil()
+			err = errorlist.Append(err, ferr)
 		}
 
 		if err != nil {

--- a/hub/finalize.go
+++ b/hub/finalize.go
@@ -8,12 +8,12 @@ import (
 	"strconv"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
-	"github.com/hashicorp/go-multierror"
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/step"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeServer) (err error) {
@@ -24,7 +24,7 @@ func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeSe
 
 	defer func() {
 		if ferr := st.Finish(); ferr != nil {
-			err = multierror.Append(err, ferr).ErrorOrNil()
+			err = errorlist.Append(err, ferr)
 		}
 
 		if err != nil {

--- a/hub/initialize.go
+++ b/hub/initialize.go
@@ -10,11 +10,11 @@ import (
 	"path/filepath"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
-	"github.com/hashicorp/go-multierror"
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/step"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 const connectionString = "postgresql://localhost:%d/template1?gp_session_role=utility&search_path="
@@ -27,7 +27,7 @@ func (s *Server) Initialize(in *idl.InitializeRequest, stream idl.CliToHub_Initi
 
 	defer func() {
 		if ferr := st.Finish(); ferr != nil {
-			err = multierror.Append(err, ferr).ErrorOrNil()
+			err = errorlist.Append(err, ferr)
 		}
 
 		if err != nil {
@@ -42,7 +42,7 @@ func (s *Server) Initialize(in *idl.InitializeRequest, stream idl.CliToHub_Initi
 		}
 		defer func() {
 			if cerr := conn.Close(); cerr != nil {
-				err = multierror.Append(err, cerr).ErrorOrNil()
+				err = errorlist.Append(err, cerr)
 			}
 		}()
 
@@ -65,7 +65,7 @@ func (s *Server) InitializeCreateCluster(in *idl.InitializeCreateClusterRequest,
 
 	defer func() {
 		if ferr := st.Finish(); ferr != nil {
-			err = multierror.Append(err, ferr).ErrorOrNil()
+			err = errorlist.Append(err, ferr)
 		}
 
 		if err != nil {

--- a/hub/rename_data_directories_test.go
+++ b/hub/rename_data_directories_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/hub"
@@ -116,19 +115,8 @@ func TestRenameSegmentDataDirs(t *testing.T) {
 
 		err := hub.RenameSegmentDataDirs(agentConns, m)
 
-		var multiErr *multierror.Error
-		if !errors.As(err, &multiErr) {
-			t.Fatalf("got error %#v, want type %T", err, multiErr)
-		}
-
-		if len(multiErr.Errors) != 1 {
-			t.Errorf("received %d errors, want %d", len(multiErr.Errors), 1)
-		}
-
-		for _, err := range multiErr.Errors {
-			if !errors.Is(err, expected) {
-				t.Errorf("got error %#v, want %#v", expected, err)
-			}
+		if !errors.Is(err, expected) {
+			t.Errorf("got error %#v, want %#v", err, expected)
 		}
 	})
 }

--- a/hub/restore_source_cluster.go
+++ b/hub/restore_source_cluster.go
@@ -11,13 +11,13 @@ import (
 	"sync"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
-	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/upgrade"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 	"github.com/greenplum-db/gpupgrade/utils/rsync"
 )
 
@@ -49,12 +49,12 @@ func RsyncMasterAndPrimaries(stream step.OutStreams, agentConns []*Connection, s
 	wg.Wait()
 	close(errs)
 
-	var mErr *multierror.Error
-	for err := range errs {
-		mErr = multierror.Append(mErr, err)
+	var err error
+	for e := range errs {
+		err = errorlist.Append(err, e)
 	}
 
-	return mErr.ErrorOrNil()
+	return err
 }
 
 func RsyncMasterAndPrimariesTablespaces(stream step.OutStreams, agentConns []*Connection, source *greenplum.Cluster, tablespaces greenplum.Tablespaces) error {
@@ -76,12 +76,12 @@ func RsyncMasterAndPrimariesTablespaces(stream step.OutStreams, agentConns []*Co
 	wg.Wait()
 	close(errs)
 
-	var mErr *multierror.Error
-	for err := range errs {
-		mErr = multierror.Append(mErr, err)
+	var err error
+	for e := range errs {
+		err = errorlist.Append(err, e)
 	}
 
-	return mErr.ErrorOrNil()
+	return err
 }
 
 // Restoring the mirrors is needed in copy mode on 5X since the source cluster
@@ -230,12 +230,12 @@ func RestoreMasterAndPrimariesPgControl(streams step.OutStreams, agentConns []*C
 	wg.Wait()
 	close(errs)
 
-	var mErr *multierror.Error
-	for err := range errs {
-		mErr = multierror.Append(mErr, err)
+	var err error
+	for e := range errs {
+		err = errorlist.Append(err, e)
 	}
 
-	return mErr.ErrorOrNil()
+	return err
 }
 
 func restorePrimariesPgControl(agentConns []*Connection, source *greenplum.Cluster) error {

--- a/hub/revert.go
+++ b/hub/revert.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
-	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"golang.org/x/xerrors"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 	"github.com/greenplum-db/gpupgrade/utils"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 var ErrMissingMirrorsAndStandby = errors.New("Source cluster does not have mirrors and/or standby. Cannot restore source cluster. Please contact support.")
@@ -31,7 +31,7 @@ func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) 
 
 	defer func() {
 		if ferr := st.Finish(); ferr != nil {
-			err = multierror.Append(err, ferr).ErrorOrNil()
+			err = errorlist.Append(err, ferr)
 		}
 
 		if err != nil {

--- a/hub/rpc.go
+++ b/hub/rpc.go
@@ -6,7 +6,7 @@ package hub
 import (
 	"sync"
 
-	"github.com/hashicorp/go-multierror"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 func ExecuteRPC(agentConns []*Connection, executeRequest func(conn *Connection) error) error {
@@ -28,10 +28,10 @@ func ExecuteRPC(agentConns []*Connection, executeRequest func(conn *Connection) 
 	wg.Wait()
 	close(errs)
 
-	var mErr *multierror.Error
-	for err := range errs {
-		mErr = multierror.Append(mErr, err)
+	var err error
+	for e := range errs {
+		err = errorlist.Append(err, e)
 	}
 
-	return mErr.ErrorOrNil()
+	return err
 }

--- a/hub/rpc_test.go
+++ b/hub/rpc_test.go
@@ -9,8 +9,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/hashicorp/go-multierror"
-
 	"github.com/greenplum-db/gpupgrade/hub"
 )
 
@@ -62,19 +60,9 @@ func TestExecuteRPC(t *testing.T) {
 		}
 
 		err := hub.ExecuteRPC(agentConns, request)
-		var multiErr *multierror.Error
-		if !errors.As(err, &multiErr) {
-			t.Fatalf("got error %#v, want type %T", err, multiErr)
-		}
 
-		if len(multiErr.Errors) != 1 {
-			t.Errorf("received %d errors, want %d", len(multiErr.Errors), 1)
-		}
-
-		for _, err := range multiErr.Errors {
-			if !errors.Is(err, expected) {
-				t.Errorf("got error %#v, want %#v", expected, err)
-			}
+		if !errors.Is(err, expected) {
+			t.Errorf("got error %#v, want %#v", err, expected)
 		}
 	})
 }

--- a/hub/server.go
+++ b/hub/server.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
-	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
@@ -31,6 +30,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/upgrade"
 	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/greenplum-db/gpupgrade/utils/daemon"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 	"github.com/greenplum-db/gpupgrade/utils/log"
 )
 
@@ -259,12 +259,12 @@ func RestartAgents(ctx context.Context,
 		hosts = append(hosts, h)
 	}
 
-	var multiErr *multierror.Error
-	for err := range errs {
-		multiErr = multierror.Append(multiErr, err)
+	var err error
+	for e := range errs {
+		err = errorlist.Append(err, e)
 	}
 
-	return hosts, multiErr.ErrorOrNil()
+	return hosts, err
 }
 
 func (s *Server) AgentConns() ([]*Connection, error) {

--- a/hub/update_catalog_test.go
+++ b/hub/update_catalog_test.go
@@ -13,12 +13,12 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	. "github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/upgrade"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 // Sentinel error values to make error case testing easier.
@@ -226,14 +226,14 @@ func TestUpdateCatalog(t *testing.T) {
 			mock.ExpectRollback().WillReturnError(ErrRollback)
 		},
 		func(t *testing.T, err error) {
-			multiErr, ok := err.(*multierror.Error)
+			errs, ok := err.(errorlist.Errors)
 			if !ok {
-				t.Fatal("did not return a multierror")
+				t.Fatal("did not return an Errors list")
 			}
-			if !errors.Is(multiErr.Errors[0], ErrSentinel) {
+			if !errors.Is(errs[0], ErrSentinel) {
 				t.Errorf("first error was %#v want %#v", err, ErrSentinel)
 			}
-			if !errors.Is(multiErr.Errors[1], ErrRollback) {
+			if !errors.Is(errs[1], ErrRollback) {
 				t.Errorf("second error was %#v want %#v", err, ErrRollback)
 			}
 		},

--- a/hub/upgrade_mirrors.go
+++ b/hub/upgrade_mirrors.go
@@ -10,11 +10,11 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/utils"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 const defaultFTSTimeout = 2 * time.Minute
@@ -114,7 +114,7 @@ func doUpgrade(db *sql.DB, stateDir string, mirrors []greenplum.SegConfig, targe
 	defer func() {
 		if !fileClosed {
 			if cerr := f.Close(); cerr != nil {
-				err = multierror.Append(err, cerr).ErrorOrNil()
+				err = errorlist.Append(err, cerr)
 			}
 		}
 	}()

--- a/hub/upgrade_mirrors_test.go
+++ b/hub/upgrade_mirrors_test.go
@@ -16,11 +16,11 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/utils"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 type greenplumStub struct {
@@ -274,16 +274,16 @@ func TestDoUpgrade(t *testing.T) {
 
 		err = doUpgrade(db, "/state/dir", mirrors, stub)
 
-		var merr *multierror.Error
-		if !errors.As(err, &merr) {
-			t.Fatalf("returned error %#v, want error type %T", err, merr)
+		var errs errorlist.Errors
+		if !errors.As(err, &errs) {
+			t.Fatalf("returned error %#v, want error type %T", err, errs)
 		}
 
-		if len(merr.Errors) != 2 {
+		if len(errs) != 2 {
 			t.Errorf("expected exactly two errors")
 		}
 
-		for _, err := range merr.Errors {
+		for _, err := range errs {
 			if !errors.Is(err, os.ErrInvalid) {
 				t.Errorf("returned error %#v want %#v", err, os.ErrInvalid)
 			}

--- a/integrations/integrations_suite_test.go
+++ b/integrations/integrations_suite_test.go
@@ -11,7 +11,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 func init() {
@@ -28,7 +28,7 @@ func init() {
 	for _, bin := range []string{"gpupgrade"} {
 		binPath, err := exec.LookPath(bin)
 		if err != nil {
-			allErrs = multierror.Append(allErrs, err)
+			allErrs = errorlist.Append(allErrs, err)
 			continue
 		}
 
@@ -40,7 +40,7 @@ func init() {
 	if allErrs != nil {
 		panic(fmt.Sprintf(
 			"Please put gpupgrade binaries on your PATH before running integration tests.\n%s",
-			multierror.Flatten(allErrs),
+			allErrs,
 		))
 	}
 }

--- a/step/step.go
+++ b/step/step.go
@@ -11,11 +11,11 @@ import (
 	"strings"
 
 	"github.com/greenplum-db/gp-common-go-libs/operating"
-	multierror "github.com/hashicorp/go-multierror"
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 	"github.com/greenplum-db/gpupgrade/utils/stopwatch"
 )
 
@@ -79,7 +79,7 @@ func GetStatusFile(stateDir string) (path string, err error) {
 
 	defer func() {
 		if cErr := f.Close(); cErr != nil {
-			err = multierror.Append(err, cErr).ErrorOrNil()
+			err = errorlist.Append(err, cErr)
 		}
 	}()
 
@@ -169,7 +169,7 @@ func (s *Step) run(substep idl.Substep, f func(OutStreams) error, alwaysRun bool
 	timer := stopwatch.Start()
 	defer func() {
 		if pErr := s.printDuration(substep, timer.Stop()); pErr != nil {
-			err = multierror.Append(err, pErr).ErrorOrNil()
+			err = errorlist.Append(err, pErr)
 		}
 	}()
 
@@ -193,7 +193,7 @@ func (s *Step) run(substep idl.Substep, f func(OutStreams) error, alwaysRun bool
 
 	case err != nil:
 		if werr := s.write(substep, idl.Status_FAILED); werr != nil {
-			err = multierror.Append(err, werr).ErrorOrNil()
+			err = errorlist.Append(err, werr)
 		}
 		return
 	}

--- a/utils/errorlist/errorlist.go
+++ b/utils/errorlist/errorlist.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package errorlist
+
+import "github.com/hashicorp/go-multierror"
+
+// Append takes at least two errors and combines them into a list. The rules are
+// as follows:
+//
+//  - If all of the errors being appended are nil, Append returns nil.
+//  - If exactly one of the errors being appended is non-nil, Append returns
+//    that error unchanged.
+//  - Otherwise, Append returns a slice of errors (wrapped in an Errors
+//    instance) consisting of the inputs, minus any nil errors.
+//
+// If any of the passed errors are themselves Errors slices, their contents will
+// be flattened into the resulting error. This behavior can be prevented by
+// wrapping input Errors slices in their own context, for example using
+// fmt.Errorf.
+func Append(a, b error, e ...error) error {
+	errs := append([]error{a, b}, e...)
+
+	var all Errors
+	for _, err := range errs {
+		switch v := err.(type) {
+		case nil:
+			continue
+		case Errors:
+			all = append(all, v...)
+		default:
+			all = append(all, v)
+		}
+	}
+
+	switch len(all) {
+	case 0:
+		return nil
+	case 1:
+		return all[0]
+	default:
+		return all
+	}
+}
+
+// Errors is a slice of error values that can be treated like a single error
+// value. Use Append to create Errors instances.
+type Errors []error
+
+func (e Errors) Error() string {
+	// TODO: For now we maintain the old multierror output, but this should be
+	// redesigned.
+	return multierror.ListFormatFunc(e)
+}

--- a/utils/errorlist/errorlist_test.go
+++ b/utils/errorlist/errorlist_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package errorlist_test
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
+)
+
+func TestAppend(t *testing.T) {
+	t.Run("multiple nils appended together are still nil", func(t *testing.T) {
+		cases := []struct {
+			desc   string
+			actual error
+		}{
+			{"nil, nil", errorlist.Append(nil, nil)},
+			{"nil, nil, nil, nil", errorlist.Append(nil, nil, nil, nil)},
+		}
+
+		for _, c := range cases {
+			if c.actual != nil {
+				t.Errorf("Append(%s) = %#v, want nil", c.desc, c.actual)
+			}
+		}
+	})
+
+	t.Run("nil appended with one error is just the error itself", func(t *testing.T) {
+		expected := errors.New("it broke")
+
+		cases := []struct {
+			desc   string
+			actual error
+		}{
+			{"err, nil", errorlist.Append(expected, nil)},
+			{"nil, err", errorlist.Append(nil, expected)},
+			{"nil, nil, err, nil, nil", errorlist.Append(nil, nil, expected, nil, nil)},
+		}
+
+		for _, c := range cases {
+			if c.actual != expected {
+				t.Errorf("Append(%s) = %#v, want %#v", c.desc, c.actual, expected)
+			}
+		}
+	})
+
+	t.Run("two plain errors appended together results in an Errors list", func(t *testing.T) {
+		first := errors.New("ahhh")
+		second := errors.New("it broke")
+
+		expected := errorlist.Errors{first, second}
+		testlist(t, expected, first, second)
+	})
+
+	t.Run("an error appended to an Errors list gets added to the end", func(t *testing.T) {
+		expected := errorlist.Errors{
+			errors.New("ahhh"),
+			errors.New("it broke"),
+			errors.New("bad"),
+		}
+
+		first := errorlist.Errors{expected[0], expected[1]}
+		second := expected[2]
+
+		testlist(t, expected, first, second)
+	})
+
+	t.Run("Errors lists appended together are concatenated in order", func(t *testing.T) {
+		expected := errorlist.Errors{
+			errors.New("ahhh"),
+			errors.New("it broke"),
+			errors.New("bad"),
+			errors.New("really bad"),
+			errors.New("five"),
+			errors.New("six"),
+		}
+
+		first := errorlist.Errors{expected[0], expected[1]}
+		second := errorlist.Errors{expected[2], expected[3]}
+		third := errorlist.Errors{expected[4], expected[5]}
+
+		testlist(t, expected, first, second, third)
+	})
+
+	t.Run("wrapped Errors lists are not concatenated", func(t *testing.T) {
+		expected := errorlist.Errors{
+			errors.New("ahhh"),
+			fmt.Errorf("context: %w", errorlist.Errors{
+				errors.New("wrapped 1"),
+				errors.New("wrapped 2"),
+			}),
+			errors.New("it broke"),
+		}
+
+		testlist(t, expected, expected[0], expected[1], expected[2])
+	})
+}
+
+// testlist Append()s all input and tests that the result is equivalent to the
+// expected Errors list.
+func testlist(t *testing.T, expected errorlist.Errors, input ...error) {
+	t.Helper()
+
+	actual := errorlist.Append(input[0], input[1], input[2:]...)
+
+	var errs errorlist.Errors
+	if !errors.As(actual, &errs) {
+		t.Fatalf("Append%q = %#v, want type %T", input, actual, errs)
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("Append%q = %#v, want %#v", input, actual, expected)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	t.Run("Error() uses old multierror format for now", func(t *testing.T) {
+		errs := errorlist.Errors{
+			fmt.Errorf("context: %w", errors.New("ahhh")),
+			errors.New("it broke"),
+			errors.New("bad"),
+		}
+
+		actual := errs.Error()
+		expected := `3 errors occurred:
+	* context: ahhh
+	* it broke
+	* bad
+
+`
+
+		if actual != expected {
+			t.Errorf("Error() = %q, want %q", actual, expected)
+		}
+	})
+}

--- a/utils/errorlist/example_test.go
+++ b/utils/errorlist/example_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package errorlist_test
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
+)
+
+func ExampleAppend() {
+	errs := make(chan error)
+
+	go func() {
+		errs <- errors.New("one")
+		errs <- errors.New("two")
+		errs <- errors.New("three")
+	}()
+
+	var err error
+	for i := 0; i < 3; i++ {
+		err = errorlist.Append(err, <-errs)
+	}
+
+	fmt.Println(err)
+
+	// Output:
+	// 3 errors occurred:
+	//	* one
+	//	* two
+	//	* three
+}

--- a/utils/sys_utils.go
+++ b/utils/sys_utils.go
@@ -13,7 +13,8 @@ import (
 	"time"
 
 	"github.com/google/renameio"
-	"github.com/hashicorp/go-multierror"
+
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 var (
@@ -123,7 +124,7 @@ func AtomicallyWrite(path string, data []byte) (err error) {
 	}
 	defer func() {
 		if cErr := file.Cleanup(); cErr != nil {
-			err = multierror.Append(err, cErr).ErrorOrNil()
+			err = errorlist.Append(err, cErr)
 		}
 	}()
 


### PR DESCRIPTION
`multierror` is used throughout the codebase, but its API is subtly unsuited to our most common use case, which is simply accumulating zero or more errors from concurrent goroutines. Among the problems:

- If you call `multierror.Append` with only `nil` errors, the result is not `nil`. It's a `multierror.Error` that contains zero errors.

- To combat that problem, you can call `multierror.Error.ErrorOrNil()`, which will collapse the error tree. The need to do this (and the ease of forgetting to do it) results in subtle mistakes that need to be caught during PR review.

- If the `multierror.Error` contains only a single non-nil error, `ErrorOrNil()` will not flatten the result to only that error. Instead, it'll return a `multierror.Error` that wraps a single error, which results in an unnecessary `1 error occurred:` in the error message, and complicates testing for single-error cases since the result must be unwrapped.

- `multierror's Unwrap` implementation is subtly broken, because it treats its contents as if they wrap each other as opposed to being distinct. So `errors.Is` will return true if _any_ of the contained errors match, which is a bit like saying "a basket containing an apple, an orange, and a stapler is itself an apple." This has consequences for clients that want to check error properties using `errors.Is`/`As`.

`errorlist.Append` is designed to fix these issues:

- If an error and `nil` are `Append`ed together, the result is the original error instead of a wrapper type.

- The wrapper type that is returned by `Append`, `errorlist.Errors`, is just a slice of `error`s. It can be ranged over, you can call `len()` on it, you can construct it directly for testing purposes, etc.

- The `Errors` wrapper type does not implement `Unwrap`/`Is`/`As`, because a basket containing an apple, an orange, and a stapler is neither an apple, nor an orange, nor a stapler -- it's a basket.

The end result is that accumulating a list of errors now looks exactly like accumulating any other slice...

```go
var err error
for i := 0; i < 3; i++ {
    err = errorlist.Append(err, <-errChan)
}
return err
```

...and due to the nil-accumulation rule, it's impossible for the `Errors` wrappers to contain fewer than two errors, as long as clients only construct them using `Append`.