### PR TITLE
Fix precision diff

### DIFF
--- a/ci/scripts/filters/double_precision.go
+++ b/ci/scripts/filters/double_precision.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package filters
+
+import (
+	"regexp"
+	"strings"
+)
+
+func ReplacePrecision(line string) string {
+	excludeRegex := regexp.MustCompile(`VALUES.* WITH \(tablename|perform pg_sleep|time.sleep`)
+	if excludeRegex.MatchString(line) {
+		return line
+	}
+
+	floatRegex := regexp.MustCompile(`((?:^|[^\d\.]))(\d*)\.(\d+)((?:[^\d.]|$))`)
+	match := floatRegex.FindStringSubmatch(line)
+	for match != nil {
+		match[3] = ".XX"
+		line = strings.Replace(line, match[0], strings.Join(match[1:], ""), 1)
+		match = floatRegex.FindStringSubmatch(line)
+	}
+
+	return line
+}

--- a/ci/scripts/filters/double_precision_test.go
+++ b/ci/scripts/filters/double_precision_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package filters
+
+import "testing"
+
+func TestReplacePrecision(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			name: "returns the string as is if no replacement is performed",
+			line: "adfasdfasdf	127.90.90.1	12.",
+			want: "adfasdfasdf	127.90.90.1	12.",
+		},
+		{
+			name: "replaces precision values of floating point number in tab delimited data",
+			line: ".12	adfasdfasdf	127.90.90.1	12.12	.13",
+			want: ".XX	adfasdfasdf	127.90.90.1	12.XX	.XX",
+		},
+		{
+			name: "replaces comma separated values in parantheses brackets",
+			line: "(0.90000000000000002, 6.0999999999999996)",
+			want: "(0.XX, 6.XX)",
+		},
+		{
+			name: "replaces precision values in ddl clause",
+			line: "START (0::double precision) END (.89999999999999991::double precision) EVERY (1.2::double precision) WITH (tablename='multivarblock_parttab_1_prt_p1_2_prt_2', checksum=true, appendonly=true, orientation=column ) ",
+			want: "START (0::double precision) END (.XX::double precision) EVERY (1.XX::double precision) WITH (tablename='multivarblock_parttab_1_prt_p1_2_prt_2', checksum=true, appendonly=true, orientation=column ) ",
+		},
+		{
+			name: "replaces consecutive pairs of values in parentheses in square brackets",
+			line: "State Hwy 92                  Ramp\t[(-122.1204,37.267000000000003),(-1.123,3.271000000000001)]",
+			want: "State Hwy 92                  Ramp\t[(-122.XX,37.XX),(-1.XX,3.XX)]",
+		},
+		{
+			name: "replaces precision values in curly braces with single quotes",
+			line: "    large_content double precision[] DEFAULT '{1234567890.1199999,1234567890.11999993}'::double precision[] ",
+			want: "    large_content double precision[] DEFAULT '{1234567890.XX,1234567890.XX}'::double precision[] ",
+		},
+		{
+			name: "replaces precision values in curly braces",
+			line: "[0:1]={1.1000000000000001,2.2000000000000002,3}",
+			want: "[0:1]={1.XX,2.XX,3}",
+		},
+		{
+			name: "replaces consecutive pairs of values in parentheses brackets",
+			line: "0\tOakland\t((-122,37.899999999999999),(-121.7,37.899999999999999),(-121.7,37.399999999999999),(-122,37.399999999999999))",
+			want: "0\tOakland\t((-122,37.XX),(-121.XX,37.XX),(-121.XX,37.XX),(-122,37.XX))",
+		},
+		{
+			name: "excludes replacing precision values in ddl clause containing values function",
+			line: "VALUES(0.06, 0.01, 0.02, 0.07, 0.08) WITH (tablename='aopart_lineitem_1_prt_p2_2_prt_4_3_prt_5_4_prt_2', orientation=row, appendonly=true, checksum=false, compresstype=zlib, compresslevel=1 )",
+			want: "VALUES(0.06, 0.01, 0.02, 0.07, 0.08) WITH (tablename='aopart_lineitem_1_prt_p2_2_prt_4_3_prt_5_4_prt_2', orientation=row, appendonly=true, checksum=false, compresstype=zlib, compresslevel=1 )",
+		},
+		{
+			name: "excludes replacing precision values if the line contains perform pg_sleep",
+			line: "perform pg_sleep(0.05) [0:1]={1.23,2.45,3}",
+			want: "perform pg_sleep(0.05) [0:1]={1.23,2.45,3}",
+		},
+		{
+			name: "excludes replacing precision values if the line contains time.sleep",
+			line: "time.sleep(0.05) [0:1]={1.23,2.45,3}",
+			want: "time.sleep(0.05) [0:1]={1.23,2.45,3}",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ReplacePrecision(c.line)
+			if got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/ci/scripts/filters/formatting.go
+++ b/ci/scripts/filters/formatting.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package filters
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	Formatters       []formatter
+	LineRegexes      []*regexp.Regexp
+	BlockRegexes     []*regexp.Regexp
+	ReplacementFuncs []ReplacementFunc
+)
+
+// function to identify if the line matches a pattern
+type shouldFormatFunc func(line string) bool
+
+// function to create a formatted string using the tokens
+type formatFunc func(tokens []string) (string, error)
+
+// identifier and corresponding formatting function
+type formatter struct {
+	shouldFormat shouldFormatFunc
+	format       formatFunc
+}
+
+type ReplacementFunc func(line string) string
+
+// hold the current tokens for the formatting function
+type formatContext struct {
+	tokens     []string
+	formatFunc formatFunc
+}
+
+func NewFormattingContext() *formatContext {
+	return &formatContext{}
+}
+
+// is formatting currently in progress
+func (f *formatContext) Formatting() bool {
+	return f.formatFunc != nil
+}
+
+func (f *formatContext) AddTokens(line string) {
+	f.tokens = append(f.tokens, strings.Fields(line)...)
+}
+
+func EndFormatting(line string) bool {
+	return strings.Contains(line, ";")
+}
+
+func (f *formatContext) Format() (string, error) {
+	return f.formatFunc(f.tokens)
+}
+
+func (f *formatContext) Find(formatters []formatter, line string) {
+	if f.formatFunc != nil {
+		return
+	}
+
+	for _, x := range formatters {
+		if x.shouldFormat(line) {
+			f.formatFunc = x.format
+			break
+		}
+	}
+}

--- a/ci/scripts/filters/rules5x.go
+++ b/ci/scripts/filters/rules5x.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package filters
+
+func Init5x() {
+	ReplacementFuncs = []ReplacementFunc{
+		ReplacePrecision,
+	}
+}

--- a/ci/scripts/filters/rules6x.go
+++ b/ci/scripts/filters/rules6x.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package filters
+
+import (
+	"regexp"
+)
+
+func Init6x() {
+	// linePatterns remove exactly what is matched, on a line-by-line basis.
+	linePatterns := []string{
+		`ALTER DATABASE .+ SET gp_use_legacy_hashops TO 'on';`,
+		// TODO: There may be false positives because of the below
+		// pattern, and we might have to do a look ahead to really identify
+		// if it can be deleted.
+		`START WITH \d`,
+	}
+
+	// blockPatterns remove lines that match, AND any comments or whitespace
+	// immediately preceding them.
+	blockPatterns := []string{
+		"CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;",
+		"COMMENT ON EXTENSION plpgsql IS",
+		"COMMENT ON DATABASE postgres IS",
+	}
+
+	ReplacementFuncs = []ReplacementFunc{
+		FormatWithClause,
+		ReplacePrecision,
+	}
+
+	// patten matching functions and corresponding formatting functions
+	Formatters = []formatter{
+		{shouldFormat: IsViewOrRuleDdl, format: FormatViewOrRuleDdl},
+		{shouldFormat: IsTriggerDdl, format: FormatTriggerDdl},
+	}
+
+	for _, pattern := range linePatterns {
+		LineRegexes = append(LineRegexes, regexp.MustCompile(pattern))
+	}
+	for _, pattern := range blockPatterns {
+		BlockRegexes = append(BlockRegexes, regexp.MustCompile(pattern))
+	}
+}

--- a/ci/scripts/upgrade-cluster.bash
+++ b/ci/scripts/upgrade-cluster.bash
@@ -53,11 +53,18 @@ compare_dumps() {
             # First filter out any algorithmically-fixable differences, then
             # patch out the remaining expected diffs explicitly.
             ssh mdw "
-                /tmp/filter < '$target_dump' > '$target_dump.filtered'
+                /tmp/filter -version=6 -inputFile='$target_dump' > '$target_dump.filtered'
                 patch -R '$target_dump.filtered'
             " < ./ci/scripts/filters/${DIFF_FILE}
 
             target_dump="$target_dump.filtered"
+
+            # Run the filter on the source dump
+            ssh mdw "
+                /tmp/filter -version=5 -inputFile='$source_dump' > '$source_dump.filtered'
+            "
+
+            source_dump="$source_dump.filtered"
         fi
     popd
 


### PR DESCRIPTION
This PR does the following:
1. Refactor: Make the rules for greenplum 6x to its separate file

    This commit refactors the main filter driver and separates it in
    modules so that it's not tightly coupled with greenplum 6x. One can
    add a new rule for another version of greenplum and it will pick the
    specified rules.
2. Add filtering to replace precision values with .XX
3. Add rules for filtering 5x and 6x dump for precision values


