### PR TITLE
Pass PGPORT to gprecoverseg

### DIFF
--- a/hub/restore_source_cluster.go
+++ b/hub/restore_source_cluster.go
@@ -93,7 +93,7 @@ func Recoverseg(stream step.OutStreams, cluster *greenplum.Cluster) error {
 		return nil
 	}
 
-	script := fmt.Sprintf("source %[1]s/greenplum_path.sh && MASTER_DATA_DIRECTORY=%[2]s %[1]s/bin/gprecoverseg -a", cluster.GPHome, cluster.MasterDataDir())
+	script := fmt.Sprintf("source %[1]s/greenplum_path.sh && MASTER_DATA_DIRECTORY=%[2]s PGPORT=%[3]d %[1]s/bin/gprecoverseg -a", cluster.GPHome, cluster.MasterDataDir(), cluster.MasterPort())
 	cmd := RecoversegCmd("bash", "-c", script)
 
 	cmd.Stdout = stream.Stdout()

--- a/hub/restore_source_cluster_test.go
+++ b/hub/restore_source_cluster_test.go
@@ -198,7 +198,7 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 				t.Errorf("got %q want bash", utility)
 			}
 
-			expected := []string{"-c", fmt.Sprintf("source /usr/local/greenplum-db/greenplum_path.sh && MASTER_DATA_DIRECTORY=%s /usr/local/greenplum-db/bin/gprecoverseg -a", cluster.MasterDataDir())}
+			expected := []string{"-c", fmt.Sprintf("source /usr/local/greenplum-db/greenplum_path.sh && MASTER_DATA_DIRECTORY=%s PGPORT=%d /usr/local/greenplum-db/bin/gprecoverseg -a", cluster.MasterDataDir(), cluster.MasterPort())}
 			if !reflect.DeepEqual(args, expected) {
 				t.Errorf("got %q want %q", args, expected)
 			}


### PR DESCRIPTION
gprecoverseg connects to default port 5432 if PGPORT variable is not set
in the environment before triggering gprecoverseg. This commit passes
PGPORT while invoking gprecoverseg command.