### PR TITLE
version: use -q when ssh'ing for remote version

### DIFF
--- a/greenplum/common_test.go
+++ b/greenplum/common_test.go
@@ -21,6 +21,10 @@ func MockExecCommand(ctrl *gomock.Controller) (mock *exectest.MockCommandSpy, cl
 	return mock, ResetExecCommand
 }
 
+func SetExecCommand(cmdFunc exectest.Command) {
+	execCommand = cmdFunc
+}
+
 func ResetExecCommand() {
 	execCommand = nil
 }

--- a/greenplum/version.go
+++ b/greenplum/version.go
@@ -61,7 +61,7 @@ func version(gphome string, host string) (semver.Version, error) {
 	args := []string{"--gp-version"}
 	if host != "" {
 		name = "ssh"
-		args = []string{host, fmt.Sprintf(`bash -c "%s --gp-version"`, postgres)}
+		args = []string{"-q", host, fmt.Sprintf(`bash -c "%s --gp-version"`, postgres)}
 	}
 
 	cmd := execCommand(name, args...)

--- a/upgrade/version.go
+++ b/upgrade/version.go
@@ -40,7 +40,7 @@ func version(host string) (string, error) {
 	args := []string{"version", "--format", "oneline"}
 	if host != "" {
 		name = "ssh"
-		args = []string{host, fmt.Sprintf(`bash -c "%s version --format oneline"`, gpupgradePath)}
+		args = []string{"-q", host, fmt.Sprintf(`bash -c "%s version --format oneline"`, gpupgradePath)}
 	}
 
 	cmd := execCommand(name, args...)

--- a/upgrade/version_test.go
+++ b/upgrade/version_test.go
@@ -98,13 +98,14 @@ func TestGpupgradeVersionOnHost(t *testing.T) {
 	testlog.SetupLogger()
 	host := "sdw1"
 
-	t.Run("returns the version", func(t *testing.T) {
+	t.Run("returns remote version using -q to suppress motd banner messages from polluting the version output", func(t *testing.T) {
 		execCmd := exectest.NewCommandWithVerifier(gpupgradeVersion, func(cmd string, args ...string) {
 			if cmd != "ssh" {
 				t.Errorf("got cmd %q want ssh", cmd)
 			}
 
 			expected := []string{
+				"-q",
 				host,
 				fmt.Sprintf(`bash -c "%s/gpupgrade version --format oneline"`, testutils.MustGetExecutablePath(t)),
 			}


### PR DESCRIPTION
If the remote machine uses motd banners or other messages this will get mingled with the output of the version command leading to errors. Suppress motd banner messages by using the ssh -q parameter.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:sshVersion