### PR TITLE
add a unit test to validate that  initializeConfirmationText contains all gpugprade_config fields

### DIFF
--- a/cli/commands/confirmation_text_test.go
+++ b/cli/commands/confirmation_text_test.go
@@ -1,0 +1,32 @@
+//  Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+//  SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/greenplum-db/gpupgrade/testutils"
+)
+
+const GPUPGRADE_CONFIG="../../gpupgrade_config"
+
+func TestInitializeConfirmationText(t *testing.T) {
+	t.Run("contains all names defined in the example config file", func(t *testing.T){
+		config := testutils.MustReadFile(t, GPUPGRADE_CONFIG)
+
+		names, err := parseParams(strings.NewReader(config))
+		if err != nil {
+			t.Fatalf("unexpected error %#v", err)
+		}
+
+		// Since the confirmation text is free-form, there's not much parsing we can do
+		// other than make sure "name:" appears in the file somewhere.
+		for name := range names {
+			if !strings.Contains(initializeConfirmationText, name+ ":") {
+				t.Errorf("expected %q to contain %q", initializeConfirmationText, name)
+			}
+		}
+	})
+}


### PR DESCRIPTION
We make sure gppugrade_config is accurately represented in the confirmation dialog for initialize.

We refactor ParseConfig to separate out transforming the gpupgrade config file name from the corresponding flag name as well as erroring out on empty values.

This allows us to test the committed gpupgrade_config file, which has empty values to indicate to the user that they neeed to fill those in before running gpupgrade initialize.

This test was added because https://github.com/greenplum-db/gpupgrade/pull/497 added `use_hba_hostnames` to the config file but not to the confirmation text.  So we want to test this.