### PR TITLE
config: add target-port

### DIFF
--- a/cli/bash/gpupgrade.bash
+++ b/cli/bash/gpupgrade.bash
@@ -344,6 +344,8 @@ _gpupgrade_config_show()
     local_nonpersistent_flags+=("--target-datadir")
     flags+=("--target-gphome")
     local_nonpersistent_flags+=("--target-gphome")
+    flags+=("--target-port")
+    local_nonpersistent_flags+=("--target-port")
 
     must_have_one_flag=()
     must_have_one_noun=()

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -157,6 +157,7 @@ func createConfigShowSubcommand() *cobra.Command {
 	subShow.Flags().Bool("source-gphome", false, "show path for the source Greenplum installation")
 	subShow.Flags().Bool("target-gphome", false, "show path for the target Greenplum installation")
 	subShow.Flags().Bool("target-datadir", false, "show temporary data directory for target gpdb cluster")
+	subShow.Flags().Bool("target-port", false, "show temporary master port for target cluster")
 
 	return subShow
 }

--- a/hub/config.go
+++ b/hub/config.go
@@ -5,6 +5,7 @@ package hub
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/greenplum-db/gpupgrade/idl"
 
@@ -27,6 +28,10 @@ func (s *Server) GetConfig(ctx context.Context, in *idl.GetConfigRequest) (*idl.
 	case "target-datadir":
 		if s.Target != nil {
 			resp.Value = s.Target.MasterDataDir()
+		}
+	case "target-port":
+		if s.TargetInitializeConfig.Master.Port != 0 {
+			resp.Value = strconv.Itoa(s.TargetInitializeConfig.Master.Port)
 		}
 	default:
 		return nil, status.Errorf(codes.NotFound, "%s is not a valid configuration key", in.Name)

--- a/test/config.bats
+++ b/test/config.bats
@@ -13,11 +13,14 @@ setup() {
 
     gpupgrade kill-services
 
+    TARGET_PGPORT=6020
+
     gpupgrade initialize \
         --automatic \
         --source-gphome "$GPHOME_SOURCE" \
         --target-gphome "$GPHOME_TARGET" \
         --source-master-port ${PGPORT} \
+        --temp-port-range "$TARGET_PGPORT"-6040 \
         --stop-before-cluster-creation \
         --disk-free-ratio 0 3>&-
 }
@@ -48,4 +51,5 @@ teardown() {
     [ "${lines[1]}" = "source-gphome - $GPHOME_SOURCE" ]
     [ "${lines[2]}" = "target-datadir - " ] # This isn't populated until cluster creation, but it's still displayed here
     [ "${lines[3]}" = "target-gphome - $GPHOME_TARGET" ]
+    [ "${lines[4]}" = "target-port - $TARGET_PGPORT" ]
 }


### PR DESCRIPTION
For ease in testing show temporary coordinator port for the target cluster.


Test Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:targetPort