### PR TITLE
    check source and target versions in initialize

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -395,6 +395,7 @@ func initialize() *cobra.Command {
 
 			// Past this point, we want any errors to be accompanied by helper
 			// text describing the next actions to take.
+			suggestRevert := true
 			defer func() {
 				if err != nil {
 					// XXX work around an annoying UI nit: the error message is
@@ -403,13 +404,14 @@ func initialize() *cobra.Command {
 					// opposed to pushed into business logic.
 					fmt.Println()
 
-					err = cli.NewNextActions(err, "initialize")
+					err = cli.NewNextActions(err, "initialize", suggestRevert)
 				}
 			}()
 
 			// Check for valid versions BEFORE running any initialize
 			// implementation code; why boot a hub if the versions are wrong?
 			if err := cli.ValidateVersions(sourceGPHome, targetGPHome); err != nil {
+				suggestRevert = false
 				return err
 			}
 

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -407,6 +407,12 @@ func initialize() *cobra.Command {
 				}
 			}()
 
+			// Check for valid versions BEFORE running any initialize
+			// implementation code; why boot a hub if the versions are wrong?
+			if err := cli.ValidateVersions(sourceGPHome, targetGPHome); err != nil {
+				return err
+			}
+
 			fmt.Println()
 			fmt.Println("Initialize in progress.")
 			fmt.Println()

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -10,24 +10,29 @@ import "fmt"
 // message is printed.
 type NextActions struct {
 	error
-	Subcommand string // the gpupgrade subcommand name to print
+	Subcommand    string // the gpupgrade subcommand name to print
+	suggestRevert bool
 }
 
-func NewNextActions(err error, subcommand string) NextActions {
+func NewNextActions(err error, subcommand string, suggestRevert bool) NextActions {
 	return NextActions{
-		error:      err,
-		Subcommand: subcommand,
+		error:         err,
+		Subcommand:    subcommand,
+		suggestRevert: suggestRevert,
 	}
 }
 
 func (n NextActions) PrintHelp() {
-	// TODO: consider making the "revert" text optional, if we end up using this
-	// in contexts (such as finalize) where revert is not an option.
-	fmt.Printf(`
+	text := `
 NEXT ACTIONS
 ------------
 Please address the above issue and run "gpupgrade %s" again.
+`
+	if n.suggestRevert {
+		text += `
 
 If you would like to return the cluster to its original state, please run "gpupgrade revert".
-`, n.Subcommand)
+`
+	}
+	fmt.Printf(text, n.Subcommand)
 }

--- a/cli/versions.go
+++ b/cli/versions.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/blang/semver/v4"
+
+	"github.com/greenplum-db/gpupgrade/greenplum"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
+)
+
+// Note that we represent the source and target versions separately.  Another
+// option is a matrix explicitly listing supported source/target combinations.
+// However, pg_upgrade supports upgrade from any version to any version.
+// We are not sure yet if we are doing that for gpupgrade.
+
+var (
+	// sourceVersionAllowed returns whether or not the given semver.Version is a
+	// valid source GPDB cluster version.
+	sourceVersionAllowed semver.Range
+
+	// targetVersionAllowed returns whether or not the given semver.Version is a
+	// valid target GPDB cluster version.
+	targetVersionAllowed semver.Range
+)
+
+// Source and Target Versions: modify these lists to control what will be allowed
+// by the utility.  Map entries are of the form: GPDB_VERSION : MIN_ALLOWED_SEMVER
+
+var minSourceVersions = map[int]string{
+	5: "5.28.0",
+	6: "6.9.0",
+}
+
+var minTargetVersions = map[int]string{
+	6: "6.9.0",
+}
+
+// The below boilerplate turns the source/targetRanges variables into
+// source/targetVersionAllowed. You shouldn't need to touch it.
+
+func init() {
+	accumulateRanges(&sourceVersionAllowed, minSourceVersions)
+	accumulateRanges(&targetVersionAllowed, minTargetVersions)
+}
+
+func accumulateRanges(a *semver.Range, minVersions map[int]string) {
+	for v, min := range minVersions {
+		// for example, 5: "5.28.0" becomes the Range string ">=5.28.0 <6.0.0"
+		str := fmt.Sprintf(">=%s <%d.0.0", min, v+1)
+		r := semver.MustParseRange(str)
+
+		if *a == nil {
+			*a = r
+		} else {
+			*a = a.OR(r)
+		}
+	}
+}
+
+func minSourceVersion() string {
+	var min int
+	for major := range minSourceVersions {
+		if min == 0 {
+			min = major
+		}
+		if major < min {
+			min = major
+		}
+	}
+	return semver.MustParse(minSourceVersions[min]).String()
+}
+
+var gpHomeVersion = greenplum.GPHomeVersion
+
+func ValidateVersions(sourceGPHome, targetGPHome string) error {
+	var err error
+
+	vErr := validateVersion(sourceGPHome, "source")
+	err = errorlist.Append(err, vErr)
+
+	vErr = validateVersion(targetGPHome, "target")
+	err = errorlist.Append(err, vErr)
+
+	return err
+}
+
+func validateVersion(gpHome string, context string) error {
+	versionsAllowed := sourceVersionAllowed
+	minVersions := minSourceVersions
+	if context == "target" {
+		versionsAllowed = targetVersionAllowed
+		minVersions = minTargetVersions
+	}
+
+	version, err := gpHomeVersion(gpHome)
+	if err == nil && !versionsAllowed(version) {
+		errStr := fmt.Sprintf("%s cluster version %%s is not supported.", context)
+
+		major := version.Major
+		minVersion, ok := minVersions[int(major)]
+		if !ok {
+			minVersion = minSourceVersion()
+		}
+
+		errStr = fmt.Sprintf(errStr, version)
+		errStr = fmt.Sprintf("%s  The minimum required version is %s. We recommend the latest version.",
+			errStr, minVersion)
+
+		err = fmt.Errorf(errStr)
+	} else if err != nil {
+		err = fmt.Errorf("could not determine %s cluster version: %w", context, err)
+	}
+	return err
+}

--- a/cli/versions_test.go
+++ b/cli/versions_test.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	"github.com/greenplum-db/gpupgrade/greenplum"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
+)
+
+func TestAllowedVersions(t *testing.T) {
+	cases := []struct {
+		name          string
+		versions      []string
+		validator     semver.Range
+		validatorName string
+		expected      bool
+	}{
+		{
+			"allowed source versions",
+			[]string{
+				"5.28.0",
+				"5.28.1",
+				"5.50.0",
+				"6.9.0",
+				"6.9.1",
+				"6.50.1",
+			},
+			sourceVersionAllowed,
+			"sourceVersionAllowed",
+			true,
+		}, {
+			"disallowed source versions",
+			[]string{
+				"4.3.0",
+				"5.0.0",
+				"5.27.0",
+				"6.0.0",
+				"6.8.9",
+				"7.0.0",
+			},
+			sourceVersionAllowed,
+			"sourceVersionAllowed",
+			false,
+		}, {
+			"allowed target versions",
+			[]string{
+				"6.9.0",
+				"6.9.1",
+				"6.50.1",
+			},
+			targetVersionAllowed,
+			"targetVersionAllowed",
+			true,
+		}, {
+			"disallowed target versions",
+			[]string{
+				"4.3.0",
+				"5.0.0",
+				"5.27.0",
+				"5.28.0",
+				"5.50.0",
+				"6.0.0",
+				"6.8.0",
+				"7.0.0",
+			},
+			targetVersionAllowed,
+			"targetVersionAllowed",
+			false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			for _, v := range c.versions {
+				ver := semver.MustParse(v)
+				actual := c.validator(ver)
+
+				if actual != c.expected {
+					t.Errorf("%s(%q) = %t, want %t", c.validatorName, v, actual, c.expected)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateVersions(t *testing.T) {
+	t.Run("passes when given supported versions", func(t *testing.T) {
+		gpHomeVersion = func(str string) (semver.Version, error) {
+			return semver.MustParse("6.9.0"), nil
+		}
+		defer func() {
+			gpHomeVersion = greenplum.GPHomeVersion
+		}()
+
+		err := ValidateVersions("/does/not/matter", "/does/not/matter")
+		if err != nil {
+			t.Errorf("got unexpected error %#v", err)
+		}
+
+	})
+}
+
+func TestValidateVersionsErrorCases(t *testing.T) {
+	cases := []struct {
+		name         string
+		mockFunction func(string) (semver.Version, error)
+		expected     string
+	}{
+		{
+			"fails when gpHomeVersion returns an error",
+			func(str string) (semver.Version, error) {
+				return semver.MustParse("1.2.3"), errors.New("some error")
+			},
+			"could not determine %s cluster version: some error",
+		},
+		{
+			"fails when sourceVersion and targetVersion have unsupported minor versions",
+			func(str string) (semver.Version, error) {
+				return semver.MustParse("6.8.0"), nil
+			},
+			"%s cluster version 6.8.0 is not supported.  The minimum required version is 6.9.0. We recommend the latest version.",
+		},
+		{
+			"fails when sourceVersion and targetVersion have unsupported major versions",
+			func(str string) (semver.Version, error) {
+				return semver.MustParse("0.0.0"), nil
+			},
+			"%s cluster version 0.0.0 is not supported.  The minimum required version is 5.28.0. We recommend the latest version.",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gpHomeVersion = c.mockFunction
+			defer func() {
+				gpHomeVersion = greenplum.GPHomeVersion
+			}()
+
+			err := ValidateVersions("/does/not/matter", "/does/not/matter")
+
+			// make sure both source and target produce an error and that they match
+			// the expected error string
+
+			var errs errorlist.Errors
+			if !(errors.As(err, &errs)) {
+				t.Fatalf("got %T wanted %T", err, errs)
+			}
+			if len(errs) != 2 {
+				t.Fatalf("got %d errors instead of 2", len(errs))
+			}
+
+			expected := fmt.Sprintf(c.expected, "source")
+			if errs[0].Error() != expected {
+				t.Errorf("got %s want %s", errs[0].Error(), expected)
+			}
+			expected = fmt.Sprintf(c.expected, "target")
+			if errs[1].Error() != expected {
+				t.Errorf("got %s want %s", errs[1].Error(), expected)
+			}
+		})
+	}
+}

--- a/test/args.bats
+++ b/test/args.bats
@@ -40,8 +40,8 @@ teardown() {
 @test "gpupgrade initialize --file with verbose uses the configured values" {
     config_file=${STATE_DIR}/gpupgrade_config
     cat <<- EOF > "$config_file"
-		source-gphome = /usr/local/source
-		target-gphome = /usr/local/target
+		source-gphome = $GPHOME_SOURCE
+		target-gphome = $GPHOME_TARGET
 		source-master-port = ${PGPORT}
 		disk-free-ratio = 0
 		stop-before-cluster-creation = true
@@ -49,28 +49,28 @@ teardown() {
 
     gpupgrade initialize --verbose --file "$config_file"
 
-    run gpupgrade config show --target-gphome
-    [ "$status" -eq 0 ]
-    [ "$output" = "/usr/local/target" ]
-
     run gpupgrade config show --source-gphome
     [ "$status" -eq 0 ]
-    [ "$output" = "/usr/local/source" ]
+    [ "$output" = "$GPHOME_SOURCE" ]
+
+    run gpupgrade config show --target-gphome
+    [ "$status" -eq 0 ]
+    [ "$output" = "$GPHOME_TARGET" ]
 }
 
 @test "initialize sanitizes source-gphome and target-gphome" {
     gpupgrade initialize \
-        --source-gphome "/usr/local/source/" \
-        --target-gphome "/usr/local/target//" \
+        --source-gphome "${GPHOME_SOURCE}/" \
+        --target-gphome "${GPHOME_TARGET}//" \
         --source-master-port ${PGPORT} \
         --stop-before-cluster-creation \
         --disk-free-ratio 0 3>&-
 
     run gpupgrade config show --source-gphome
     [ "$status" -eq 0 ]
-    [ "$output" = "/usr/local/source" ]
+    [ "$output" = "$GPHOME_SOURCE" ]
 
     run gpupgrade config show --target-gphome
     [ "$status" -eq 0 ]
-    [ "$output" = "/usr/local/target" ]
+    [ "$output" = "$GPHOME_TARGET" ]
 }

--- a/test/checks.bats
+++ b/test/checks.bats
@@ -85,8 +85,8 @@ are_equivalent_within_tolerance() {
 
     run gpupgrade initialize \
         --disk-free-ratio=1.0 \
-        --source-gphome="$PWD" \
-        --target-gphome="$PWD" \
+        --source-gphome="$GPHOME_SOURCE" \
+        --target-gphome="$GPHOME_TARGET" \
         --source-master-port="${PGPORT}" \
         --stop-before-cluster-creation 3>&-
 

--- a/test/config.bats
+++ b/test/config.bats
@@ -14,8 +14,8 @@ setup() {
     gpupgrade kill-services
 
     gpupgrade initialize \
-        --source-gphome "/usr/local/source" \
-        --target-gphome "/usr/local/target" \
+        --source-gphome "$GPHOME_SOURCE" \
+        --target-gphome "$GPHOME_TARGET" \
         --source-master-port ${PGPORT} \
         --stop-before-cluster-creation \
         --disk-free-ratio 0 3>&-
@@ -33,18 +33,18 @@ teardown() {
     run gpupgrade config show --target-gphome
     echo $output
     [ "$status" -eq 0 ]
-    [ "$output" = "/usr/local/target" ]
+    [ "$output" = "$GPHOME_TARGET" ]
 
     run gpupgrade config show --source-gphome
     [ "$status" -eq 0 ]
-    [ "$output" = "/usr/local/source" ]
+    [ "$output" = "$GPHOME_SOURCE" ]
 }
 
 @test "configuration can be dumped as a whole" {
     run gpupgrade config show
     [ "$status" -eq 0 ]
     [[ "${lines[0]}" = "id - "* ]] # this is randomly generated; we could replace * with a base64 regex matcher
-    [ "${lines[1]}" = "source-gphome - /usr/local/source" ]
+    [ "${lines[1]}" = "source-gphome - $GPHOME_SOURCE" ]
     [ "${lines[2]}" = "target-datadir - " ] # This isn't populated until cluster creation, but it's still displayed here
-    [ "${lines[3]}" = "target-gphome - /usr/local/target" ]
+    [ "${lines[3]}" = "target-gphome - $GPHOME_TARGET" ]
 }


### PR DESCRIPTION
Only allow certain pre-defined source and target versions to be upgraded.  Error out if either is out of range.

The minimum versions, say 5.28.0 and 6.10.0, are hard-coded as a given gpupgrade release is only tested with particular versions of the database.