### PR TITLE
add newline when printing completedText

### DIFF
--- a/cli/commanders/step.go
+++ b/cli/commanders/step.go
@@ -205,7 +205,7 @@ func (s *Step) Complete(completedText string) error {
 		return cli.NewNextActions(s.Err(), msg)
 	}
 
-	fmt.Print(completedText)
+	fmt.Println(completedText)
 	return nil
 }
 

--- a/cli/commanders/step_test.go
+++ b/cli/commanders/step_test.go
@@ -132,7 +132,7 @@ func TestSubstep(t *testing.T) {
 
 		expected := "\nInitialize in progress.\n\n"
 		expected += commanders.Format(commanders.SubstepDescriptions[idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG].OutputText, idl.Status_RUNNING) + "\r"
-		expected += commanders.Format(commanders.SubstepDescriptions[idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG].OutputText, idl.Status_SKIPPED) + "\n"
+		expected += commanders.Format(commanders.SubstepDescriptions[idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG].OutputText, idl.Status_SKIPPED) + "\n\n"
 
 		actual := string(stdout)
 		if actual != expected {
@@ -231,7 +231,7 @@ func TestSubstep(t *testing.T) {
 		}
 
 		expectedStdout := "\nInitialize in progress.\n\n"
-		expectedStdout += "Initialize took 0s\n\n"
+		expectedStdout += "Initialize took 0s\n\n\n"
 
 		stdout, stderr := d.Collect()
 		d.Close()


### PR DESCRIPTION
Don't squash completed text with the shell prompt by adding a newline.

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:squashPrompt)