### PR TITLE
initialize: skip disk space check when ratio is 0

### DIFF
--- a/cli/commands/initialize.go
+++ b/cli/commands/initialize.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/xerrors"
@@ -233,9 +234,15 @@ func initialize() *cobra.Command {
 				return nil
 			})
 
-			st.RunCLISubstep(idl.Substep_CHECK_DISK_SPACE, func(streams step.OutStreams) error {
-				return commanders.CheckDiskSpace(client, diskFreeRatio)
-			})
+			if diskFreeRatio > 0 {
+				st.RunCLISubstep(idl.Substep_CHECK_DISK_SPACE, func(streams step.OutStreams) error {
+					return commanders.CheckDiskSpace(client, diskFreeRatio)
+				})
+			}
+
+			if diskFreeRatio == 0 {
+				gplog.Debug("skipping %s since disk-free-ratio is %.1f", idl.Substep_CHECK_DISK_SPACE, diskFreeRatio)
+			}
 
 			var response idl.InitializeResponse
 			st.RunHubSubstep(func(streams step.OutStreams) error {

--- a/test/initialize.bats
+++ b/test/initialize.bats
@@ -180,6 +180,21 @@ outputContains() {
     done
 }
 
+@test "initialize skips disk space check when --disk-free-ratio is 0" {
+    gpupgrade kill-services
+
+    run gpupgrade initialize \
+        --disk-free-ratio=0 \
+        --source-gphome="$GPHOME_SOURCE" \
+        --target-gphome="$GPHOME_TARGET" \
+        --source-master-port="${PGPORT}" \
+        --stop-before-cluster-creation \
+        --automatic \
+        --verbose 3>&-
+
+    [[ $output != *'CHECK_DISK_SPACE'* ]] || fail "Expected disk space check to have been skipped. $output"
+}
+
 wait_for_port_change() {
     local port=$1
     local ret=$2


### PR DESCRIPTION
This introduces a way to entirely skip the disk space check and its implementation when needed.

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:skipDiskSpace)
