### PR TITLE
Fixups

### DIFF
--- a/ci/scripts/upgrade-cluster.bash
+++ b/ci/scripts/upgrade-cluster.bash
@@ -139,8 +139,8 @@ time ssh mdw bash <<EOF
     # TODO: rather than setting a temp port range, consider carving out an
     # ip_local_reserved_ports range during/after CCP provisioning.
 
-    gpupgrade execute -a
-    gpupgrade finalize -a
+    gpupgrade execute --non-interactive
+    gpupgrade finalize --non-interactive
 EOF
 
 # On GPDB version other than 5, set the gucs before taking dumps

--- a/cli/commands/execute.go
+++ b/cli/commands/execute.go
@@ -17,7 +17,7 @@ import (
 
 func execute() *cobra.Command {
 	var verbose bool
-	var automatic bool
+	var nonInteractive bool
 
 	cmd := &cobra.Command{
 		Use:   "execute",
@@ -37,7 +37,7 @@ func execute() *cobra.Command {
 			st, err := commanders.NewStep(idl.Step_EXECUTE,
 				&step.BufferedStreams{},
 				verbose,
-				automatic,
+				nonInteractive,
 				confirmationText,
 			)
 			if err != nil {
@@ -85,8 +85,8 @@ To return the cluster to its original state, run "gpupgrade revert".`,
 	}
 
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "print the output stream from all substeps")
-	cmd.Flags().BoolVarP(&automatic, "automatic", "a", false, "do not prompt for confirmation to proceed")
-	cmd.Flags().MarkHidden("automatic") //nolint
+	cmd.Flags().BoolVar(&nonInteractive, "non-interactive", false, "do not prompt for confirmation to proceed")
+	cmd.Flags().MarkHidden("non-interactive") //nolint
 
 	return addHelpToCommand(cmd, ExecuteHelp)
 }

--- a/cli/commands/finalize.go
+++ b/cli/commands/finalize.go
@@ -18,7 +18,7 @@ import (
 
 func finalize() *cobra.Command {
 	var verbose bool
-	var automatic bool
+	var nonInteractive bool
 
 	cmd := &cobra.Command{
 		Use:   "finalize",
@@ -37,7 +37,7 @@ func finalize() *cobra.Command {
 			st, err := commanders.NewStep(idl.Step_FINALIZE,
 				&step.BufferedStreams{},
 				verbose,
-				automatic,
+				nonInteractive,
 				confirmationText,
 			)
 			if err != nil {
@@ -101,8 +101,7 @@ indexes, and roles that were dropped or altered to resolve migration issues.`,
 	}
 
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "print the output stream from all substeps")
-	cmd.Flags().BoolVarP(&automatic, "automatic", "a", false, "do not prompt for confirmation to proceed")
-	cmd.Flags().MarkHidden("automatic") //nolint
-
+	cmd.Flags().BoolVar(&nonInteractive, "non-interactive", false, "do not prompt for confirmation to proceed")
+	cmd.Flags().MarkHidden("non-interactive") //nolint
 	return addHelpToCommand(cmd, FinalizeHelp)
 }

--- a/cli/commands/initialize.go
+++ b/cli/commands/initialize.go
@@ -32,7 +32,7 @@ The source cluster does not have %s.
 After "gpupgrade execute" has been run, there will be no way to
 return the cluster to its original state using "gpupgrade revert".
 
-If you do no already have a backup, we strongly recommend that
+If you do not already have a backup, we strongly recommend that
 you run "gpupgrade revert" now and take a backup of the cluster.
 `
 

--- a/cli/commands/revert.go
+++ b/cli/commands/revert.go
@@ -18,7 +18,7 @@ import (
 
 func revert() *cobra.Command {
 	var verbose bool
-	var automatic bool
+	var nonInteractive bool
 
 	cmd := &cobra.Command{
 		Use:   "revert",
@@ -37,7 +37,7 @@ func revert() *cobra.Command {
 			st, err := commanders.NewStep(idl.Step_REVERT,
 				&step.BufferedStreams{},
 				verbose,
-				automatic,
+				nonInteractive,
 				confirmationText,
 			)
 			if err != nil {
@@ -97,8 +97,8 @@ To restart the upgrade, run "gpupgrade initialize" again.`,
 	}
 
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "print the output stream from all substeps")
-	cmd.Flags().BoolVarP(&automatic, "automatic", "a", false, "do not prompt for confirmation to proceed")
-	cmd.Flags().MarkHidden("automatic") //nolint
+	cmd.Flags().BoolVar(&nonInteractive, "non-interactive", false, "do not prompt for confirmation to proceed")
+	cmd.Flags().MarkHidden("non-interactive") //nolint
 
 	return addHelpToCommand(cmd, RevertHelp)
 }

