### PR TITLE
initialize: 7X gpinitsystem only accepts 6-field config file format

### DIFF
--- a/hub/init_target_cluster.go
+++ b/hub/init_target_cluster.go
@@ -170,7 +170,8 @@ func WriteSegmentArray(config []string, targetInitializeConfig InitializeConfig)
 
 	master := targetInitializeConfig.Master
 	config = append(config,
-		fmt.Sprintf("QD_PRIMARY_ARRAY=%s~%d~%s~%d~%d",
+		fmt.Sprintf("QD_PRIMARY_ARRAY=%s~%s~%d~%s~%d~%d",
+			master.Hostname,
 			master.Hostname,
 			master.Port,
 			master.DataDir,
@@ -182,7 +183,8 @@ func WriteSegmentArray(config []string, targetInitializeConfig InitializeConfig)
 	config = append(config, "declare -a PRIMARY_ARRAY=(")
 	for _, segment := range targetInitializeConfig.Primaries {
 		config = append(config,
-			fmt.Sprintf("\t%s~%d~%s~%d~%d",
+			fmt.Sprintf("\t%s~%s~%d~%s~%d~%d",
+				segment.Hostname,
 				segment.Hostname,
 				segment.Port,
 				segment.DataDir,

--- a/hub/init_target_cluster_test.go
+++ b/hub/init_target_cluster_test.go
@@ -138,10 +138,10 @@ func TestWriteSegmentArray(t *testing.T) {
 		}
 
 		test(t, config, []string{
-			"QD_PRIMARY_ARRAY=mdw~15433~/data/qddir_upgrade/seg-1~1~-1",
+			"QD_PRIMARY_ARRAY=mdw~mdw~15433~/data/qddir_upgrade/seg-1~1~-1",
 			"declare -a PRIMARY_ARRAY=(",
-			"\tsdw1~15434~/data/dbfast1_upgrade/seg1~2~0",
-			"\tsdw2~15434~/data/dbfast2_upgrade/seg2~3~1",
+			"\tsdw1~sdw1~15434~/data/dbfast1_upgrade/seg1~2~0",
+			"\tsdw2~sdw2~15434~/data/dbfast2_upgrade/seg2~3~1",
 			")",
 		})
 	})


### PR DESCRIPTION
Create the target cluster's gpinitsystem config file only in the new 6-field format.  This format is accepted in 6X as one of two formats(5-field or 6-field), but in 7X as the only format.

Since we only support 6X and later, use the 6-field format only.

Note that we should be having the second field in the 6-field format be the host address of the segment, not the hostname.  However, we do not preserve this in the current 5->6 upgrade(that is, the target cluster will contain the hostname in the address field even if that were not the case in the source cluster).  The current behavior does what `gpinitsystem` does internally in 6X, which is copy the host field into the address field.

For a 7->7 upgrade, with this two additions(which will be handled in future PRs), this current PR can run 7->7 gpupgrade initialize until the `pg_upgrade --check` calls in initialize but still passes the 6X [pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:7X_gpupgrade_gpinitsystem_2) as well.

1). diff --git a/hub/init_target_cluster.go b/hub/init_target_cluster.go
```C
 func GetCheckpointSegmentsAndEncoding(gpinitsystemConfig []string, dbConnector *dbconn.DBConn) ([]string, error) {
-       checkpointSegments, err := dbconn.SelectString(dbConnector, "SELECT current_setting('checkpoint_segments') AS string")
-       if err != nil {
-               return gpinitsystemConfig, xerrors.Errorf("retrieve checkpoint segments: %w", err)
-       }
+       //checkpointSegments, err := dbconn.SelectString(dbConnector, "SELECT current_setting('checkpoint_segments') AS string")
+       //if err != nil {
+       //      return gpinitsystemConfig, xerrors.Errorf("retrieve checkpoint segments: %w", err)
+       //}
        encoding, err := dbconn.SelectString(dbConnector, "SELECT current_setting('server_encoding') AS string")
        if err != nil {
                return gpinitsystemConfig, xerrors.Errorf("retrieve server encoding: %w", err)
        }
        gpinitsystemConfig = append(gpinitsystemConfig,
-               fmt.Sprintf("CHECK_POINT_SEGMENTS=%s", checkpointSegments),
+               //fmt.Sprintf("CHECK_POINT_SEGMENTS=%s", checkpointSegments),
                fmt.Sprintf("ENCODING=%s", encoding))
        return gpinitsystemConfig, nil
 }
```
2). diff --git a/hub/initialize.go b/hub/initialize.go
```C
-const connectionString = "postgresql://localhost:%d/template1?gp_session_role=utility&search_path="
+const connectionString = "postgresql://localhost:%d/template1?gp_role=utility&search_path="
```
