### PR TITLE
data-migration-scripts: fix paths and tweak names

### DIFF
--- a/data-migration-scripts/migration_executor_sql.bash
+++ b/data-migration-scripts/migration_executor_sql.bash
@@ -6,26 +6,26 @@
 function print_usage() {
 echo '
 Executes scripts addressing catalog inconsistencies between Greenplum versions.
-Before running this command, run migration_generator_sql.bash.
+Before running this command, run gpupgrade-migration-sql-generator.bash.
 This command should be run only during the downtime window.
 
 Usage: '$(basename $0)' <GPHOME> <PGPORT> <INPUT_DIR>
      <GPHOME>    : the path to the source Greenplum installation directory
      <PGPORT>    : the source Greenplum system port number
      <INPUT_DIR> : the directory containing the scripts to execute. This is the
-                   <OUTPUT_DIR> you specified earlier in migration_generator_sql.bash,
+                   <OUTPUT_DIR> you specified earlier in gpupgrade-migration-sql-generator.bash,
                    with a subdirectory appended as in the use cases below. The
                    subdirectories are pre-initialize, post-finalize, and post-revert.
 
 Use cases:
 - Before "gpupgrade initialize", drop and alter objects:
-migration_executor_sql.bash /path/to/gphome 5432 /path/to/output_dir/pre-initialize
+gpupgrade-migration-sql-executor.bash /path/to/gphome 5432 /path/to/output_dir/pre-initialize
 
 - Following "gpupgrade finalize", restore and recreate objects:
-migration_executor_sql.bash /path/to/gphome 5432 /path/to/output_dir/post-finalize
+gpupgrade-migration-sql-executor.bash /path/to/gphome 5432 /path/to/output_dir/post-finalize
 
 - Following "gpupgrade revert", restore objects:
-migration_executor_sql.bash /path/to/gphome 5432 /path/to/output_dir/post-revert
+gpupgrade-migration-sql-executor.bash /path/to/gphome 5432 /path/to/output_dir/post-revert
 
 Log files can be found in INPUT_DIR/data_migration.log'
 }

--- a/data-migration-scripts/migration_generator_sql.bash
+++ b/data-migration-scripts/migration_generator_sql.bash
@@ -19,8 +19,8 @@ The output directory structure is:
      + post-finalize   restore and recreate objects following "gpupgrade finalize"
      + post-revert     restore objects following "gpupgrade revert"
 
-After running migration_generator_sql.bash, run migration_executor_sql.bash.
-Run migration_executor_sql.bash -h for more information.'
+After running gpupgrade-migration-sql-generator.bash, run gpupgrade-migration-sql-executor.bash.
+Run gpupgrade-migration-sql-executor.bash -h for more information.'
 }
 
 if [ "$#" -eq 0 ] || ([ "$#" -eq 1 ] && ([ "$1" = -h ] || [ "$1" = --help ])) ; then
@@ -28,7 +28,7 @@ if [ "$#" -eq 0 ] || ([ "$#" -eq 1 ] && ([ "$1" = -h ] || [ "$1" = --help ])) ; 
     exit 0
 fi
 
-if [ "$#" -ne 3 ]; then
+if ! { [ "$#" -eq 3 ] || [ "$#" -eq 4 ]; } ; then
     echo ""
     echo "Error: Incorrect number of arguments"
     print_usage
@@ -38,6 +38,8 @@ fi
 GPHOME=$1
 PGPORT=$2
 OUTPUT_DIR=$3
+# INPUT_DIR is a hidden option used for internal testing or support
+INPUT_DIR=${4:-"$(dirname "$0")/greenplum/gpupgrade/data-migration-scripts"}
 APPLY_ONCE_FILES=("gen_alter_gphdfs_roles.sql")
 
 get_databases(){
@@ -93,7 +95,7 @@ execute_script_directory() {
     local dir=$1; shift
     local databases=( "$@" )
 
-    local paths=($(find "$(dirname "$0")/${dir}" -type f \( -name "*.sql" -o -name "*.sh" \) | sort -n))
+    local paths=($(find "${INPUT_DIR}/${dir}" -type f \( -name "*.sql" -o -name "*.sh" \) | sort -n))
     local output_dir="${OUTPUT_DIR}/${dir}"
 
     mkdir -p "$output_dir"

--- a/test/migration_scripts.bats
+++ b/test/migration_scripts.bats
@@ -75,7 +75,7 @@ drop_unfixable_objects() {
     MIGRATION_DIR=`mktemp -d /tmp/migration.XXXXXX`
     register_teardown rm -r "$MIGRATION_DIR"
 
-    "$SCRIPTS_DIR"/migration_generator_sql.bash "$GPHOME_SOURCE" "$PGPORT" "$MIGRATION_DIR"
+    "$SCRIPTS_DIR"/migration_generator_sql.bash "$GPHOME_SOURCE" "$PGPORT" "$MIGRATION_DIR" "$SCRIPTS_DIR"
 
     drop_unfixable_objects
 
@@ -127,7 +127,7 @@ drop_unfixable_objects() {
     "$GPHOME_SOURCE"/bin/pg_dump --schema-only "$TEST_DBNAME" $EXCLUSIONS -f "$MIGRATION_DIR"/before.sql
 
 
-    $SCRIPTS_DIR/migration_generator_sql.bash $GPHOME_SOURCE $PGPORT $MIGRATION_DIR
+    $SCRIPTS_DIR/migration_generator_sql.bash $GPHOME_SOURCE $PGPORT $MIGRATION_DIR "$SCRIPTS_DIR"
     $SCRIPTS_DIR/migration_executor_sql.bash $GPHOME_SOURCE $PGPORT $MIGRATION_DIR/pre-initialize
 
     gpupgrade initialize \
@@ -164,7 +164,7 @@ drop_unfixable_objects() {
     export PSQLRC="$MIGRATION_DIR"/psqlrc
     printf '\! kill $PPID\n' > "$PSQLRC"
 
-    "$SCRIPTS_DIR"/migration_generator_sql.bash "$GPHOME_SOURCE" "$PGPORT" "$MIGRATION_DIR"
+    "$SCRIPTS_DIR"/migration_generator_sql.bash "$GPHOME_SOURCE" "$PGPORT" "$MIGRATION_DIR" "$SCRIPTS_DIR"
     drop_unfixable_objects
     "$SCRIPTS_DIR"/migration_executor_sql.bash "$GPHOME_SOURCE" "$PGPORT" "$MIGRATION_DIR"/pre-initialize
 


### PR DESCRIPTION
Update the migration binaries to find the correct script location. During RPM installation the data-migration binaries are located in `/usr/local/bin` and the scripts are in `/usr/local/bin/greenplum/gpupgrade/data-migration-scripts/`.

The RPM renames the scripts to `gpupgrade-migration-sql-generator.bash` and `gpupgrade-migration-sql-executor.bash`, so update the usage and help accordingly.

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixDataMigration)