### PR TITLE
pass current step name in prompt

### DIFF
--- a/cli/commanders/step.go
+++ b/cli/commanders/step.go
@@ -60,7 +60,7 @@ func NewStep(currentStep idl.Step, streams *step.BufferedStreams, verbose bool, 
 	if !interactive {
 		fmt.Println(confirmationText)
 
-		proceed, err := Prompt(bufio.NewReader(os.Stdin))
+		proceed, err := Prompt(bufio.NewReader(os.Stdin), currentStep)
 		if err != nil {
 			return &Step{}, err
 		}
@@ -236,9 +236,9 @@ func logDuration(operation string, verbose bool, timer *stopwatch.Stopwatch) {
 	gplog.Debug(msg)
 }
 
-func Prompt(reader *bufio.Reader) (bool, error) {
+func Prompt(reader *bufio.Reader, step idl.Step) (bool, error) {
 	for {
-		fmt.Print("Continue with gpupgrade initialize?  Yy|Nn: ")
+		fmt.Printf("Continue with gpupgrade %s?  Yy|Nn: ", strings.ToLower(step.String()))
 		input, err := reader.ReadString('\n')
 		if err != nil {
 			return false, err

--- a/cli/commanders/step_test.go
+++ b/cli/commanders/step_test.go
@@ -681,7 +681,7 @@ func TestPrompt(t *testing.T) {
 	t.Run("returns error when failing to read input", func(t *testing.T) {
 		input := ""
 		reader := bufio.NewReader(strings.NewReader(input))
-		proceed, err := commanders.Prompt(reader)
+		proceed, err := commanders.Prompt(reader, idl.Step_EXECUTE)
 		if err != io.EOF {
 			t.Errorf("Prompt(%q) returned error: %+v ", input, io.EOF)
 		}
@@ -694,7 +694,7 @@ func TestPrompt(t *testing.T) {
 	t.Run("returns true when user proceeds", func(t *testing.T) {
 		for _, input := range []string{"y\n", "Y\n"} {
 			reader := bufio.NewReader(strings.NewReader(input))
-			proceed, err := commanders.Prompt(reader)
+			proceed, err := commanders.Prompt(reader, idl.Step_EXECUTE)
 			if err != nil {
 				t.Errorf("Prompt(%q) returned error: %+v ", input, err)
 			}
@@ -708,7 +708,7 @@ func TestPrompt(t *testing.T) {
 	t.Run("returns false when user cancels", func(t *testing.T) {
 		for _, input := range []string{"n\n", "N\n"} {
 			reader := bufio.NewReader(strings.NewReader(input))
-			proceed, err := commanders.Prompt(reader)
+			proceed, err := commanders.Prompt(reader, idl.Step_EXECUTE)
 			if err != nil {
 				t.Errorf("Prompt(%q) returned error: %+v ", input, err)
 			}


### PR DESCRIPTION
Before the prompt was incorrectly hard coded to initialize. Fix it to dynamically display the correct step.


[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixPrompt)