### PR TITLE
data_migration_scripts: correctly find .header file

### DIFF
--- a/data_migration_scripts/migration_generator_sql.bash
+++ b/data_migration_scripts/migration_generator_sql.bash
@@ -40,10 +40,19 @@ exec_script(){
     if [[ -n "$records" ]]; then
         # change database before header, to allow header to define SQL functions
         echo "\c $database" >> "${output_dir}/${output_file}"
-        header_file=$(echo "${path/.sql/.header}")
-        if [[ -f $header_file ]]; then
-            cat $header_file >> "${output_dir}/${output_file}"
+
+        local basename suffix header_file
+        basename=$(basename "$path")
+        suffix=${basename##*.}
+        if [[ "$suffix" == "$basename" ]]; then
+          header_file="${path}.header"
+        else
+          header_file=${path/%.$suffix/.header}
         fi
+        if [[ -f $header_file ]]; then
+            cat "$header_file" >> "${output_dir}/${output_file}"
+        fi
+
         echo "$records" >> "${output_dir}/${output_file}"
     fi
 }


### PR DESCRIPTION
This PR uses a robust scheme to determine if there is a .header
file associated with the given script.  The existing code only
worked correctly for files ending in ".sql"; if the file ended
in any other suffix, the code treated the entire file as the
.header file.

Note that this PR now has a header file even work on a file with no suffix.  That is, a data_migration_script called "do_this_to_tables" can have a corresponding header file "do_this_to_tables.header".  

Testing was done manually, and a pipeline is running.