### PR TITLE
Remove demo_cluster.sh symlink workaround

### DIFF
--- a/ci/scripts/install-tests.bash
+++ b/ci/scripts/install-tests.bash
@@ -44,10 +44,6 @@ chown -R gpadmin:gpadmin "$GPHOME_TARGET"
 chown -R gpadmin:gpadmin gpdb_src_source/gpAux/gpdemo
 source "$GPHOME_SOURCE"/greenplum_path.sh
 
-# XXX: Need to update demo_cluster.sh to handle symlinks by using find -H.
-# A PR for this should be made.
-sed -i.bak -E 's/(^GPPATH=`find) (\$GPSEARCH -name .*$)/\1 -H \2/' gpdb_src_source/gpAux/gpdemo/demo_cluster.sh
-
 pushd gpdb_src_source/gpAux/gpdemo
     time su gpadmin -c "make create-demo-cluster"
     source gpdemo-env.sh


### PR DESCRIPTION
Now that demo_cluster.sh has been updated to handle symlinks which is useful when GPDB is installed using RPMs we can remove this workaround.

[Test pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:remove_demo_cluster_workaround)