### PR TITLE
Increase min versions to 5.28.6 and 6.15.0

### DIFF
--- a/agent/upgrade_primaries_test.go
+++ b/agent/upgrade_primaries_test.go
@@ -90,7 +90,7 @@ func TestUpgradePrimary(t *testing.T) {
 			DataDirPairs:  pairs,
 			CheckOnly:     true,
 			UseLinkMode:   false,
-			TargetVersion: "6.9.0",
+			TargetVersion: "6.15.0",
 		}
 		err := agent.UpgradePrimaries(tempDir, request)
 		if err == nil {
@@ -119,7 +119,7 @@ func TestUpgradePrimary(t *testing.T) {
 			DataDirPairs:  pairs,
 			CheckOnly:     false,
 			UseLinkMode:   false,
-			TargetVersion: "6.9.0"}
+			TargetVersion: "6.15.0"}
 		err := agent.UpgradePrimaries(tempDir, request)
 		if err == nil {
 			t.Fatal("UpgradeSegments() returned no error")
@@ -300,6 +300,6 @@ func buildRequest(pairs []*idl.DataDirPair) *idl.UpgradePrimariesRequest {
 		CheckOnly:       false,
 		UseLinkMode:     false,
 		MasterBackupDir: "/some/master/backup/dir",
-		TargetVersion:   "6.9.0",
+		TargetVersion:   "6.15.0",
 	}
 }

--- a/greenplum/allowed_gpdb_versions.go
+++ b/greenplum/allowed_gpdb_versions.go
@@ -30,12 +30,12 @@ var (
 // by the utility.  Map entries are of the form: GPDB_VERSION : MIN_ALLOWED_SEMVER
 
 var minSourceVersions = map[int]string{
-	5: "5.28.0",
-	6: "6.9.0",
+	5: "5.28.6",
+	6: "6.15.0",
 }
 
 var minTargetVersions = map[int]string{
-	6: "6.9.0",
+	6: "6.15.0",
 }
 
 // The below boilerplate turns the source/targetRanges variables into

--- a/greenplum/allowed_gpdb_versions_test.go
+++ b/greenplum/allowed_gpdb_versions_test.go
@@ -23,11 +23,11 @@ func TestAllowedVersions(t *testing.T) {
 		{
 			"allowed source versions",
 			[]string{
-				"5.28.0",
-				"5.28.1",
+				"5.28.6",
+				"5.28.7",
 				"5.50.0",
-				"6.9.0",
-				"6.9.1",
+				"6.15.0",
+				"6.15.1",
 				"6.50.1",
 			},
 			sourceVersionAllowed,
@@ -38,9 +38,10 @@ func TestAllowedVersions(t *testing.T) {
 			[]string{
 				"4.3.0",
 				"5.0.0",
-				"5.27.0",
+				"5.28.0",
+				"5.28.5",
 				"6.0.0",
-				"6.8.9",
+				"6.14.9",
 				"7.0.0",
 			},
 			sourceVersionAllowed,
@@ -49,8 +50,8 @@ func TestAllowedVersions(t *testing.T) {
 		}, {
 			"allowed target versions",
 			[]string{
-				"6.9.0",
-				"6.9.1",
+				"6.15.0",
+				"6.15.1",
 				"6.50.1",
 			},
 			targetVersionAllowed,
@@ -65,7 +66,7 @@ func TestAllowedVersions(t *testing.T) {
 				"5.28.0",
 				"5.50.0",
 				"6.0.0",
-				"6.8.0",
+				"6.14.0",
 				"7.0.0",
 			},
 			targetVersionAllowed,
@@ -91,7 +92,7 @@ func TestAllowedVersions(t *testing.T) {
 func TestValidateVersions(t *testing.T) {
 	t.Run("passes when given supported versions", func(t *testing.T) {
 		gpdbVersion = func(str string) (semver.Version, error) {
-			return semver.MustParse("6.9.0"), nil
+			return semver.MustParse("6.15.0"), nil
 		}
 		defer func() {
 			gpdbVersion = LocalVersion
@@ -126,16 +127,16 @@ func TestValidateVersionsErrorCases(t *testing.T) {
 			func(string) (semver.Version, error) {
 				return semver.MustParse("6.8.0"), nil
 			},
-			"source cluster version 6.8.0 is not supported.  The minimum required version is 6.9.0. We recommend the latest version.",
-			"target cluster version 6.8.0 is not supported.  The minimum required version is 6.9.0. We recommend the latest version.",
+			"source cluster version 6.8.0 is not supported.  The minimum required version is 6.15.0. We recommend the latest version.",
+			"target cluster version 6.8.0 is not supported.  The minimum required version is 6.15.0. We recommend the latest version.",
 		},
 		{
 			"fails when sourceVersion and targetVersion have unsupported major versions",
 			func(string) (semver.Version, error) {
 				return semver.MustParse("0.0.0"), nil
 			},
-			"source cluster version 0.0.0 is not supported.  The minimum required version is 5.28.0. We recommend the latest version.",
-			"target cluster version 0.0.0 is not supported.  The minimum required version is 6.9.0. We recommend the latest version.",
+			"source cluster version 0.0.0 is not supported.  The minimum required version is 5.28.6. We recommend the latest version.",
+			"target cluster version 0.0.0 is not supported.  The minimum required version is 6.15.0. We recommend the latest version.",
 		},
 	}
 

--- a/hub/upgrade_master_test.go
+++ b/hub/upgrade_master_test.go
@@ -169,7 +169,7 @@ func TestUpgradeMaster(t *testing.T) {
 		{ContentID: -1, Port: 5433, DataDir: "/data/new", DbID: 2, Role: "p"},
 	})
 	target.GPHome = "/usr/local/target"
-	target.Version = dbconn.NewVersion("6.9.0")
+	target.Version = dbconn.NewVersion("6.15.0")
 
 	// We need a real temporary directory to change to. Replace MkdirAll() so
 	// that we can make sure the directory is the correct one.

--- a/upgrade/run_test.go
+++ b/upgrade/run_test.go
@@ -320,7 +320,7 @@ func TestRun(t *testing.T) {
 		}{
 			{
 				"the master (default)",
-				semver.MustParse("6.9.0"),
+				semver.MustParse("6.15.0"),
 				[]upgrade.Option{},
 			},
 			{
@@ -330,36 +330,36 @@ func TestRun(t *testing.T) {
 			},
 			{
 				"segments",
-				semver.MustParse("6.9.0"),
+				semver.MustParse("6.15.0"),
 				[]upgrade.Option{upgrade.WithSegmentMode()}},
 			{
 				"--check mode on master",
-				semver.MustParse("6.9.0"),
+				semver.MustParse("6.15.0"),
 				[]upgrade.Option{upgrade.WithCheckOnly()},
 			},
 			{
 				"--check mode on segments",
-				semver.MustParse("6.9.0"),
+				semver.MustParse("6.15.0"),
 				[]upgrade.Option{upgrade.WithSegmentMode(), upgrade.WithCheckOnly()},
 			},
 			{
 				"--link mode on master",
-				semver.MustParse("6.9.0"),
+				semver.MustParse("6.15.0"),
 				[]upgrade.Option{upgrade.WithLinkMode()},
 			},
 			{
 				"--link mode on segments",
-				semver.MustParse("6.9.0"),
+				semver.MustParse("6.15.0"),
 				[]upgrade.Option{upgrade.WithSegmentMode(), upgrade.WithLinkMode()},
 			},
 			{
 				"--old-tablespaces-file flag on segments",
-				semver.MustParse("6.9.0"),
+				semver.MustParse("6.15.0"),
 				[]upgrade.Option{upgrade.WithTablespaceFile("tablespaceMappingFile.txt"), upgrade.WithSegmentMode()},
 			},
 			{
 				"--old-options on master",
-				semver.MustParse("6.9.0"),
+				semver.MustParse("6.15.0"),
 				[]upgrade.Option{upgrade.WithOldOptions("option value")},
 			},
 		}


### PR DESCRIPTION
Increase min versions to 5.28.6 and 6.15.0

- 5X/6X  `Limit anyarray coercion to INSERT statements`    This needs to wait until 5.28.6 is [posted to TanzuNet](https://network.pivotal.io/products/pivotal-gpdb/).  6.14.1 already has it.
- 6X `24d5e99cac8 (origin/6X_STABLE) check_gp.c: Use pg_catalog to empty out search path` needs to be in the 6X release.  It should be in 6.15.0(check).

For Tracker story: https://www.pivotaltracker.com/story/show/177189379
Concourse pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:version_update