### PR TITLE
github actions: update golangci-lint-action to v2

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint specified without patch version
-          version: v1.26
+          version: v1.29


### PR DESCRIPTION
v1.2.2 is deprecated due to forgetting to change the minimum version of golangci-lint to v1.28.3. See issue: https://github.com/golangci/golangci-lint-action/issues/39

