### PR TITLE
hub: persist archive directory

### DIFF
--- a/hub/server_internal_test.go
+++ b/hub/server_internal_test.go
@@ -25,6 +25,7 @@ func TestConfig(t *testing.T) {
 		// forget to add them to this test. Be kind and document those that are
 		// not clear with comments.
 		original := &Config{
+			"logArchiveDir",
 			source,
 			target,
 			&connURI.Conn{},

--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -6,6 +6,7 @@ package hub_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -25,6 +26,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/testutils/mock_agent"
 	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/upgrade"
+	"github.com/greenplum-db/gpupgrade/utils"
 )
 
 const timeout = 1 * time.Second
@@ -356,6 +358,72 @@ func TestHubSaveConfig(t *testing.T) {
 
 		if !reflect.DeepEqual(actual, h.Config) {
 			t.Errorf("wrote config %#v want %#v", actual, h.Config)
+		}
+	})
+}
+
+func TestGetArchiveDir(t *testing.T) {
+	stateDir := testutils.GetTempDir(t, "")
+	defer testutils.MustRemoveAll(t, stateDir)
+
+	resetEnv := testutils.SetEnv(t, "GPUPGRADE_HOME", stateDir)
+	defer resetEnv()
+
+	source, target := testutils.CreateMultinodeSampleClusterPair("/data")
+	conf := &hub.Config{
+		Source:                 source,
+		Target:                 target,
+		TargetInitializeConfig: hub.InitializeConfig{},
+		Port:                   12345,
+		AgentPort:              54321,
+		UseLinkMode:            false,
+		UpgradeID:              0,
+	}
+
+	server := hub.New(conf, nil, "")
+
+	t.Run("returns log archive directory and persists it", func(t *testing.T) {
+		actual, err := server.GetLogArchiveDir()
+		if err != nil {
+			t.Fatalf("unexpected error: %#v", err)
+		}
+
+		logDir, err := utils.GetLogDir()
+		if err != nil {
+			t.Fatalf("failed to get log dir: %v", err)
+		}
+
+		id := "AAAAAAAAAAA" // all zeroes in base64. 8 bytes decoded -> 11 bytes encoded
+		expectedPrefix := fmt.Sprintf("%s-%s-", logDir, id)
+
+		if !strings.HasPrefix(actual, expectedPrefix) {
+			t.Errorf("got %v want prefix %v", actual, expectedPrefix)
+		}
+
+		// copy actual output of GetLogArchiveDir() to expected
+		var sb strings.Builder
+		sb.WriteString(actual)
+		expected := sb.String()
+
+		// assert that it is persisted
+		actualConf := new(hub.Config)
+		err = hub.LoadConfig(actualConf, upgrade.GetConfigFile())
+		if err != nil {
+			t.Fatalf("reading config: %v", err)
+		}
+
+		if actualConf.LogArchiveDir != expected {
+			t.Errorf("got %v want %v", actual, expectedPrefix)
+		}
+
+		// returns the same persisted archive directory if it is already set
+		actual, err = server.GetLogArchiveDir()
+		if err != nil {
+			t.Errorf("unexpected error: %#v", err)
+		}
+
+		if actual != expected {
+			t.Errorf("got %v want prefix %v", actual, expectedPrefix)
 		}
 	})
 }


### PR DESCRIPTION
Persist the archive directory so that during re-runs and restarts the correct directory is sent from the hub to cli and displayed to the user.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:archiveDir