### PR TITLE
initialize: fix overlapping ports test

### DIFF
--- a/hub/fill_cluster_configs_test.go
+++ b/hub/fill_cluster_configs_test.go
@@ -265,7 +265,16 @@ func TestEnsureTempPortRangeDoesNotOverlapWithSourceClusterPorts(t *testing.T) {
 	t.Run("ensureTempPortRangeDoesNotOverlapWithSourceClusterPorts succeeds", func(t *testing.T) {
 		err := ensureTempPortRangeDoesNotOverlapWithSourceClusterPorts(source, target)
 		if err != nil {
-			t.Errorf("expected error %#v got nil", err)
+			t.Errorf("unexpected error %#v", err)
+		}
+	})
+
+	t.Run("allow the same port on different hosts", func(t *testing.T) {
+		target.Standby.Port = source.MasterPort()
+
+		err := ensureTempPortRangeDoesNotOverlapWithSourceClusterPorts(source, target)
+		if err != nil {
+			t.Errorf("unexpected error %#v", err)
 		}
 	})
 

--- a/test/acceptance/gpupgrade/initialize.bats
+++ b/test/acceptance/gpupgrade/initialize.bats
@@ -210,7 +210,7 @@ outputContains() {
 
     [ "$status" -eq 1 ] || fail
     echo $output
-    [[ $output = *"temp_port_range contains port ${PGPORT} which overlaps with the source cluster ports. Specify a non-overlapping temp_port_range."* ]] || fail
+    [[ $output = *"temp_port_range contains port ${PGPORT} which overlaps with the source cluster ports on host $(hostname). Specify a non-overlapping temp_port_range."* ]] || fail
 }
 
 wait_for_port_change() {


### PR DESCRIPTION
When checking overlapping ports check target cluster ports in order of master, standby, primaries, and mirrors. This enables the 6->6 initialize.bats to succeed when checking the conflicting port.

[Pipeline](https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:overlapPorts)