--- a/test/execute.bats
+++ b/test/execute.bats
@@ -112,7 +112,7 @@ ensure_hardlinks_for_relfilenode_on_master_and_segments() {
 
     NEW_CLUSTER="$(gpupgrade config show --target-datadir)"
 
-    gpupgrade execute -a --verbose
+    gpupgrade execute --non-interactive --verbose
 
     ensure_hardlinks_for_relfilenode_on_master_and_segments $GPHOME_TARGET 6020 'test_linking' 2
 
@@ -151,7 +151,7 @@ ensure_hardlinks_for_relfilenode_on_master_and_segments() {
     # --delete flag
     mkdir "${datadir}"/base_extra
     touch "${datadir}"/base_extra/1101
-    gpupgrade execute -a --verbose
+    gpupgrade execute --non-interactive --verbose
     
     # check that the extraneous files are deleted
     [ ! -d "${datadir}"/base_extra ]
@@ -177,7 +177,7 @@ ensure_hardlinks_for_relfilenode_on_master_and_segments() {
 
     NEW_CLUSTER="$(gpupgrade config show --target-datadir)"
 
-    gpupgrade execute -a --verbose 3>&-
+    gpupgrade execute --non-interactive --verbose 3>&-
 
     # On GPDB5, restore the primary and master directories before starting the cluster
     restore_cluster
@@ -189,7 +189,7 @@ ensure_hardlinks_for_relfilenode_on_master_and_segments() {
     # Mark every substep in the status file as failed. Then re-execute.
     sed -i.bak -e 's/"COMPLETE"/"FAILED"/g' "$GPUPGRADE_HOME/substeps.json"
 
-    gpupgrade execute -a --verbose 3>&-
+    gpupgrade execute --non-interactive --verbose 3>&-
 
     restore_cluster
 }

--- a/test/finalize.bats
+++ b/test/finalize.bats
@@ -68,13 +68,13 @@ upgrade_cluster() {
             "$LINK_MODE" \
             "$HBA_HOSTNAMES" \
             --verbose 3>&-
-        gpupgrade execute -a --verbose
+        gpupgrade execute --non-interactive --verbose
 
         # do before gpupgrade finalize shuts down the hub
         local upgradeID new_datadir
         upgradeID=$(gpupgrade config show --id)
 
-        gpupgrade finalize -a --verbose
+        gpupgrade finalize --non-interactive --verbose
 
         if is_GPDB5 "$GPHOME_SOURCE"; then
             check_tablespace_data

--- a/test/initialize.bats
+++ b/test/initialize.bats
@@ -131,8 +131,8 @@ outputContains() {
 
     commands=(
         'config show'
-        'execute -a'
-        'revert -a'
+        'execute --non-interactive'
+        'revert --non-interactive'
     )
 
     # We don't want to have to wait for the default one-second timeout for all
@@ -356,7 +356,7 @@ wait_for_port_change() {
         --disk-free-ratio 0 \
         --automatic \
         --verbose 3>&-
-    register_teardown gpupgrade revert -a
+    register_teardown gpupgrade revert --non-interactive
 
     echo "$output"
     [[ $output != *"libxml2.so.2: no version information available"* ]] || \

--- a/test/migration_scripts.bats
+++ b/test/migration_scripts.bats
@@ -92,8 +92,8 @@ drop_unfixable_objects() {
         --disk-free-ratio 0 \
         --automatic \
         --verbose
-    gpupgrade execute -a --verbose
-    gpupgrade finalize -a --verbose
+    gpupgrade execute --non-interactive --verbose
+    gpupgrade finalize --non-interactive --verbose
 
     "$SCRIPTS_DIR"/migration_executor_sql.bash "$GPHOME_TARGET" "$PGPORT" "$MIGRATION_DIR"/post-finalize
 
@@ -138,8 +138,8 @@ drop_unfixable_objects() {
         --disk-free-ratio 0 \
         --automatic \
         --verbose
-    gpupgrade execute -a --verbose
-    gpupgrade revert -a --verbose
+    gpupgrade execute --non-interactive --verbose
+    gpupgrade revert --non-interactive --verbose
 
     $SCRIPTS_DIR/migration_executor_sql.bash "$GPHOME_SOURCE" "$PGPORT" "$MIGRATION_DIR"/post-revert
 
@@ -176,7 +176,7 @@ drop_unfixable_objects() {
         --disk-free-ratio 0 \
         --automatic \
         --verbose
-    gpupgrade revert -a --verbose
+    gpupgrade revert --non-interactive --verbose
 
     "$SCRIPTS_DIR"/migration_executor_sql.bash "$GPHOME_TARGET" "$PGPORT" "$MIGRATION_DIR"/post-revert
 }

--- a/test/pg_upgrade.bats
+++ b/test/pg_upgrade.bats
@@ -126,7 +126,7 @@ count_primary_gp_dbids() {
         --disk-free-ratio=0 3>&-
     NEW_CLUSTER="$(gpupgrade config show --target-datadir)"
 
-    gpupgrade execute -a --verbose
+    gpupgrade execute --non-interactive --verbose
 
     local new_dbid_num=$(count_primary_gp_dbids $GPHOME_TARGET 6020)
 

--- a/test/revert.bats
+++ b/test/revert.bats
@@ -92,7 +92,7 @@ query_host_datadirs() {
     target_hosts_dirs=$(jq -r '.Target.Primaries[] | .Hostname + " " + .DataDir' "${GPUPGRADE_HOME}/config.json")
     upgradeID=$(gpupgrade config show --id)
 
-    gpupgrade revert -a --verbose
+    gpupgrade revert --non-interactive --verbose
 
     # gpupgrade processes are stopped
     ! process_is_running "[g]pupgrade hub" || fail 'expected hub to have been stopped'
@@ -168,7 +168,7 @@ test_revert_after_execute() {
         --mode "$mode" \
         --automatic \
         --verbose 3>&-
-    gpupgrade execute -a --verbose
+    gpupgrade execute --non-interactive --verbose
 
     # Modify the table on the target cluster
     $PSQL -p $target_master_port postgres -c "TRUNCATE ${TABLE}"
@@ -180,7 +180,7 @@ test_revert_after_execute() {
     fi
 
     # Revert
-    gpupgrade revert -a --verbose
+    gpupgrade revert --non-interactive --verbose
 
     # Verify the table modifications were reverted
     rows=$($PSQL postgres -Atc "SELECT COUNT(*) FROM ${TABLE}")
@@ -236,9 +236,9 @@ test_revert_after_execute() {
         --automatic \
         --verbose 3>&-
 
-    gpupgrade execute -a --verbose
+    gpupgrade execute --non-interactive --verbose
 
-    gpupgrade revert -a --verbose
+    gpupgrade revert --non-interactive --verbose
 
     gpupgrade initialize \
         --source-gphome="$GPHOME_SOURCE" \
@@ -249,10 +249,10 @@ test_revert_after_execute() {
         --automatic \
         --verbose 3>&-
 
-    gpupgrade execute -a --verbose
+    gpupgrade execute --non-interactive --verbose
 
     # This last revert is used for test cleanup.
-    gpupgrade revert -a --verbose
+    gpupgrade revert --non-interactive --verbose
 }
 
 # gp_segment_configuration does not show us the status correctly. We must check that the
@@ -375,13 +375,13 @@ test_revert_after_execute_pg_upgrade_failure() {
         --verbose 3>&-
 
     # Execute should fail.
-    run gpupgrade execute -a --verbose
+    run gpupgrade execute --non-interactive --verbose
     echo "$output"   # run swallows the output...log it explicitly to allow debugging.
     [ "$status" -ne 0 ] || fail "expected execute to fail"
     [[ "$output" == *"$failed_substep"*"FAILED"* ]] || fail "expected output to contain $failed_substep as FAILED"
 
     # Revert
-    gpupgrade revert -a --verbose
+    gpupgrade revert --non-interactive --verbose
 
     # Verify the table is untouched
     rows=$($PSQL postgres -Atc "SELECT COUNT(*) FROM ${TABLE}")


### PR DESCRIPTION
1) fix typo in initialize warning message

2) rename automatic flag for execute, finalize, revert
Rename to --non-interactive to prevent customers from accidentally using -a or --automatic for commands other than initialize.


[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixups)