### PR TITLE
finalize: for 7X target, do not update non-existent gpperfmon.conf

### DIFF
--- a/hub/finalize.go
+++ b/hub/finalize.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"golang.org/x/xerrors"
 
@@ -55,6 +56,7 @@ func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeSe
 
 	st.Run(idl.Substep_UPDATE_TARGET_CONF_FILES, func(streams step.OutStreams) error {
 		return UpdateConfFiles(streams,
+			semver.MustParse(s.Target.Version.SemVer.String()),
 			s.Target.MasterDataDir(),
 			s.TargetInitializeConfig.Master.Port,
 			s.Source.MasterPort(),

--- a/hub/update_conf_files.go
+++ b/hub/update_conf_files.go
@@ -7,12 +7,16 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/blang/semver/v4"
+
 	"github.com/greenplum-db/gpupgrade/step"
 )
 
-func UpdateConfFiles(streams step.OutStreams, masterDataDir string, oldPort, newPort int) error {
-	if err := UpdateGpperfmonConf(streams, masterDataDir); err != nil {
-		return err
+func UpdateConfFiles(streams step.OutStreams, version semver.Version, masterDataDir string, oldPort, newPort int) error {
+	if version.Major < 7 {
+		if err := UpdateGpperfmonConf(streams, masterDataDir); err != nil {
+			return err
+		}
 	}
 
 	if err := UpdatePostgresqlConf(streams, masterDataDir, oldPort, newPort); err != nil {


### PR DESCRIPTION
In a 5X to 6X upgrade, we need to update the contents of the
gpperfmon.conf file located in the master data directory.

In 7X, there is no such conf file.

The bats tests also need to be updated, but will be handled separately.  This PR enables manual 6->7 upgrade testing.

[pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:7_to_7_no_gpperfmon_conf)