### PR TITLE
Archive the state directory to preserve logs for debugging

### DIFF
--- a/test/args.bats
+++ b/test/args.bats
@@ -18,7 +18,7 @@ teardown() {
     skip_if_no_gpdb
 
     gpupgrade kill-services
-    rm -r "$STATE_DIR"
+    archive_state_dir "$STATE_DIR"
 }
 
 @test "gpupgrade initialize fails when passed insufficient arguments" {

--- a/test/checks.bats
+++ b/test/checks.bats
@@ -21,7 +21,7 @@ teardown() {
     fi
 
     gpupgrade kill-services
-    rm -r "$STATE_DIR"
+    archive_state_dir "$STATE_DIR"
 }
 
 # Writes the available disk space, in KiB, on the filesystem containing the

--- a/test/config.bats
+++ b/test/config.bats
@@ -25,7 +25,7 @@ teardown() {
     # XXX Beware, BATS_TEST_SKIPPED is not a documented export.
     if [ -z "${BATS_TEST_SKIPPED}" ]; then
         gpupgrade kill-services
-        rm -r "${STATE_DIR}"
+        archive_state_dir "$STATE_DIR"
     fi
 }
 

--- a/test/execute.bats
+++ b/test/execute.bats
@@ -25,7 +25,7 @@ teardown() {
     $PSQL postgres -c "drop table if exists test_linking;"
 
     gpupgrade kill-services
-    rm -r "$STATE_DIR"
+    archive_state_dir "$STATE_DIR"
 
     if [ -n "$NEW_CLUSTER" ]; then
         delete_cluster $GPHOME_TARGET $NEW_CLUSTER

--- a/test/finalize.bats
+++ b/test/finalize.bats
@@ -12,7 +12,7 @@ setup() {
     skip_if_no_gpdb
 
     STATE_DIR=$(mktemp -d /tmp/gpupgrade.XXXXXX)
-    register_teardown rm -r "$STATE_DIR"
+    register_teardown archive_state_dir "$STATE_DIR"
 
     export GPUPGRADE_HOME="${STATE_DIR}/gpupgrade"
     gpupgrade kill-services

--- a/test/gpinitsystem.bats
+++ b/test/gpinitsystem.bats
@@ -23,7 +23,7 @@ teardown() {
     skip_if_no_gpdb
 
     gpupgrade kill-services
-    rm -r "$STATE_DIR"
+    archive_state_dir "$STATE_DIR"
 
     if [ -n "$NEW_CLUSTER" ]; then
         delete_cluster $GPHOME_TARGET $NEW_CLUSTER

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -358,3 +358,8 @@ backup_source_cluster() {
     gpstart -a
     register_teardown stop_any_cluster
 }
+
+archive_state_dir() {
+    state_dir=$1
+    mv "${state_dir}" "${state_dir}_${BATS_TEST_NAME}"
+}

--- a/test/initialize.bats
+++ b/test/initialize.bats
@@ -10,7 +10,7 @@ setup() {
     skip_if_no_gpdb
 
     STATE_DIR=`mktemp -d /tmp/gpupgrade.XXXXXX`
-    register_teardown rm -r "$STATE_DIR"
+    register_teardown archive_state_dir "$STATE_DIR"
 
     export GPUPGRADE_HOME="${STATE_DIR}/gpupgrade"
 

--- a/test/migration_scripts.bats
+++ b/test/migration_scripts.bats
@@ -12,7 +12,7 @@ setup() {
     skip_if_no_gpdb
 
     STATE_DIR=$(mktemp -d /tmp/gpupgrade.XXXXXX)
-    register_teardown rm -r "$STATE_DIR"
+    register_teardown archive_state_dir "$STATE_DIR"
 
     export GPUPGRADE_HOME="${STATE_DIR}/gpupgrade"
     gpupgrade kill-services

--- a/test/out-of-order.bats
+++ b/test/out-of-order.bats
@@ -24,7 +24,7 @@ setup() {
 
 teardown() {
     gpupgrade kill-services
-    rm -r "${STATE_DIR}"
+    archive_state_dir "$STATE_DIR"
 }
 
 # todo: add tests

--- a/test/pg_upgrade.bats
+++ b/test/pg_upgrade.bats
@@ -26,7 +26,7 @@ teardown() {
 
     gpupgrade kill-services
     if [ $KEEP_STATE_DIR -eq 0 ]; then
-        rm -r "$STATE_DIR"
+        archive_state_dir "$STATE_DIR"
     else
         echo "state dir: $STATE_DIR"
     fi

--- a/test/revert.bats
+++ b/test/revert.bats
@@ -37,7 +37,7 @@ setup_state_dirs() {
     # host.
     for host in "${hosts[@]}"; do
         ssh "$host" mkdir -p "$STATE_DIR"
-        register_teardown ssh "$host" rm -r "$STATE_DIR"
+        register_teardown ssh "$host" mv "$STATE_DIR" "${STATE_DIR}_${BATS_TEST_NAME}"
     done
 }
 

--- a/test/services.bats
+++ b/test/services.bats
@@ -25,7 +25,7 @@ teardown() {
     skip_if_no_gpdb
 
     gpupgrade kill-services
-    rm -r "$STATE_DIR"
+    archive_state_dir "$STATE_DIR"
 
     if [ -n "${TMP_DIR}" ]; then
         rm -r "${TMP_DIR}"


### PR DESCRIPTION
Instead of removing the state directory, archive the state directory so
that logs could be preserved in case debugging is required.