### PR TITLE
Fix name scripts

### DIFF
--- a/data_migration_scripts/complete/gen_complete_text_to_name_type_columns.sql
+++ b/data_migration_scripts/complete/gen_complete_text_to_name_type_columns.sql
@@ -1,31 +1,6 @@
 -- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
 -- SPDX-License-Identifier: Apache-2.0
 
--- Portions Copyright © 1996-2020, The PostgreSQL Global Development Group
---
--- Portions Copyright © 1994, The Regents of the University of California
---
--- Permission to use, copy, modify, and distribute this software and its
--- documentation for any purpose, without fee, and without a written
--- agreement is hereby granted, provided that the above copyright notice
--- and this paragraph and the following two paragraphs appear in all copies.
---
--- IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
--- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
--- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
--- EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY
--- OF SUCH DAMAGE.
---
--- THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
--- BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
--- A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS,
--- AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE,
--- SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
--- generate ALTER TABLE ALTER COLUMN commands for tables with name datatype attributes
--- The DDL command to alter the name datatype is executed on root partitions and
--- non-partitioned tables. The ALTER command executed on root partitions cascades
--- to child partitions, and thus are excluded here.
 WITH distcols as
 (
    SELECT
@@ -43,7 +18,7 @@ partitionedKeys as
 )
 SELECT 'DO $$ BEGIN ALTER TABLE ' || c.oid::pg_catalog.regclass ||
        ' ALTER COLUMN ' || pg_catalog.quote_ident(a.attname) ||
