### PR TITLE
upgrade master: set failedAction in error output

### DIFF
--- a/hub/upgrade_master.go
+++ b/hub/upgrade_master.go
@@ -114,23 +114,37 @@ func UpgradeMaster(args UpgradeMasterArgs) error {
 			errText = strings.ReplaceAll(errText, errFile, filepath.Join(wd, errFile))
 		}
 
-		return UpgradeMasterError{ErrorText: errText, err: err}
+		return NewUpgradeMasterError(args.CheckOnly, errText, err)
 	}
 
 	return nil
 }
 
 type UpgradeMasterError struct {
-	ErrorText string
-	err       error
+	FailedAction string
+	ErrorText    string
+	err          error
+}
+
+func NewUpgradeMasterError(checkOnly bool, errText string, err error) UpgradeMasterError {
+	failedAction := "upgrade"
+	if checkOnly {
+		failedAction = "check"
+	}
+
+	return UpgradeMasterError{
+		FailedAction: failedAction,
+		ErrorText:    errText,
+		err:          err,
+	}
 }
 
 func (u UpgradeMasterError) Error() string {
 	if u.ErrorText == "" {
-		return fmt.Sprintf("upgrading master: %v", u.err)
+		return fmt.Sprintf("%s master: %v", u.FailedAction, u.err)
 	}
 
-	return fmt.Sprintf("upgrading master: %s: %v", u.ErrorText, u.err)
+	return fmt.Sprintf("%s master: %s: %v", u.FailedAction, u.ErrorText, u.err)
 }
 
 func (u UpgradeMasterError) Unwrap() error {


### PR DESCRIPTION
Followup to PR https://github.com/greenplum-db/gpupgrade/pull/457 Correctly set "upgrading" or "checking" in error text depending if pg_upgrade --check is being run or not.

Before:
```
* upgrade master: Checking for users assigned the gphdfs role                 fatal
```

After
```
* check master: Checking for users assigned the gphdfs role                 fatal
```

[Test pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:upgrade-master-error-text)