### PR TITLE
refactor version functions

### DIFF
--- a/cli/commands/initialize.go
+++ b/cli/commands/initialize.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/cli"
 	"github.com/greenplum-db/gpupgrade/cli/commanders"
+	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/upgrade"
@@ -172,7 +173,7 @@ func initialize() *cobra.Command {
 					return nil
 				}
 
-				err := cli.ValidateVersions(sourceGPHome, targetGPHome)
+				err := greenplum.VerifyCompatibleGPDBVersions(sourceGPHome, targetGPHome)
 				if err != nil {
 					nextActions := fmt.Sprintf(`Please address the above issue and run "gpupgrade %s" again.`, strings.ToLower(idl.Step_INITIALIZE.String()))
 					return cli.NewNextActions(err, nextActions)

--- a/greenplum/allowed_gpdb_versions.go
+++ b/greenplum/allowed_gpdb_versions.go
@@ -1,14 +1,13 @@
-// Copyright (c) 2020 VMware, Inc. or its affiliates
-// SPDX-License-Identifier: Apache-2.0
+//  Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+//  SPDX-License-Identifier: Apache-2.0
 
-package cli
+package greenplum
 
 import (
 	"fmt"
 
 	"github.com/blang/semver/v4"
 
-	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
@@ -83,9 +82,9 @@ func getMinVersion(version semver.Version, minVersions map[int]string) string {
 	return semver.MustParse(minVersions[lowest]).String()
 }
 
-var gpHomeVersion = greenplum.GPHomeVersion
+var gpHomeVersion = GPHomeVersion
 
-func ValidateVersions(sourceGPHome, targetGPHome string) error {
+func VerifyCompatibleGPDBVersions(sourceGPHome, targetGPHome string) error {
 	var err error
 
 	vErr := validateVersion(sourceGPHome, "source")

--- a/greenplum/allowed_gpdb_versions.go
+++ b/greenplum/allowed_gpdb_versions.go
@@ -82,7 +82,7 @@ func getMinVersion(version semver.Version, minVersions map[int]string) string {
 	return semver.MustParse(minVersions[lowest]).String()
 }
 
-var gpHomeVersion = GPHomeVersion
+var gpdbVersion = GPDBVersion
 
 func VerifyCompatibleGPDBVersions(sourceGPHome, targetGPHome string) error {
 	var err error
@@ -104,7 +104,7 @@ func validateVersion(gpHome string, context string) error {
 		minVersions = minTargetVersions
 	}
 
-	version, err := gpHomeVersion(gpHome)
+	version, err := gpdbVersion(gpHome)
 	if err == nil && !versionsAllowed(version) {
 		min := getMinVersion(version, minVersions)
 		errStr := fmt.Sprintf("%s cluster version %s is not supported.  "+

--- a/greenplum/allowed_gpdb_versions_test.go
+++ b/greenplum/allowed_gpdb_versions_test.go
@@ -90,11 +90,11 @@ func TestAllowedVersions(t *testing.T) {
 
 func TestValidateVersions(t *testing.T) {
 	t.Run("passes when given supported versions", func(t *testing.T) {
-		gpHomeVersion = func(str string) (semver.Version, error) {
+		gpdbVersion = func(str string) (semver.Version, error) {
 			return semver.MustParse("6.9.0"), nil
 		}
 		defer func() {
-			gpHomeVersion = GPHomeVersion
+			gpdbVersion = GPDBVersion
 		}()
 
 		err := VerifyCompatibleGPDBVersions("/does/not/matter", "/does/not/matter")
@@ -113,7 +113,7 @@ func TestValidateVersionsErrorCases(t *testing.T) {
 		expectedTarget string
 	}{
 		{
-			"fails when gpHomeVersion returns an error",
+			"fails when gpdbVersion returns an error",
 			func(str string) (semver.Version, error) {
 				return semver.MustParse("1.2.3"), errors.New("some error")
 			},
@@ -140,9 +140,9 @@ func TestValidateVersionsErrorCases(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			gpHomeVersion = c.mockFunction
+			gpdbVersion = c.mockFunction
 			defer func() {
-				gpHomeVersion = GPHomeVersion
+				gpdbVersion = GPDBVersion
 			}()
 
 			err := VerifyCompatibleGPDBVersions("/does/not/matter", "/does/not/matter")

--- a/greenplum/allowed_gpdb_versions_test.go
+++ b/greenplum/allowed_gpdb_versions_test.go
@@ -1,7 +1,7 @@
-// Copyright (c) 2020 VMware, Inc. or its affiliates
-// SPDX-License-Identifier: Apache-2.0
+//  Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+//  SPDX-License-Identifier: Apache-2.0
 
-package cli
+package greenplum
 
 import (
 	"errors"
@@ -9,7 +9,6 @@ import (
 
 	"github.com/blang/semver/v4"
 
-	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
@@ -95,10 +94,10 @@ func TestValidateVersions(t *testing.T) {
 			return semver.MustParse("6.9.0"), nil
 		}
 		defer func() {
-			gpHomeVersion = greenplum.GPHomeVersion
+			gpHomeVersion = GPHomeVersion
 		}()
 
-		err := ValidateVersions("/does/not/matter", "/does/not/matter")
+		err := VerifyCompatibleGPDBVersions("/does/not/matter", "/does/not/matter")
 		if err != nil {
 			t.Errorf("got unexpected error %#v", err)
 		}
@@ -143,10 +142,10 @@ func TestValidateVersionsErrorCases(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			gpHomeVersion = c.mockFunction
 			defer func() {
-				gpHomeVersion = greenplum.GPHomeVersion
+				gpHomeVersion = GPHomeVersion
 			}()
 
-			err := ValidateVersions("/does/not/matter", "/does/not/matter")
+			err := VerifyCompatibleGPDBVersions("/does/not/matter", "/does/not/matter")
 
 			// make sure both source and target produce an error and that they match
 			// the expected error string

--- a/greenplum/version.go
+++ b/greenplum/version.go
@@ -15,9 +15,9 @@ import (
 
 var ErrUnknownVersion = errors.New("unknown GPDB version")
 
-// GPHomeVersion returns the semantic version of a GPDB installation located at
+// GPDBVersion returns the semantic version of a GPDB installation located at
 // the given GPHOME.
-func GPHomeVersion(gphome string) (semver.Version, error) {
+func GPDBVersion(gphome string) (semver.Version, error) {
 	postgres := filepath.Join(gphome, "bin", "postgres")
 	cmd := execCommand(postgres, "--gp-version")
 

--- a/greenplum/version_test.go
+++ b/greenplum/version_test.go
@@ -69,7 +69,7 @@ func TestGPHomeVersion(t *testing.T) {
 				Command(postgresPath, []string{"--gp-version"}).
 				Return(c.execMain)
 
-			version, err := GPHomeVersion(gphome)
+			version, err := GPDBVersion(gphome)
 			if err != nil {
 				t.Errorf("returned error: %+v", err)
 			}
@@ -114,7 +114,7 @@ func TestGPHomeVersion(t *testing.T) {
 			Command(postgresPath, []string{"--gp-version"}).
 			Return(exectest.Failure)
 
-		_, err := GPHomeVersion(gphome)
+		_, err := GPDBVersion(gphome)
 
 		var exitErr *exec.ExitError
 		if !errors.As(err, &exitErr) {

--- a/hub/fill_cluster_configs.go
+++ b/hub/fill_cluster_configs.go
@@ -5,7 +5,6 @@ package hub
 
 import (
 	"database/sql"
-	"os"
 	"path/filepath"
 	"sort"
 
@@ -187,13 +186,4 @@ func sanitize(ports []int) []int {
 	}
 
 	return dedupe
-}
-
-func getBinaryPath() (string, error) {
-	hubPath, err := os.Executable()
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(filepath.Dir(hubPath), "gpupgrade"), nil
 }

--- a/hub/init_target_cluster.go
+++ b/hub/init_target_cluster.go
@@ -110,7 +110,7 @@ func (s *Server) CreateTargetCluster(stream step.OutStreams) error {
 }
 
 func (s *Server) InitTargetCluster(stream step.OutStreams) error {
-	version, err := greenplum.GPHomeVersion(s.TargetGPHome)
+	version, err := greenplum.GPDBVersion(s.TargetGPHome)
 	if err != nil {
 		return err
 	}

--- a/hub/initialize.go
+++ b/hub/initialize.go
@@ -52,7 +52,7 @@ func (s *Server) Initialize(in *idl.InitializeRequest, stream idl.CliToHub_Initi
 	// we need the cluster information to determine what hosts to check, so we do this check
 	// as early as possible after that information is available
 	st.RunInternalSubstep(func() error {
-		return ValidateGpupgradeVersion(s.Source.MasterHostname(), AgentHosts(s.Source))
+		return EnsureGpupgradeAndGPDBVersionsMatch(AgentHosts(s.Source), s.Source.MasterHostname())
 	})
 
 	st.Run(idl.Substep_START_AGENTS, func(_ step.OutStreams) error {

--- a/hub/server.go
+++ b/hub/server.go
@@ -232,7 +232,7 @@ func RestartAgents(ctx context.Context,
 			gplog.Debug("failed to dial agent on %s: %+v", host, err)
 			gplog.Info("starting agent on %s", host)
 
-			path, err := getBinaryPath()
+			path, err := utils.GetGpupgradePath()
 			if err != nil {
 				errs <- err
 				return

--- a/hub/version.go
+++ b/hub/version.go
@@ -11,6 +11,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"golang.org/x/xerrors"
 
+	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
@@ -39,12 +40,12 @@ func (a agents) String() string {
 }
 
 func ValidateGpupgradeVersion(hubHost string, agentHosts []string) error {
-	path, err := getBinaryPath()
+	gpupgradePath, err := utils.GetGpupgradePath()
 	if err != nil {
 		return xerrors.Errorf("getting gpupgrade binary path: %w", err)
 	}
 
-	hubVersion, err := GetVersionFunc(hubHost, path)
+	hubVersion, err := GetVersionFunc(hubHost, gpupgradePath)
 	if err != nil {
 		return xerrors.Errorf("getting hub version: %w", err)
 	}
@@ -56,7 +57,7 @@ func ValidateGpupgradeVersion(hubHost string, agentHosts []string) error {
 		wg.Add(1)
 		go func(host string) {
 			defer wg.Done()
-			version, err := GetVersionFunc(host, path)
+			version, err := GetVersionFunc(host, gpupgradePath)
 			agentChan <- agentVersion{host, version, err}
 		}(host)
 	}

--- a/utils/sys_utils.go
+++ b/utils/sys_utils.go
@@ -130,6 +130,15 @@ func GetJSONFile(stateDir string, fileName string) (path string, err error) {
 	return path, nil
 }
 
+func GetGpupgradePath() (string, error) {
+	hubPath, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(filepath.Dir(hubPath), "gpupgrade"), nil
+}
+
 // Calling os.Rename for a directory is allowed only when both the
 // source and the destination path are on the top layer of filesystem.
 // Otherwise, it returns EXDEV error ("cross-device link not permitted").


### PR DESCRIPTION
This is a pre-factor PR with various renames and moving code around for clarity. Namely, to distinguish between gpupgradeVersion and GPDBVersion.

Also, refactor the gpupgrade version consistency error message to print the list of hosts on a single line as this is the more common scenario. That is, it's more common for the same incorrect gpupgrade binary to be on all hosts. Thus, print all mismatched hosts on one line rather than a host per line which could be many lines for when there are numerous hosts.

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:multiHostValidateVersions)