### PR TITLE
print run initialize in next actions when any step is run before initialize

### DIFF
--- a/cli/commanders/step.go
+++ b/cli/commanders/step.go
@@ -170,7 +170,7 @@ func (s *CLIStep) Complete(completedText string) error {
 	}
 
 	if s.Err() != nil {
-		fmt.Println()
+		fmt.Println() // Separate the step status from the error text
 
 		// allow substpes to override the default next actions
 		var nextActions cli.NextActions
@@ -183,7 +183,7 @@ If you would like to return the cluster to its original state, please run "gpupg
 		return cli.NewNextActions(s.Err(), msg)
 	}
 
-	fmt.Println(completedText)
+	fmt.Print(completedText)
 	return nil
 }
 

--- a/cli/commanders/step.go
+++ b/cli/commanders/step.go
@@ -15,6 +15,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/cli"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/step"
+	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 	"github.com/greenplum-db/gpupgrade/utils/stopwatch"
 )
@@ -35,7 +36,10 @@ type CLIStep struct {
 func NewStep(step idl.Step, streams *step.BufferedStreams, verbose bool) (*CLIStep, error) {
 	store, err := NewStepStore()
 	if err != nil {
-		return &CLIStep{}, cli.NewNextActions(err, StepErr.Error())
+		gplog.Error("creating step store: %v", err)
+		context := fmt.Sprintf("Note: If commands were issued in order, ensure gpupgrade can write to %s", utils.GetStateDir())
+		wrappedErr := xerrors.Errorf("%v\n\n%v", StepErr, context)
+		return &CLIStep{}, cli.NewNextActions(wrappedErr, RunInitialize)
 	}
 
 	err = store.ValidateStep(step)

--- a/cli/commanders/step_store.go
+++ b/cli/commanders/step_store.go
@@ -86,11 +86,13 @@ type stepCondition struct {
 }
 
 var StepErr = errors.New(`gpupgrade commands must be issued in correct order
+
   1. initialize   runs pre-upgrade checks and prepares the cluster for upgrade
   2. execute      upgrades the master and primary segments to the target
                   Greenplum version
   3. finalize     upgrades the standby master and mirror segments to the target
                   Greenplum version. Revert cannot be run after finalize has started.
+
 Use "gpupgrade --help" for more information`)
 
 const RunInitialize = `To begin the upgrade, run "gpupgrade initialize".`

--- a/cli/commanders/step_test.go
+++ b/cli/commanders/step_test.go
@@ -130,7 +130,6 @@ func TestSubstep(t *testing.T) {
 		expected := "\nInitialize in progress.\n\n"
 		expected += commanders.Format(commanders.SubstepDescriptions[idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG].OutputText, idl.Status_RUNNING) + "\r"
 		expected += commanders.Format(commanders.SubstepDescriptions[idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG].OutputText, idl.Status_SKIPPED) + "\n"
-		expected += "\n"
 
 		actual := string(stdout)
 		if actual != expected {
@@ -230,7 +229,6 @@ func TestSubstep(t *testing.T) {
 
 		expectedStdout := "\nInitialize in progress.\n\n"
 		expectedStdout += "Initialize took 0s\n\n"
-		expectedStdout += "\n"
 
 		stdout, stderr := d.Collect()
 		d.Close()

--- a/cli/commanders/step_test.go
+++ b/cli/commanders/step_test.go
@@ -365,8 +365,8 @@ func TestSubstep(t *testing.T) {
 			t.Errorf("got %T, want %T", err, nextActionsErr)
 		}
 
-		if nextActionsErr.NextAction != commanders.StepErr.Error() {
-			t.Errorf("got %q want %q", nextActionsErr.NextAction, commanders.StepErr.Error())
+		if nextActionsErr.NextAction != commanders.RunInitialize {
+			t.Errorf("got %q want %q", nextActionsErr.NextAction, commanders.RunInitialize)
 		}
 	})
 

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -489,8 +489,8 @@ NEXT ACTIONS
 To proceed with the upgrade, run "gpupgrade execute"
 followed by "gpupgrade finalize".
 
-To return the cluster to its original state, run "gpupgrade revert".
-`, warningMessage))
+To return the cluster to its original state, run "gpupgrade revert".`,
+				warningMessage))
 		},
 	}
 	subInit.Flags().StringVarP(&file, "file", "f", "", "the configuration file to use")
@@ -555,8 +555,8 @@ NEXT ACTIONS
 If you are satisfied with the state of the cluster, run "gpupgrade finalize" 
 to proceed with the upgrade.
 
-To return the cluster to its original state, run "gpupgrade revert".
-`, response.GetTarget().GetPort(), response.GetTarget().GetMasterDataDirectory()))
+To return the cluster to its original state, run "gpupgrade revert".`,
+				response.GetTarget().GetPort(), response.GetTarget().GetMasterDataDirectory()))
 		},
 	}
 
@@ -604,8 +604,8 @@ MASTER_DATA_DIRECTORY: %s
 NEXT ACTIONS
 ------------
 Run the “complete” data migration scripts, and recreate any additional tables,
-indexes, and roles that were dropped or altered to resolve migration issues.
-`, response.GetTargetVersion(), response.GetTarget().GetPort(), response.GetTarget().GetMasterDataDirectory()))
+indexes, and roles that were dropped or altered to resolve migration issues.`,
+				response.GetTargetVersion(), response.GetTarget().GetPort(), response.GetTarget().GetMasterDataDirectory()))
 		},
 	}
 
@@ -671,8 +671,8 @@ To use the reverted cluster, run the “revert” data migration scripts, and
 recreate any additional tables, indexes, and roles that were dropped or
 altered to resolve migration issues.
 
-To restart the upgrade, run "gpupgrade initialize" again.
-`, response.GetSourceVersion(), response.GetSource().GetPort(), response.GetSource().GetMasterDataDirectory(), response.GetLogArchiveDirectory()))
+To restart the upgrade, run "gpupgrade initialize" again.`,
+				response.GetSourceVersion(), response.GetSource().GetPort(), response.GetSource().GetMasterDataDirectory(), response.GetLogArchiveDirectory()))
 		},
 	}
 


### PR DESCRIPTION
When any command is run before initialize print a helpful `Note` about not being able to write to the state directory in case it is a legitimate error. Add the run initialize help text in the next actions. This PR also adds the correct spacing to `stepErr`.

This PR also adds a minor fix to remove an extra trailing newline to the completed text.

Before Fix:
```
Error: getting "steps.json" file: open /home/gpadmin/.gpupgrade/steps.json: no such file or directory

NEXT ACTIONS
------------
gpupgrade commands must be issued in correct order
  1. initialize   runs pre-upgrade checks and prepares the cluster for upgrade
  2. execute      upgrades the master and primary segments to the target
                  Greenplum version
  3. finalize     upgrades the standby master and mirror segments to the target
                  Greenplum version. Revert cannot be run after finalize has started.
Use "gpupgrade --help" for more information
```

After Fix:
```
Error: gpupgrade commands must be issued in correct order

  1. initialize   runs pre-upgrade checks and prepares the cluster for upgrade
  2. execute      upgrades the master and primary segments to the target
                  Greenplum version
  3. finalize     upgrades the standby master and mirror segments to the target
                  Greenplum version. Revert cannot be run after finalize has started.

Use "gpupgrade --help" for more information

Note: If commands were issued in order, ensure gpupgrade can write to /Users/gpadmin/.gpupgrade

NEXT ACTIONS
------------
To begin the upgrade, run "gpupgrade initialize".
```

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixValidateStep)