### PR TITLE
Format the new trigger DDL statement on gpdb6 to match the old DDL atement for gpdb5

### DIFF
--- a/ci/scripts/filters/filter/filter_test.go
+++ b/ci/scripts/filters/filter/filter_test.go
@@ -200,4 +200,29 @@ CREATE RULE two AS ON INSERT TO public.oid_consistency_bar2 DO INSTEAD INSERT IN
 			t.Errorf("wrote %q want %q", out.String(), expected)
 		}
 	})
+
+	t.Run("formats the trigger ddl to multi line statement", func(t *testing.T) {
+		var in, out bytes.Buffer
+		in.WriteString(`--
+-- Name: after_trigger; Type: TRIGGER; Schema: public; Owner: gpadmin
+--
+
+CREATE TRIGGER after_trigger AFTER INSERT OR DELETE ON public.bfv_dml_trigger_test FOR EACH ROW EXECUTE PROCEDURE public.bfv_dml_error_func();`)
+
+		expected := `--
+-- Name: after_trigger; Type: TRIGGER; Schema: public; Owner: gpadmin
+--
+
+CREATE TRIGGER after_trigger
+    AFTER INSERT OR DELETE ON public.bfv_dml_trigger_test
+    FOR EACH ROW
+    EXECUTE PROCEDURE public.bfv_dml_error_func();
+`
+
+		Filter(&in, &out)
+
+		if out.String() != expected {
+			t.Errorf("wrote %q want %q", out.String(), expected)
+		}
+	})
 }

--- a/ci/scripts/filters/partition_tables.go
+++ b/ci/scripts/filters/partition_tables.go
@@ -15,6 +15,7 @@ func FormatWithClause(line string) string {
 	if result == nil {
 		return line
 	}
+
 	groups := result[0]
 	// replace all occurrences of single quotes
 	stringWithoutSingleQuotes := strings.ReplaceAll(groups[2], "'", "")

--- a/ci/scripts/filters/partition_tables_test.go
+++ b/ci/scripts/filters/partition_tables_test.go
@@ -27,7 +27,9 @@ func Test_FormatWithClause(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := FormatWithClause(tt.input); got != tt.result {
+			got := FormatWithClause(tt.input)
+
+			if got != tt.result {
 				t.Errorf("got %v, want %v", got, tt.result)
 			}
 		})

--- a/ci/scripts/filters/trigger.go
+++ b/ci/scripts/filters/trigger.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package filters
+
+import (
+	"errors"
+	"regexp"
+)
+
+var triggerCreateRegex *regexp.Regexp
+
+func init() {
+	triggerCreateRegex = regexp.MustCompile(`CREATE TRIGGER `)
+}
+
+func IsTriggerDdl(line string) bool {
+	return triggerCreateRegex.MatchString(line)
+}
+
+func FormatTriggerDdl(tokens []string) (string, error) {
+	if len(tokens) == 0 {
+		return "", errors.New("tokens cannot be of zero length")
+	}
+
+	var line string
+	for _, token := range tokens {
+		if line == "" {
+			// processing the first element
+			line = token
+			continue
+		}
+
+		// by default add single space between tokens, but if a token is identified which marks a new line
+		// use a new line and 4 character space indentation to match the format of old dump
+		indentation := " "
+		for _, identifier := range []string{"AFTER", "BEFORE", "FOR", "EXECUTE"} {
+			if token == identifier {
+				indentation = "\n    "
+				break
+			}
+		}
+
+		line = line + indentation + token
+	}
+
+	return line, nil
+}

--- a/ci/scripts/filters/trigger_test.go
+++ b/ci/scripts/filters/trigger_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package filters
+
+import (
+	"testing"
+)
+
+func TestFormatTriggerDdl(t *testing.T) {
+	tests := []struct {
+		name    string
+		tokens  []string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "formats create trigger statement and body in to one line",
+			tokens: []string{"CREATE", "TRIGGER", "after_trigger", "AFTER", "INSERT", "OR", "DELETE", "ON",
+				"public.foo", "FOR", "EACH", "ROW", "EXECUTE", "PROCEDURE", "public.bfv_dml_error_func();"},
+			want:    "CREATE TRIGGER after_trigger\n    AFTER INSERT OR DELETE ON public.foo\n    FOR EACH ROW\n    EXECUTE PROCEDURE public.bfv_dml_error_func();",
+			wantErr: false,
+		},
+		{
+			name:    "formats create trigger statement and body in to one line",
+			tokens:  []string{},
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FormatTriggerDdl(tt.tokens)
+
+			if err == nil && tt.wantErr {
+				t.Errorf("expect an error")
+			}
+
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsTriggerDdl(t *testing.T) {
+	tests := []struct {
+		name   string
+		line   string
+		result bool
+	}{
+		{
+			name:   "line contains create trigger statement",
+			line:   "CREATE TRIGGER mytrigger AS",
+			result: true,
+		},
+		{
+			name:   "line does not create trigger statement",
+			line:   "CREATE TABLE mytable AS",
+			result: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTriggerDdl(tt.line); got != tt.result {
+				t.Errorf("got %t, want %t", got, tt.result)
+			}
+		})
+	}
+}

--- a/ci/scripts/filters/view_and_rule_test.go
+++ b/ci/scripts/filters/view_and_rule_test.go
@@ -4,85 +4,44 @@
 package filters
 
 import (
-	"reflect"
 	"testing"
 )
 
-func TestBuildViewOrRuleDdl(t *testing.T) {
-	type args struct {
-		line      string
-		allTokens []string
-	}
-	type result struct {
-		line               string
-		finishedFormatting bool
-		resultTokens       []string
-	}
-	tests := []struct {
-		name   string
-		args   args
-		result result
-	}{
-		{
-			name: "returns completed ddl",
-			args: args{
-				line:      "SELECT name FROM mytable;",
-				allTokens: []string{"CREATE", "VIEW", "myview", "AS"},
-			},
-			result: result{
-				line:               "CREATE VIEW myview AS\nSELECT name FROM mytable;",
-				resultTokens:       []string{"CREATE", "VIEW", "myview", "AS", "SELECT", "name", "FROM", "mytable;"},
-				finishedFormatting: true,
-			},
-		},
-		{
-			name: "still processing view ddl",
-			args: args{
-				line:      "CREATE VIEW myview AS",
-				allTokens: nil,
-			},
-			result: result{
-				finishedFormatting: false,
-				resultTokens:       []string{"CREATE", "VIEW", "myview", "AS"},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			completeDdl, resultTokens, finishedFormatting := BuildViewOrRuleDdl(tt.args.line, tt.args.allTokens)
-			if completeDdl != tt.result.line {
-				t.Errorf("got %v, want %v", completeDdl, tt.result.line)
-			}
-			if finishedFormatting != tt.result.finishedFormatting {
-				t.Errorf("got %t, want %t", finishedFormatting, tt.result.finishedFormatting)
-			}
-			if !reflect.DeepEqual(resultTokens, tt.result.resultTokens) {
-				t.Errorf("got %q, want %q", resultTokens, tt.result.resultTokens)
-			}
-		})
-	}
-}
-
 func TestFormatViewOrRuleDdl(t *testing.T) {
 	tests := []struct {
-		name      string
-		allTokens []string
-		want      string
+		name    string
+		tokens  []string
+		want    string
+		wantErr bool
 	}{
 		{
-			name:      "formats view with create view and select in two separate lines",
-			allTokens: []string{"CREATE", "VIEW", "myview", "AS", "SELECT", "name", "FROM", "mytable", ";"},
-			want:      "CREATE VIEW myview AS\nSELECT name FROM mytable ;",
+			name:    "formats view with create view and select in two separate lines",
+			tokens:  []string{"CREATE", "VIEW", "myview", "AS", "SELECT", "name", "FROM", "mytable", ";"},
+			want:    "CREATE VIEW myview AS\nSELECT name FROM mytable ;",
+			wantErr: false,
 		},
 		{
-			name:      "formats rule with create view and body in single lines",
-			allTokens: []string{"CREATE", "RULE", "myrule", "AS", "ON", "INSERT", "TO", "public.bar_ao", "DO", "INSTEAD", "DELETE", "FROM", "public.foo_ao;"},
-			want:      "CREATE RULE myrule AS ON INSERT TO public.bar_ao DO INSTEAD DELETE FROM public.foo_ao;",
+			name:    "formats rule with create view and body in single lines",
+			tokens:  []string{"CREATE", "RULE", "myrule", "AS", "ON", "INSERT", "TO", "public.bar_ao", "DO", "INSTEAD", "DELETE", "FROM", "public.foo_ao;"},
+			want:    "CREATE RULE myrule AS ON INSERT TO public.bar_ao DO INSTEAD DELETE FROM public.foo_ao;",
+			wantErr: false,
+		},
+		{
+			name:    "returns error if token list does not contain atleast 4 elements",
+			tokens:  []string{"CREATE", "RULE", "myrule"},
+			want:    "",
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := FormatViewOrRuleDdl(tt.allTokens); got != tt.want {
+			got, err := FormatViewOrRuleDdl(tt.tokens)
+
+			if err == nil && tt.wantErr {
+				t.Errorf("expect an error")
+			}
+
+			if got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
 		})
@@ -90,52 +49,31 @@ func TestFormatViewOrRuleDdl(t *testing.T) {
 }
 
 func TestIsViewOrRuleDdl(t *testing.T) {
-	type args struct {
-		buf  []string
-		line string
-	}
 	tests := []struct {
-		name string
-		args args
-		want bool
+		name   string
+		line   string
+		result bool
 	}{
 		{
-			name: "buffer is empty",
-			args: args{
-				buf:  nil,
-				line: "",
-			},
-			want: false,
+			name:   "line contains create view statement",
+			line:   "CREATE VIEW myview AS",
+			result: true,
 		},
 		{
-			name: "buffer contains identifier for view comment and line contains create view statement",
-			args: args{
-				buf:  []string{"-- Name: myview; Type: VIEW; Schema: public; Owner: gpadmin"},
-				line: "CREATE VIEW myview AS",
-			},
-			want: true,
+			name:   "line contains create rule statement",
+			line:   "CREATE RULE myrule AS",
+			result: true,
 		},
 		{
-			name: "buffer contains identifier for rule comment and line contains create rule statement",
-			args: args{
-				buf:  []string{"-- Name: bar_ao two; Type: RULE; Schema: public; Owner: gpadmin"},
-				line: "CREATE RULE myrule AS",
-			},
-			want: true,
-		},
-		{
-			name: "buffer does not contains view / rule identifier",
-			args: args{
-				buf:  []string{"-- Name: lineitem; Type: TABLE; Schema: public; Owner: gpadmin; Tablespace:"},
-				line: "CREATE TABLE mytable AS",
-			},
-			want: false,
+			name:   "buffer does not contains view / rule identifier",
+			line:   "CREATE TABLE mytable AS",
+			result: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsViewOrRuleDdl(tt.args.buf, tt.args.line); got != tt.want {
-				t.Errorf("got %t, want %t", got, tt.want)
+			if got := IsViewOrRuleDdl(tt.line); got != tt.result {
+				t.Errorf("got %t, want %t", got, tt.result)
 			}
 		})
 	}


### PR DESCRIPTION
Format the new trigger DDL statement on gpdb6 to match the old DDL statement for gpdb5

Also Use a common framework to make replacement for the blocks
identified by a pattern to hide the complexity of the formatting
function rules used by different type of statement from the main loop.
Views, Rule, Trigger, With Clause formatting all follow similar set of
actions to perform the reformatting of the dump, so use a common runner
from the main driver to perform the changes.