### PR TITLE
data_migration_scripts: ignore any environmental .psqlrc 

### DIFF
--- a/data_migration_scripts/migration_executor_sql.bash
+++ b/data_migration_scripts/migration_executor_sql.bash
@@ -26,7 +26,7 @@ main(){
     fi
 
     for file in ${files[*]}; do
-        local cmd="${GPHOME}/bin/psql -d postgres -p ${PGPORT} -f ${file} --echo-queries --quiet"
+        local cmd="${GPHOME}/bin/psql -X -d postgres -p ${PGPORT} -f ${file} --echo-queries --quiet"
         echo "Executing command: ${cmd}" | tee -a "$log_file"
         ${cmd} 2>&1 | tee -a "$log_file"
     done

--- a/data_migration_scripts/migration_generator_sql.bash
+++ b/data_migration_scripts/migration_generator_sql.bash
@@ -15,7 +15,7 @@ OUTPUT_DIR=$3
 APPLY_ONCE_FILES=("gen_alter_gphdfs_roles.sql")
 
 get_databases(){
-    databases=$("$GPHOME"/bin/psql -d postgres -p "$PGPORT" -Atc "SELECT datname FROM pg_database WHERE datname != 'template0';")
+    databases=$("$GPHOME"/bin/psql -X -d postgres -p "$PGPORT" -Atc "SELECT datname FROM pg_database WHERE datname != 'template0';")
     echo "$databases"
 }
 
@@ -32,7 +32,7 @@ exec_script(){
 
     local records
     if [[ $path == *".sql" ]]; then
-        records=$("$GPHOME"/bin/psql -d "$database" -p "$PGPORT" -Atf "$path")
+        records=$("$GPHOME"/bin/psql -X -d "$database" -p "$PGPORT" -Atf "$path")
     else
         records=$("$path" "$GPHOME" "$PGPORT" "$database")
     fi

--- a/data_migration_scripts/revert/recreate_gphdfs_external_tables.sh
+++ b/data_migration_scripts/revert/recreate_gphdfs_external_tables.sh
@@ -20,6 +20,9 @@ main() {
     local tables=()
 
     # Find all GPHDFS external tables.
+    #
+    # NOTE: psql's -c implies -X; we don't need to worry about .psqlrc
+    # influencing these queries. For 8.3 this is undocumented but still true.
     while read -r table; do
         tables+=(-t "$table")
     done < <($psql -d "$DBNAME" -p "$PGPORT" -Atc "

--- a/test/finalize.bats
+++ b/test/finalize.bats
@@ -31,35 +31,6 @@ teardown() {
     run_teardowns
 }
 
-# backup_source_cluster creates an rsync'd backup of a demo cluster and restores
-# its original contents during teardown.
-backup_source_cluster() {
-    local backup_dir=$1
-
-    if [[ "$MASTER_DATA_DIRECTORY" != *"/datadirs/qddir/demoDataDir-1" ]]; then
-        abort "refusing to back up cluster with master '$MASTER_DATA_DIRECTORY'; demo directory layout required"
-    fi
-
-    # Don't use -p. It's important that the backup directory not exist so that
-    # we know we have control over it. Also, don't assume set -e is enabled: if
-    # it's not, registering an rm -rf teardown anyway could be extremely
-    # dangerous.
-    mkdir "$backup_dir" || return $?
-    register_teardown rm -rf "$backup_dir"
-
-    local datadir_root
-    datadir_root="$(realpath "$MASTER_DATA_DIRECTORY"/../..)"
-
-    gpstop -af
-    register_teardown gpstart -a
-
-    rsync --archive "${datadir_root:?}"/ "${backup_dir:?}"/
-    register_teardown rsync --archive -I --delete "${backup_dir:?}"/ "${datadir_root:?}"/
-
-    gpstart -a
-    register_teardown stop_any_cluster
-}
-
 upgrade_cluster() {
         LINK_MODE=$1
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -329,3 +329,32 @@ get_segment_configuration() {
         "
     fi
 }
+
+# backup_source_cluster creates an rsync'd backup of a demo cluster and restores
+# its original contents during teardown.
+backup_source_cluster() {
+    local backup_dir=$1
+
+    if [[ "$MASTER_DATA_DIRECTORY" != *"/datadirs/qddir/demoDataDir-1" ]]; then
+        abort "refusing to back up cluster with master '$MASTER_DATA_DIRECTORY'; demo directory layout required"
+    fi
+
+    # Don't use -p. It's important that the backup directory not exist so that
+    # we know we have control over it. Also, don't assume set -e is enabled: if
+    # it's not, registering an rm -rf teardown anyway could be extremely
+    # dangerous.
+    mkdir "$backup_dir" || return $?
+    register_teardown rm -rf "$backup_dir"
+
+    local datadir_root
+    datadir_root="$(realpath "$MASTER_DATA_DIRECTORY"/../..)"
+
+    gpstop -af
+    register_teardown gpstart -a
+
+    rsync --archive "${datadir_root:?}"/ "${backup_dir:?}"/
+    register_teardown rsync --archive -I --delete "${backup_dir:?}"/ "${datadir_root:?}"/
+
+    gpstart -a
+    register_teardown stop_any_cluster
+}


### PR DESCRIPTION
.psqlrc settings can really mess up the script generation/execution (e.g. enabling `\timing` in a .psqlrc leads to script failure). Ignore .psqlrc by passing the `-X` option to psql.

The attached end-to-end test works only for source clusters of 6X and onward, since it uses the `PSQLRC` envvar that showed up in the 9.x line.

The prefactoring commit in this PR moves the migration tests to the teardown framework.