### PR TITLE
revert: update RevertHelp text to match actual substeps run

### DIFF
--- a/cli/commands/help_text.go
+++ b/cli/commands/help_text.go
@@ -57,12 +57,15 @@ func init() {
 	RevertHelp = GenerateHelpString(revertHelp, []idl.Substep{
 		idl.Substep_SHUTDOWN_TARGET_CLUSTER,
 		idl.Substep_DELETE_TARGET_CLUSTER_DATADIRS,
+		idl.Substep_DELETE_TABLESPACES,
+		idl.Substep_RESTORE_PGCONTROL,
+		idl.Substep_RESTORE_SOURCE_CLUSTER,
+		idl.Substep_START_SOURCE_CLUSTER,
+		idl.Substep_RECOVERSEG_SOURCE_CLUSTER,
+		idl.Substep_ARCHIVE_LOG_DIRECTORIES,
 		idl.Substep_DELETE_SEGMENT_STATEDIRS,
 		idl.Substep_STOP_HUB_AND_AGENTS,
 		idl.Substep_DELETE_MASTER_STATEDIR,
-		idl.Substep_ARCHIVE_LOG_DIRECTORIES,
-		idl.Substep_RESTORE_SOURCE_CLUSTER,
-		idl.Substep_START_SOURCE_CLUSTER,
 	})
 	Help = map[string]string{
 		"initialize": InitializeHelp,


### PR DESCRIPTION
The list of substeps was outdated; this is what it does now, if all substeps are run.  This assumes link mode and a 5X source cluster that requires recoverseg.  This seems like the right thing to do because, if those extra steps are not run, they are "done" as no-ops implicitly.  That is, the revert will work.

Note `Re-enable source cluster` is for restoring pg_control(`idl.Substep_RESTORE_PGCONTROL`) and `Restore Source Cluster` is for `idl.Substep_RESTORE_SOURCE_CLUSTER`, but the similarity in their step descriptions is coincidental so I leave both.

```
Revert will carry out some or all of the following steps:
 - Stop target cluster
 - Delete target cluster data directories
 - Delete target tablespace directories
 - Re-enable source cluster
 - Restore source cluster
 - Start source cluster
 - Recover source cluster mirrors
 - Archive log directories
 - Delete state directories on the segments
 - Stop hub and agents
 - Delete master state directory
```