### PR TITLE
Final diffs

### DIFF
--- a/ci/generated/pipeline.yml
+++ b/ci/generated/pipeline.yml
@@ -430,7 +430,6 @@ jobs:
         run:
           path: gpupgrade_src/ci/scripts/upgrade-cluster.bash
       params:
-        COMPARE_DIFF: 1
     - task: validate_mirrors_and_standby
       config:
         platform: linux
@@ -527,7 +526,6 @@ jobs:
         run:
           path: gpupgrade_src/ci/scripts/upgrade-cluster.bash
       params:
-        COMPARE_DIFF: 1
     - task: validate_mirrors_and_standby
       config:
         platform: linux
@@ -629,7 +627,6 @@ jobs:
           path: gpupgrade_src/ci/scripts/upgrade-cluster.bash
       params:
         FILTER_DIFF: 1
-        COMPARE_DIFF: 0
     - task: validate_mirrors_and_standby
       config:
         platform: linux
@@ -731,7 +728,6 @@ jobs:
           path: gpupgrade_src/ci/scripts/upgrade-cluster.bash
       params:
         FILTER_DIFF: 1
-        COMPARE_DIFF: 0
     - task: validate_mirrors_and_standby
       config:
         platform: linux
@@ -834,7 +830,6 @@ jobs:
       params:
         FILTER_DIFF: 1
         USE_LINK_MODE: 1
-        COMPARE_DIFF: 0
     - task: validate_mirrors_and_standby
       config:
         platform: linux
@@ -936,7 +931,6 @@ jobs:
           path: gpupgrade_src/ci/scripts/upgrade-cluster.bash
       params:
         FILTER_DIFF: 1
-        COMPARE_DIFF: 0
   ensure:
     <<: *set_failed
   on_success:
@@ -1024,7 +1018,6 @@ jobs:
           path: gpupgrade_src/ci/scripts/upgrade-cluster.bash
       params:
         FILTER_DIFF: 1
-        COMPARE_DIFF: 0
   ensure:
     <<: *set_failed
   on_success:
@@ -1124,7 +1117,6 @@ jobs:
       params:
         FILTER_DIFF: 1
         DIFF_FILE: retail_demo.diff
-        COMPARE_DIFF: 1
     - task: validate_mirrors_and_standby
       config:
         platform: linux
@@ -1227,7 +1219,6 @@ jobs:
       params:
         FILTER_DIFF: 1
         USE_LINK_MODE: 1
-        COMPARE_DIFF: 0
     - task: validate_mirrors_and_standby
       config:
         platform: linux
@@ -1329,7 +1320,6 @@ jobs:
           path: gpupgrade_src/ci/scripts/upgrade-cluster.bash
       params:
         FILTER_DIFF: 1
-        COMPARE_DIFF: 0
   ensure:
     <<: *set_failed
   on_success:
@@ -1417,7 +1407,6 @@ jobs:
           path: gpupgrade_src/ci/scripts/upgrade-cluster.bash
       params:
         FILTER_DIFF: 1
-        COMPARE_DIFF: 0
   ensure:
     <<: *set_failed
   on_success:
@@ -1517,7 +1506,6 @@ jobs:
       params:
         FILTER_DIFF: 1
         DIFF_FILE: retail_demo.diff
-        COMPARE_DIFF: 1
     - task: validate_mirrors_and_standby
       config:
         platform: linux

