### PR TITLE
ci: use published RPMs for source version

### DIFF
--- a/ci/generated/pipeline.yml
+++ b/ci/generated/pipeline.yml
@@ -69,19 +69,19 @@ resources:
   type: s3
   source:
     access_key_id: ((bucket-access-key-id))
-    bucket: ((gpdb-stable-builds-bucket-name))
+    bucket: ((gpdb5-release-bucket-name))
     region_name: ((aws-region))
     secret_access_key: ((bucket-secret-access-key))
-    regexp: release_candidates/gpdb_rpm_installer_centos6/gpdb5/greenplum-db-(5.*)-rhel6-x86_64.rpm
+    regexp: deliverables/greenplum-db-(5.*)-rhel6-x86_64.rpm
 
 - name: rpm_gpdb5_centos7
   type: s3
   source:
     access_key_id: ((bucket-access-key-id))
-    bucket: ((gpdb-stable-builds-bucket-name))
+    bucket: ((gpdb5-release-bucket-name))
     region_name: ((aws-region))
     secret_access_key: ((bucket-secret-access-key))
-    regexp: release_candidates/gpdb_rpm_installer_centos7/gpdb5/greenplum-db-(5.*)-rhel7-x86_64.rpm
+    regexp: deliverables/greenplum-db-(5.*)-rhel7-x86_64.rpm
 
 
 - name: rpm_oss

--- a/ci/template.yml
+++ b/ci/template.yml
@@ -49,10 +49,10 @@ resources:
   type: s3
   source:
     access_key_id: ((bucket-access-key-id))
-    bucket: ((gpdb-stable-builds-bucket-name))
+    bucket: ((gpdb5-release-bucket-name))
     region_name: ((aws-region))
     secret_access_key: ((bucket-secret-access-key))
-    regexp: release_candidates/gpdb_rpm_installer_centos{{.CentosVersion}}/gpdb{{ majorVersion .GPVersion }}/greenplum-db-({{escapeVersion .GPVersion}}.*)-rhel{{.CentosVersion}}-x86_64.rpm
+    regexp: deliverables/greenplum-db-({{escapeVersion .GPVersion}}.*)-rhel{{.CentosVersion}}-x86_64.rpm
 {{- else }}
 - name: rpm_gpdb{{.GPVersion}}_centos{{.CentosVersion}}
   type: gcs


### PR DESCRIPTION
Previously, gpupgrade was using release candidate RPMs for the source cluster. However, a 5X release candidate have not been successfully built in a month even though a release has occurred within that time. This was partly due to tech debt with pipeline jobs pulling python dependencies from the internet which was flakey rather than caching dependencies.

In the meantime a new pg_upgrade check was added (See GPDB commits f2136bd and 49fc6fc) to coerce unknown-type literals to type text. This requires a function to be present in both the users source and target GPHOME. However, gpupgrade was testing with release candidate RPMs for the source version which did not contain the function causing initialize to fail with the following: 
```
 ERROR:
could not find function "view_has_unknown_casts" in file
"/usr/local/greenplum-db-5.28.6/lib/postgresql/pg_upgrade_support.so" 
```

One of the downsides of using published RPMs is slower feedback cycle and increased blocked pipeline. We could adopt a way to test with both released candidate RPMs and published RPMs using whichever is newer in order to not block releasing gpupgrade.

[Test Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:published_RPMS)

--- 

**Note** after merging re-fly the prod pipeline with: make set-pipeline GIT_URI=https://github.com/greenplum-db/gpupgrade BRANCH=master FLY_TARGET=prod PIPELINE_NAME=gpupgrade
