### PR TITLE
ci: update to registery-image and use GCR

### DIFF
--- a/ci/generated/pipeline.yml
+++ b/ci/generated/pipeline.yml
@@ -215,8 +215,7 @@ anchors:
           image_resource:
             type: registry-image
             source:
-              repository: pivotaldata/ccp
-              tag: "7"
+              repository: gcr.io/data-gpdb-public-images/ccp
           inputs:
             - name: ccp_src
             - name: terraform
@@ -424,7 +423,7 @@ jobs:
         source:
           # NOTE: Since we build isolation2 the build image OS needs to match
           # the GPDB target version we are testing.
-          repository: pivotaldata/gpdb6-centos6-test
+          repository: gcr.io/data-gpdb-public-images/gpdb6-centos6-test
           tag: "latest"
       inputs:
         - name: rpm_enterprise
@@ -471,7 +470,7 @@ jobs:
         source:
           # NOTE: Since we build isolation2 the build image OS needs to match
           # the GPDB target version we are testing.
-          repository: pivotaldata/gpdb6-centos7-test
+          repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test
           tag: "latest"
       inputs:
         - name: rpm_enterprise
@@ -559,7 +558,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
         - name: terraform
@@ -576,7 +575,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
           - name: gpupgrade_src
@@ -658,7 +657,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
         - name: terraform
@@ -675,7 +674,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
           - name: gpupgrade_src
@@ -761,7 +760,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
         - name: terraform
@@ -779,7 +778,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
           - name: gpupgrade_src
@@ -865,7 +864,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
         - name: terraform
@@ -883,7 +882,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
           - name: gpupgrade_src
@@ -969,7 +968,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
         - name: terraform
@@ -988,7 +987,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
           - name: gpupgrade_src
@@ -1074,7 +1073,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
         - name: terraform
@@ -1164,7 +1163,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
         - name: terraform
@@ -1250,7 +1249,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test
             tag: latest
         inputs:
           - name: gpupgrade_src
@@ -1265,7 +1264,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
         - name: terraform
@@ -1284,7 +1283,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
           - name: gpupgrade_src
@@ -1370,7 +1369,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
         - name: terraform
@@ -1389,7 +1388,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
           - name: gpupgrade_src
@@ -1475,7 +1474,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
         - name: terraform
@@ -1565,7 +1564,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
         - name: terraform
@@ -1651,7 +1650,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test
             tag: latest
         inputs:
           - name: gpupgrade_src
@@ -1666,7 +1665,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
         - name: terraform
@@ -1685,7 +1684,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
           - name: gpupgrade_src
@@ -1762,7 +1761,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
           - name: terraform
@@ -1844,7 +1843,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
           - name: terraform
@@ -1930,7 +1929,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
           - name: terraform
@@ -2016,7 +2015,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
           - name: terraform

--- a/ci/generated/pipeline.yml
+++ b/ci/generated/pipeline.yml
@@ -5,18 +5,18 @@
 
 resource_types:
 - name: gcs
-  type: docker-image
+  type: registry-image
   source:
     repository: frodenas/gcs-resource
 
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
 
 - name: terraform
-  type: docker-image
+  type: registry-image
   source:
     repository: ljfranklin/terraform-resource
     tag: 0.11.14
@@ -213,7 +213,7 @@ anchors:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: pivotaldata/ccp
               tag: "7"
@@ -323,7 +323,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
           repository: golangci/golangci-lint
       inputs:
@@ -420,7 +420,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
           # NOTE: Since we build isolation2 the build image OS needs to match
           # the GPDB target version we are testing.
@@ -467,7 +467,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
           # NOTE: Since we build isolation2 the build image OS needs to match
           # the GPDB target version we are testing.
@@ -539,7 +539,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: alpine
             tag: latest
@@ -557,7 +557,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -574,7 +574,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -638,7 +638,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: alpine
             tag: latest
@@ -656,7 +656,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -673,7 +673,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -740,7 +740,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: alpine
             tag: latest
