### PR TITLE
version: use -q when ssh'ing for remote version

### DIFF
--- a/greenplum/common_test.go
+++ b/greenplum/common_test.go
@@ -21,6 +21,10 @@ func MockExecCommand(ctrl *gomock.Controller) (mock *exectest.MockCommandSpy, cl
 	return mock, ResetExecCommand
 }
 
+func SetExecCommand(cmdFunc exectest.Command) {
+	execCommand = cmdFunc
+}
+
 func ResetExecCommand() {
 	execCommand = nil
 }

--- a/greenplum/version.go
+++ b/greenplum/version.go
@@ -61,7 +61,7 @@ func version(gphome string, host string) (semver.Version, error) {
 	args := []string{"--gp-version"}
 	if host != "" {
 		name = "ssh"
-		args = []string{host, fmt.Sprintf(`bash -c "%s --gp-version"`, postgres)}
+		args = []string{host, fmt.Sprintf(`-q bash -c "%s --gp-version"`, postgres)}
 	}
 
 	cmd := execCommand(name, args...)

--- a/greenplum/version_test.go
+++ b/greenplum/version_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -41,7 +42,7 @@ func init() {
 		PostgresGPVersion_11_341_31,
 	)
 	postgresPath = filepath.Join(gphome, "bin", "postgres")
-	remotePostgresCmd = fmt.Sprintf(`bash -c "%s --gp-version"`, postgresPath)
+	remotePostgresCmd = fmt.Sprintf(`-q bash -c "%s --gp-version"`, postgresPath)
 }
 
 var postgresPath, remotePostgresCmd string
@@ -153,4 +154,38 @@ func runVersionTest(t *testing.T, versionFunc func(string) (semver.Version, erro
 	if !version.Equals(expectedVer) {
 		t.Errorf("got version %v, want %v", version, expectedVer)
 	}
+}
+
+func TestGPHomeVersion_OnRemoteHost(t *testing.T) {
+	host := "sdw1"
+
+	t.Run("returns remote version using -q to suppress motd banner messages from polluting the version output", func(t *testing.T) {
+		execCmd := exectest.NewCommandWithVerifier(PostgresGPVersion_11_341_31, func(cmd string, args ...string) {
+			if cmd != "ssh" {
+				t.Errorf("got cmd %q want ssh", cmd)
+			}
+
+			expected := []string{
+				host,
+				`-q bash -c "/usr/local/my-gpdb-home/bin/postgres --gp-version"`,
+			}
+
+			if !reflect.DeepEqual(args, expected) {
+				t.Errorf("got args %q want %q", args, expected)
+			}
+		})
+
+		SetExecCommand(execCmd)
+		defer ResetExecCommand()
+
+		version, err := NewVersions(gphome).Remote(host)
+		if err != nil {
+			t.Errorf("unexpected errr %#v", err)
+		}
+
+		expected := "11.341.31"
+		if version != expected {
+			t.Errorf("got version %v, want %v", version, expected)
+		}
+	})
 }

--- a/upgrade/version.go
+++ b/upgrade/version.go
@@ -40,7 +40,7 @@ func version(host string) (string, error) {
 	args := []string{"version", "--format", "oneline"}
 	if host != "" {
 		name = "ssh"
-		args = []string{host, fmt.Sprintf(`bash -c "%s version --format oneline"`, gpupgradePath)}
+		args = []string{host, fmt.Sprintf(`-q bash -c "%s version --format oneline"`, gpupgradePath)}
 	}
 
 	cmd := execCommand(name, args...)

--- a/upgrade/version_test.go
+++ b/upgrade/version_test.go
@@ -98,7 +98,7 @@ func TestGpupgradeVersionOnHost(t *testing.T) {
 	testlog.SetupLogger()
 	host := "sdw1"
 
-	t.Run("returns the version", func(t *testing.T) {
+	t.Run("returns remote version using -q to suppress motd banner messages from polluting the version output", func(t *testing.T) {
 		execCmd := exectest.NewCommandWithVerifier(gpupgradeVersion, func(cmd string, args ...string) {
 			if cmd != "ssh" {
 				t.Errorf("got cmd %q want ssh", cmd)
@@ -106,7 +106,7 @@ func TestGpupgradeVersionOnHost(t *testing.T) {
 
 			expected := []string{
 				host,
-				fmt.Sprintf(`bash -c "%s/gpupgrade version --format oneline"`, testutils.MustGetExecutablePath(t)),
+				fmt.Sprintf(`-q bash -c "%s/gpupgrade version --format oneline"`, testutils.MustGetExecutablePath(t)),
 			}
 
 			if !reflect.DeepEqual(args, expected) {


### PR DESCRIPTION
Draft PR for now, until I have a bit more time to add final touches.

If the remote machine uses motd banners or other messages this will get mingled with the output of the version command leading to errors. Suppress motd banner messages by using the ssh -q parameter.