### PR TITLE
Reduce the path of the tablespace directories

### DIFF
--- a/test/tablespace_helpers.bash
+++ b/test/tablespace_helpers.bash
@@ -37,7 +37,9 @@ create_tablespace_with_tables() {
 
     local host dbid datadir
     while read -r host dbid datadir; do
-        tablespace_dir="${TABLESPACE_ROOT}/${datadir}"
+        # if symlink length is > 100, it will get trimmed and result in an invalid symlink when pg_basebackup will
+        # copy the master to standby, so keep them short
+        tablespace_dir="${TABLESPACE_ROOT}/${dbid}"/$(basename "$datadir")
 
         ssh -n "$host" mkdir -p "$(dirname "$tablespace_dir")"
         echo "${host}:${dbid}:${tablespace_dir}" >> "$TABLESPACE_CONFIG"


### PR DESCRIPTION
If the path of the tablespace directory is greater than 100 character,
pg_basebackup truncates the symlink and creates an invalid symlink
pointing to a non-existing directory. For example:

```
02:03 $ pg_basebackup -c fast -D /Users/xxxxxxxxxx/workspace/gpdb5/gpAux/gpdemo/datadirs/standby2 -h bchaudhary-a01.vmware.com -p 15432 --xlog --force-overwrite --write-recovery-conf --target-gp-dbid 5 -E ./db_dumps -E ./gpperfmon/data -E ./gpperfmon/logs -E ./promote --progress --verbose
pg_basebackup: initiating base backup, waiting for checkpoint to complete
WARNING:  symbolic link "pg_tblspc/16385" target is too long and will not be added to the backup
DETAIL:  The symbolic link with target "/tmp/gpupgrade.WbT1c8/testfs/Users/xxxxxxxxxx/workspace/gpdb5/gpAux/gpdemo/datadirs/qddir/demoDataDir-1/16385/1" is too long. Symlink targets with length greater than 100 characters would be truncated.
pg_basebackup: checkpoint completed
transaction log start point: 0/24000028 on timeline 1
121623/121623 kB (100%), 1/1 tablespace
transaction log end point: 0/240000D0
pg_basebackup: base backup completed
```

So create a shorter path for tablespaces during testing