### PR TITLE
7X upgrade: use proper utility mode connection string

### DIFF
--- a/db/connURI/connection.go
+++ b/db/connURI/connection.go
@@ -1,0 +1,101 @@
+//  Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+//  SPDX-License-Identifier: Apache-2.0
+
+package connURI
+
+import (
+	"fmt"
+
+	"github.com/blang/semver/v4"
+)
+
+// NOTE: This package is specific to the supported upgrade matrix of gpupgrade.
+// For instance, URI() will return the wrong result if the request is to
+// AllowSystemTableMods() on a 5X cluster as that parameter differs from 6X and 7X.
+
+// TODO: we should add the source/target ports here too, but they
+//  are known after we need to first call this package.
+type Conn struct {
+	sourceVersion semver.Version
+	targetVersion semver.Version
+}
+
+func Connection(sourceVersion semver.Version, targetVersion semver.Version) *Conn {
+	conn := new(Conn)
+	conn.sourceVersion = sourceVersion
+	conn.targetVersion = targetVersion
+
+	return conn
+}
+
+func (c *Conn) URI(options ...Option) string {
+	opts := newOptionList(options...)
+
+	version := c.sourceVersion
+	if opts.connectToTarget {
+		version = c.targetVersion
+	}
+
+	connURI := fmt.Sprintf("postgresql://localhost:%d/template1?search_path=", opts.port)
+
+	if opts.utilityMode {
+		if version.LT(semver.MustParse("7.0.0")) {
+			connURI += "&gp_session_role=utility"
+		} else {
+			connURI += "&gp_role=utility"
+		}
+	}
+
+	if opts.allowSystemTableMods {
+		connURI += "&allow_system_table_mods=true"
+	}
+
+	return connURI
+}
+
+type Option func(*optionList)
+
+func ToSource() Option {
+	return func(options *optionList) {
+		options.connectToTarget = false
+	}
+}
+
+func ToTarget() Option {
+	return func(options *optionList) {
+		options.connectToTarget = true
+	}
+}
+
+func Port(port int) Option {
+	return func(options *optionList) {
+		options.port = port
+	}
+}
+
+func UtilityMode() Option {
+	return func(options *optionList) {
+		options.utilityMode = true
+	}
+}
+
+func AllowSystemTableMods() Option {
+	return func(options *optionList) {
+		options.allowSystemTableMods = true
+	}
+}
+
+type optionList struct {
+	connectToTarget      bool
+	port                 int
+	utilityMode          bool
+	allowSystemTableMods bool
+}
+
+func newOptionList(opts ...Option) *optionList {
+	o := new(optionList)
+	for _, option := range opts {
+		option(o)
+	}
+	return o
+}

--- a/db/connURI/connection_test.go
+++ b/db/connURI/connection_test.go
@@ -1,0 +1,95 @@
+//  Copyright (c) 2017-2020 VMware, Inc. or its affiliates
+//  SPDX-License-Identifier: Apache-2.0
+
+package connURI_test
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	"github.com/greenplum-db/gpupgrade/db/connURI"
+)
+
+var v5X = semver.MustParse("5.0.0")
+var v6X = semver.MustParse("6.0.0")
+var v7X = semver.MustParse("7.0.0")
+
+func TestConnURI(t *testing.T) {
+	cases := []struct {
+		name     string
+		source   semver.Version
+		target   semver.Version
+		options  []connURI.Option
+		expected string
+	}{
+		{
+			"default string",
+			v5X,
+			v6X,
+			[]connURI.Option{},
+			"postgresql://localhost:0/template1?search_path=",
+		},
+		{
+			"set port to a value",
+			v5X,
+			v6X,
+			[]connURI.Option{
+				connURI.Port(12345),
+			},
+			"postgresql://localhost:12345/template1?search_path=",
+		},
+		{
+			"connect to source version less than 7X",
+			v5X,
+			v6X,
+			[]connURI.Option{
+				connURI.ToSource(),
+				connURI.UtilityMode(),
+			},
+			"postgresql://localhost:0/template1?search_path=&gp_session_role=utility",
+		},
+		{
+			"connect to target version of 7X",
+			v6X,
+			v7X,
+			[]connURI.Option{
+				connURI.ToTarget(),
+				connURI.UtilityMode(),
+			},
+			"postgresql://localhost:0/template1?search_path=&gp_role=utility",
+		},
+		{
+			"allow system table mods",
+			v6X,
+			v7X,
+			[]connURI.Option{
+				connURI.AllowSystemTableMods(),
+			},
+			"postgresql://localhost:0/template1?search_path=&allow_system_table_mods=true",
+		},
+		{
+			"set all options to a 7X target",
+			v6X,
+			v7X,
+			[]connURI.Option{
+				connURI.ToTarget(),
+				connURI.Port(12345),
+				connURI.UtilityMode(),
+				connURI.AllowSystemTableMods(),
+			},
+			"postgresql://localhost:12345/template1?search_path=&gp_role=utility&allow_system_table_mods=true",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			conn := connURI.Connection(c.source, c.target)
+
+			actual := conn.URI(c.options...)
+			if actual != c.expected {
+				t.Errorf("got %q, want %q", actual, c.expected)
+			}
+		})
+	}
+}

--- a/hub/finalize.go
+++ b/hub/finalize.go
@@ -99,7 +99,7 @@ func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeSe
 				return seg.IsMirror()
 			}
 
-			return UpgradeMirrors(s.StateDir, s.Target.MasterPort(),
+			return UpgradeMirrors(s.StateDir, s.Connection, s.Target.MasterPort(),
 				s.Source.SelectSegments(mirrors), greenplum.NewRunner(s.Target, streams), s.UseHbaHostnames)
 		})
 	}
@@ -128,10 +128,10 @@ func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeSe
 
 	message := &idl.Message{Contents: &idl.Message_Response{Response: &idl.Response{Contents: &idl.Response_FinalizeResponse{
 		FinalizeResponse: &idl.FinalizeResponse{
-			TargetVersion: s.Target.Version.VersionString,
-			LogArchiveDirectory: archiveDir,
+			TargetVersion:                     s.Target.Version.VersionString,
+			LogArchiveDirectory:               archiveDir,
 			ArchivedSourceMasterDataDirectory: s.Config.TargetInitializeConfig.Master.DataDir + upgrade.OldSuffix,
-			UpgradeID: s.Config.UpgradeID.String(),
+			UpgradeID:                         s.Config.UpgradeID.String(),
 			Target: &idl.Cluster{
 				Port:                int32(s.Target.MasterPort()),
 				MasterDataDirectory: s.Target.MasterDataDir(),

--- a/hub/server.go
+++ b/hub/server.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc/reflection"
 	grpcStatus "google.golang.org/grpc/status"
 
+	"github.com/greenplum-db/gpupgrade/db/connURI"
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/upgrade"
@@ -358,6 +359,11 @@ type Config struct {
 	// Target is the upgraded GPDB cluster. It is populated during the target
 	// gpinitsystem execution in the initialize step; before that, it is nil.
 	Target *greenplum.Cluster
+
+	// Connection is a utility object that generates connection URIs to the
+	// source or target databases.  It also contains the Source.Version and
+	// Target.Version internally.
+	Connection *connURI.Conn
 
 	// TargetInitializeConfig contains all the info needed to initialize the
 	// target cluster's master, standby, primaries and mirrors.

--- a/hub/server_internal_test.go
+++ b/hub/server_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/greenplum-db/gpupgrade/db/connURI"
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/upgrade"
@@ -26,6 +27,7 @@ func TestConfig(t *testing.T) {
 		original := &Config{
 			source,
 			target,
+			&connURI.Conn{},
 			targetInitializeConfig,
 			12345,           // Port
 			54321,           // AgentPort

--- a/hub/upgrade_mirrors.go
+++ b/hub/upgrade_mirrors.go
@@ -12,6 +12,7 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/greenplum-db/gpupgrade/db/connURI"
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/greenplum-db/gpupgrade/utils/errorlist"
@@ -91,9 +92,14 @@ func waitForFTS(db *sql.DB, timeout time.Duration) error {
 	}
 }
 
-func UpgradeMirrors(stateDir string, masterPort int, mirrors []greenplum.SegConfig, targetRunner greenplum.Runner, useHbaHostnames bool) (err error) {
-	connURI := fmt.Sprintf("postgresql://localhost:%d/template1?gp_session_role=utility&search_path=", masterPort)
-	db, err := utils.System.SqlOpen("pgx", connURI)
+func UpgradeMirrors(stateDir string, conn *connURI.Conn, masterPort int, mirrors []greenplum.SegConfig, targetRunner greenplum.Runner, useHbaHostnames bool) (err error) {
+	options := []connURI.Option{
+		connURI.ToTarget(),
+		connURI.Port(masterPort),
+		connURI.UtilityMode(),
+	}
+
+	db, err := utils.System.SqlOpen("pgx", conn.URI(options...))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
NOTE: this PR only does the implementation; it does not modify the bats tests.  That will be done separately, as currently this PR itself enables manual 6->7 gpugrade testing.

[pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:6_to_7_utility_mode_option_name)

Prior to 7X, a utility mode connection to the cluster uses the string "gp_session_role=utility".  In 7X and later, we use the string "gp_role=utility".  

This PR makes the necessary changes to allow any utility connection to know the correct version string to use.

One subtley in the implementation involves the different types we use for version in gpupgrade.  The Cluster object that is used to store the source and target information uses dbconn.Version, which is in gp-common-go-libs and contains both a string and a semver-v3.  But in checking the compatibility of versions to allow gpugprade, we use just a semver-v4, and that is the only version we want to use in gpupgrade.  But dbconn.Version's semver is NOT just a semver.MustParse(versionString); it is hand-constructed. This and the semver-v3 and semver-v4 incompatibility is why we use semver-v4.MustParse(cluster.Version.semver-v3.String()) method to get the semver for finding the utility connection.

Things to consider:
* is the correct cluster(source or target) being used to determine the version?


