### PR TITLE
Non-upgradeable test for views referencing deprecated tables

### DIFF
--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/views_referencing_deprecated_tables.out
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/views_referencing_deprecated_tables.out
@@ -1,0 +1,67 @@
+-- Copyright (c) 2017-2021 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- GPDB5: Certain tables are deprecated with respect to a major version
+-- upgrade from 5. Views that reference these tables error out during schema
+-- restore, rendering them non-upgradeable. They must be dropped before running
+-- an upgrade.
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+
+-- Create views containing references to deprecated table pg_filespace_entry in
+-- various portions of a potential view query tree (such as subquery, join and
+-- CTE) to ensure that check_node_deprecated_tables_walker correctly flags these
+-- as non-upgradeable.
+CREATE VIEW dep_rel_view AS SELECT * from pg_filespace_entry;
+CREATE
+CREATE VIEW dep_rel_view_subquery AS (SELECT * from (select * from pg_filespace_entry)sub);
+CREATE
+CREATE VIEW dep_rel_view_join AS SELECT * from pg_filespace_entry, pg_database;
+CREATE
+CREATE VIEW dep_rel_view_cte AS (WITH dep_rel_cte AS (SELECT * FROM pg_filespace_entry) SELECT * FROM dep_rel_cte);
+CREATE
+CREATE VIEW dep_rel_sublink AS SELECT dbid FROM gp_segment_configuration WHERE 0 < ALL (SELECT fsedbid FROM pg_filespace_entry);
+CREATE
+
+-- Create a view containing a reference to a deprecated table that is in the
+-- gp_toolkit schema. We use a slightly different detection mechanism for such
+-- tables (they don't have static Oids, so we have to perform a dynamic Oid
+-- lookup)
+CREATE VIEW dep_rel_dynamic_oid AS SELECT * FROM gp_toolkit.__gp_localid;
+CREATE
+
+--------------------------------------------------------------------------------
+-- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+--------------------------------------------------------------------------------
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --automatic;
+-- start_ignore
+-- end_ignore
+(exited with code 1)
+! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/view_deprecated_tables.txt | LC_ALL=C sort -b;
+Database: isolation2test
+  public.dep_rel_dynamic_oid 
+  public.dep_rel_sublink 
+  public.dep_rel_view 
+  public.dep_rel_view_cte 
+  public.dep_rel_view_join 
+  public.dep_rel_view_subquery 
+
+
+--------------------------------------------------------------------------------
+-- Workaround to unblock upgrade
+--------------------------------------------------------------------------------
+DROP VIEW dep_rel_view;
+DROP
+DROP VIEW dep_rel_view_subquery;
+DROP
+DROP VIEW dep_rel_view_join;
+DROP
+DROP VIEW dep_rel_view_cte;
+DROP
+DROP VIEW dep_rel_sublink;
+DROP
+
+DROP VIEW dep_rel_dynamic_oid;
+DROP

--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/non_upgradeable_schedule
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/non_upgradeable_schedule
@@ -10,4 +10,5 @@ test: mismatched_partition_schemas
 test: name_col
 test: partitioned_heap_table_with_dropped_columns
 test: tsquery_col
+test: views_referencing_deprecated_tables
 test: views_with_lag_lead_functions

--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/views_referencing_deprecated_tables.sql
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/views_referencing_deprecated_tables.sql
@@ -1,0 +1,44 @@
+-- Copyright (c) 2017-2021 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- GPDB5: Certain tables are deprecated with respect to a major version
+-- upgrade from 5. Views that reference these tables error out during schema
+-- restore, rendering them non-upgradeable. They must be dropped before running
+-- an upgrade.
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+
+-- Create views containing references to deprecated table pg_filespace_entry in
+-- various portions of a potential view query tree (such as subquery, join and
+-- CTE) to ensure that check_node_deprecated_tables_walker correctly flags these
+-- as non-upgradeable.
+CREATE VIEW dep_rel_view AS SELECT * from pg_filespace_entry;
+CREATE VIEW dep_rel_view_subquery AS (SELECT * from (select * from pg_filespace_entry)sub);
+CREATE VIEW dep_rel_view_join AS SELECT * from pg_filespace_entry, pg_database;
+CREATE VIEW dep_rel_view_cte AS (WITH dep_rel_cte AS (SELECT * FROM pg_filespace_entry) SELECT * FROM dep_rel_cte);
+CREATE VIEW dep_rel_sublink AS SELECT dbid FROM gp_segment_configuration WHERE 0 < ALL (SELECT fsedbid FROM pg_filespace_entry);
+
+-- Create a view containing a reference to a deprecated table that is in the
+-- gp_toolkit schema. We use a slightly different detection mechanism for such
+-- tables (they don't have static Oids, so we have to perform a dynamic Oid
+-- lookup)
+CREATE VIEW dep_rel_dynamic_oid AS SELECT * FROM gp_toolkit.__gp_localid;
+
+--------------------------------------------------------------------------------
+-- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+--------------------------------------------------------------------------------
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --automatic;
+! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/view_deprecated_tables.txt | LC_ALL=C sort -b;
+
+--------------------------------------------------------------------------------
+-- Workaround to unblock upgrade
+--------------------------------------------------------------------------------
+DROP VIEW dep_rel_view;
+DROP VIEW dep_rel_view_subquery;
+DROP VIEW dep_rel_view_join;
+DROP VIEW dep_rel_view_cte;
+DROP VIEW dep_rel_sublink;
+
+DROP VIEW dep_rel_dynamic_oid;


### PR DESCRIPTION
This tests the functionality added to pg_upgrade --check in order to
flag views referencing deprecated relations as non-upgradeable. This
functionality was added in GPDB PRs:
https://github.com/greenplum-db/gpdb/pull/12072
https://github.com/greenplum-db/gpdb/pull/12073