### PR TITLE
allow substeps to override the default next actions

### DIFF
--- a/cli/commanders/step_test.go
+++ b/cli/commanders/step_test.go
@@ -309,6 +309,25 @@ func TestSubstep(t *testing.T) {
 		}
 	})
 
+	t.Run("substeps can override the default next actions error", func(t *testing.T) {
+		st := commanders.NewStep(idl.Step_INITIALIZE, &step.BufferedStreams{}, false)
+
+		subcommand := "subcommand"
+		st.RunHubSubstep(func(streams step.OutStreams) error {
+			return cli.NewNextActions(errors.New("oops"), subcommand, false)
+		})
+
+		err := st.Complete("")
+		var nextActions cli.NextActions
+		if !errors.As(err, &nextActions) {
+			t.Errorf("got type %T want %T", err, nextActions)
+		}
+
+		if nextActions.Subcommand != subcommand {
+			t.Errorf("got subcommand %q want %q", nextActions.Subcommand, subcommand)
+		}
+	})
+
 	t.Run("substep duration is printed", func(t *testing.T) {
 		d := commanders.BufferStandardDescriptors(t)
 

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -401,8 +401,7 @@ func initialize() *cobra.Command {
 
 				err := cli.ValidateVersions(sourceGPHome, targetGPHome)
 				if err != nil {
-					st.SetNextActions(false)
-					return err
+					return cli.NewNextActions(err, strings.ToLower(idl.Step_INITIALIZE.String()), false)
 				}
 
 				return nil


### PR DESCRIPTION
allow substeps to override the default next actions

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:nextActions)