### PR TITLE
ci: update tasks to use registry-image and GCR

### DIFF
--- a/ci/tasks/build.yml
+++ b/ci/tasks/build.yml
@@ -5,9 +5,9 @@ PLATFORM: linux
 
 # Use a Centos/RHEL image to build the rpms
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: pivotaldata/gpdb6-centos7-test-golang
+    repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
     tag: "latest"
 
 inputs:

--- a/ci/tasks/install-tests.yml
+++ b/ci/tasks/install-tests.yml
@@ -4,9 +4,9 @@
 PLATFORM: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: pivotaldata/gpdb6-centos7-test-golang
+    repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
     tag: "latest"
 
 inputs:

--- a/ci/tasks/load-dump.yml
+++ b/ci/tasks/load-dump.yml
@@ -3,7 +3,7 @@
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: alpine
     tag: latest

--- a/ci/tasks/noinstall-tests.yml
+++ b/ci/tasks/noinstall-tests.yml
@@ -4,6 +4,13 @@
 PLATFORM: linux
 
 image_resource:
+  # Use docker-image instead of registry-image due to the following error.
+  # See: https://github.com/concourse/registry-image-resource/issues/283
+  #  --- FAIL: TestLocal (0.00s)
+  #    disk_test.go:269: Local.Filesystems() returned error &fs.PathError{Op:"open", Path:"/etc/mtab", Err:0x2}
+  #    disk_test.go:272: Local.Filesystems() returned no entries
+  #  FAIL
+  #  FAIL	github.com/greenplum-db/gpupgrade/utils/disk	0.030s
   type: docker-image
   source:
     repository: golang


### PR DESCRIPTION
https://github.com/greenplum-db/gpupgrade/pull/554 missed a few references of pivotaldata and docker-image used within tasks.

Use GCR to reduce docker pull count from docker. Use the registry-image resource type which is a newer replacement for the docker-image resource.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:updateDocker2

