### PR TITLE
Handle cases where target object is not yet created.

### DIFF
--- a/hub/delete_data_directories.go
+++ b/hub/delete_data_directories.go
@@ -97,6 +97,10 @@ func DeleteTargetTablespacesOnMaster(streams step.OutStreams, target *greenplum.
 
 func DeleteTargetTablespacesOnPrimaries(agentConns []*Connection, target *greenplum.Cluster, tablespaces greenplum.Tablespaces, catalogVersion string) error {
 	request := func(conn *Connection) error {
+		if target == nil {
+			return nil
+		}
+
 		primaries := target.SelectSegments(func(seg *greenplum.SegConfig) bool {
 			return seg.IsOnHost(conn.Hostname) && seg.IsPrimary() && !seg.IsMaster()
 		})

--- a/hub/delete_data_directories_test.go
+++ b/hub/delete_data_directories_test.go
@@ -350,6 +350,24 @@ func TestDeleteTablespaceDirectories(t *testing.T) {
 			t.Errorf("got error %#v, want %#v", err, expected)
 		}
 	})
+
+	t.Run("must not error out when target is not yet created", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		sdw1 := mock_idl.NewMockAgentClient(ctrl)
+		sdw2 := mock_idl.NewMockAgentClient(ctrl)
+
+		agentConns := []*hub.Connection{
+			{nil, sdw1, "sdw1", nil},
+			{nil, sdw2, "sdw2", nil},
+		}
+
+		err := hub.DeleteTargetTablespacesOnPrimaries(agentConns, nil, nil, "")
+		if err != nil {
+			t.Errorf("unexpected error %#v", err)
+		}
+	})
 }
 
 // equivalentRequest is a Matcher that can handle differences in order between

--- a/hub/revert.go
+++ b/hub/revert.go
@@ -165,7 +165,7 @@ func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) 
 			return err
 		}
 
-		return ArchiveSegmentLogDirectories(s.agentConns, s.Config.Target.MasterHostname(), archiveDir)
+		return ArchiveSegmentLogDirectories(s.agentConns, s.Config.Source.MasterHostname(), archiveDir)
 	})
 
 	st.Run(idl.Substep_DELETE_SEGMENT_STATEDIRS, func(_ step.OutStreams) error {


### PR DESCRIPTION
This commit handles revert failure when the target cluster is not yet
created.