### PR TITLE
Makefile: add enterprise and oss tarball targets 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 /gpupgrade
 /.vagrant
+gpupgrade-*.tar.gz
+CHECKSUM

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,8 @@ VERSION_LD_STR := -X 'github.com/greenplum-db/$(MODULE_NAME)/cli/commands.Versio
 VERSION_LD_STR += -X 'github.com/greenplum-db/$(MODULE_NAME)/cli/commands.Commit=$(COMMIT)'
 VERSION_LD_STR += -X 'github.com/greenplum-db/$(MODULE_NAME)/cli/commands.Release=$(RELEASE)'
 
-BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 LINUX_ENV := env GOOS=linux GOARCH=amd64
 MAC_ENV := env GOOS=darwin GOARCH=amd64
-LINUX_EXTENSION := .linux.$(BRANCH)
-MAC_EXTENSION := .darwin.$(BRANCH)
 
 # depend-dev will install the necessary Go dependencies for running `go
 # generate`. (This recipe does not have to be run in order to build the
@@ -84,12 +81,11 @@ sshd_build:
 		make -C integrations/sshd
 
 BUILD_ENV = $($(OS)_ENV)
-EXTENSION = $($(OS)_EXTENSION)
 
 .PHONY: build build_linux build_mac
 
 build:
-	$(BUILD_ENV) go build -o gpupgrade$(EXTENSION) $(BUILD_FLAGS) github.com/greenplum-db/gpupgrade/cmd/gpupgrade
+	$(BUILD_ENV) go build -o gpupgrade $(BUILD_FLAGS) github.com/greenplum-db/gpupgrade/cmd/gpupgrade
 	go generate ./cli/bash
 
 build_linux: OS := LINUX
@@ -128,6 +124,7 @@ clean:
 		rm -rf /tmp/unit*
 
 # You can override these from the command line.
+BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 GIT_URI := $(shell git ls-remote --get-url)
 
 ifeq ($(GIT_URI),https://github.com/greenplum-db/gpupgrade)

--- a/open_source_licenses.txt
+++ b/open_source_licenses.txt
@@ -1,0 +1,3063 @@
+open_source_licenses.txt
+
+VMware Tanzu Greenplum Upgrade 0.4.0 Beta
+
+======================================================================
+
+The following copyright statements and licenses apply to various open
+source software packages (or portions thereof) that are distributed with
+this VMware Product.
+
+The VMware Product may also include other VMware components, which may
+contain additional open source software packages. One or more such
+open_source_licenses.txt files may therefore accompany this VMware
+Product.
+
+The VMware Product that includes this file does not necessarily use all
+the open source software packages referred to below and may also only
+use portions of a given package.
+
+=============== TABLE OF CONTENTS =============================
+
+The following is a listing of the open source components detailed in
+this document. This list is provided for your convenience; please read
+further if you wish to review the copyright notice(s) and the full text
+of the license associated with each component.
+
+
+SECTION 1: Apache License, V2.0
+
+   >>> cloudfoundry_gosigar-v1.1.0
+   >>> genproto-c66870c02cf8
+   >>> golang_mock-v1.4.4
+   >>> google_renameio-v0.1.0
+   >>> gpupgrade-0.4.0
+   >>> greenplum-db_gp-common-go-libs-v1.0.4
+   >>> grpc-v1.24.0
+   >>> inconshreveable_mousetrap-v1.0.0
+   >>> spf13_cobra-v1.0.0
+   >>> yaml_v2-v2.2.4
+
+
+SECTION 2: BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES
+
+   >>> blang_semver-v3.5.1
+   >>> blang_semver_v4-v4.0.0
+   >>> data-dog_go-sqlmock-v1.4.1
+   >>> fsnotify_v1-v1.4.7
+   >>> golang_protobuf-v1.3.2
+   >>> hpcloud_tail-v1.0.0
+   >>> hpcloud_tail_ratelimiter-v1.0.0
+   >>> jackc_pgx-v3.2.0
+   >>> jmoiron_sqlx-0dae4fefe7c0
+   >>> kballard_go-shellquote-95032a82bc51
+   >>> lib_pq-v1.8.0
+   >>> onsi_ginkgo-v1.12.0
+   >>> onsi_ginkgo_reporters_stenographer_support_go-colorable-v1.12.0
+   >>> onsi_ginkgo_reporters_stenographer_support_go-isatty-v1.12.0
+   >>> onsi_gomega-v1.7.1
+   >>> pkg_errors-v0.9.1
+   >>> spf13_pflag-v1.0.5
+   >>> tomb_v1-dd632973f1e7
+   >>> x_crypto-123391ffb6de
+   >>> x_net-0de0cce0169b
+   >>> x_sys-5acd03effb82
+   >>> x_text-v0.3.2
+   >>> x_xerrors-5ec99f83aff1
+
+
+SECTION 3: Mozilla Public License, V2.0
+
+   >>> hashicorp_errwrap-v1.0.0
+   >>> hashicorp_go-multierror-v1.1.0
+
+
+APPENDIX. Standard License Files
+
+   >>> Apache License, V2.0
+
+   >>> Mozilla Public License, V2.0
+
+
+
+--------------- SECTION 1: Apache License, V2.0 ----------
+
+Apache License, V2.0 is applicable to the following component(s).
+
+
+>>> cloudfoundry_gosigar-v1.1.0
+
+Copyright (c) 2015-Present CloudFoundry.org Foundation, Inc. All Rights Reserved.
+
+This project contains software that is Copyright (c) [2009-2011] VMware, Inc.
+
+This project is licensed to you under the Apache License, Version 2.0 (the "License").
+
+You may not use this project except in compliance with the License.
+
+This project may include a number of subcomponents with separate copyright notices
+and license terms. Your use of these subcomponents is subject to the terms and 
+conditions of the subcomponent's license, as noted in the LICENSE file.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> BSD-2
+
+cloudfoundry-gosigar-v1.1.0.tar.gz\cloudfoundry-gosigar-v1.1.0.tar\gosigar-1.1.0\vendor\github.com\pkg\errors\LICENSE
+
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+> BSD-3
+
+cloudfoundry-gosigar-v1.1.0.tar.gz\cloudfoundry-gosigar-v1.1.0.tar\gosigar-1.1.0\vendor\github.com\pmezard\go-difflib\LICENSE
+
+Copyright (c) 2013, Patrick Mezard
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+The names of its contributors may not be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+> MIT
+
+cloudfoundry-gosigar-v1.1.0.tar.gz\cloudfoundry-gosigar-v1.1.0.tar\gosigar-1.1.0\vendor\github.com\davecgh\go-spew\spew\spew.go
+
+Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+cloudfoundry-gosigar-v1.1.0.tar.gz\cloudfoundry-gosigar-v1.1.0.tar\gosigar-1.1.0\vendor\github.com\davecgh\go-spew\LICENSE
+
+ISC License
+
+Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+>>> genproto-c66870c02cf8
+
+License: Apache 2.0
+
+>>> golang_mock-v1.4.4
+
+ADDITIONAL LICENSE INFORMATION:
+
+> Apache2.0
+
+mock-1.4.4/gomock/call.go
+
+mock-1.4.4/gomock/controller.go
+
+mock-1.4.4/gomock/matchers.go
+
+mock-1.4.4/gomock/matchers_test.go
+
+mock-1.4.4/mockgen/mockgen.go
+
+Copyright 2010 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mock-1.4.4/gomock/callset.go
+
+mock-1.4.4/gomock/callset_test.go
+
+mock-1.4.4/gomock/controller_test.go
+
+Copyright 2011 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mock-1.4.4/mockgen/model/model.go
+
+mock-1.4.4/mockgen/parse.go
+
+mock-1.4.4/mockgen/reflect.go
+
+Copyright 2012 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mock-1.4.4/mockgen/version.1.11.go
+
+mock-1.4.4/mockgen/version.1.12.go
+
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+>>> google_renameio-v0.1.0
+
+Copyright 2018 Google Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> Apache2.0
+
+renameio-0.1.0/doc.go
+
+renameio-0.1.0/example_test.go
+
+renameio-0.1.0/symlink_test.go
+
+renameio-0.1.0/tempfile.go
+
+renameio-0.1.0/tempfile_linux_test.go
+
+renameio-0.1.0/writefile.go
+
+renameio-0.1.0/writefile_test.go
+
+Copyright 2018 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+>>> gpupgrade-0.4.0
+
+Greenplum Database Upgrade
+Copyright 2020 VMware, Inc. or its affiliates. All Rights Reserved.
+
+This product is licensed to you under the Apache 2.0 license (the "License").  You may not use this product except in compliance with the Apache 2.0 License.
+
+This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> MIT
+
+gpupgrade-0.4.0/data_migration_scripts/start/gen_alter_name_type_columns.sql
+
+Portions Copyright (c) 1994, The Regents of the University of California
+
+1994, The Regents of the University of California
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice
+-- and this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+-- BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+-- A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS,
+-- AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE,
+-- SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+>>> greenplum-db_gp-common-go-libs-v1.0.4
+
+Found in: gp-common-go-libs-1.0.4/NOTICE
+
+Copyright (c) 2017-2019 Pivotal Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+>>> grpc-v1.24.0
+
+Copyright 2016 gRPC authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+>>> inconshreveable_mousetrap-v1.0.0
+
+Copyright 2014 Alan Shreve
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+>>> spf13_cobra-v1.0.0
+
+Copyright © 2013 Steve Francia <spf@spf13.com>.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+>>> yaml_v2-v2.2.4
+
+Copyright 2011-2016 Canonical Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> MIT
+
+go_yaml-yaml-v2.2.4.tar.gz\go_yaml-yaml-v2.2.4.tar.gz\yaml.v2\LICENSE.libyaml
+
+The following files were ported to Go from C files of libyaml, and thus
+are still covered by their original copyright and license:
+
+    apic.go
+    emitterc.go
+    parserc.go
+    readerc.go
+    scannerc.go
+    writerc.go
+    yamlh.go
+    yamlprivateh.go
+
+Copyright (c) 2006 Kirill Simonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--------------- SECTION 2: BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES ----------
+
+BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES are applicable to the following component(s).
+
+
+>>> blang_semver-v3.5.1
+
+The MIT License
+
+Copyright (c) 2014 Benedikt Lang <github at benediktlang.de>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+>>> blang_semver_v4-v4.0.0
+
+Found in: semver-4.0.0/LICENSE
+
+Copyright (c) 2014 Benedikt Lang
+
+The MIT License
+
+Copyright ([c]) [2014] [Benedikt] [Lang] <[github] [at] [benediktlang].[de]>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+>>> data-dog_go-sqlmock-v1.4.1
+
+ADDITIONAL LICENSE INFORMATION:
+
+> BSD Intel License
+
+go-sqlmock-1.4.1/LICENSE
+
+Copyright (c) 2013-2019, DATA-DOG team
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* The name [DataDog].[lt] may not be used to endorse or promote products
+  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL [MICHAEL] [BOSTOCK] BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+>>> fsnotify_v1-v1.4.7
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright (c) 2012 fsnotify Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+* Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+>>> golang_protobuf-v1.3.2
+
+Copyright 2010 The Go Authors.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+>>> hpcloud_tail-v1.0.0
+
+The MIT License (MIT)
+
+© Copyright 2015 Hewlett Packard Enterprise Development LP
+Copyright (c) 2014 ActiveState
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> BSD-3
+
+tail-1.0.0.tar.gz\tail-1.0.0.tar\tail-1.0.0\vendor\gopkg.in\fsnotify.v1\LICENSE
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright (c) 2012 fsnotify Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+* Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+>>> hpcloud_tail_ratelimiter-v1.0.0
+
+Copyright (C) 2013 99designs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+>>> jackc_pgx-v3.2.0
+
+Copyright (c) 2013 Jack Christensen
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> BSD-3
+
+jackc-pgx-v3.2.0.tar.gz\jackc-pgx-v3.2.0.tar\pgx-3.2.0\go_stdlib.go
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+* Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+>>> jmoiron_sqlx-0dae4fefe7c0
+
+Found in: sqlx-0dae4fefe7c0/LICENSE
+
+Copyright (c) 2013, Jason Moiron
+
+Permission is hereby granted, free of charge, to any person
+ obtaining a copy of this software and associated documentation
+ files (the "Software"), to deal in the Software without
+ restriction, including without limitation the rights to use,
+ copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following
+ conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+>>> kballard_go-shellquote-95032a82bc51
+
+Copyright (C) 2014 Kevin Ballard
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> MIT
+
+go-shellquote-95032a82bc51/LICENSE
+
+Copyright (c) 2014 Kevin Ballard
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+>>> lib_pq-v1.8.0
+
+Found in: pq-1.8.0/LICENSE.md
+
+Portions Copyright (c) 2011 Blake Mizerany
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> BSD-2
+
+pq-1.8.0/scram/scram.go
+
+Copyright (c) 2014 - Gustavo Niemeyer <gustavo@niemeyer.net>
+
+Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+>>> onsi_ginkgo-v1.12.0
+
+Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
+
+MIT License (Expat)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+>>> onsi_ginkgo_reporters_stenographer_support_go-colorable-v1.12.0
+
+Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
+
+MIT License (Expat)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+>>> onsi_ginkgo_reporters_stenographer_support_go-isatty-v1.12.0
+
+Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
+
+MIT License (Expat)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+>>> onsi_gomega-v1.7.1
+
+Copyright (c) 2013-2014 Onsi Fakhouri
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+>>> pkg_errors-v0.9.1
+
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+>>> spf13_pflag-v1.0.5
+
+Copyright (c) 2012 Alex Ogier. All rights reserved.
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+* Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> BSD
+
+spf13-pflag-v1.0.5.tar.gz\spf13-pflag-v1.0.5.tar.gz\pflag\golangflag.go
+
+Copyright 2009 The Go Authors. All rights reserved.
+Use of this source code is governed by a BSD-style
+license that can be found in the LICENSE file.
+
+>>> tomb_v1-dd632973f1e7
+
+tomb - support for clean goroutine termination in Go.
+
+Copyright (c) 2010-2011 - Gustavo Niemeyer <gustavo@niemeyer.net>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+>>> x_crypto-123391ffb6de
+
+Found in: crypto-123391ffb6de/LICENSE
+
+Copyright (c) 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> BSD-3
+
+crypto-123391ffb6de/md4/md4block.go
+
+crypto-123391ffb6de/md4/md4.go
+
+crypto-123391ffb6de/md4/md4_test.go
+
+crypto-123391ffb6de/xtea/block.go
+
+crypto-123391ffb6de/xtea/cipher.go
+
+crypto-123391ffb6de/xtea/xtea_test.go
+
+Copyright 2009 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+crypto-123391ffb6de/blowfish/block.go
+
+crypto-123391ffb6de/blowfish/blowfish_test.go
+
+crypto-123391ffb6de/blowfish/cipher.go
+
+crypto-123391ffb6de/blowfish/const.go
+
+crypto-123391ffb6de/cast5/cast5.go
+
+crypto-123391ffb6de/cast5/cast5_test.go
+
+crypto-123391ffb6de/openpgp/armor/armor.go
+
+crypto-123391ffb6de/openpgp/armor/armor_test.go
+
+crypto-123391ffb6de/openpgp/armor/encode.go
+
+crypto-123391ffb6de/openpgp/errors/errors.go
+
+crypto-123391ffb6de/openpgp/packet/ocfb.go
+
+crypto-123391ffb6de/openpgp/packet/ocfb_test.go
+
+crypto-123391ffb6de/ripemd160/ripemd160block.go
+
+crypto-123391ffb6de/ripemd160/ripemd160.go
+
+crypto-123391ffb6de/ripemd160/ripemd160_test.go
+
+Copyright 2010 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+crypto-123391ffb6de/bcrypt/base64.go
+
+crypto-123391ffb6de/bcrypt/bcrypt.go
+
+crypto-123391ffb6de/bcrypt/bcrypt_test.go
+
+crypto-123391ffb6de/openpgp/canonical_text.go
+
+crypto-123391ffb6de/openpgp/canonical_text_test.go
+
+crypto-123391ffb6de/openpgp/elgamal/elgamal.go
+
+crypto-123391ffb6de/openpgp/elgamal/elgamal_test.go
+
+crypto-123391ffb6de/openpgp/keys.go
+
+crypto-123391ffb6de/openpgp/packet/compressed.go
+
+crypto-123391ffb6de/openpgp/packet/compressed_test.go
+
+crypto-123391ffb6de/openpgp/packet/encrypted_key.go
+
+crypto-123391ffb6de/openpgp/packet/encrypted_key_test.go
+
+crypto-123391ffb6de/openpgp/packet/literal.go
+
+crypto-123391ffb6de/openpgp/packet/one_pass_signature.go
+
+crypto-123391ffb6de/openpgp/packet/opaque_test.go
+
+crypto-123391ffb6de/openpgp/packet/packet.go
+
+crypto-123391ffb6de/openpgp/packet/packet_test.go
+
+crypto-123391ffb6de/openpgp/packet/private_key.go
+
+crypto-123391ffb6de/openpgp/packet/private_key_test.go
+
+crypto-123391ffb6de/openpgp/packet/public_key.go
+
+crypto-123391ffb6de/openpgp/packet/public_key_test.go
+
+crypto-123391ffb6de/openpgp/packet/reader.go
+
+crypto-123391ffb6de/openpgp/packet/signature.go
+
+crypto-123391ffb6de/openpgp/packet/signature_test.go
+
+crypto-123391ffb6de/openpgp/packet/symmetrically_encrypted.go
+
+crypto-123391ffb6de/openpgp/packet/symmetrically_encrypted_test.go
+
+crypto-123391ffb6de/openpgp/packet/symmetric_key_encrypted.go
+
+crypto-123391ffb6de/openpgp/packet/symmetric_key_encrypted_test.go
+
+crypto-123391ffb6de/openpgp/packet/userattribute_test.go
+
+crypto-123391ffb6de/openpgp/packet/userid.go
+
+crypto-123391ffb6de/openpgp/packet/userid_test.go
+
+crypto-123391ffb6de/openpgp/read.go
+
+crypto-123391ffb6de/openpgp/read_test.go
+
+crypto-123391ffb6de/openpgp/s2k/s2k.go
+
+crypto-123391ffb6de/openpgp/s2k/s2k_test.go
+
+crypto-123391ffb6de/openpgp/write.go
+
+crypto-123391ffb6de/openpgp/write_test.go
+
+crypto-123391ffb6de/ssh/buffer_test.go
+
+crypto-123391ffb6de/ssh/channel.go
+
+crypto-123391ffb6de/ssh/cipher.go
+
+crypto-123391ffb6de/ssh/cipher_test.go
+
+crypto-123391ffb6de/ssh/client_auth.go
+
+crypto-123391ffb6de/ssh/client_auth_test.go
+
+crypto-123391ffb6de/ssh/client.go
+
+crypto-123391ffb6de/ssh/common.go
+
+crypto-123391ffb6de/ssh/doc.go
+
+crypto-123391ffb6de/ssh/example_test.go
+
+crypto-123391ffb6de/ssh/messages.go
+
+crypto-123391ffb6de/ssh/messages_test.go
+
+crypto-123391ffb6de/ssh/server.go
+
+crypto-123391ffb6de/ssh/session.go
+
+crypto-123391ffb6de/ssh/session_test.go
+
+crypto-123391ffb6de/ssh/ssh_gss.go
+
+crypto-123391ffb6de/ssh/tcpip.go
+
+crypto-123391ffb6de/ssh/terminal/terminal.go
+
+crypto-123391ffb6de/ssh/terminal/terminal_test.go
+
+crypto-123391ffb6de/ssh/terminal/util.go
+
+crypto-123391ffb6de/ssh/terminal/util_windows.go
+
+crypto-123391ffb6de/ssh/transport.go
+
+crypto-123391ffb6de/ssh/transport_test.go
+
+crypto-123391ffb6de/twofish/twofish.go
+
+crypto-123391ffb6de/twofish/twofish_test.go
+
+Copyright 2011 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+crypto-123391ffb6de/bn256/bn256.go
+
+crypto-123391ffb6de/bn256/bn256_test.go
+
+crypto-123391ffb6de/bn256/constants.go
+
+crypto-123391ffb6de/bn256/curve.go
+
+crypto-123391ffb6de/bn256/example_test.go
+
+crypto-123391ffb6de/bn256/gfp12.go
+
+crypto-123391ffb6de/bn256/gfp2.go
+
+crypto-123391ffb6de/bn256/gfp6.go
+
+crypto-123391ffb6de/bn256/optate.go
+
+crypto-123391ffb6de/bn256/twist.go
+
+crypto-123391ffb6de/curve25519/curve25519_amd64.go
+
+crypto-123391ffb6de/curve25519/curve25519_amd64.s
+
+crypto-123391ffb6de/curve25519/curve25519_test.go
+
+crypto-123391ffb6de/nacl/box/box.go
+
+crypto-123391ffb6de/nacl/box/box_test.go
+
+crypto-123391ffb6de/nacl/secretbox/secretbox.go
+
+crypto-123391ffb6de/nacl/secretbox/secretbox_test.go
+
+crypto-123391ffb6de/openpgp/clearsign/clearsign.go
+
+crypto-123391ffb6de/openpgp/clearsign/clearsign_test.go
+
+crypto-123391ffb6de/openpgp/packet/config.go
+
+crypto-123391ffb6de/openpgp/packet/opaque.go
+
+crypto-123391ffb6de/otr/libotr_test_helper.c
+
+crypto-123391ffb6de/otr/otr.go
+
+crypto-123391ffb6de/otr/otr_test.go
+
+crypto-123391ffb6de/otr/smp.go
+
+crypto-123391ffb6de/pbkdf2/pbkdf2.go
+
+crypto-123391ffb6de/pbkdf2/pbkdf2_test.go
+
+crypto-123391ffb6de/poly1305/poly1305.go
+
+crypto-123391ffb6de/poly1305/poly1305_test.go
+
+crypto-123391ffb6de/poly1305/sum_amd64.go
+
+crypto-123391ffb6de/poly1305/sum_amd64.s
+
+crypto-123391ffb6de/salsa20/salsa20.go
+
+crypto-123391ffb6de/salsa20/salsa20_test.go
+
+crypto-123391ffb6de/salsa20/salsa/hsalsa20.go
+
+crypto-123391ffb6de/salsa20/salsa/salsa208.go
+
+crypto-123391ffb6de/salsa20/salsa/salsa20_amd64.go
+
+crypto-123391ffb6de/salsa20/salsa/salsa20_amd64.s
+
+crypto-123391ffb6de/salsa20/salsa/salsa20_ref.go
+
+crypto-123391ffb6de/salsa20/salsa/salsa_test.go
+
+crypto-123391ffb6de/scrypt/scrypt.go
+
+crypto-123391ffb6de/scrypt/scrypt_test.go
+
+crypto-123391ffb6de/ssh/agent/client.go
+
+crypto-123391ffb6de/ssh/agent/client_test.go
+
+crypto-123391ffb6de/ssh/agent/server.go
+
+crypto-123391ffb6de/ssh/agent/server_test.go
+
+crypto-123391ffb6de/ssh/buffer.go
+
+crypto-123391ffb6de/ssh/certs.go
+
+crypto-123391ffb6de/ssh/keys.go
+
+crypto-123391ffb6de/ssh/mac.go
+
+crypto-123391ffb6de/ssh/test/dial_unix_test.go
+
+crypto-123391ffb6de/ssh/test/doc.go
+
+crypto-123391ffb6de/ssh/test/forward_unix_test.go
+
+crypto-123391ffb6de/ssh/test/session_test.go
+
+crypto-123391ffb6de/ssh/test/test_unix_test.go
+
+crypto-123391ffb6de/xts/xts.go
+
+crypto-123391ffb6de/xts/xts_test.go
+
+Copyright 2012 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+crypto-123391ffb6de/curve25519/curve25519_generic.go
+
+crypto-123391ffb6de/ocsp/ocsp.go
+
+crypto-123391ffb6de/ocsp/ocsp_test.go
+
+crypto-123391ffb6de/openpgp/packet/public_key_v3.go
+
+crypto-123391ffb6de/openpgp/packet/public_key_v3_test.go
+
+crypto-123391ffb6de/openpgp/packet/signature_v3.go
+
+crypto-123391ffb6de/openpgp/packet/signature_v3_test.go
+
+crypto-123391ffb6de/openpgp/packet/userattribute.go
+
+crypto-123391ffb6de/ssh/benchmark_test.go
+
+crypto-123391ffb6de/ssh/certs_test.go
+
+crypto-123391ffb6de/ssh/connection.go
+
+crypto-123391ffb6de/ssh/handshake.go
+
+crypto-123391ffb6de/ssh/handshake_test.go
+
+crypto-123391ffb6de/ssh/kex.go
+
+crypto-123391ffb6de/ssh/kex_test.go
+
+crypto-123391ffb6de/ssh/mempipe_test.go
+
+crypto-123391ffb6de/ssh/mux.go
+
+crypto-123391ffb6de/ssh/mux_test.go
+
+crypto-123391ffb6de/ssh/terminal/util_bsd.go
+
+crypto-123391ffb6de/ssh/terminal/util_linux.go
+
+Copyright 2013 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+crypto-123391ffb6de/hkdf/example_test.go
+
+crypto-123391ffb6de/hkdf/hkdf.go
+
+crypto-123391ffb6de/hkdf/hkdf_test.go
+
+crypto-123391ffb6de/sha3/doc.go
+
+crypto-123391ffb6de/sha3/hashes.go
+
+crypto-123391ffb6de/sha3/keccakf.go
+
+crypto-123391ffb6de/sha3/register.go
+
+crypto-123391ffb6de/sha3/sha3.go
+
+crypto-123391ffb6de/sha3/sha3_test.go
+
+crypto-123391ffb6de/sha3/shake.go
+
+crypto-123391ffb6de/ssh/agent/forward.go
+
+crypto-123391ffb6de/ssh/agent/keyring.go
+
+crypto-123391ffb6de/ssh/agent/testdata_test.go
+
+crypto-123391ffb6de/ssh/client_test.go
+
+crypto-123391ffb6de/ssh/internal/bcrypt_pbkdf/bcrypt_pbkdf.go
+
+crypto-123391ffb6de/ssh/internal/bcrypt_pbkdf/bcrypt_pbkdf_test.go
+
+crypto-123391ffb6de/ssh/keys_test.go
+
+crypto-123391ffb6de/ssh/tcpip_test.go
+
+crypto-123391ffb6de/ssh/test/agent_unix_test.go
+
+crypto-123391ffb6de/ssh/test/banner_test.go
+
+crypto-123391ffb6de/ssh/test/cert_test.go
+
+crypto-123391ffb6de/ssh/testdata/doc.go
+
+crypto-123391ffb6de/ssh/testdata/keys.go
+
+crypto-123391ffb6de/ssh/testdata_test.go
+
+crypto-123391ffb6de/ssh/test/testdata_test.go
+
+Copyright 2014 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+crypto-123391ffb6de/acme/acme.go
+
+crypto-123391ffb6de/acme/acme_test.go
+
+crypto-123391ffb6de/acme/jws.go
+
+crypto-123391ffb6de/acme/jws_test.go
+
+crypto-123391ffb6de/pkcs12/bmp-string.go
+
+crypto-123391ffb6de/pkcs12/bmp-string_test.go
+
+crypto-123391ffb6de/pkcs12/crypto.go
+
+crypto-123391ffb6de/pkcs12/crypto_test.go
+
+crypto-123391ffb6de/pkcs12/errors.go
+
+crypto-123391ffb6de/pkcs12/internal/rc2/bench_test.go
+
+crypto-123391ffb6de/pkcs12/internal/rc2/rc2.go
+
+crypto-123391ffb6de/pkcs12/internal/rc2/rc2_test.go
+
+crypto-123391ffb6de/pkcs12/mac.go
+
+crypto-123391ffb6de/pkcs12/mac_test.go
+
+crypto-123391ffb6de/pkcs12/pbkdf.go
+
+crypto-123391ffb6de/pkcs12/pbkdf_test.go
+
+crypto-123391ffb6de/pkcs12/pkcs12.go
+
+crypto-123391ffb6de/pkcs12/pkcs12_test.go
+
+crypto-123391ffb6de/pkcs12/safebags.go
+
+crypto-123391ffb6de/sha3/keccakf_amd64.go
+
+crypto-123391ffb6de/sha3/keccakf_amd64.s
+
+crypto-123391ffb6de/sha3/xor_generic.go
+
+crypto-123391ffb6de/sha3/xor.go
+
+crypto-123391ffb6de/sha3/xor_unaligned.go
+
+crypto-123391ffb6de/ssh/agent/keyring_test.go
+
+crypto-123391ffb6de/ssh/terminal/util_solaris.go
+
+crypto-123391ffb6de/tea/cipher.go
+
+crypto-123391ffb6de/tea/tea_test.go
+
+Copyright 2015 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+crypto-123391ffb6de/acme/autocert/autocert.go
+
+crypto-123391ffb6de/acme/autocert/autocert_test.go
+
+crypto-123391ffb6de/acme/autocert/cache.go
+
+crypto-123391ffb6de/acme/autocert/cache_test.go
+
+crypto-123391ffb6de/acme/autocert/renewal.go
+
+crypto-123391ffb6de/acme/autocert/renewal_test.go
+
+crypto-123391ffb6de/acme/types.go
+
+crypto-123391ffb6de/blake2b/blake2b_amd64.go
+
+crypto-123391ffb6de/blake2b/blake2b_amd64.s
+
+crypto-123391ffb6de/blake2b/blake2bAVX2_amd64.go
+
+crypto-123391ffb6de/blake2b/blake2bAVX2_amd64.s
+
+crypto-123391ffb6de/blake2b/blake2b_generic.go
+
+crypto-123391ffb6de/blake2b/blake2b.go
+
+crypto-123391ffb6de/blake2b/blake2b_ref.go
+
+crypto-123391ffb6de/blake2b/blake2b_test.go
+
+crypto-123391ffb6de/blake2s/blake2s_386.go
+
+crypto-123391ffb6de/blake2s/blake2s_386.s
+
+crypto-123391ffb6de/blake2s/blake2s_amd64.go
+
+crypto-123391ffb6de/blake2s/blake2s_amd64.s
+
+crypto-123391ffb6de/blake2s/blake2s_generic.go
+
+crypto-123391ffb6de/blake2s/blake2s.go
+
+crypto-123391ffb6de/blake2s/blake2s_ref.go
+
+crypto-123391ffb6de/blake2s/blake2s_test.go
+
+crypto-123391ffb6de/chacha20/chacha_generic.go
+
+crypto-123391ffb6de/chacha20/chacha_test.go
+
+crypto-123391ffb6de/chacha20poly1305/chacha20poly1305_amd64.go
+
+crypto-123391ffb6de/chacha20poly1305/chacha20poly1305_amd64.s
+
+crypto-123391ffb6de/chacha20poly1305/chacha20poly1305_generic.go
+
+crypto-123391ffb6de/chacha20poly1305/chacha20poly1305.go
+
+crypto-123391ffb6de/chacha20poly1305/chacha20poly1305_noasm.go
+
+crypto-123391ffb6de/chacha20poly1305/chacha20poly1305_test.go
+
+crypto-123391ffb6de/chacha20poly1305/chacha20poly1305_vectors_test.go
+
+crypto-123391ffb6de/ed25519/ed25519.go
+
+crypto-123391ffb6de/ed25519/ed25519_test.go
+
+crypto-123391ffb6de/ed25519/internal/edwards25519/const.go
+
+crypto-123391ffb6de/ed25519/internal/edwards25519/edwards25519.go
+
+crypto-123391ffb6de/nacl/secretbox/example_test.go
+
+crypto-123391ffb6de/ssh/agent/example_test.go
+
+crypto-123391ffb6de/ssh/terminal/util_plan9.go
+
+Copyright 2016 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+crypto-123391ffb6de/acme/autocert/example_test.go
+
+crypto-123391ffb6de/acme/autocert/listener.go
+
+crypto-123391ffb6de/acme/types_test.go
+
+crypto-123391ffb6de/argon2/argon2.go
+
+crypto-123391ffb6de/argon2/argon2_test.go
+
+crypto-123391ffb6de/argon2/blake2b.go
+
+crypto-123391ffb6de/argon2/blamka_amd64.go
+
+crypto-123391ffb6de/argon2/blamka_amd64.s
+
+crypto-123391ffb6de/argon2/blamka_generic.go
+
+crypto-123391ffb6de/argon2/blamka_ref.go
+
+crypto-123391ffb6de/blake2b/blake2x.go
+
+crypto-123391ffb6de/blake2b/register.go
+
+crypto-123391ffb6de/blake2s/blake2x.go
+
+crypto-123391ffb6de/blake2s/register.go
+
+crypto-123391ffb6de/cryptobyte/asn1/asn1.go
+
+crypto-123391ffb6de/cryptobyte/asn1.go
+
+crypto-123391ffb6de/cryptobyte/asn1_test.go
+
+crypto-123391ffb6de/cryptobyte/builder.go
+
+crypto-123391ffb6de/cryptobyte/cryptobyte_test.go
+
+crypto-123391ffb6de/cryptobyte/example_test.go
+
+crypto-123391ffb6de/cryptobyte/string.go
+
+crypto-123391ffb6de/md4/example_test.go
+
+crypto-123391ffb6de/nacl/auth/auth.go
+
+crypto-123391ffb6de/nacl/auth/auth_test.go
+
+crypto-123391ffb6de/nacl/auth/example_test.go
+
+crypto-123391ffb6de/scrypt/example_test.go
+
+crypto-123391ffb6de/sha3/hashes_generic.go
+
+crypto-123391ffb6de/sha3/sha3_s390x.go
+
+crypto-123391ffb6de/sha3/sha3_s390x.s
+
+crypto-123391ffb6de/sha3/shake_generic.go
+
+crypto-123391ffb6de/ssh/knownhosts/knownhosts.go
+
+crypto-123391ffb6de/ssh/knownhosts/knownhosts_test.go
+
+crypto-123391ffb6de/ssh/test/multi_auth_test.go
+
+crypto-123391ffb6de/ssh/test/sshd_test_pw.c
+
+Copyright 2017 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+crypto-123391ffb6de/acme/autocert/internal/acmetest/ca.go
+
+crypto-123391ffb6de/acme/http.go
+
+crypto-123391ffb6de/acme/http_test.go
+
+crypto-123391ffb6de/chacha20/chacha_arm64.go
+
+crypto-123391ffb6de/chacha20/chacha_arm64.s
+
+crypto-123391ffb6de/chacha20/chacha_noasm.go
+
+crypto-123391ffb6de/chacha20/chacha_s390x.go
+
+crypto-123391ffb6de/chacha20/chacha_s390x.s
+
+crypto-123391ffb6de/chacha20poly1305/xchacha20poly1305.go
+
+crypto-123391ffb6de/chacha20/vectors_test.go
+
+crypto-123391ffb6de/internal/subtle/aliasing_appengine.go
+
+crypto-123391ffb6de/internal/subtle/aliasing.go
+
+crypto-123391ffb6de/internal/subtle/aliasing_test.go
+
+crypto-123391ffb6de/nacl/sign/sign.go
+
+crypto-123391ffb6de/nacl/sign/sign_test.go
+
+crypto-123391ffb6de/poly1305/mac_noasm.go
+
+crypto-123391ffb6de/poly1305/sum_generic.go
+
+crypto-123391ffb6de/poly1305/sum_s390x.go
+
+crypto-123391ffb6de/poly1305/sum_s390x.s
+
+crypto-123391ffb6de/poly1305/vectors_test.go
+
+crypto-123391ffb6de/ssh/terminal/util_aix.go
+
+Copyright 2018 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+crypto-123391ffb6de/chacha20/xor.go
+
+Copyright 2018 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found [src] the LICENSE file.
+
+crypto-123391ffb6de/acme/internal/acmeprobe/prober.go
+
+crypto-123391ffb6de/acme/rfc8555.go
+
+crypto-123391ffb6de/acme/rfc8555_test.go
+
+crypto-123391ffb6de/acme/version_go112.go
+
+crypto-123391ffb6de/chacha20/chacha_ppc64le.go
+
+crypto-123391ffb6de/chacha20/chacha_ppc64le.s
+
+crypto-123391ffb6de/curve25519/curve25519.go
+
+crypto-123391ffb6de/curve25519/curve25519_noasm.go
+
+crypto-123391ffb6de/curve25519/vectors_test.go
+
+crypto-123391ffb6de/ed25519/ed25519_go113.go
+
+crypto-123391ffb6de/ed25519/go113_test.go
+
+crypto-123391ffb6de/internal/wycheproof/aes_cbc_test.go
+
+crypto-123391ffb6de/internal/wycheproof/dsa_test.go
+
+crypto-123391ffb6de/internal/wycheproof/ecdsa_test.go
+
+crypto-123391ffb6de/internal/wycheproof/eddsa_test.go
+
+crypto-123391ffb6de/internal/wycheproof/hkdf_test.go
+
+crypto-123391ffb6de/internal/wycheproof/internal/dsa/dsa.go
+
+crypto-123391ffb6de/internal/wycheproof/rsa_pss_test.go
+
+crypto-123391ffb6de/internal/wycheproof/rsa_signature_test.go
+
+crypto-123391ffb6de/internal/wycheproof/wycheproof_test.go
+
+crypto-123391ffb6de/poly1305/bits_compat.go
+
+crypto-123391ffb6de/poly1305/bits_go1.13.go
+
+crypto-123391ffb6de/poly1305/sum_ppc64le.go
+
+crypto-123391ffb6de/poly1305/sum_ppc64le.s
+
+crypto-123391ffb6de/salsa20/salsa/salsa20_amd64_test.go
+
+crypto-123391ffb6de/salsa20/salsa/salsa20_noasm.go
+
+crypto-123391ffb6de/ssh/common_test.go
+
+Copyright 2019 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+>>> x_net-0de0cce0169b
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+>>> x_sys-5acd03effb82
+
+Found in: sys-5acd03effb82/LICENSE
+
+Copyright (c) 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> BSD-3
+
+sys-5acd03effb82/unix/syscall_darwin.go
+
+sys-5acd03effb82/unix/syscall_freebsd.go
+
+sys-5acd03effb82/unix/syscall_netbsd.go
+
+sys-5acd03effb82/unix/syscall_openbsd.go
+
+Copyright 2009,2010 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+sys-5acd03effb82/plan9/asm_plan9_386.s
+
+sys-5acd03effb82/plan9/asm_plan9_amd64.s
+
+sys-5acd03effb82/plan9/asm_plan9_arm.s
+
+sys-5acd03effb82/plan9/str.go
+
+sys-5acd03effb82/plan9/syscall.go
+
+sys-5acd03effb82/unix/asm_darwin_386.s
+
+sys-5acd03effb82/unix/asm_darwin_amd64.s
+
+sys-5acd03effb82/unix/asm_dragonfly_amd64.s
+
+sys-5acd03effb82/unix/asm_freebsd_386.s
+
+sys-5acd03effb82/unix/asm_freebsd_amd64.s
+
+sys-5acd03effb82/unix/asm_linux_386.s
+
+sys-5acd03effb82/unix/asm_linux_amd64.s
+
+sys-5acd03effb82/unix/asm_linux_arm.s
+
+sys-5acd03effb82/unix/asm_netbsd_386.s
+
+sys-5acd03effb82/unix/asm_netbsd_amd64.s
+
+sys-5acd03effb82/unix/asm_openbsd_386.s
+
+sys-5acd03effb82/unix/asm_openbsd_amd64.s
+
+sys-5acd03effb82/unix/dirent.go
+
+sys-5acd03effb82/unix/linux/types.go
+
+sys-5acd03effb82/unix/str.go
+
+sys-5acd03effb82/unix/syscall_bsd.go
+
+sys-5acd03effb82/unix/syscall_darwin_386.go
+
+sys-5acd03effb82/unix/syscall_darwin_amd64.go
+
+sys-5acd03effb82/unix/syscall_dragonfly_amd64.go
+
+sys-5acd03effb82/unix/syscall_dragonfly.go
+
+sys-5acd03effb82/unix/syscall_freebsd_386.go
+
+sys-5acd03effb82/unix/syscall_freebsd_amd64.go
+
+sys-5acd03effb82/unix/syscall.go
+
+sys-5acd03effb82/unix/syscall_illumos.go
+
+sys-5acd03effb82/unix/syscall_linux_386.go
+
+sys-5acd03effb82/unix/syscall_linux_amd64.go
+
+sys-5acd03effb82/unix/syscall_linux_arm.go
+
+sys-5acd03effb82/unix/syscall_linux.go
+
+sys-5acd03effb82/unix/syscall_linux_ppc64x.go
+
+sys-5acd03effb82/unix/syscall_linux_sparc64.go
+
+sys-5acd03effb82/unix/syscall_netbsd_386.go
+
+sys-5acd03effb82/unix/syscall_netbsd_amd64.go
+
+sys-5acd03effb82/unix/syscall_openbsd_386.go
+
+sys-5acd03effb82/unix/syscall_openbsd_amd64.go
+
+sys-5acd03effb82/unix/syscall_solaris_amd64.go
+
+sys-5acd03effb82/unix/syscall_solaris.go
+
+sys-5acd03effb82/unix/syscall_unix.go
+
+sys-5acd03effb82/unix/types_darwin.go
+
+sys-5acd03effb82/unix/types_dragonfly.go
+
+sys-5acd03effb82/unix/types_freebsd.go
+
+sys-5acd03effb82/unix/types_netbsd.go
+
+sys-5acd03effb82/unix/types_openbsd.go
+
+sys-5acd03effb82/unix/types_solaris.go
+
+sys-5acd03effb82/windows/exec_windows.go
+
+sys-5acd03effb82/windows/mksyscall.go
+
+sys-5acd03effb82/windows/str.go
+
+sys-5acd03effb82/windows/syscall.go
+
+sys-5acd03effb82/windows/syscall_windows.go
+
+Copyright 2009 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+sys-5acd03effb82/plan9/mkall.sh
+
+sys-5acd03effb82/plan9/mkerrors.sh
+
+sys-5acd03effb82/plan9/mksysnum_plan9.sh
+
+sys-5acd03effb82/unix/mkall.sh
+
+sys-5acd03effb82/unix/mkerrors.sh
+
+Copyright 2009 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+sys-5acd03effb82/unix/env_unix.go
+
+sys-5acd03effb82/windows/env_windows.go
+
+Copyright 2010 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+sys-5acd03effb82/plan9/env_plan9.go
+
+sys-5acd03effb82/plan9/errors_plan9.go
+
+sys-5acd03effb82/plan9/syscall_plan9.go
+
+sys-5acd03effb82/unix/sockcmsg_linux.go
+
+sys-5acd03effb82/unix/sockcmsg_unix.go
+
+sys-5acd03effb82/windows/dll_windows.go
+
+sys-5acd03effb82/windows/types_windows_386.go
+
+sys-5acd03effb82/windows/types_windows_amd64.go
+
+sys-5acd03effb82/windows/types_windows.go
+
+Copyright 2011 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+sys-5acd03effb82/plan9/dir_plan9.go
+
+sys-5acd03effb82/plan9/race0.go
+
+sys-5acd03effb82/plan9/race.go
+
+sys-5acd03effb82/unix/asm_freebsd_arm.s
+
+sys-5acd03effb82/unix/creds_test.go
+
+sys-5acd03effb82/unix/race0.go
+
+sys-5acd03effb82/unix/race.go
+
+sys-5acd03effb82/unix/syscall_freebsd_arm.go
+
+sys-5acd03effb82/windows/eventlog.go
+
+sys-5acd03effb82/windows/race0.go
+
+sys-5acd03effb82/windows/race.go
+
+sys-5acd03effb82/windows/security_windows.go
+
+sys-5acd03effb82/windows/service.go
+
+sys-5acd03effb82/windows/svc/debug/log.go
+
+sys-5acd03effb82/windows/svc/debug/service.go
+
+sys-5acd03effb82/windows/svc/event.go
+
+sys-5acd03effb82/windows/svc/eventlog/install.go
+
+sys-5acd03effb82/windows/svc/eventlog/log.go
+
+sys-5acd03effb82/windows/svc/eventlog/log_test.go
+
+sys-5acd03effb82/windows/svc/example/beep.go
+
+sys-5acd03effb82/windows/svc/example/install.go
+
+sys-5acd03effb82/windows/svc/example/main.go
+
+sys-5acd03effb82/windows/svc/example/manage.go
+
+sys-5acd03effb82/windows/svc/example/service.go
+
+sys-5acd03effb82/windows/svc/go12.c
+
+sys-5acd03effb82/windows/svc/mgr/config.go
+
+sys-5acd03effb82/windows/svc/mgr/mgr.go
+
+sys-5acd03effb82/windows/svc/mgr/mgr_test.go
+
+sys-5acd03effb82/windows/svc/mgr/service.go
+
+sys-5acd03effb82/windows/svc/security.go
+
+sys-5acd03effb82/windows/svc/service.go
+
+sys-5acd03effb82/windows/svc/svc_test.go
+
+sys-5acd03effb82/windows/svc/sys_386.s
+
+sys-5acd03effb82/windows/svc/sys_amd64.s
+
+sys-5acd03effb82/windows/syscall_windows_test.go
+
+Copyright 2012 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+sys-5acd03effb82/plan9/syscall_test.go
+
+sys-5acd03effb82/unix/asm_netbsd_arm.s
+
+sys-5acd03effb82/unix/syscall_netbsd_arm.go
+
+sys-5acd03effb82/unix/syscall_test.go
+
+sys-5acd03effb82/unix/syscall_unix_test.go
+
+sys-5acd03effb82/windows/mkwinsyscall/mkwinsyscall.go
+
+sys-5acd03effb82/windows/syscall_test.go
+
+Copyright 2013 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+sys-5acd03effb82/plan9/asm.s
+
+sys-5acd03effb82/unix/asm_linux_ppc64x.s
+
+sys-5acd03effb82/unix/asm_solaris_amd64.s
+
+sys-5acd03effb82/unix/fcntl.go
+
+sys-5acd03effb82/unix/fcntl_linux_32bit.go
+
+sys-5acd03effb82/unix/mmap_unix_test.go
+
+sys-5acd03effb82/unix/syscall_bsd_test.go
+
+sys-5acd03effb82/unix/syscall_freebsd_test.go
+
+sys-5acd03effb82/windows/svc/go12.go
+
+sys-5acd03effb82/windows/svc/go13.go
+
+Copyright 2014 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+sys-5acd03effb82/plan9/pwd_go15_plan9.go
+
+sys-5acd03effb82/plan9/pwd_plan9.go
+
+sys-5acd03effb82/unix/asm_darwin_arm64.s
+
+sys-5acd03effb82/unix/asm_darwin_arm.s
+
+sys-5acd03effb82/unix/asm_linux_arm64.s
+
+sys-5acd03effb82/unix/asm_linux_mips64x.s
+
+sys-5acd03effb82/unix/constants.go
+
+sys-5acd03effb82/unix/export_test.go
+
+sys-5acd03effb82/unix/gccgo_c.c
+
+sys-5acd03effb82/unix/gccgo.go
+
+sys-5acd03effb82/unix/gccgo_linux_amd64.go
+
+sys-5acd03effb82/unix/syscall_darwin_arm64.go
+
+sys-5acd03effb82/unix/syscall_darwin_arm.go
+
+sys-5acd03effb82/unix/syscall_linux_arm64.go
+
+sys-5acd03effb82/unix/syscall_linux_mips64x.go
+
+sys-5acd03effb82/windows/registry/export_test.go
+
+sys-5acd03effb82/windows/registry/key.go
+
+sys-5acd03effb82/windows/registry/mksyscall.go
+
+sys-5acd03effb82/windows/registry/registry_test.go
+
+sys-5acd03effb82/windows/registry/syscall.go
+
+sys-5acd03effb82/windows/registry/value.go
+
+Copyright 2015 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+sys-5acd03effb82/unix/asm_linux_mipsx.s
+
+sys-5acd03effb82/unix/asm_linux_s390x.s
+
+sys-5acd03effb82/unix/bluetooth_linux.go
+
+sys-5acd03effb82/unix/endian_big.go
+
+sys-5acd03effb82/unix/endian_little.go
+
+sys-5acd03effb82/unix/mkpost.go
+
+sys-5acd03effb82/unix/openbsd_test.go
+
+sys-5acd03effb82/unix/pledge_openbsd.go
+
+sys-5acd03effb82/unix/syscall_linux_amd64_gc.go
+
+sys-5acd03effb82/unix/syscall_linux_mipsx.go
+
+sys-5acd03effb82/unix/syscall_linux_s390x.go
+
+sys-5acd03effb82/unix/syscall_linux_test.go
+
+sys-5acd03effb82/unix/syscall_unix_gc.go
+
+Copyright 2016 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+sys-5acd03effb82/unix/asm_openbsd_arm.s
+
+sys-5acd03effb82/unix/cap_freebsd.go
+
+sys-5acd03effb82/unix/dev_darwin.go
+
+sys-5acd03effb82/unix/dev_dragonfly.go
+
+sys-5acd03effb82/unix/dev_freebsd.go
+
+sys-5acd03effb82/unix/dev_linux.go
+
+sys-5acd03effb82/unix/dev_linux_test.go
+
+sys-5acd03effb82/unix/dev_netbsd.go
+
+sys-5acd03effb82/unix/dev_openbsd.go
+
+sys-5acd03effb82/unix/errors_freebsd_386.go
+
+sys-5acd03effb82/unix/errors_freebsd_amd64.go
+
+sys-5acd03effb82/unix/errors_freebsd_arm.go
+
+sys-5acd03effb82/unix/linux/mkall.go
+
+sys-5acd03effb82/unix/pagesize_unix.go
+
+sys-5acd03effb82/unix/syscall_openbsd_arm.go
+
+sys-5acd03effb82/unix/syscall_solaris_test.go
+
+sys-5acd03effb82/unix/timestruct.go
+
+sys-5acd03effb82/unix/timestruct_test.go
+
+sys-5acd03effb82/windows/memory_windows.go
+
+Copyright 2017 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+sys-5acd03effb82/cpu/asm_aix_ppc64.s
+
+sys-5acd03effb82/cpu/cpu_arm.go
+
+sys-5acd03effb82/cpu/cpu_gccgo_x86.c
+
+sys-5acd03effb82/cpu/cpu_gccgo_x86.go
+
+sys-5acd03effb82/cpu/cpu_gc_x86.go
+
+sys-5acd03effb82/cpu/cpu.go
+
+sys-5acd03effb82/cpu/cpu_linux_arm64.go
+
+sys-5acd03effb82/cpu/cpu_linux.go
+
+sys-5acd03effb82/cpu/cpu_linux_ppc64x.go
+
+sys-5acd03effb82/cpu/cpu_mips64x.go
+
+sys-5acd03effb82/cpu/cpu_mipsx.go
+
+sys-5acd03effb82/cpu/cpu_test.go
+
+sys-5acd03effb82/cpu/cpu_x86.go
+
+sys-5acd03effb82/cpu/cpu_x86.s
+
+sys-5acd03effb82/plan9/mksyscall.go
+
+sys-5acd03effb82/unix/affinity_linux.go
+
+sys-5acd03effb82/unix/aliases.go
+
+sys-5acd03effb82/unix/asm_aix_ppc64.s
+
+sys-5acd03effb82/unix/asm_freebsd_arm64.s
+
+sys-5acd03effb82/unix/darwin_test.go
+
+sys-5acd03effb82/unix/dev_aix_ppc64.go
+
+sys-5acd03effb82/unix/dev_aix_ppc.go
+
+sys-5acd03effb82/unix/example_exec_test.go
+
+sys-5acd03effb82/unix/example_flock_test.go
+
+sys-5acd03effb82/unix/ioctl.go
+
+sys-5acd03effb82/unix/linux/mksysnum.go
+
+sys-5acd03effb82/unix/mkasm_darwin.go
+
+sys-5acd03effb82/unix/mksyscall.go
+
+sys-5acd03effb82/unix/mksysnum.go
+
+sys-5acd03effb82/unix/sendfile_test.go
+
+sys-5acd03effb82/unix/syscall_aix.go
+
+sys-5acd03effb82/unix/syscall_aix_ppc64.go
+
+sys-5acd03effb82/unix/syscall_aix_ppc.go
+
+sys-5acd03effb82/unix/syscall_aix_test.go
+
+sys-5acd03effb82/unix/syscall_darwin_libSystem.go
+
+sys-5acd03effb82/unix/syscall_darwin_test.go
+
+sys-5acd03effb82/unix/syscall_freebsd_arm64.go
+
+sys-5acd03effb82/unix/syscall_linux_gc_386.go
+
+sys-5acd03effb82/unix/syscall_linux_gccgo_386.go
+
+sys-5acd03effb82/unix/syscall_linux_gccgo_arm.go
+
+sys-5acd03effb82/unix/syscall_linux_gc.go
+
+sys-5acd03effb82/unix/syscall_linux_riscv64.go
+
+sys-5acd03effb82/unix/syscall_netbsd_test.go
+
+sys-5acd03effb82/unix/syscall_openbsd_test.go
+
+sys-5acd03effb82/unix/syscall_unix_gc_ppc64x.go
+
+sys-5acd03effb82/unix/types_aix.go
+
+sys-5acd03effb82/unix/unveil_openbsd.go
+
+sys-5acd03effb82/unix/xattr_bsd.go
+
+sys-5acd03effb82/unix/xattr_test.go
+
+sys-5acd03effb82/windows/aliases.go
+
+sys-5acd03effb82/windows/svc/mgr/recovery.go
+
+sys-5acd03effb82/windows/svc/sys_arm.s
+
+sys-5acd03effb82/windows/types_windows_arm.go
+
+Copyright 2018 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+sys-5acd03effb82/cpu/byteorder.go
+
+sys-5acd03effb82/cpu/cpu_aix.go
+
+sys-5acd03effb82/cpu/cpu_arm64.go
+
+sys-5acd03effb82/cpu/cpu_arm64.s
+
+sys-5acd03effb82/cpu/cpu_gc_arm64.go
+
+sys-5acd03effb82/cpu/cpu_gccgo_arm64.go
+
+sys-5acd03effb82/cpu/cpu_gccgo_s390x.go
+
+sys-5acd03effb82/cpu/cpu_gc_s390x.go
+
+sys-5acd03effb82/cpu/cpu_linux_arm.go
+
+sys-5acd03effb82/cpu/cpu_linux_noinit.go
+
+sys-5acd03effb82/cpu/cpu_linux_s390x.go
+
+sys-5acd03effb82/cpu/cpu_other_arm64.go
+
+sys-5acd03effb82/cpu/cpu_riscv64.go
+
+sys-5acd03effb82/cpu/cpu_s390x.s
+
+sys-5acd03effb82/cpu/cpu_wasm.go
+
+sys-5acd03effb82/cpu/hwcap_linux.go
+
+sys-5acd03effb82/cpu/syscall_aix_ppc64_gc.go
+
+sys-5acd03effb82/unix/asm_linux_riscv64.s
+
+sys-5acd03effb82/unix/asm_netbsd_arm64.s
+
+sys-5acd03effb82/unix/asm_openbsd_arm64.s
+
+sys-5acd03effb82/unix/dirent_test.go
+
+sys-5acd03effb82/unix/fcntl_darwin.go
+
+sys-5acd03effb82/unix/fdset.go
+
+sys-5acd03effb82/unix/fdset_test.go
+
+sys-5acd03effb82/unix/getdirentries_test.go
+
+sys-5acd03effb82/unix/mksyscall_aix_ppc64.go
+
+sys-5acd03effb82/unix/mksyscall_aix_ppc.go
+
+sys-5acd03effb82/unix/mksyscall_solaris.go
+
+sys-5acd03effb82/unix/mksysctl_openbsd.go
+
+sys-5acd03effb82/unix/readdirent_getdents.go
+
+sys-5acd03effb82/unix/readdirent_getdirentries.go
+
+sys-5acd03effb82/unix/sockcmsg_dragonfly.go
+
+sys-5acd03effb82/unix/sockcmsg_unix_other.go
+
+sys-5acd03effb82/unix/syscall_darwin.1_12.go
+
+sys-5acd03effb82/unix/syscall_darwin.1_13.go
+
+sys-5acd03effb82/unix/syscall_darwin_386.1_11.go
+
+sys-5acd03effb82/unix/syscall_darwin_amd64.1_11.go
+
+sys-5acd03effb82/unix/syscall_darwin_arm.1_11.go
+
+sys-5acd03effb82/unix/syscall_darwin_arm64.1_11.go
+
+sys-5acd03effb82/unix/syscall_internal_linux_test.go
+
+sys-5acd03effb82/unix/syscall_netbsd_arm64.go
+
+sys-5acd03effb82/unix/syscall_openbsd_arm64.go
+
+sys-5acd03effb82/windows/empty.s
+
+Copyright 2019 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+sys-5acd03effb82/windows/mkerrors.bash
+
+sys-5acd03effb82/windows/mkknownfolderids.bash
+
+Copyright 2019 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+>>> x_text-v0.3.2
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+>>> x_xerrors-5ec99f83aff1
+
+Found in: xerrors-5ec99f83aff1/LICENSE
+
+Copyright (c) 2019 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> BSD-3
+
+xerrors-5ec99f83aff1/errors.go
+
+xerrors-5ec99f83aff1/errors_test.go
+
+Copyright 2011 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+xerrors-5ec99f83aff1/example_test.go
+
+Copyright 2012 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+xerrors-5ec99f83aff1/adaptor.go
+
+xerrors-5ec99f83aff1/fmt.go
+
+xerrors-5ec99f83aff1/fmt_test.go
+
+xerrors-5ec99f83aff1/fmt_unexported_test.go
+
+xerrors-5ec99f83aff1/format.go
+
+xerrors-5ec99f83aff1/frame.go
+
+xerrors-5ec99f83aff1/internal/internal.go
+
+xerrors-5ec99f83aff1/stack_test.go
+
+xerrors-5ec99f83aff1/wrap.go
+
+xerrors-5ec99f83aff1/wrap_test.go
+
+Copyright 2018 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+xerrors-5ec99f83aff1/doc.go
+
+xerrors-5ec99f83aff1/example_As_test.go
+
+xerrors-5ec99f83aff1/example_FormatError_test.go
+
+xerrors-5ec99f83aff1/wrap_113_test.go
+
+Copyright 2019 The Go Authors.
+
+Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+--------------- SECTION 3: Mozilla Public License, V2.0 ----------
+
+Mozilla Public License, V2.0 is applicable to the following component(s).
+
+
+>>> hashicorp_errwrap-v1.0.0
+
+License : MPL 2.0
+
+>>> hashicorp_go-multierror-v1.1.0
+
+License : MPL 2.0
+
+
+=============== APPENDIX. Standard License Files ============== 
+
+
+
+--------------- SECTION 1: Apache License, V2.0 -----------
+
+Apache License 
+
+Version 2.0, January 2004 
+http://www.apache.org/licenses/ 
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the
+copyright owner that is granting the License.  
+
+"Legal Entity" shall mean the union of the acting entity and all other
+entities that control, are controlled by, or are under common control
+with that entity. For the purposes of this definition, "control" means
+(i) the power, direct or indirect, to cause the direction or management
+of such entity, whether by contract or otherwise, or (ii) ownership
+of fifty percent (50%) or more of the outstanding shares, or (iii)
+beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.  
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation source,
+and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation
+or translation of a Source form, including but not limited to compiled
+object code, generated documentation, and conversions to other media
+types.  
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a copyright
+notice that is included in or attached to the work (an example is provided
+in the Appendix below).  
+
+"Derivative Works" shall mean any work, whether in Source or Object form,
+that is based on (or derived from) the Work and for which the editorial
+revisions, annotations, elaborations, or other modifications represent,
+as a whole, an original work of authorship. For the purposes of this
+License, Derivative Works shall not include works that remain separable
+from, or merely link (or bind by name) to the interfaces of, the Work
+and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the
+original version of the Work and any modifications or additions to
+that Work or Derivative Works thereof, that is intentionally submitted
+to Licensor for inclusion in the Work by the copyright owner or by an
+individual or Legal Entity authorized to submit on behalf of the copyright
+owner. For the purposes of this definition, "submitted" means any form of
+electronic, verbal, or written communication sent to the Licensor or its
+representatives, including but not limited to communication on electronic
+mailing lists, source code control systems, and issue tracking systems
+that are managed by, or on behalf of, the Licensor for the purpose of
+discussing and improving the Work, but excluding communication that is
+conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License.
+Subject to the terms and conditions of this License, each Contributor
+hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable copyright license to reproduce, prepare
+Derivative Works of, publicly display, publicly perform, sublicense, and
+distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+Subject to the terms and conditions of this License, each Contributor
+hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty- free, irrevocable (except as stated in this section) patent
+license to make, have made, use, offer to sell, sell, import, and
+otherwise transfer the Work, where such license applies only to those
+patent claims licensable by such Contributor that are necessarily
+infringed by their Contribution(s) alone or by combination of
+their Contribution(s) with the Work to which such Contribution(s)
+was submitted. If You institute patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Work or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses granted
+to You under this License for that Work shall terminate as of the date
+such litigation is filed.
+
+4. Redistribution.
+You may reproduce and distribute copies of the Work or Derivative Works
+thereof in any medium, with or without modifications, and in Source or
+Object form, provided that You meet the following conditions:
+
+  a. You must give any other recipients of the Work or Derivative Works
+     a copy of this License; and
+
+  b. You must cause any modified files to carry prominent notices stating
+     that You changed the files; and
+
+  c. You must retain, in the Source form of any Derivative Works that
+     You distribute, all copyright, patent, trademark, and attribution
+     notices from the Source form of the Work, excluding those notices
+     that do not pertain to any part of the Derivative Works; and
+
+  d. If the Work includes a "NOTICE" text file as part of its
+     distribution, then any Derivative Works that You distribute must
+     include a readable copy of the attribution notices contained
+     within such NOTICE file, excluding those notices that do not
+     pertain to any part of the Derivative Works, in at least one of
+     the following places: within a NOTICE text file distributed as part
+     of the Derivative Works; within the Source form or documentation,
+     if provided along with the Derivative Works; or, within a display
+     generated by the Derivative Works, if and wherever such third-party
+     notices normally appear. The contents of the NOTICE file are for
+     informational purposes only and do not modify the License. You
+     may add Your own attribution notices within Derivative Works that
+     You distribute, alongside or as an addendum to the NOTICE text
+     from the Work, provided that such additional attribution notices
+     cannot be construed as modifying the License.  You may add Your own
+     copyright statement to Your modifications and may provide additional
+     or different license terms and conditions for use, reproduction, or
+     distribution of Your modifications, or for any such Derivative Works
+     as a whole, provided Your use, reproduction, and distribution of the
+     Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions.
+Unless You explicitly state otherwise, any Contribution intentionally
+submitted for inclusion in the Work by You to the Licensor shall be
+under the terms and conditions of this License, without any additional
+terms or conditions.  Notwithstanding the above, nothing herein shall
+supersede or modify the terms of any separate license agreement you may
+have executed with Licensor regarding such Contributions.
+
+6. Trademarks.
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+Unless required by applicable law or agreed to in writing, Licensor
+provides the Work (and each Contributor provides its Contributions) on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied, including, without limitation, any warranties or
+conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR
+A PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any risks
+associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability.
+In no event and under no legal theory, whether in tort (including
+negligence), contract, or otherwise, unless required by applicable law
+(such as deliberate and grossly negligent acts) or agreed to in writing,
+shall any Contributor be liable to You for damages, including any direct,
+indirect, special, incidental, or consequential damages of any character
+arising as a result of this License or out of the use or inability to
+use the Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all other
+commercial damages or losses), even if such Contributor has been advised
+of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+While redistributing the Work or Derivative Works thereof, You may
+choose to offer, and charge a fee for, acceptance of support, warranty,
+indemnity, or other liability obligations and/or rights consistent with
+this License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf of
+any other Contributor, and only if You agree to indemnify, defend, and
+hold each Contributor harmless for any liability incurred by, or claims
+asserted against, such Contributor by reason of your accepting any such
+warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+
+--------------- SECTION 2: Mozilla Public License, V2.0 -----------
+
+Mozilla Public License
+Version 2.0
+
+1. Definitions
+
+1.1. “Contributor”
+means each individual or legal entity that creates, contributes to the creation of, or owns Covered Software.
+
+1.2. “Contributor Version”
+means the combination of the Contributions of others (if any) used by a Contributor and that particular Contributor’s Contribution.
+
+1.3. “Contribution”
+means Covered Software of a particular Contributor.
+
+1.4. “Covered Software”
+means Source Code Form to which the initial Contributor has attached the notice in Exhibit A, the Executable Form of such Source Code Form, and Modifications of such Source Code Form, in each case including portions thereof.
+
+1.5. “Incompatible With Secondary Licenses”
+means
+
+that the initial Contributor has attached the notice described in Exhibit B to the Covered Software; or
+
+that the Covered Software was made available under the terms of version 1.1 or earlier of the License, but not also under the terms of a Secondary License.
+
+1.6. “Executable Form”
+means any form of the work other than Source Code Form.
+
+1.7. “Larger Work”
+means a work that combines Covered Software with other material, in a separate file or files, that is not Covered Software.
+
+1.8. “License”
+means this document.
+
+1.9. “Licensable”
+means having the right to grant, to the maximum extent possible, whether at the time of the initial grant or subsequently, any and all of the rights conveyed by this License.
+
+1.10. “Modifications”
+means any of the following:
+
+any file in Source Code Form that results from an addition to, deletion from, or modification of the contents of Covered Software; or
+
+any new file in Source Code Form that contains any Covered Software.
+
+1.11. “Patent Claims” of a Contributor
+means any patent claim(s), including without limitation, method, process, and apparatus claims, in any patent Licensable by such Contributor that would be infringed, but for the grant of the License, by the making, using, selling, offering for sale, having made, import, or transfer of either its Contributions or its Contributor Version.
+
+1.12. “Secondary License”
+means either the GNU General Public License, Version 2.0, the GNU Lesser General Public License, Version 2.1, the GNU Affero General Public License, Version 3.0, or any later versions of those licenses.
+
+1.13. “Source Code Form”
+means the form of the work preferred for making modifications.
+
+1.14. “You” (or “Your”)
+means an individual or a legal entity exercising rights under this License. For legal entities, “You” includes any entity that controls, is controlled by, or is under common control with You. For purposes of this definition, “control” means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or beneficial ownership of such entity.
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:
+
+under intellectual property rights (other than patent or trademark) Licensable by such Contributor to use, reproduce, make available, modify, display, perform, distribute, and otherwise exploit its Contributions, either on an unmodified basis, with Modifications, or as part of a Larger Work; and
+
+under Patent Claims of such Contributor to make, use, sell, offer for sale, have made, import, and otherwise transfer either its Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution become effective for each Contribution on the date the Contributor first distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under this License. No additional rights or licenses will be implied from the distribution or licensing of Covered Software under this License. Notwithstanding Section 2.1(b) above, no patent license is granted by a Contributor:
+
+for any code that a Contributor has removed from Covered Software; or
+
+for infringements caused by: (i) Your and any other third party’s modifications of Covered Software, or (ii) the combination of its Contributions with other software (except as part of its Contributor Version); or
+
+under Patent Claims infringed by Covered Software in the absence of its Contributions.
+
+This License does not grant any rights in the trademarks, service marks, or logos of any Contributor (except as may be necessary to comply with the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to distribute the Covered Software under a subsequent version of this License (see Section 10.2) or under the terms of a Secondary License (if permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its Contributions are its original creation(s) or it has sufficient rights to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under applicable copyright doctrines of fair use, fair dealing, or other equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in Section 2.1.
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any Modifications that You create or to which You contribute, must be under the terms of this License. You must inform recipients that the Source Code Form of the Covered Software is governed by the terms of this License, and how they can obtain a copy of this License. You may not attempt to alter or restrict the recipients’ rights in the Source Code Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+such Covered Software must also be made available in Source Code Form, as described in Section 3.1, and You must inform recipients of the Executable Form how they can obtain a copy of such Source Code Form by reasonable means in a timely manner, at a charge no more than the cost of distribution to the recipient; and
+
+You may distribute such Executable Form under the terms of this License, or sublicense it under different terms, provided that the license for the Executable Form does not attempt to limit or alter the recipients’ rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice, provided that You also comply with the requirements of this License for the Covered Software. If the Larger Work is a combination of Covered Software with a work governed by one or more Secondary Licenses, and the Covered Software is not Incompatible With Secondary Licenses, this License permits You to additionally distribute such Covered Software under the terms of such Secondary License(s), so that the recipient of the Larger Work may, at their option, further distribute the Covered Software under the terms of either this License or such Secondary License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices (including copyright notices, patent notices, disclaimers of warranty, or limitations of liability) contained within the Source Code Form of the Covered Software, except that You may alter any license notices to the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of Covered Software. However, You may do so only on Your own behalf, and not on behalf of any Contributor. You must make it absolutely clear that any such warranty, support, indemnity, or liability obligation is offered by You alone, and You hereby agree to indemnify every Contributor for any liability incurred by such Contributor as a result of warranty, support, indemnity or liability terms You offer. You may include additional disclaimers of warranty and limitations of liability specific to any jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+If it is impossible for You to comply with any of the terms of this License with respect to some or all of the Covered Software due to statute, judicial order, or regulation then You must: (a) comply with the terms of this License to the maximum extent possible; and (b) describe the limitations and the code they affect. Such description must be placed in a text file included with all distributions of the Covered Software under this License. Except to the extent prohibited by statute or regulation, such description must be sufficiently detailed for a recipient of ordinary skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You fail to comply with any of its terms. However, if You become compliant, then the rights granted under this License from a particular Contributor are reinstated (a) provisionally, unless and until such Contributor explicitly and finally terminates Your grants, and (b) on an ongoing basis, if such Contributor fails to notify You of the non-compliance by some reasonable means prior to 60 days after You have come back into compliance. Moreover, Your grants from a particular Contributor are reinstated on an ongoing basis if such Contributor notifies You of the non-compliance by some reasonable means, this is the first time You have received notice of non-compliance with this License from such Contributor, and You become compliant prior to 30 days after Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent infringement claim (excluding declaratory judgment actions, counter-claims, and cross-claims) alleging that a Contributor Version directly or indirectly infringes any patent, then the rights granted to You by any and all Contributors for the Covered Software under Section 2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user license agreements (excluding distributors and resellers) which have been validly granted by You or Your distributors under this License prior to termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+Covered Software is provided under this License on an “as is” basis, without warranty of any kind, either expressed, implied, or statutory, including, without limitation, warranties that the Covered Software is free of defects, merchantable, fit for a particular purpose or non-infringing. The entire risk as to the quality and performance of the Covered Software is with You. Should any Covered Software prove defective in any respect, You (not any Contributor) assume the cost of any necessary servicing, repair, or correction. This disclaimer of warranty constitutes an essential part of this License. No use of any Covered Software is authorized under this License except under this disclaimer.
+
+7. Limitation of Liability
+
+Under no circumstances and under no legal theory, whether tort (including negligence), contract, or otherwise, shall any Contributor, or anyone who distributes Covered Software as permitted above, be liable to You for any direct, indirect, special, incidental, or consequential damages of any character including, without limitation, damages for lost profits, loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses, even if such party shall have been informed of the possibility of such damages. This limitation of liability shall not apply to liability for death or personal injury resulting from such party’s negligence to the extent applicable law prohibits such limitation. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so this exclusion and limitation may not apply to You.
+
+8. Litigation
+
+Any litigation relating to this License may be brought only in the courts of a jurisdiction where the defendant maintains its principal place of business and such litigation shall be governed by laws of that jurisdiction, without reference to its conflict-of-law provisions. Nothing in this Section shall prevent a party’s ability to bring cross-claims or counter-claims.
+
+9. Miscellaneous
+
+This License represents the complete agreement concerning the subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable. Any law or regulation which provides that the language of a contract shall be construed against the drafter shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section 10.3, no one other than the license steward has the right to modify or publish new versions of this License. Each version will be given a distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version of the License under which You originally received the Covered Software, or under the terms of any subsequent version published by the license steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to create a new license for such software, you may create and use a modified version of this License if you rename the license and remove any references to the name of the license steward (except to note that such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With Secondary Licenses under the terms of this version of the License, the notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then You may include the notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.
+
+
+
+======================================================================
+
+To the extent any open source components are licensed under the GPL
+and/or LGPL, or other similar licenses that require the source code
+and/or modifications to source code to be made available (as would be
+noted above), you may obtain a copy of the source code corresponding to
+the binaries for such open source components and modifications thereto,
+if any, (the "Source Files"), by downloading the Source Files from
+VMware's website at http://www.vmware.com/download/open_source.html, or
+by sending a request, with your name and address to: VMware, Inc., 3401
+Hillview Avenue, Palo Alto, CA 94304, United States of America. All such
+requests should clearly specify: OPEN SOURCE FILES REQUEST, Attention
+General Counsel. VMware shall mail a copy of the Source Files to you on
+a CD or equivalent physical medium. This offer to obtain a copy of the
+Source Files is valid for three years from the date you acquired this
+Software product. Alternatively, the Source Files may accompany the
+VMware product.
+
+[GREENPLUMUPGRADE040BSR090120]


### PR DESCRIPTION
The main difference between enterprise and open source tarball is that the version command outputs the associated release type, and the enterprise tarball contains the open_source_licenses.txt file. Committing the license file is the recommended approach as that easily allows us to embed it in the RPM. The only slight gotcha is that we will need to update/commit a new license file before each release.

To allow the RELEASE type to be set the version string variables was enclosed inside the build target.

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:tarball)