### PR TITLE
build: update golang to 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ pg_upgrade supports two upgrade modes: link and copy.
 
 ### Prerequisites
 
-- Golang. We currently develop against latest stable Golang, which was v1.15 as of October 2020.
+- Golang. We currently develop against latest stable Golang, which was v1.16 as of October 2020.
 - protoc. This is the compiler for the [gRPC protobuf](https://grpc.io/) 
 system which can be installed on macOS with `brew install protobuf`.
 - Run `make && make depend-dev` to install other developer dependencies. Note 

--- a/ci/generated/pipeline.yml
+++ b/ci/generated/pipeline.yml
@@ -1923,7 +1923,7 @@ jobs:
           type: docker-image
           source:
             repository: golang
-            tag: '1.15'
+            tag: '1.16'
         inputs:
           - name: gpupgrade_src
           - name: rpm_oss

--- a/ci/tasks/noinstall-tests.yml
+++ b/ci/tasks/noinstall-tests.yml
@@ -7,7 +7,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: '1.15'
+    tag: '1.16'
 
 inputs:
 - name: gpupgrade_src

--- a/ci/template.yml
+++ b/ci/template.yml
@@ -594,7 +594,7 @@ jobs:
           type: docker-image
           source:
             repository: golang
-            tag: '1.15'
+            tag: '1.16'
         inputs:
           - name: gpupgrade_src
           - name: rpm_oss

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/greenplum-db/gpupgrade
 
-go 1.15
+go 1.16
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.4.1

--- a/test/goversion.bats
+++ b/test/goversion.bats
@@ -5,8 +5,8 @@
 
 load helpers
 
-@test "gpupupgrade is compiled with golang version 1.15.X" {
-    local EXPECTED="gpupgrade: go1.15."
+@test "gpupupgrade is compiled with golang version 1.16.X" {
+    local EXPECTED="gpupgrade: go1.16."
     run go version gpupgrade
     [ "$status" -eq 0 ]
     [[ "$output" =~ $EXPECTED ]] || fail "expected: $EXPECTED got: $output"


### PR DESCRIPTION
Note this requires a corresponding update to the version used in our
test pipelines.

The gpugprade pipeline passes except for the `goversion.bats` that tests that that we built with the correct version.  It's catch-22: the `noinstall` tests use the image-baking image which is currently on `1.15.7` and the `install` tests use the docker image which is changed to `1.16.2` here.  My plan is to, at the end of the day once this is approved, to merge the image-baking pipeline and then in the morning, merge this one.  Then all should be good.

The fact that all bats tests other than the `go version` check pass gives me high confidence that all our other tests will pass on 1.16.2. 

https://github.com/pivotal/gp-image-baking/pull/121 is the pipeline for that.

[pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:update_golang_to_1.16.2)
