### PR TITLE
7x gpupgrade pg upgrade tablespace dbids

### DIFF
--- a/agent/upgrade_primaries_test.go
+++ b/agent/upgrade_primaries_test.go
@@ -85,11 +85,12 @@ func TestUpgradePrimary(t *testing.T) {
 		defer ResetCommands()
 
 		request := &idl.UpgradePrimariesRequest{
-			SourceBinDir: "/old/bin",
-			TargetBinDir: "/new/bin",
-			DataDirPairs: pairs,
-			CheckOnly:    true,
-			UseLinkMode:  false,
+			SourceBinDir:  "/old/bin",
+			TargetBinDir:  "/new/bin",
+			DataDirPairs:  pairs,
+			CheckOnly:     true,
+			UseLinkMode:   false,
+			TargetVersion: "6.9.0",
 		}
 		err := agent.UpgradePrimaries(tempDir, request)
 		if err == nil {
@@ -113,11 +114,12 @@ func TestUpgradePrimary(t *testing.T) {
 		defer ResetCommands()
 
 		request := &idl.UpgradePrimariesRequest{
-			SourceBinDir: "/old/bin",
-			TargetBinDir: "/new/bin",
-			DataDirPairs: pairs,
-			CheckOnly:    false,
-			UseLinkMode:  false}
+			SourceBinDir:  "/old/bin",
+			TargetBinDir:  "/new/bin",
+			DataDirPairs:  pairs,
+			CheckOnly:     false,
+			UseLinkMode:   false,
+			TargetVersion: "6.9.0"}
 		err := agent.UpgradePrimaries(tempDir, request)
 		if err == nil {
 			t.Fatal("UpgradeSegments() returned no error")
@@ -298,5 +300,6 @@ func buildRequest(pairs []*idl.DataDirPair) *idl.UpgradePrimariesRequest {
 		CheckOnly:       false,
 		UseLinkMode:     false,
 		MasterBackupDir: "/some/master/backup/dir",
+		TargetVersion:   "6.9.0",
 	}
 }

--- a/agent/upgrade_primary.go
+++ b/agent/upgrade_primary.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/blang/semver/v4"
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
@@ -72,7 +73,7 @@ func performUpgrade(segment Segment, request *idl.UpgradePrimariesRequest) error
 		options = append(options, upgrade.WithLinkMode())
 	}
 
-	return upgrade.Run(segmentPair, options...)
+	return upgrade.Run(segmentPair, semver.MustParse(request.TargetVersion), options...)
 }
 
 func restoreBackup(request *idl.UpgradePrimariesRequest, segment Segment) error {

--- a/hub/upgrade_master.go
+++ b/hub/upgrade_master.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
@@ -81,7 +82,11 @@ func UpgradeMaster(args UpgradeMasterArgs) error {
 		}
 	}
 
-	err = upgrade.Run(pair, options...)
+	// FIXME: args.Target.Version comes from gp-common-go-libs, which uses a deprecated version of semver.
+	//   It is not compatible with the semver v4 we use in gpupgrade.
+	targetVersion := semver.MustParse(args.Target.Version.SemVer.String())
+
+	err = upgrade.Run(pair, targetVersion, options...)
 	if err != nil {
 		// Error details from stdout are added to any errors containing "fatal"
 		// such as pg_ugprade check errors.

--- a/hub/upgrade_master_test.go
+++ b/hub/upgrade_master_test.go
@@ -169,6 +169,7 @@ func TestUpgradeMaster(t *testing.T) {
 		{ContentID: -1, Port: 5433, DataDir: "/data/new", DbID: 2, Role: "p"},
 	})
 	target.GPHome = "/usr/local/target"
+	target.Version = dbconn.NewVersion("6.9.0")
 
 	// We need a real temporary directory to change to. Replace MkdirAll() so
 	// that we can make sure the directory is the correct one.


### PR DESCRIPTION
upgrade: only pass dbids to pg_upgrade for 6X and earlier clusters

6X has a different tablespace layout in the filesystem relative to 5X.
This required passing the source and target segment dbids to pg_upgrade
for 5->6.

6->7 does not have this difference.

The unit tests have been updated as well.

[pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:7X_gpupgrade_pg_upgrade_tablespace_dbids)