--- a/ci/scripts/filters/double_precision.go
+++ b/ci/scripts/filters/double_precision.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ReplacePrecision(line string) string {
-	excludeRegex := regexp.MustCompile(`VALUES.* WITH \(tablename|perform pg_sleep|time.sleep`)
+	excludeRegex := regexp.MustCompile(`VALUES.* WITH \(tablename|perform pg_sleep|time.sleep|COALESCE`)
 	if excludeRegex.MatchString(line) {
 		return line
 	}

--- a/ci/scripts/filters/filter/filter.go
+++ b/ci/scripts/filters/filter/filter.go
@@ -93,11 +93,11 @@ nextline:
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		formattingContext.Find(filters.Formatters, line)
+		formattingContext.Find(filters.Formatters, buf, line)
 		if formattingContext.Formatting() {
 			formattingContext.AddTokens(line)
 			if filters.EndFormatting(line) {
-				stmt, err := formattingContext.Format()
+				stmt, err := formattingContext.Format(buf)
 				if err != nil {
 					log.Fatalf("unexpected error: %#v", err)
 				}

--- a/ci/scripts/filters/formatting.go
+++ b/ci/scripts/filters/formatting.go
@@ -16,7 +16,7 @@ var (
 )
 
 // function to identify if the line matches a pattern
-type shouldFormatFunc func(line string) bool
+type shouldFormatFunc func(buf []string, line string) bool
 
 // function to create a formatted string using the tokens
 type formatFunc func(tokens []string) (string, error)
@@ -52,17 +52,17 @@ func EndFormatting(line string) bool {
 	return strings.Contains(line, ";")
 }
 
-func (f *formatContext) Format() (string, error) {
+func (f *formatContext) Format(buf []string) (string, error) {
 	return f.formatFunc(f.tokens)
 }
 
-func (f *formatContext) Find(formatters []formatter, line string) {
+func (f *formatContext) Find(formatters []formatter, buf []string, line string) {
 	if f.formatFunc != nil {
 		return
 	}
 
 	for _, x := range formatters {
-		if x.shouldFormat(line) {
+		if x.shouldFormat(buf, line) {
 			f.formatFunc = x.format
 			break
 		}

--- a/ci/scripts/filters/replacement.go
+++ b/ci/scripts/filters/replacement.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package filters
+
+import "regexp"
+
+type Replacer struct {
+	Regex       *regexp.Regexp
+	Replacement string
+}
+
+func (t *Replacer) replace(line string) string {
+	return t.Regex.ReplaceAllString(line, t.Replacement)
+}
+
+func InitReplacementRegex(patterns map[string]string) []*Replacer {
+	var replacer []*Replacer
+	for regex, replacement := range patterns {
+		replacer = append(replacer, &Replacer{
+			Regex:       regexp.MustCompile(regex),
+			Replacement: replacement,
+		})
+	}
+
+	return replacer
+}
+
+func Replacements(line string) string {
+	patterns := map[string]string{
+		`(DEFAULT.*[^B])('\d+')::"bit"`: `${1}B${2}::"bit"`,
+	}
+
+	replacer := InitReplacementRegex(patterns)
+	for _, r := range replacer {
+		line = r.replace(line)
+	}
+
+	return line
+}

--- a/ci/scripts/filters/replacement_test.go
+++ b/ci/scripts/filters/replacement_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package filters
+
+import (
+	"testing"
+)
+
+func TestReplacements(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		expected string
+	}{
+		{
+			name:     `append B to the pattern 'n'::"bit"`,
+			line:     `a39 bit(1) DEFAULT '0'::"bit" ENCODING`,
+			expected: `a39 bit(1) DEFAULT B'0'::"bit" ENCODING`,
+		},
+		{
+			name:     `append B to the pattern ('n'::"bit")`,
+			line:     `a40 bit varying(5) DEFAULT ('1'::"bit")::bit varying`,
+			expected: `a40 bit varying(5) DEFAULT (B'1'::"bit")::bit varying`,
+		},
+		{
+			name:     `does not append B to the pattern B'n'::"bit"`,
+			line:     `a39 bit(1) DEFAULT B'0'::"bit" ENCODING`,
+			expected: `a39 bit(1) DEFAULT B'0'::"bit" ENCODING`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := Replacements(tt.line)
+			if actual != tt.expected {
+				t.Errorf("got %v, expected %v", actual, tt.expected)
+			}
+		})
+	}
+}

--- a/ci/scripts/filters/rules6x.go
+++ b/ci/scripts/filters/rules6x.go
@@ -28,6 +28,7 @@ func Init6x() {
 	ReplacementFuncs = []ReplacementFunc{
 		FormatWithClause,
 		ReplacePrecision,
+		Replacements,
 	}
 
 	// patten matching functions and corresponding formatting functions

--- a/ci/scripts/filters/trigger.go
+++ b/ci/scripts/filters/trigger.go
@@ -6,16 +6,21 @@ package filters
 import (
 	"errors"
 	"regexp"
+	"strings"
 )
 
-var triggerCreateRegex *regexp.Regexp
+var (
+	triggerCommentRegex *regexp.Regexp
+	triggerCreateRegex  *regexp.Regexp
+)
 
 func init() {
+	triggerCommentRegex = regexp.MustCompile(`; Type: TRIGGER;`)
 	triggerCreateRegex = regexp.MustCompile(`CREATE TRIGGER `)
 }
 
-func IsTriggerDdl(line string) bool {
-	return triggerCreateRegex.MatchString(line)
+func IsTriggerDdl(buf []string, line string) bool {
+	return len(buf) > 0 && triggerCommentRegex.MatchString(strings.Join(buf, " ")) && triggerCreateRegex.MatchString(line)
 }
 
 func FormatTriggerDdl(tokens []string) (string, error) {

--- a/ci/scripts/filters/trigger_test.go
+++ b/ci/scripts/filters/trigger_test.go
@@ -9,36 +9,36 @@ import (
 
 func TestFormatTriggerDdl(t *testing.T) {
 	tests := []struct {
-		name    string
-		tokens  []string
-		want    string
-		wantErr bool
+		name        string
+		tokens      []string
+		expected    string
+		expectedErr bool
 	}{
 		{
 			name: "formats create trigger statement and body in to one line",
 			tokens: []string{"CREATE", "TRIGGER", "after_trigger", "AFTER", "INSERT", "OR", "DELETE", "ON",
 				"public.foo", "FOR", "EACH", "ROW", "EXECUTE", "PROCEDURE", "public.bfv_dml_error_func();"},
-			want:    "CREATE TRIGGER after_trigger\n    AFTER INSERT OR DELETE ON public.foo\n    FOR EACH ROW\n    EXECUTE PROCEDURE public.bfv_dml_error_func();",
-			wantErr: false,
+			expected:    "CREATE TRIGGER after_trigger\n    AFTER INSERT OR DELETE ON public.foo\n    FOR EACH ROW\n    EXECUTE PROCEDURE public.bfv_dml_error_func();",
+			expectedErr: false,
 		},
 		{
-			name:    "formats create trigger statement and body in to one line",
-			tokens:  []string{},
-			want:    "",
-			wantErr: true,
+			name:        "formats create trigger statement and body in to one line",
+			tokens:      []string{},
+			expected:    "",
+			expectedErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := FormatTriggerDdl(tt.tokens)
+			actual, err := FormatTriggerDdl(tt.tokens)
 
-			if err == nil && tt.wantErr {
+			if err == nil && tt.expectedErr {
 				t.Errorf("expect an error")
 			}
 
-			if got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
+			if actual != tt.expected {
+				t.Errorf("got %q, want %q", actual, tt.expected)
 			}
 		})
 	}
@@ -46,25 +46,28 @@ func TestFormatTriggerDdl(t *testing.T) {
 
 func TestIsTriggerDdl(t *testing.T) {
 	tests := []struct {
-		name   string
-		line   string
-		result bool
+		name     string
+		buf      []string
+		line     string
+		expected bool
 	}{
 		{
-			name:   "line contains create trigger statement",
-			line:   "CREATE TRIGGER mytrigger AS",
-			result: true,
+			name:     "line contains create trigger statement",
+			buf:      []string{"-- Name: mytrigger; Type: TRIGGER; Schema: public; Owner: gpadmin"},
+			line:     "CREATE TRIGGER mytrigger AS",
+			expected: true,
 		},
 		{
-			name:   "line does not create trigger statement",
-			line:   "CREATE TABLE mytable AS",
-			result: false,
+			name:     "line does not create trigger statement",
+			buf:      []string{"-- Name: mytable; Type: TABLE; Schema: public; Owner: gpadmin"},
+			line:     "CREATE TABLE mytable AS",
+			expected: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsTriggerDdl(tt.line); got != tt.result {
-				t.Errorf("got %t, want %t", got, tt.result)
+			if actual := IsTriggerDdl(tt.buf, tt.line); actual != tt.expected {
+				t.Errorf("got %t, want %t", actual, tt.expected)
 			}
 		})
 	}

--- a/ci/scripts/filters/view_and_rule_test.go
+++ b/ci/scripts/filters/view_and_rule_test.go
@@ -50,30 +50,34 @@ func TestFormatViewOrRuleDdl(t *testing.T) {
 
 func TestIsViewOrRuleDdl(t *testing.T) {
 	tests := []struct {
-		name   string
-		line   string
-		result bool
+		name     string
+		buf      []string
+		line     string
+		expected bool
 	}{
 		{
-			name:   "line contains create view statement",
-			line:   "CREATE VIEW myview AS",
-			result: true,
+			name:     "line contains create view statement",
+			buf:      []string{"-- Name: myview; Type: VIEW; Schema: public; Owner: gpadmin"},
+			line:     "CREATE VIEW myview AS",
+			expected: true,
 		},
 		{
-			name:   "line contains create rule statement",
-			line:   "CREATE RULE myrule AS",
-			result: true,
+			name:     "line contains create rule statement",
+			buf:      []string{"-- Name: myrule; Type: RULE; Schema: public; Owner: gpadmin"},
+			line:     "CREATE RULE myrule AS",
+			expected: true,
 		},
 		{
-			name:   "buffer does not contains view / rule identifier",
-			line:   "CREATE TABLE mytable AS",
-			result: false,
+			name:     "buffer does not contains view / rule identifier",
+			buf:      []string{"-- Name: myrule; Type: TABLE; Schema: public; Owner: gpadmin"},
+			line:     "CREATE TABLE mytable AS",
+			expected: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsViewOrRuleDdl(tt.line); got != tt.result {
-				t.Errorf("got %t, want %t", got, tt.result)
+			if actual := IsViewOrRuleDdl(tt.buf, tt.line); actual != tt.expected {
+				t.Errorf("got %t, want %t", actual, tt.expected)
 			}
 		})
 	}

--- a/ci/template.yml
+++ b/ci/template.yml
@@ -424,9 +424,6 @@ jobs:
         {{- end}}
         {{- if .RetailDemo}}
         DIFF_FILE: retail_demo.diff
-        COMPARE_DIFF: 1
-        {{- else }}
-        COMPARE_DIFF: {{if ne (majorVersion .Source) "5"}}1{{else}}0{{end}}
         {{- end }}
     {{- if not .NoStandby -}}
     {{- if not .PrimariesOnly }}


### PR DESCRIPTION
This PR does the following:
- Move replacement initialization to a common function
- Add replacement for bit varying pattern to match 5x format
- Use Buffer to ensure what we are formatting

    CREATE VIEW Statement could appear in the body of a function or as a
    standalone DDL in the dump. View formatting should not be done when it's
    in the body of the function, so use the buffer to ensure that only the
    standalone VIEW statement are being formatted. Same applies for triggers
    and rules.
- Exclude precision replacement in lines containing COALESCE, i.e line part of DDL statement
- reindex target database and run filter on the source and target dump before comparision

    During upgrade bitmap indexes are marked invalid, so reindex the target
    database so that pg_dumpall could dump their DDL. The DDL for bitmap
    indexes exists in source dump as they were valid before upgrade.
- remove compare diff variable




