### PR TITLE
testutils.MustRemoveAll: print errors in detail mode

### DIFF
--- a/testutils/test_utils.go
+++ b/testutils/test_utils.go
@@ -88,7 +88,7 @@ func MustRemoveAll(t *testing.T, dir string) {
 
 	err := os.RemoveAll(dir)
 	if err != nil {
-		t.Fatalf("removing temp dir %q: %#v", dir, err)
+		t.Fatalf("removing temp dir %q: %+v", dir, err)
 	}
 }
 


### PR DESCRIPTION
`%#v` obfuscates the error meaning; use `%+v` instead.