### PR TITLE
Fix RevertResponse to return source cluster information

### DIFF
--- a/hub/execute.go
+++ b/hub/execute.go
@@ -108,12 +108,13 @@ func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_Execut
 		return nil
 	})
 
-	message := &idl.Message{Contents: &idl.Message_Response{Response: &idl.Response{
-		Contents: &idl.Response_ExecuteResponse{ExecuteResponse: &idl.ExecuteResponse{
+	message := &idl.Message{Contents: &idl.Message_Response{Response: &idl.Response{Contents: &idl.Response_ExecuteResponse{
+		ExecuteResponse: &idl.ExecuteResponse{
 			Target: &idl.Cluster{
 				Port:                int32(s.Target.MasterPort()),
 				MasterDataDirectory: s.Target.MasterDataDir(),
-			}}}}}}
+			}},
+	}}}}
 
 	if err = stream.Send(message); err != nil {
 		return err

--- a/hub/finalize.go
+++ b/hub/finalize.go
@@ -99,13 +99,15 @@ func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeSe
 		})
 	}
 
-	message := &idl.Message{Contents: &idl.Message_Response{Response: &idl.Response{
-		Contents: &idl.Response_FinalizeResponse{FinalizeResponse: &idl.FinalizeResponse{
+	message := &idl.Message{Contents: &idl.Message_Response{Response: &idl.Response{Contents: &idl.Response_FinalizeResponse{
+		FinalizeResponse: &idl.FinalizeResponse{
 			TargetVersion: s.Target.Version.VersionString,
 			Target: &idl.Cluster{
 				Port:                int32(s.Target.MasterPort()),
 				MasterDataDirectory: s.Target.MasterDataDir(),
-			}}}}}}
+			},
+		},
+	}}}}
 
 	if err = stream.Send(message); err != nil {
 		return err

--- a/hub/initialize.go
+++ b/hub/initialize.go
@@ -121,11 +121,12 @@ func (s *Server) InitializeCreateCluster(in *idl.InitializeCreateClusterRequest,
 		return s.CheckUpgrade(stream, conns)
 	})
 
-	message := &idl.Message{Contents: &idl.Message_Response{Response: &idl.Response{
-		Contents: &idl.Response_InitializeResponse{InitializeResponse: &idl.InitializeResponse{
+	message := &idl.Message{Contents: &idl.Message_Response{Response: &idl.Response{Contents: &idl.Response_InitializeResponse{
+		InitializeResponse: &idl.InitializeResponse{
 			HasMirrors: s.Config.Source.HasMirrors(),
 			HasStandby: s.Config.Source.HasStandby(),
-		}}}}}
+		},
+	}}}}
 
 	if err = stream.Send(message); err != nil {
 		return err

--- a/hub/revert.go
+++ b/hub/revert.go
@@ -172,22 +172,16 @@ func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) 
 		return DeleteStateDirectories(s.agentConns, s.Source.MasterHostname())
 	})
 
-	message := &idl.Message{
-		Contents: &idl.Message_Response{
-			Response: &idl.Response{
-				Contents: &idl.Response_RevertResponse{
-					RevertResponse: &idl.RevertResponse{
-						Source: &idl.Cluster{
-							Port:                int32(s.Target.MasterPort()),
-							MasterDataDirectory: s.Target.MasterDataDir(),
-						},
-						SourceVersion:       s.Source.Version.VersionString,
-						LogArchiveDirectory: archiveDir,
-					},
-				},
+	message := &idl.Message{Contents: &idl.Message_Response{Response: &idl.Response{Contents: &idl.Response_RevertResponse{
+		RevertResponse: &idl.RevertResponse{
+			SourceVersion:       s.Source.Version.VersionString,
+			LogArchiveDirectory: archiveDir,
+			Source: &idl.Cluster{
+				Port:                int32(s.Source.MasterPort()),
+				MasterDataDirectory: s.Source.MasterDataDir(),
 			},
 		},
-	}
+	}}}}
 
 	if err := stream.Send(message); err != nil {
 		return xerrors.Errorf("sending response message: %w", err)


### PR DESCRIPTION
It was accidentally returning the target cluster information. Also update the style/formatting of the other responses for readability.

[pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixRevertResponse)