### PR TITLE
correctly use "check" or "upgrade" in error message

### DIFF
--- a/agent/upgrade_primaries.go
+++ b/agent/upgrade_primaries.go
@@ -70,7 +70,11 @@ func UpgradePrimaries(stateDir string, request *idl.UpgradePrimariesRequest) err
 	// Collect and handle errors
 	//
 	if err != nil {
-		return xerrors.Errorf("upgrading primaries: %w", err)
+		failedAction := "upgrade"
+		if request.CheckOnly {
+			failedAction = "check"
+		}
+		return xerrors.Errorf("%s primaries: %w", failedAction, err)
 	}
 
 	// success
@@ -84,7 +88,7 @@ func buildSegments(request *idl.UpgradePrimariesRequest, stateDir string) ([]Seg
 		workdir := upgrade.SegmentWorkingDirectory(stateDir, int(dataPair.Content))
 		err := utils.System.MkdirAll(workdir, 0700)
 		if err != nil {
-			return nil, xerrors.Errorf("upgrading primaries: %w", err)
+			return nil, xerrors.Errorf("creating pg_upgrade work directory: %w", err)
 		}
 
 		segments = append(segments, Segment{

--- a/agent/upgrade_primaries_test.go
+++ b/agent/upgrade_primaries_test.go
@@ -99,7 +99,8 @@ func TestUpgradePrimary(t *testing.T) {
 		// XXX it'd be nice if we didn't couple against a hardcoded string here,
 		// but it's difficult to unwrap multierror with the new xerrors
 		// interface.
-		if !strings.Contains(err.Error(), "check primary on host") ||
+		if !strings.Contains(err.Error(), "check primaries") ||
+			!strings.Contains(err.Error(), "check primary on host") ||
 			!strings.Contains(err.Error(), "with content 1") {
 			t.Errorf("error %q did not contain expected contents 'check primary on host' and 'content 1'",
 				err.Error())
@@ -125,7 +126,8 @@ func TestUpgradePrimary(t *testing.T) {
 		// XXX it'd be nice if we didn't couple against a hardcoded string here,
 		// but it's difficult to unwrap multierror with the new xerrors
 		// interface.
-		if !strings.Contains(err.Error(), "upgrade primary on host") ||
+		if !strings.Contains(err.Error(), "upgrade primaries") ||
+			!strings.Contains(err.Error(), "upgrade primary on host") ||
 			!strings.Contains(err.Error(), "with content 1") {
 			t.Errorf("error %q did not contain expected contents 'upgrade primary on host' and 'content 1'",
 				err.Error())

--- a/hub/upgrade_primaries.go
+++ b/hub/upgrade_primaries.go
@@ -40,7 +40,11 @@ func UpgradePrimaries(args UpgradePrimaryArgs) error {
 			TablespacesMappingFilePath: args.TablespacesMappingFile,
 		})
 		if err != nil {
-			return xerrors.Errorf("upgrade primary segment on host %s: %w", conn.Hostname, err)
+			failedAction := "upgrade"
+			if args.CheckOnly {
+				failedAction = "check"
+			}
+			return xerrors.Errorf("%s primary segment on host %s: %w", failedAction, conn.Hostname, err)
 		}
 
 		return nil


### PR DESCRIPTION
Correctly use "check" or "upgrade" in error message when either checking or upgrading the primary.

Before the fix:
```
Error: initialize create cluster: InitializeCreateCluster: rpc error: code = Unknown desc = substep "CHECK_UPGRADE": upgrade primary segment on host kkrempely-a01.vmware.com: rpc error: code = Unknown desc = upgrading primaries: 3 errors occurred:
    * check primary on host kkrempely-a01.vmware.com with content 1: oops
    * check primary on host kkrempely-a01.vmware.com with content 2: oops
    * check primary on host kkrempely-a01.vmware.com with content 0: oops
```


After the fix:
```
Error: initialize create cluster: InitializeCreateCluster: rpc error: code = Unknown desc = substep "CHECK_UPGRADE": check primary segment on host kkrempely-a01.vmware.com: rpc error: code = Unknown desc = check primaries: 3 errors occurred:
    * check primary on host kkrempely-a01.vmware.com with content 0: oops
    * check primary on host kkrempely-a01.vmware.com with content 1: oops
    * check primary on host kkrempely-a01.vmware.com with content 2: oops
```



[Test pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:check_or_upgrade_primary_error)