### PR TITLE
initialize: make init target cluster idempotent

### DIFF
--- a/hub/initialize.go
+++ b/hub/initialize.go
@@ -84,7 +84,12 @@ func (s *Server) InitializeCreateCluster(in *idl.InitializeCreateClusterRequest,
 	})
 
 	st.Run(idl.Substep_INIT_TARGET_CLUSTER, func(stream step.OutStreams) error {
-		err := s.CreateTargetCluster(stream)
+		err := s.RemoveTargetCluster(stream)
+		if err != nil {
+			return err
+		}
+
+		err = s.CreateTargetCluster(stream)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Stop any running target cluster processes and remove any dangling data directories before initializing the target cluster.

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:initTargetCluster)