@@ -759,7 +759,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -777,7 +777,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -844,7 +844,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: alpine
             tag: latest
@@ -863,7 +863,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -881,7 +881,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -948,7 +948,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: alpine
             tag: latest
@@ -967,7 +967,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -986,7 +986,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -1053,7 +1053,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: alpine
             tag: latest
@@ -1072,7 +1072,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -1143,7 +1143,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: alpine
             tag: latest
@@ -1162,7 +1162,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -1231,7 +1231,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: alpine
             tag: latest
@@ -1248,7 +1248,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test
             tag: latest
@@ -1263,7 +1263,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -1282,7 +1282,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -1349,7 +1349,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: alpine
             tag: latest
@@ -1368,7 +1368,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -1387,7 +1387,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -1454,7 +1454,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: alpine
             tag: latest
@@ -1473,7 +1473,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -1544,7 +1544,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: alpine
             tag: latest
@@ -1563,7 +1563,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -1632,7 +1632,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: alpine
             tag: latest
@@ -1649,7 +1649,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test
             tag: latest
@@ -1664,7 +1664,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -1683,7 +1683,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -1744,7 +1744,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: alpine
             tag: latest
@@ -1760,7 +1760,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -1826,7 +1826,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: alpine
             tag: latest
@@ -1842,7 +1842,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -1911,7 +1911,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: alpine
             tag: latest
@@ -1928,7 +1928,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -1997,7 +1997,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: alpine
             tag: latest
@@ -2014,7 +2014,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -2090,7 +2090,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: golang
             tag: '1.16'

--- a/ci/template.yml
+++ b/ci/template.yml
@@ -4,18 +4,18 @@
 
 resource_types:
 - name: gcs
-  type: docker-image
+  type: registry-image
   source:
     repository: frodenas/gcs-resource
 
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
 
 - name: terraform
-  type: docker-image
+  type: registry-image
   source:
     repository: ljfranklin/terraform-resource
     tag: 0.11.14
@@ -192,7 +192,7 @@ anchors:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: pivotaldata/ccp
               tag: "7"
@@ -293,7 +293,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
           repository: golangci/golangci-lint
       inputs:
@@ -370,7 +370,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
           # NOTE: Since we build isolation2 the build image OS needs to match
           # the GPDB target version we are testing.
@@ -461,7 +461,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: alpine
             tag: latest
@@ -481,7 +481,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test
             tag: latest
@@ -500,7 +500,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -528,7 +528,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -598,7 +598,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: alpine
             tag: latest
@@ -617,7 +617,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: pivotaldata/gpdb6-centos7-test-golang
             tag: "latest"
@@ -678,7 +678,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source:
             repository: golang
             tag: '1.16'

--- a/ci/template.yml
+++ b/ci/template.yml
@@ -194,8 +194,7 @@ anchors:
           image_resource:
             type: registry-image
             source:
-              repository: pivotaldata/ccp
-              tag: "7"
+              repository: gcr.io/data-gpdb-public-images/ccp
           inputs:
             - name: ccp_src
             - name: terraform
@@ -374,7 +373,7 @@ jobs:
         source:
           # NOTE: Since we build isolation2 the build image OS needs to match
           # the GPDB target version we are testing.
-          repository: pivotaldata/gpdb{{.Target}}-centos{{.CentosVersion}}-test
+          repository: gcr.io/data-gpdb-public-images/gpdb{{.Target}}-centos{{.CentosVersion}}-test
           tag: "latest"
       inputs:
         - name: rpm_enterprise
@@ -483,7 +482,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test
             tag: latest
         inputs:
           - name: gpupgrade_src
@@ -502,7 +501,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
         - name: terraform
@@ -530,7 +529,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
           - name: gpupgrade_src
@@ -619,7 +618,7 @@ jobs:
         image_resource:
           type: registry-image
           source:
-            repository: pivotaldata/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: "latest"
         inputs:
           - name: terraform


### PR DESCRIPTION
- update to registry-image instead of docker-image resource
- use GCR instead of docker hub

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:updateDocker