### PR TITLE
update golang to 1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ pg_upgrade supports two upgrade modes: link and copy.
 
 ### Prerequisites
 
-- Golang. We currently develop against latest stable Golang, which was v1.14 as of April 2020.
+- Golang. We currently develop against latest stable Golang, which was v1.15 as of October 2020.
 - protoc. This is the compiler for the [gRPC protobuf](https://grpc.io/) 
 system which can be installed on macOS with `brew install protobuf`.
 - Run `make && make depend-dev` to install other developer dependencies. Note 

--- a/ci/generated/pipeline.yml
+++ b/ci/generated/pipeline.yml
@@ -419,8 +419,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
         - name: terraform
         - name: ccp_src
@@ -437,8 +437,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
           - name: gpupgrade_src
           - name: cluster_env_files
@@ -516,8 +516,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
         - name: terraform
         - name: ccp_src
@@ -534,8 +534,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
           - name: gpupgrade_src
           - name: cluster_env_files
@@ -617,8 +617,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
         - name: terraform
         - name: ccp_src
@@ -636,8 +636,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
           - name: gpupgrade_src
           - name: cluster_env_files
@@ -719,8 +719,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
         - name: terraform
         - name: ccp_src
@@ -738,8 +738,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
           - name: gpupgrade_src
           - name: cluster_env_files
@@ -821,8 +821,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
         - name: terraform
         - name: ccp_src
@@ -841,8 +841,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
           - name: gpupgrade_src
           - name: cluster_env_files
@@ -924,8 +924,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
         - name: terraform
         - name: ccp_src
@@ -1012,8 +1012,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
         - name: terraform
         - name: ccp_src
@@ -1111,8 +1111,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
         - name: terraform
         - name: ccp_src
@@ -1131,8 +1131,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
           - name: gpupgrade_src
           - name: cluster_env_files
@@ -1214,8 +1214,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
         - name: terraform
         - name: ccp_src
@@ -1234,8 +1234,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
           - name: gpupgrade_src
           - name: cluster_env_files
@@ -1317,8 +1317,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
         - name: terraform
         - name: ccp_src
@@ -1405,8 +1405,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
         - name: terraform
         - name: ccp_src
@@ -1504,8 +1504,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
         - name: terraform
         - name: ccp_src
@@ -1524,8 +1524,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
           - name: gpupgrade_src
           - name: cluster_env_files
@@ -1598,8 +1598,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
           - name: terraform
           - name: ccp_src
@@ -1677,8 +1677,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
           - name: terraform
           - name: ccp_src
@@ -1760,8 +1760,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
           - name: terraform
           - name: ccp_src
@@ -1843,8 +1843,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
           - name: terraform
           - name: ccp_src
@@ -1913,7 +1913,7 @@ jobs:
           type: docker-image
           source:
             repository: golang
-            tag: '1.14'
+            tag: '1.15'
         inputs:
           - name: gpupgrade_src
           - name: bin_gpupgrade

--- a/ci/tasks/build.yml
+++ b/ci/tasks/build.yml
@@ -7,7 +7,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: '1.14'
+    tag: '1.15'
 
 inputs:
 - name: gpupgrade_src

--- a/ci/tasks/install-tests.yml
+++ b/ci/tasks/install-tests.yml
@@ -6,8 +6,8 @@ PLATFORM: linux
 image_resource:
   type: docker-image
   source:
-    repository: pivotaldata/centos-gpdb-dev
-    tag: "7-gcc6.2-llvm3.7"
+    repository: pivotaldata/gpdb6-centos7-test-golang
+    tag: "latest"
 
 inputs:
 - name: gpupgrade_src

--- a/ci/tasks/noinstall-tests.yml
+++ b/ci/tasks/noinstall-tests.yml
@@ -7,7 +7,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: '1.14'
+    tag: '1.15'
 
 inputs:
 - name: gpupgrade_src

--- a/ci/template.yml
+++ b/ci/template.yml
@@ -405,8 +405,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
         - name: terraform
         - name: ccp_src
@@ -436,8 +436,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
           - name: gpupgrade_src
           - name: cluster_env_files
@@ -522,8 +522,8 @@ jobs:
         image_resource:
           type: docker-image
           source:
-            repository: pivotaldata/centos-gpdb-dev
-            tag: "6-gcc6.2-llvm3.7"
+            repository: pivotaldata/gpdb6-centos7-test-golang
+            tag: "latest"
         inputs:
           - name: terraform
           - name: ccp_src
@@ -575,7 +575,7 @@ jobs:
           type: docker-image
           source:
             repository: golang
-            tag: '1.14'
+            tag: '1.15'
         inputs:
           - name: gpupgrade_src
           - name: bin_gpupgrade

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/greenplum-db/gpupgrade
 
-go 1.14
+go 1.15
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.4.1

--- a/test/goversion.bats
+++ b/test/goversion.bats
@@ -1,0 +1,13 @@
+#! /usr/bin/env bats
+#
+# Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+load helpers
+
+@test "gpupupgrade is compiled with golang version 1.15.X" {
+    local EXPECTED="gpupgrade: go1.15."
+    run go version gpupgrade
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ $EXPECTED ]] || fail "expected: $EXPECTED got: $output"
+}


### PR DESCRIPTION
Since golang is backward source compatible, we update to the current
latest version of golang for our gpupgrade compilation as well as
testing.

A test that makes sure the bats tests are run with this version of
golang is also included.  We were previously running a golang version
of 1.13.X, even though we were supposed to be on 1.14, so a test to
catch this in the future is in order.

We created a new docker image for this PR, pivotaldata/gpdb6-centos7-test-golang,
which is a GPDB run environment that contains golang 1.15 pre-installed.

After this PR is merged, the prod pipeline will be reflown. 