-       ' TYPE VARCHAR(63); EXCEPTION WHEN feature_not_supported THEN PERFORM pg_temp.notsupported(''' || c.oid::pg_catalog.regclass || '''); END $$;'
+       ' TYPE NAME; EXCEPTION WHEN feature_not_supported THEN PERFORM pg_temp.notsupported(''' || c.oid::pg_catalog.regclass || '''); END $$;'
 FROM
    pg_catalog.pg_class c
    JOIN

--- a/data_migration_scripts/revert/gen_revert_text_to_name_type_columns.sql
+++ b/data_migration_scripts/revert/gen_revert_text_to_name_type_columns.sql
@@ -1,31 +1,6 @@
 -- Copyright (c) 2017-2020 VMware, Inc. or its affiliates
 -- SPDX-License-Identifier: Apache-2.0
 
--- Portions Copyright © 1996-2020, The PostgreSQL Global Development Group
---
--- Portions Copyright © 1994, The Regents of the University of California
---
--- Permission to use, copy, modify, and distribute this software and its
--- documentation for any purpose, without fee, and without a written
--- agreement is hereby granted, provided that the above copyright notice
--- and this paragraph and the following two paragraphs appear in all copies.
---
--- IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
--- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
--- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
--- EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY
--- OF SUCH DAMAGE.
---
--- THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
--- BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
--- A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS,
--- AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE,
--- SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-
--- generate ALTER TABLE ALTER COLUMN commands for tables with name datatype attributes
--- The DDL command to alter the name datatype is executed on root partitions and
--- non-partitioned tables. The ALTER command executed on root partitions cascades
--- to child partitions, and thus are excluded here.
 WITH distcols as
 (
    SELECT
@@ -43,7 +18,7 @@ partitionedKeys as
 )
 SELECT 'DO $$ BEGIN ALTER TABLE ' || c.oid::pg_catalog.regclass ||
        ' ALTER COLUMN ' || pg_catalog.quote_ident(a.attname) ||
-       ' TYPE VARCHAR(63); EXCEPTION WHEN feature_not_supported THEN PERFORM pg_temp.notsupported(''' || c.oid::pg_catalog.regclass || '''); END $$;'
+       ' TYPE NAME; EXCEPTION WHEN feature_not_supported THEN PERFORM pg_temp.notsupported(''' || c.oid::pg_catalog.regclass || '''); END $$;'
 FROM
    pg_catalog.pg_class c
    JOIN

--- a/data_migration_scripts/start/gen_alter_name_type_columns.header
+++ b/data_migration_scripts/start/gen_alter_name_type_columns.header
@@ -1,8 +1,16 @@
 -- The below SQL alters, where possible, the name data type to varchar(63)
--- in columns other than the first.  For a partition table, SQL is only generated
--- for root partitions as that cascades to the child partitions. Where not possible,
--- a message is logged, and such tables must be manually modified to remove the name
--- data type prior to running gpugprade.
+-- in columns other than the first.
+-- For a partition table, SQL is only generated for root partitions as that
+-- cascades to the child partitions.
+-- SQL statements are not generated for distribution columns with name data type,
+-- one can alter the datatype using the below steps:
+--   1. ALTER TABLE <tablename> SET DISTRIBUTED RANDOMLY;
+--   2. ALTER TABLE <tablename> ALTER COLUMN <columnname> TYPE VARCHAR(63);
+--   3. ALTER TABLE <tablename> SET DISTRIBUTED BY (columnname);
+-- SQL statements are not generated for partitioning columns with name data type, one
+-- has to manually recreate the table with datatype other than name such as varchar(63).
+-- Where not possible, a message is logged, and such tables must be manually
+-- modified to remove the name data type prior to running gpugprade.
 
 \set VERBOSITY terse
 

--- a/data_migration_scripts/test/create_nonupgradable_objects.sql
+++ b/data_migration_scripts/test/create_nonupgradable_objects.sql
@@ -114,6 +114,32 @@ CREATE TABLE partition_table_partitioned_by_name_type(a int, b name) PARTITION B
 DROP TABLE IF EXISTS table_distributed_by_name_type;
 CREATE TABLE table_distributed_by_name_type(a int, b name) DISTRIBUTED BY (b);
 INSERT INTO table_distributed_by_name_type VALUES (1,'z'),(2,'x');
+-- create table / views with name dataype
+CREATE TABLE t1_with_name(a name, b name) DISTRIBUTED RANDOMLY;
+INSERT INTO t1_with_name SELECT 'aaa', 'bbb';
+CREATE TABLE t2_with_name(a int, b name) DISTRIBUTED RANDOMLY;
+INSERT INTO t2_with_name SELECT 1, 'bbb';
+CREATE VIEW v2_on_t2_with_name AS SELECT * FROM t2_with_name;
+-- multilevel partition table with partitioning keys using name datatype
+CREATE TABLE multilevel_part_with_partition_col_name_datatype (trans_id int, country name, amount decimal(9,2), region name)
+DISTRIBUTED BY (trans_id)
+PARTITION BY LIST (country)
+SUBPARTITION BY LIST (region)
+SUBPARTITION TEMPLATE
+( SUBPARTITION south VALUES ('south'),
+    DEFAULT SUBPARTITION other_regions)
+    (PARTITION usa VALUES ('usa'),
+    DEFAULT PARTITION outlying_country );
+-- multilevel partition table with partitioning keys using not using name datatype
+CREATE TABLE multilevel_part_with_partition_col_text_datatype (trans_id int, country text, state name, region text)
+DISTRIBUTED BY (trans_id)
+PARTITION BY LIST (country)
+SUBPARTITION BY LIST (region)
+SUBPARTITION TEMPLATE
+( SUBPARTITION south VALUES ('south'),
+    DEFAULT SUBPARTITION other_regions)
+    (PARTITION usa VALUES ('usa'),
+    DEFAULT PARTITION outlying_country );
 
 -- create tables with tsquery datatype
 DROP TABLE IF EXISTS table_with_tsquery_datatype_columns;

--- a/test/migration_scripts.bats
+++ b/test/migration_scripts.bats
@@ -48,6 +48,9 @@ drop_unfixable_objects() {
     $GPHOME_SOURCE/bin/psql -d $TEST_DBNAME -p $PGPORT -c "DROP TABLE table_with_primary_constraint_p;"
     $GPHOME_SOURCE/bin/psql -d $TEST_DBNAME -p $PGPORT -c "DROP TABLE partition_table_partitioned_by_name_type;"
     $GPHOME_SOURCE/bin/psql -d $TEST_DBNAME -p $PGPORT -c "DROP TABLE table_distributed_by_name_type;"
+    $GPHOME_SOURCE/bin/psql -d $TEST_DBNAME -p $PGPORT -c "DROP VIEW v2_on_t2_with_name;"
+    $GPHOME_SOURCE/bin/psql -d $TEST_DBNAME -p $PGPORT -c "DROP TABLE t2_with_name;"
+    $GPHOME_SOURCE/bin/psql -d $TEST_DBNAME -p $PGPORT -c "DROP TABLE multilevel_part_with_partition_col_name_datatype;"
 }
 
 @test "migration scripts generate sql to modify non-upgradeable objects and fix pg_upgrade check errors" {


### PR DESCRIPTION
This PR contains couple of commits which does the following
1. Only pulls relkind = 'r' from pg_class else alter table statement was created for views which is incorrect.
2. Excludes relations which has views on it, as alter will fail on those tables
3. Exclude sql statements for altering distribution keys as they also fail when executed.
4. Exclude sql statements for altering partition keys as they will also fail when executed