### PR TITLE
rename store's to stepStore and substepStore

### DIFF
--- a/cli/commanders/step_store.go
+++ b/cli/commanders/step_store.go
@@ -29,9 +29,7 @@ func NewStepStore() (*StepStore, error) {
 		return &StepStore{}, xerrors.Errorf("getting %q file: %w", StepsFileName, err)
 	}
 
-	return &StepStore{
-		store: step.NewSubstepFileStore(path),
-	}, nil
+	return &StepStore{store: step.NewSubstepStoreUsingFile(path)}, nil
 }
 
 func (s *StepStore) Write(stepName idl.Step, status idl.Status) error {

--- a/cli/commanders/step_store.go
+++ b/cli/commanders/step_store.go
@@ -20,7 +20,7 @@ import (
 // file store as substeps.json. An internal substep enum STEP_STATUS is used to
 // track the overall step status and should not be used as a normal substep.
 type StepStore struct {
-	store *step.FileStore
+	store *step.SubstepFileStore
 }
 
 func NewStepStore() (*StepStore, error) {
@@ -30,7 +30,7 @@ func NewStepStore() (*StepStore, error) {
 	}
 
 	return &StepStore{
-		store: step.NewFileStore(path),
+		store: step.NewSubstepFileStore(path),
 	}, nil
 }
 

--- a/cli/commanders/step_store_test.go
+++ b/cli/commanders/step_store_test.go
@@ -32,19 +32,19 @@ func TestStepStore(t *testing.T) {
 	resetEnv := testutils.SetEnv(t, "GPUPGRADE_HOME", stateDir)
 	defer resetEnv()
 
-	store, err := commanders.NewStepStore()
+	stepStore, err := commanders.NewStepStore()
 	if err != nil {
 		t.Fatalf("NewStepStore failed: %v", err)
 	}
 
 	t.Run("write persists the step status", func(t *testing.T) {
 		expected := idl.Status_RUNNING
-		err := store.Write(idl.Step_INITIALIZE, expected)
+		err := stepStore.Write(idl.Step_INITIALIZE, expected)
 		if err != nil {
 			t.Errorf("unexpected err %#v", err)
 		}
 
-		status, err := store.Read(idl.Step_INITIALIZE)
+		status, err := stepStore.Read(idl.Step_INITIALIZE)
 		if err != nil {
 			t.Errorf("Read failed %#v", err)
 		}
@@ -58,15 +58,15 @@ func TestStepStore(t *testing.T) {
 		resetEnv := testutils.SetEnv(t, "GPUPGRADE_HOME", "/does/not/exist")
 		defer resetEnv()
 
-		store, err := commanders.NewStepStore()
+		stepStore, err := commanders.NewStepStore()
 		var pathErr *os.PathError
 		if !errors.As(err, &pathErr) {
 			t.Errorf("got %T, want %T", err, pathErr)
 		}
 
 		expected := &commanders.StepStore{}
-		if !reflect.DeepEqual(store, expected) {
-			t.Errorf("got %v want %v", store, expected)
+		if !reflect.DeepEqual(stepStore, expected) {
+			t.Errorf("got %v want %v", stepStore, expected)
 		}
 	})
 
@@ -84,7 +84,7 @@ func TestStepStore(t *testing.T) {
 		resetEnv := testutils.SetEnv(t, "GPUPGRADE_HOME", stateDir)
 		defer resetEnv()
 
-		store, err := commanders.NewStepStore()
+		stepStore, err := commanders.NewStepStore()
 		if err != nil {
 			t.Fatalf("NewStepStore failed: %v", err)
 		}
@@ -94,13 +94,13 @@ func TestStepStore(t *testing.T) {
 			t.Fatalf("removing temp state directory: %v", err)
 		}
 
-		err = store.Write(idl.Step_INITIALIZE, idl.Status_RUNNING)
+		err = stepStore.Write(idl.Step_INITIALIZE, idl.Status_RUNNING)
 		var pathErr *os.PathError
 		if !errors.As(err, &pathErr) {
 			t.Errorf("returned error type %T want %T", err, pathErr)
 		}
 
-		status, err := store.Read(idl.Step_INITIALIZE)
+		status, err := stepStore.Read(idl.Step_INITIALIZE)
 		if !errors.As(err, &pathErr) {
 			t.Errorf("returned error type %T want %T", err, pathErr)
 		}
@@ -125,7 +125,7 @@ func TestStepStore(t *testing.T) {
 		resetEnv := testutils.SetEnv(t, "GPUPGRADE_HOME", stateDir)
 		defer resetEnv()
 
-		store, err := commanders.NewStepStore()
+		stepStore, err := commanders.NewStepStore()
 		if err != nil {
 			t.Fatalf("NewStepStore failed: %v", err)
 		}
@@ -141,7 +141,7 @@ func TestStepStore(t *testing.T) {
 			return true
 		}
 
-		hasStatus, err := store.HasStatus(idl.Step_INITIALIZE, check)
+		hasStatus, err := stepStore.HasStatus(idl.Step_INITIALIZE, check)
 		var pathErr *os.PathError
 		if !errors.As(err, &pathErr) {
 			t.Errorf("returned error type %T want %T", err, pathErr)
@@ -159,12 +159,12 @@ func TestStepStore(t *testing.T) {
 	t.Run("HasStepStarted returns true if a step's status is running, complete, or failed", func(t *testing.T) {
 		statuses := []idl.Status{idl.Status_RUNNING, idl.Status_COMPLETE, idl.Status_FAILED}
 		for _, status := range statuses {
-			err := store.Write(idl.Step_INITIALIZE, status)
+			err := stepStore.Write(idl.Step_INITIALIZE, status)
 			if err != nil {
 				t.Errorf("Write failed %#v", err)
 			}
 
-			started, err := store.HasStepStarted(idl.Step_INITIALIZE)
+			started, err := stepStore.HasStepStarted(idl.Step_INITIALIZE)
 			if err != nil {
 				t.Errorf("HasStepStarted failed %#v", err)
 			}
@@ -176,7 +176,7 @@ func TestStepStore(t *testing.T) {
 	})
 
 	t.Run("HasStepStarted returns false if a step has not started", func(t *testing.T) {
-		started, err := store.HasStepStarted(idl.Step_UNKNOWN_STEP)
+		started, err := stepStore.HasStepStarted(idl.Step_UNKNOWN_STEP)
 		if err != nil {
 			t.Errorf("HasStepStarted failed %#v", err)
 		}
@@ -187,12 +187,12 @@ func TestStepStore(t *testing.T) {
 	})
 
 	t.Run("HasStepCompleted returns true if a step's status is complete", func(t *testing.T) {
-		err := store.Write(idl.Step_INITIALIZE, idl.Status_COMPLETE)
+		err := stepStore.Write(idl.Step_INITIALIZE, idl.Status_COMPLETE)
 		if err != nil {
 			t.Errorf("Write failed %#v", err)
 		}
 
-		completed, err := store.HasStepCompleted(idl.Step_INITIALIZE)
+		completed, err := stepStore.HasStepCompleted(idl.Step_INITIALIZE)
 		if err != nil {
 			t.Errorf("HasStepCompleted failed %#v", err)
 		}
@@ -205,12 +205,12 @@ func TestStepStore(t *testing.T) {
 	t.Run("HasStepCompleted returns false if a step's status is not complete", func(t *testing.T) {
 		statuses := []idl.Status{idl.Status_RUNNING, idl.Status_FAILED, idl.Status_SKIPPED, idl.Status_UNKNOWN_STATUS}
 		for _, status := range statuses {
-			err := store.Write(idl.Step_INITIALIZE, status)
+			err := stepStore.Write(idl.Step_INITIALIZE, status)
 			if err != nil {
 				t.Errorf("Write failed %#v", err)
 			}
 
-			completed, err := store.HasStepCompleted(idl.Step_INITIALIZE)
+			completed, err := stepStore.HasStepCompleted(idl.Step_INITIALIZE)
 			if err != nil {
 				t.Errorf("HasStepCompleted failed %#v", err)
 			}
@@ -236,7 +236,7 @@ func TestValidateStep(t *testing.T) {
 	resetEnv := testutils.SetEnv(t, "GPUPGRADE_HOME", stateDir)
 	defer resetEnv()
 
-	store, err := commanders.NewStepStore()
+	stepStore, err := commanders.NewStepStore()
 	if err != nil {
 		t.Fatalf("NewStepStore failed: %v", err)
 	}
@@ -340,13 +340,13 @@ func TestValidateStep(t *testing.T) {
 
 	for _, c := range errorCases {
 		t.Run(c.name, func(t *testing.T) {
-			clearStore(t)
+			clearStepStore(t)
 
 			for _, condition := range c.preconditions {
-				mustWriteStatus(t, store, condition.step, condition.status)
+				mustWriteStatus(t, stepStore, condition.step, condition.status)
 			}
 
-			err = store.ValidateStep(c.currentStep)
+			err = stepStore.ValidateStep(c.currentStep)
 			var nextActionsErr cli.NextActions
 			if !errors.As(err, &nextActionsErr) {
 				t.Errorf("got %T, want %T", err, nextActionsErr)
@@ -439,13 +439,13 @@ func TestValidateStep(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			clearStore(t)
+			clearStepStore(t)
 
 			for _, condition := range c.preconditions {
-				mustWriteStatus(t, store, condition.step, condition.status)
+				mustWriteStatus(t, stepStore, condition.step, condition.status)
 			}
 
-			err = store.ValidateStep(c.currentStep)
+			err = stepStore.ValidateStep(c.currentStep)
 			if err != nil {
 				t.Errorf("unexpected err %#v", err)
 			}
@@ -453,18 +453,18 @@ func TestValidateStep(t *testing.T) {
 	}
 }
 
-func clearStore(t *testing.T) {
+func clearStepStore(t *testing.T) {
 	t.Helper()
 
 	path := filepath.Join(utils.GetStateDir(), commanders.StepsFileName)
 	testutils.MustWriteToFile(t, path, "{}")
 }
 
-func mustWriteStatus(t *testing.T, store *commanders.StepStore, step idl.Step, status idl.Status) {
+func mustWriteStatus(t *testing.T, stepStore *commanders.StepStore, step idl.Step, status idl.Status) {
 	t.Helper()
 
-	err := store.Write(step, status)
+	err := stepStore.Write(step, status)
 	if err != nil {
-		t.Errorf("store.Write returned error %+v", err)
+		t.Errorf("stepStore.Write returned error %+v", err)
 	}
 }

--- a/cli/commanders/step_test.go
+++ b/cli/commanders/step_test.go
@@ -461,7 +461,7 @@ func TestStepStatus(t *testing.T) {
 	resetEnv := testutils.SetEnv(t, "GPUPGRADE_HOME", stateDir)
 	defer resetEnv()
 
-	store, err := commanders.NewStepStore()
+	stepStore, err := commanders.NewStepStore()
 	if err != nil {
 		t.Fatalf("NewStepStore failed: %v", err)
 	}
@@ -472,7 +472,7 @@ func TestStepStatus(t *testing.T) {
 			t.Errorf("unexpected err %#v", err)
 		}
 
-		status, err := store.Read(idl.Step_INITIALIZE)
+		status, err := stepStore.Read(idl.Step_INITIALIZE)
 		if err != nil {
 			t.Errorf("Read failed %#v", err)
 		}
@@ -483,7 +483,7 @@ func TestStepStatus(t *testing.T) {
 		}
 	})
 
-	t.Run("when the store is disabled step.Complete does not update the status", func(t *testing.T) {
+	t.Run("when the step store is disabled step.Complete does not update the status", func(t *testing.T) {
 		st, err := commanders.NewStep(idl.Step_INITIALIZE, &step.BufferedStreams{}, false, true, "")
 		if err != nil {
 			t.Errorf("unexpected err %#v", err)
@@ -496,7 +496,7 @@ func TestStepStatus(t *testing.T) {
 			t.Errorf("unexpected err %#v", err)
 		}
 
-		status, err := store.Read(idl.Step_INITIALIZE)
+		status, err := stepStore.Read(idl.Step_INITIALIZE)
 		if err != nil {
 			t.Errorf("Read failed %#v", err)
 		}
@@ -523,7 +523,7 @@ func TestStepStatus(t *testing.T) {
 			t.Errorf("got %T, want %T", err, nextActionsErr)
 		}
 
-		status, err := store.Read(idl.Step_INITIALIZE)
+		status, err := stepStore.Read(idl.Step_INITIALIZE)
 		if err != nil {
 			t.Errorf("Read failed %#v", err)
 		}
@@ -550,7 +550,7 @@ func TestStepStatus(t *testing.T) {
 			t.Errorf("got %T, want %T", err, nextActionsErr)
 		}
 
-		status, err := store.Read(idl.Step_INITIALIZE)
+		status, err := stepStore.Read(idl.Step_INITIALIZE)
 		if err != nil {
 			t.Errorf("Read failed %#v", err)
 		}
@@ -577,7 +577,7 @@ func TestStepStatus(t *testing.T) {
 			t.Errorf("got %T, want %T", err, nextActionsErr)
 		}
 
-		status, err := store.Read(idl.Step_INITIALIZE)
+		status, err := stepStore.Read(idl.Step_INITIALIZE)
 		if err != nil {
 			t.Errorf("Read failed %#v", err)
 		}

--- a/hub/execute.go
+++ b/hub/execute.go
@@ -22,7 +22,7 @@ const executeMasterBackupName = "upgraded-master.bak"
 func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_ExecuteServer) (err error) {
 	upgradedMasterBackupDir := filepath.Join(s.StateDir, executeMasterBackupName)
 
-	st, err := step.Begin(s.StateDir, idl.Step_EXECUTE, stream)
+	st, err := step.Begin(idl.Step_EXECUTE, stream)
 	if err != nil {
 		return err
 	}

--- a/hub/finalize.go
+++ b/hub/finalize.go
@@ -21,7 +21,7 @@ import (
 )
 
 func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeServer) (err error) {
-	st, err := step.Begin(s.StateDir, idl.Step_FINALIZE, stream)
+	st, err := step.Begin(idl.Step_FINALIZE, stream)
 	if err != nil {
 		return err
 	}

--- a/hub/initialize.go
+++ b/hub/initialize.go
@@ -21,7 +21,7 @@ import (
 )
 
 func (s *Server) Initialize(in *idl.InitializeRequest, stream idl.CliToHub_InitializeServer) (err error) {
-	st, err := step.Begin(s.StateDir, idl.Step_INITIALIZE, stream)
+	st, err := step.Begin(idl.Step_INITIALIZE, stream)
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func (s *Server) Initialize(in *idl.InitializeRequest, stream idl.CliToHub_Initi
 }
 
 func (s *Server) InitializeCreateCluster(in *idl.InitializeCreateClusterRequest, stream idl.CliToHub_InitializeCreateClusterServer) (err error) {
-	st, err := step.Begin(s.StateDir, idl.Step_INITIALIZE, stream)
+	st, err := step.Begin(idl.Step_INITIALIZE, stream)
 	if err != nil {
 		return err
 	}

--- a/hub/revert.go
+++ b/hub/revert.go
@@ -23,7 +23,7 @@ import (
 var ErrMissingMirrorsAndStandby = errors.New("Source cluster does not have mirrors and/or standby. Cannot restore source cluster. Please contact support.")
 
 func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) (err error) {
-	st, err := step.Begin(s.StateDir, idl.Step_REVERT, stream)
+	st, err := step.Begin(idl.Step_REVERT, stream)
 	if err != nil {
 		return err
 	}

--- a/step/file_store.go
+++ b/step/file_store.go
@@ -12,12 +12,12 @@ import (
 	"github.com/greenplum-db/gpupgrade/utils"
 )
 
-type Store interface {
+type SubstepStore interface {
 	Read(idl.Step, idl.Substep) (idl.Status, error)
 	Write(idl.Step, idl.Substep, idl.Status) error
 }
 
-// FileStore implements step.Store by providing persistent storage on disk.
+// FileStore implements step.SubstepStore by providing persistent storage on disk.
 type FileStore struct {
 	path string
 }

--- a/step/step.go
+++ b/step/step.go
@@ -63,7 +63,7 @@ func Begin(stateDir string, step idl.Step, sender idl.MessageSender) (*Step, err
 
 	streams := newMultiplexedStream(sender, log)
 
-	return New(step, sender, NewFileStore(statusPath), streams), nil
+	return New(step, sender, NewSubstepFileStore(statusPath), streams), nil
 }
 
 func HasRun(step idl.Step, substep idl.Substep) (bool, error) {
@@ -72,7 +72,7 @@ func HasRun(step idl.Step, substep idl.Substep) (bool, error) {
 		return false, xerrors.Errorf("read %q: %w", SubstepsFileName, err)
 	}
 
-	substepStore := NewFileStore(path)
+	substepStore := NewSubstepFileStore(path)
 	status, err := substepStore.Read(step, substep)
 	if err != nil {
 		return false, err

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -307,7 +307,7 @@ func TestHasRun(t *testing.T) {
 
 			path := filepath.Join(dir, step.SubstepsFileName)
 			testutils.MustWriteToFile(t, path, "{}")
-			store := step.NewFileStore(path)
+			store := step.NewSubstepFileStore(path)
 			err := store.Write(idl.Step_INITIALIZE, idl.Substep_SAVING_SOURCE_CLUSTER_CONFIG, c.status)
 			if err != nil {
 				t.Errorf("store.Write returned error %+v", err)

--- a/step/substep_store.go
+++ b/step/substep_store.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
+	"golang.org/x/xerrors"
 )
 
 type SubstepStore interface {
@@ -22,7 +23,16 @@ type SubstepFileStore struct {
 	path string
 }
 
-func NewSubstepFileStore(path string) *SubstepFileStore {
+func NewSubstepFileStore() (*SubstepFileStore, error) {
+	path, err := utils.GetJSONFile(utils.GetStateDir(), SubstepsFileName)
+	if err != nil {
+		return &SubstepFileStore{}, xerrors.Errorf("read %q: %w", SubstepsFileName, err)
+	}
+
+	return &SubstepFileStore{path}, nil
+}
+
+func NewSubstepStoreUsingFile(path string) *SubstepFileStore {
 	return &SubstepFileStore{path}
 }
 

--- a/step/substep_store.go
+++ b/step/substep_store.go
@@ -17,13 +17,13 @@ type SubstepStore interface {
 	Write(idl.Step, idl.Substep, idl.Status) error
 }
 
-// FileStore implements step.SubstepStore by providing persistent storage on disk.
-type FileStore struct {
+// SubstepFileStore implements SubstepStore by providing persistent storage on disk.
+type SubstepFileStore struct {
 	path string
 }
 
-func NewFileStore(path string) *FileStore {
-	return &FileStore{path}
+func NewSubstepFileStore(path string) *SubstepFileStore {
+	return &SubstepFileStore{path}
 }
 
 type prettyMap = map[string]map[string]PrettyStatus
@@ -50,7 +50,7 @@ func (p *PrettyStatus) UnmarshalText(buf []byte) error {
 	return nil
 }
 
-func (f *FileStore) load() (prettyMap, error) {
+func (f *SubstepFileStore) load() (prettyMap, error) {
 	data, err := ioutil.ReadFile(f.path)
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ func (f *FileStore) load() (prettyMap, error) {
 	return substeps, nil
 }
 
-func (f *FileStore) Read(step idl.Step, substep idl.Substep) (idl.Status, error) {
+func (f *SubstepFileStore) Read(step idl.Step, substep idl.Substep) (idl.Status, error) {
 	steps, err := f.load()
 	if err != nil {
 		return idl.Status_UNKNOWN_STATUS, err
@@ -87,7 +87,7 @@ func (f *FileStore) Read(step idl.Step, substep idl.Substep) (idl.Status, error)
 // Write atomically updates the status file.
 // Load the latest values from the filesystem, rather than storing
 // in-memory on a struct to avoid having two sources of truth.
-func (f *FileStore) Write(step idl.Step, substep idl.Substep, status idl.Status) (err error) {
+func (f *SubstepFileStore) Write(step idl.Step, substep idl.Substep, status idl.Status) (err error) {
 	steps, err := f.load()
 	if err != nil {
 		return err

--- a/step/substep_store_test.go
+++ b/step/substep_store_test.go
@@ -27,7 +27,7 @@ func TestFileStore(t *testing.T) {
 	}()
 
 	path := filepath.Join(tmpDir, step.SubstepsFileName)
-	fs := step.NewFileStore(path)
+	fs := step.NewSubstepFileStore(path)
 
 	const section = idl.Step_INITIALIZE
 
@@ -169,7 +169,7 @@ func TestFileStore(t *testing.T) {
 	})
 }
 
-// clear writes an empty JSON map to the given FileStore backing path.
+// clear writes an empty JSON map to the given SubstepFileStore backing path.
 func clear(t *testing.T, path string) {
 	t.Helper()
 

--- a/step/substep_store_test.go
+++ b/step/substep_store_test.go
@@ -27,7 +27,7 @@ func TestFileStore(t *testing.T) {
 	}()
 
 	path := filepath.Join(tmpDir, step.SubstepsFileName)
-	fs := step.NewSubstepFileStore(path)
+	fs := step.NewSubstepStoreUsingFile(path)
 
 	const section = idl.Step_INITIALIZE
 


### PR DESCRIPTION
 - use stepStore and substepStore for clarity
- rename FileStore to SubstepFileStore for accuracy and clarity
 - add NewSubstepStore() encapsulates the default substep file store location. The simplifies the callers.
 
 Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:storeNaming