### PR TITLE
build and verify rpm in CI

### DIFF
--- a/ci/generated/pipeline.yml
+++ b/ci/generated/pipeline.yml
@@ -27,6 +27,7 @@ resources:
   source:
     uri: ((gpupgrade-git-remote))
     branch: ((gpupgrade-git-branch))
+    fetch_tags: true
 
 
 - name: gpdb5_src
@@ -89,6 +90,20 @@ resources:
     bucket: ((cm-intermediates-bucket))
     json_key: ((cm-gcs-service-account-key))
     versioned_file: gpupgrade
+
+- name: rpm_gpupgrade_oss
+  type: gcs
+  source:
+    bucket: ((cm-intermediates-bucket))
+    json_key: ((cm-gcs-service-account-key))
+    regexp: oss/greenplum-upgrade-(.*).rpm
+
+- name: rpm_gpupgrade_enterprise
+  type: gcs
+  source:
+    bucket: ((cm-intermediates-bucket))
+    json_key: ((cm-gcs-service-account-key))
+    regexp: enterprise/greenplum-upgrade-(.*).rpm
 
 - name: bin_gpupgrade_rc
   type: gcs
@@ -267,9 +282,16 @@ jobs:
     trigger: true
   - task: build
     file: gpupgrade_src/ci/tasks/build.yml
-  - put: bin_gpupgrade
-    params:
-      file: build_artifacts/gpupgrade
+  - in_parallel:
+    - put: bin_gpupgrade
+      params:
+        file: build_artifacts/gpupgrade
+    - put: rpm_gpupgrade_oss
+      params:
+        file: build_artifacts_oss/greenplum-upgrade*.rpm
+    - put: rpm_gpupgrade_enterprise
+      params:
+        file: build_artifacts_enterprise/greenplum-upgrade*.rpm
   on_failure:
     <<: *slack_alert
 

--- a/ci/scripts/verify-rpm.bash
+++ b/ci/scripts/verify-rpm.bash
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux -o pipefail
+
+RPM=$1
+RELEASE=$2
+VERSION=$(git describe --tags --abbrev=0)
+
+verify_gpugprade_version_output() {
+  [[ $(/usr/local/greenplum-upgrade/gpupgrade version) == *"Version: ${VERSION}"* ]]
+  [[ $(/usr/local/greenplum-upgrade/gpupgrade version) == *"Release: ${RELEASE}"* ]]
+}
+
+verify_rpm_info() {
+  local info="$1"
+
+  [[ $info == *"Name        : greenplum-upgrade"* ]]
+  [[ $info == *"Architecture: x86_64"* ]]
+  [[ $info == *"Source RPM  : greenplum-upgrade-${VERSION}-1"* ]]
+  [[ $info == *"URL         : https://github.com/greenplum-db/gpupgrade"* ]]
+
+  if [ "$RELEASE" = "Open Source" ]; then
+      [[ $info == *"License     : Apache 2.0"* ]]
+      [[ $info == *"Summary     : Greenplum Database Upgrade"* ]]
+      return
+  fi
+
+  [[ $info == *"License     : VMware Software EULA"* ]]
+  [[ $info == *"Summary     : VMware Tanzu Greenplum Upgrade"* ]]
+}
+
+verify_license_files() {
+  if [ "$RELEASE" = "Open Source" ]; then
+      [ ! -s "/usr/share/licenses/greenplum-upgrade*/open_source_licenses.txt" ]
+      [ ! -s "/usr/local/greenplum-upgrade/open_source_licenses.txt" ]
+      return
+  fi
+
+  # For ENTERPRISE release, sanity check the license file
+  [ -s "/usr/share/licenses/greenplum-upgrade-${VERSION}/open_source_licenses.txt" ]
+
+  local license_file="/usr/local/greenplum-upgrade/open_source_licenses.txt"
+  [ -s "$license_file" ]
+
+  [[ $(head -1 "$license_file") =~ open_source_licenses.txt ]]
+  [[ $(head -3 "$license_file" | tail -1) == *"VMware Tanzu Greenplum Upgrade ${VERSION}"* ]]
+  [[ $(tail -1 "$license_file") =~ "GREENPLUMUPGRADE" ]]
+}
+
+main() {
+  [ -f "$RPM" ]
+  [ "$RELEASE" = "Enterprise" ] || [ "$RELEASE" = "Open Source" ]
+
+  rpm -ivh "$RPM"
+  verify_gpugprade_version_output
+  verify_rpm_info "$(rpm -qi greenplum-upgrade)"
+  verify_license_files
+
+  rpm -ev greenplum-upgrade
+}
+
+main

