### PR TITLE
Sort pg_upgrade --check output independent of platform

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -122,9 +122,8 @@ they will skip many of the `gpupgrade initialize` substeps which were already ru
 - Note, the pg_regress framework gives us smart diffs. Specifically, the output
 from `SELECT` queries don't require an `ORDER BY` for deterministic output
 comparison. See atmsort.pl in the gpdb repo for details. However, the framework
-will *not* sort the output of shell commands such as `! cat .. ;`. An explicit
-sort will have to be provided such as `! cat .. | sort ;`.
-
+will *not* sort the output of shell commands such as `! cat .. ;`. Therefore, use
+`! cat .. | sort -b -d;` to sort results independent of platforms.
 
 ### pg_upgrade: upgradeable tests (positive tests)
 

--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/different_name_index_backed_constraint.out
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/different_name_index_backed_constraint.out
@@ -52,7 +52,7 @@ INSERT 1
 -- start_ignore
 -- end_ignore
 (exited with code 1)
-! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/unique_primary_key_constraint.txt | sort;
+! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/unique_primary_key_constraint.txt | sort -b -d;
 Constraint name "table_with_primary_constraint_au_ti" does not match index name "table_with_primary_constraint_pkey2"
 Constraint name "table_with_unique_constraint_uniq_au_ti" does not match index name "table_with_unique_constraint_author_key2"
 Database:  isolation2test

--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/foreign_key_constraint.out
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/foreign_key_constraint.out
@@ -48,10 +48,10 @@ INSERT 2
 -- start_ignore
 -- end_ignore
 (exited with code 1)
-! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/foreign_key_constraints.txt | sort;
+! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/foreign_key_constraints.txt | sort -b -d;
+Database: isolation2test
   pt_another_fkey on relation public.pt_another
   pt_fkey on relation public.pt
-Database: isolation2test
 
 
 --------------------------------------------------------------------------------

--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/indexes_on_partitions.out
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/indexes_on_partitions.out
@@ -45,17 +45,17 @@ CREATE
 -- start_ignore
 -- end_ignore
 (exited with code 1)
-! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/partitioned_tables_indexes.txt | sort;
-  public.p_ao_table has 1 index(es)
-  public.p_ao_table_1_prt_1 has 1 index(es)
-  public.p_ao_table_1_prt_2 has 1 index(es)
-  public.p_aoco_table has 1 index(es)
+! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/partitioned_tables_indexes.txt | sort -b -d;
+Database:  isolation2test
   public.p_aoco_table_1_prt_1 has 1 index(es)
   public.p_aoco_table_1_prt_2 has 1 index(es)
-  public.p_heap_table has 1 index(es)
+  public.p_aoco_table has 1 index(es)
+  public.p_ao_table_1_prt_1 has 1 index(es)
+  public.p_ao_table_1_prt_2 has 1 index(es)
+  public.p_ao_table has 1 index(es)
   public.p_heap_table_1_prt_1 has 1 index(es)
   public.p_heap_table_1_prt_2 has 1 index(es)
-Database:  isolation2test
+  public.p_heap_table has 1 index(es)
 
 
 --------------------------------------------------------------------------------

--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/mismatched_partition_schemas.out
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/mismatched_partition_schemas.out
@@ -32,11 +32,11 @@ ALTER
 -- start_ignore
 -- end_ignore
 (exited with code 1)
-! /bin/cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/mismatched_partition_schemas.txt | sort;
+! /bin/cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/mismatched_partition_schemas.txt | sort -b -d;
+Database: isolation2test
   public.multischema_partition contains child other_schema.multischema_partition_1_prt_1
   public.multischema_subpartition contains child other_schema.multischema_subpartition_1_prt_1_2_prt_2
   public.multischema_subpartition contains child other_schema.multischema_subpartition_1_prt_1_2_prt_other
-Database: isolation2test
 
 
 --------------------------------------------------------------------------------

--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/partitioned_heap_table_with_dropped_columns.out
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/partitioned_heap_table_with_dropped_columns.out
@@ -72,7 +72,7 @@ ALTER
 -- start_ignore
 -- end_ignore
 (exited with code 1)
-! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/heterogeneous_partitioned_tables.txt | sort;
+! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/heterogeneous_partitioned_tables.txt | sort -b -d;
   column ........pg.dropped.2........ of parent table public.p_diff_aligned_varlena has type 0 of length -1 and alignment 'd', but it is type 0 of length -1 and alignment 'i' in child table public.p_diff_aligned_varlena_1_prt_varlena_2_prt_varlena_first
   column ........pg.dropped.2........ of parent table public.p_different_aligned_column has type 0 of length 12 and alignment 'i', but it is type 0 of length 12 and alignment 'd' in child table public.p_differen_1_prt_p_part_w_2_prt_subpart_differnt_aligned_column
   column ........pg.dropped.2........ of parent table public.p_different_size_column has type 0 of length 4 and alignment 'i', but it is type 0 of length -1 and alignment 'i' in child table public.p_different_s_1_prt_p_part_w_2_prt_subpart_differnt_size_column

--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/views_with_lag_lead_functions.out
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/views_with_lag_lead_functions.out
@@ -32,12 +32,12 @@ CREATE
 -- start_ignore
 -- end_ignore
 (exited with code 1)
-! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/view_lead_lag_functions.txt | sort;
+! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/view_lead_lag_functions.txt | sort -b -d;
+Database: isolation2test
   public.lag_view_1 
   public.lag_view_2 
   public.lead_view_1 
   public.lead_view_2 
-Database: isolation2test
 
 
 --------------------------------------------------------------------------------

--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/different_name_index_backed_constraint.sql
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/different_name_index_backed_constraint.sql
@@ -35,7 +35,7 @@ INSERT INTO table_with_primary_constraint VALUES(2, 2);
 -- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
 --------------------------------------------------------------------------------
 !\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --automatic;
-! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/unique_primary_key_constraint.txt | sort;
+! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/unique_primary_key_constraint.txt | sort -b -d;
 
 --------------------------------------------------------------------------------
 -- Workaround to unblock upgrade

--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/foreign_key_constraint.sql
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/foreign_key_constraint.sql
@@ -37,7 +37,7 @@ INSERT INTO non_pt SELECT i FROM generate_series(1,2)i;
 -- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
 --------------------------------------------------------------------------------
 !\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --automatic;
-! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/foreign_key_constraints.txt | sort;
+! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/foreign_key_constraints.txt | sort -b -d;
 
 --------------------------------------------------------------------------------
 -- Workaround to unblock upgrade

--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/indexes_on_partitions.sql
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/indexes_on_partitions.sql
@@ -30,7 +30,7 @@ CREATE INDEX p_aoco_first_name_index ON p_aoco_table(first_name);
 -- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
 --------------------------------------------------------------------------------
 !\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --automatic;
-! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/partitioned_tables_indexes.txt | sort;
+! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/partitioned_tables_indexes.txt | sort -b -d;
 
 --------------------------------------------------------------------------------
 -- Workaround to unblock upgrade

--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/mismatched_partition_schemas.sql
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/mismatched_partition_schemas.sql
@@ -28,7 +28,7 @@ ALTER TABLE multischema_subpartition_1_prt_1_2_prt_other SET SCHEMA other_schema
 -- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
 --------------------------------------------------------------------------------
 !\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --automatic;
-! /bin/cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/mismatched_partition_schemas.txt | sort;
+! /bin/cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/mismatched_partition_schemas.txt | sort -b -d;
 
 --------------------------------------------------------------------------------
 -- Workaround to unblock upgrade

--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/partitioned_heap_table_with_dropped_columns.sql
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/partitioned_heap_table_with_dropped_columns.sql
@@ -64,7 +64,7 @@ ALTER TABLE p_different_size_column ALTER PARTITION p_part_with_different_sized_
 -- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
 --------------------------------------------------------------------------------
 !\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --automatic;
-! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/heterogeneous_partitioned_tables.txt | sort;
+! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/heterogeneous_partitioned_tables.txt | sort -b -d;
 
 --------------------------------------------------------------------------------
 -- Workaround to unblock upgrade

--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/views_with_lag_lead_functions.sql
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/views_with_lag_lead_functions.sql
@@ -23,7 +23,7 @@ CREATE VIEW lead_view_2 AS SELECT lead(b, 1::bigint) OVER (ORDER BY b) as lag FR
 -- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
 --------------------------------------------------------------------------------
 !\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --automatic;
-! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/view_lead_lag_functions.txt | sort;
+! cat ${GPUPGRADE_HOME}/pg_upgrade/seg-1/view_lead_lag_functions.txt | sort -b -d;
 
 --------------------------------------------------------------------------------
 -- Workaround to unblock upgrade


### PR DESCRIPTION
Add `-b` and `-d` options to ensure that only alphanumeric characters are
considered while sorting.

Co-authored-by: Kalen Krempely <kkrempely@vmware.com>