### PR TITLE
Scripts for tsquery

### DIFF
--- a/data_migration_scripts/complete/gen_change_text_to_tsquery.sql
+++ b/data_migration_scripts/complete/gen_change_text_to_tsquery.sql
@@ -1,0 +1,20 @@
+-- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- generates alter statement to modify text datatype to tsquery datatype
+SELECT $$ALTER TABLE $$ || n.nspname || '.' || c.relname || $$ ALTER COLUMN $$ || a.attname || $$ TYPE TSQUERY USING $$ || a.attname || $$::tsquery;$$
+FROM pg_catalog.pg_class c,
+     pg_catalog.pg_namespace n,
+     pg_catalog.pg_attribute a
+WHERE c.relkind = 'r'
+  AND c.oid = a.attrelid
+  AND NOT a.attisdropped
+  AND a.atttypid = 'pg_catalog.tsquery'::pg_catalog.regtype
+  AND c.relnamespace = n.oid
+  AND n.nspname NOT LIKE 'pg_temp_%'
+  AND n.nspname NOT LIKE 'pg_toast_temp_%'
+  AND n.nspname NOT IN ('pg_catalog',
+                        'information_schema')
+  AND c.oid NOT IN
+      (SELECT DISTINCT parchildrelid
+       FROM pg_catalog.pg_partition_rule);

--- a/data_migration_scripts/migration_executor_sql.bash
+++ b/data_migration_scripts/migration_executor_sql.bash
@@ -18,7 +18,7 @@ main(){
 
     rm -f "$log_file"
 
-    cmd="find ${INPUT_DIR} -type f -name *.sql | sort -n"
+    cmd="find ${INPUT_DIR} -type f -name \"*.sql\" | sort -n"
     local files="$(eval "$cmd")"
     if [ -z "$files" ]; then
         echo "Executing command \"${cmd}\" returned no sql files. Exiting!" | tee -a "$log_file"

--- a/data_migration_scripts/revert/gen_revert_text_to_tsquery.sql
+++ b/data_migration_scripts/revert/gen_revert_text_to_tsquery.sql
@@ -1,0 +1,20 @@
+-- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- generates alter statement to modify text datatype to tsquery datatype
+SELECT $$ALTER TABLE $$|| n.nspname || '.' || c.relname || $$ ALTER COLUMN $$ || a.attname || $$ TYPE TSQUERY USING $$ || a.attname || $$::tsquery;$$
+FROM pg_catalog.pg_class c,
+     pg_catalog.pg_namespace n,
+     pg_catalog.pg_attribute a
+WHERE c.relkind = 'r'
+  AND c.oid = a.attrelid
+  AND NOT a.attisdropped
+  AND a.atttypid = 'pg_catalog.tsquery'::pg_catalog.regtype
+  AND c.relnamespace = n.oid
+  AND n.nspname NOT LIKE 'pg_temp_%'
+  AND n.nspname NOT LIKE 'pg_toast_temp_%'
+  AND n.nspname NOT IN ('pg_catalog',
+                        'information_schema')
+  AND c.oid NOT IN
+      (SELECT DISTINCT parchildrelid
+       FROM pg_catalog.pg_partition_rule);

--- a/data_migration_scripts/start/gen_alter_tsquery_to_text.sql
+++ b/data_migration_scripts/start/gen_alter_tsquery_to_text.sql
@@ -1,0 +1,20 @@
+-- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- generates alter statement to modify tsquery datatype to text datatype
+SELECT $$ALTER TABLE $$|| n.nspname || '.' || c.relname || $$ ALTER COLUMN $$ || a.attname || $$ TYPE TEXT; $$
+FROM pg_catalog.pg_class c,
+     pg_catalog.pg_namespace n,
+     pg_catalog.pg_attribute a
+WHERE c.relkind = 'r'
+  AND c.oid = a.attrelid
+  AND NOT a.attisdropped
+  AND a.atttypid = 'pg_catalog.tsquery'::pg_catalog.regtype
+  AND c.relnamespace = n.oid
+  AND n.nspname NOT LIKE 'pg_temp_%'
+  AND n.nspname NOT LIKE 'pg_toast_temp_%'
+  AND n.nspname NOT IN ('pg_catalog',
+                        'information_schema')
+  AND c.oid NOT IN
+      (SELECT DISTINCT parchildrelid
+       FROM pg_catalog.pg_partition_rule);

--- a/data_migration_scripts/test/create_nonupgradable_objects.sql
+++ b/data_migration_scripts/test/create_nonupgradable_objects.sql
@@ -114,3 +114,12 @@ CREATE TABLE partition_table_partitioned_by_name_type(a int, b name) PARTITION B
 DROP TABLE IF EXISTS table_distributed_by_name_type;
 CREATE TABLE table_distributed_by_name_type(a int, b name) DISTRIBUTED BY (b);
 INSERT INTO table_distributed_by_name_type VALUES (1,'z'),(2,'x');
+
+-- create tables with tsquery datatype
+DROP TABLE IF EXISTS table_with_tsquery_datatype_columns;
+CREATE TABLE table_with_tsquery_datatype_columns(a tsquery, b tsquery, c tsquery, d int)
+    PARTITION BY RANGE(d) (START(1) END(4) EVERY(1));
+INSERT INTO table_with_tsquery_datatype_columns
+    VALUES  ('b & c'::tsquery, 'b & c'::tsquery, 'b & c'::tsquery, 1),
+            ('e & f'::tsquery, 'e & f'::tsquery, 'e & f'::tsquery, 2),
+            ('x & y'::tsquery, 'x & y'::tsquery, 'x & y'::tsquery, 3);


### PR DESCRIPTION
This PR contains 2 commits:

1. Add scripts to generate statement to alter columns using tsquery datatype

This commit adds the scripts for start, complete and revert phases for
altering the datatype tsquery to text and vice versa.

The below changes are done:
 start -> alters the tsquery datatype to text
  revert and complete -> alters the text datatype to tsquery

2. Quote the search string

Quoted the search string as because of environment find may not be able to find the sql statement files.