--- a/ci/tasks/build.yml
+++ b/ci/tasks/build.yml
@@ -3,17 +3,20 @@
 
 PLATFORM: linux
 
+# Use a Centos/RHEL image to build the rpms
 image_resource:
   type: docker-image
   source:
-    repository: golang
-    tag: '1.15'
+    repository: pivotaldata/gpdb6-centos7-test-golang
+    tag: "latest"
 
 inputs:
 - name: gpupgrade_src
 
 outputs:
 - name: build_artifacts
+- name: build_artifacts_oss
+- name: build_artifacts_enterprise
 
 run:
   path: bash
@@ -25,5 +28,15 @@ run:
     cd gpupgrade_src
     export GOFLAGS="-mod=readonly" # do not update dependencies during build
 
+    # TODO: when we switch to using rpms in tests, this can be removed
     make
     GOBIN=$(realpath ../build_artifacts) make install
+
+    make oss-package
+    ci/scripts/verify-rpm.bash greenplum-upgrade*.rpm "Open Source"
+    mv greenplum-upgrade*.rpm ../build_artifacts_oss
+
+    make enterprise-package
+    ci/scripts/verify-rpm.bash greenplum-upgrade*.rpm "Enterprise"
+    mv greenplum-upgrade*.rpm ../build_artifacts_enterprise
+

--- a/ci/template.yml
+++ b/ci/template.yml
@@ -26,6 +26,7 @@ resources:
   source:
     uri: ((gpupgrade-git-remote))
     branch: ((gpupgrade-git-branch))
+    fetch_tags: true
 
 {{range .AllVersions}}
 - name: gpdb{{.}}_src
@@ -68,6 +69,20 @@ resources:
     bucket: ((cm-intermediates-bucket))
     json_key: ((cm-gcs-service-account-key))
     versioned_file: gpupgrade
+
+- name: rpm_gpupgrade_oss
+  type: gcs
+  source:
+    bucket: ((cm-intermediates-bucket))
+    json_key: ((cm-gcs-service-account-key))
+    regexp: oss/greenplum-upgrade-(.*).rpm
+
+- name: rpm_gpupgrade_enterprise
+  type: gcs
+  source:
+    bucket: ((cm-intermediates-bucket))
+    json_key: ((cm-gcs-service-account-key))
+    regexp: enterprise/greenplum-upgrade-(.*).rpm
 
 - name: bin_gpupgrade_rc
   type: gcs
@@ -235,9 +250,16 @@ jobs:
     trigger: true
   - task: build
     file: gpupgrade_src/ci/tasks/build.yml
-  - put: bin_gpupgrade
-    params:
-      file: build_artifacts/gpupgrade
+  - in_parallel:
+    - put: bin_gpupgrade
+      params:
+        file: build_artifacts/gpupgrade
+    - put: rpm_gpupgrade_oss
+      params:
+        file: build_artifacts_oss/greenplum-upgrade*.rpm
+    - put: rpm_gpupgrade_enterprise
+      params:
+        file: build_artifacts_enterprise/greenplum-upgrade*.rpm
   on_failure:
     <<: *slack_alert
 


### PR DESCRIPTION
We build, verify and upload gpupgrade rpms to GCP

We intend to use rpms to distibute both the open source("oss") and enterprise("enterprise") versions of gpupgrade.

Build the rpms and verify their contents.  Note:

- we upload a version "0.4.0-1.el7.x86_64" right now based on the rpm of greenplum-upgrade-0.4.0-1.el7.x86_64.rpm since that is how Concourse versions a GCP resource
- we need to improve this versioning as that upload will continually be replaced; that is, each build right now is not unique, but only based on the git tag.  We update this infrequently.
- the verification of the rpms just sanity checks the contents; we willbe passing the rpms into the actual tests in the CI in a later PR

Follow up PRs will be done for the following:
- add the verified rpms to the RC GCP bucket for download
- use the verified rpms in the CI tests