### PR TITLE
hub: ensure agentConns are ready

### DIFF
--- a/hub/archive_log_directory.go
+++ b/hub/archive_log_directory.go
@@ -9,8 +9,8 @@ import (
 	"github.com/greenplum-db/gpupgrade/idl"
 )
 
-func ArchiveSegmentLogDirectories(agentConns []*Connection, excludeHostname, newDir string) error {
-	request := func(conn *Connection) error {
+func ArchiveSegmentLogDirectories(agentConns []*idl.Connection, excludeHostname, newDir string) error {
+	request := func(conn *idl.Connection) error {
 		if conn.Hostname == excludeHostname {
 			return nil
 		}

--- a/hub/archive_log_directory_test.go
+++ b/hub/archive_log_directory_test.go
@@ -30,7 +30,7 @@ func TestArchiveLogDirectories(t *testing.T) {
 			&idl.ArchiveLogDirectoryRequest{NewDir: newDir},
 		).Return(&idl.ArchiveLogDirectoryReply{}, nil).Times(1)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, sdwClient, "sdw", nil},
 		}
 
@@ -51,7 +51,7 @@ func TestArchiveLogDirectories(t *testing.T) {
 			gomock.Any(),
 		).Return(nil, expected).Times(1)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, failedClient, "sdw", nil},
 		}
 

--- a/hub/archive_log_directory_test.go
+++ b/hub/archive_log_directory_test.go
@@ -31,7 +31,7 @@ func TestArchiveLogDirectories(t *testing.T) {
 		).Return(&idl.ArchiveLogDirectoryReply{}, nil).Times(1)
 
 		agentConns := []*idl.Connection{
-			{nil, sdwClient, "sdw", nil},
+			{AgentClient: sdwClient, Hostname: "sdw"},
 		}
 
 		err := hub.ArchiveSegmentLogDirectories(agentConns, "", newDir)
@@ -52,7 +52,7 @@ func TestArchiveLogDirectories(t *testing.T) {
 		).Return(nil, expected).Times(1)
 
 		agentConns := []*idl.Connection{
-			{nil, failedClient, "sdw", nil},
+			{AgentClient: failedClient, Hostname: "sdw"},
 		}
 
 		err := hub.ArchiveSegmentLogDirectories(agentConns, "", newDir)

--- a/hub/check_disk_space.go
+++ b/hub/check_disk_space.go
@@ -16,7 +16,7 @@ import (
 
 var checkDiskUsage = disk.CheckUsage
 
-func CheckDiskSpace(streams step.OutStreams, agentConns []*Connection, diskFreeRatio float64, source *greenplum.Cluster, sourceTablespaces greenplum.Tablespaces) error {
+func CheckDiskSpace(streams step.OutStreams, agentConns []*idl.Connection, diskFreeRatio float64, source *greenplum.Cluster, sourceTablespaces greenplum.Tablespaces) error {
 	var wg sync.WaitGroup
 	errs := make(chan error, len(agentConns)+1)
 	usagesChan := make(chan disk.FileSystemDiskUsage, len(agentConns)+1)
@@ -65,7 +65,7 @@ func CheckDiskSpace(streams step.OutStreams, agentConns []*Connection, diskFreeR
 	return nil
 }
 
-func checkDiskSpaceOnStandbyAndSegments(agentConns []*Connection, errs chan<- error, usages chan<- disk.FileSystemDiskUsage, diskFreeRatio float64, source *greenplum.Cluster, sourceTablespaces greenplum.Tablespaces) {
+func checkDiskSpaceOnStandbyAndSegments(agentConns []*idl.Connection, errs chan<- error, usages chan<- disk.FileSystemDiskUsage, diskFreeRatio float64, source *greenplum.Cluster, sourceTablespaces greenplum.Tablespaces) {
 	var wg sync.WaitGroup
 
 	for _, conn := range agentConns {

--- a/hub/check_disk_space_test.go
+++ b/hub/check_disk_space_test.go
@@ -131,9 +131,9 @@ func TestCheckDiskSpace_OnSegments(t *testing.T) {
 		).Return(&idl.CheckDiskSpaceReply{}, nil)
 
 		agentConns := []*idl.Connection{
-			{nil, smdw, "smdw", nil},
-			{nil, sdw1, "sdw1", nil},
-			{nil, sdw2, "sdw2", nil},
+			{AgentClient: smdw, Hostname: "smdw"},
+			{AgentClient: sdw1, Hostname: "sdw1"},
+			{AgentClient: sdw2, Hostname: "sdw2"},
 		}
 
 		err := hub.CheckDiskSpace(step.DevNullStream, agentConns, diskFreeRatio, source, tablespaces)
@@ -154,7 +154,7 @@ func TestCheckDiskSpace_OnSegments(t *testing.T) {
 		).Return(nil, expected)
 
 		agentConns := []*idl.Connection{
-			{nil, failedClient, "sdw1", nil},
+			{AgentClient: failedClient, Hostname: "sdw1"},
 		}
 
 		err := hub.CheckDiskSpace(step.DevNullStream, agentConns, 0, source, tablespaces)
@@ -181,7 +181,7 @@ func TestCheckDiskSpace_OnSegments(t *testing.T) {
 		).Return(&idl.CheckDiskSpaceReply{Usage: disk.FileSystemDiskUsage{&usage}}, nil)
 
 		agentConns := []*idl.Connection{
-			{nil, failedClient, "smdw", nil},
+			{AgentClient: failedClient, Hostname: "smdw"},
 		}
 
 		err := hub.CheckDiskSpace(step.DevNullStream, agentConns, 0, source, tablespaces)
@@ -274,7 +274,7 @@ func TestCheckDiskSpace_OnSegments(t *testing.T) {
 		).Times(0) // expected to not be called for cluster with no segments
 
 		agentConns := []*idl.Connection{
-			{nil, sdw2, "sdw2", nil},
+			{AgentClient: sdw2, Hostname: "sdw2"},
 		}
 
 		masterOnlyCluster := hub.MustCreateCluster(t, []greenplum.SegConfig{

--- a/hub/check_disk_space_test.go
+++ b/hub/check_disk_space_test.go
@@ -47,7 +47,7 @@ func TestCheckDiskSpace_OnMaster(t *testing.T) {
 		hub.SetCheckDiskUsage(MasterHostCheckDiskUsagePasses)
 		defer hub.ResetCheckDiskUsage()
 
-		err := hub.CheckDiskSpace(step.DevNullStream, []*hub.Connection{}, 0, source, tablespaces)
+		err := hub.CheckDiskSpace(step.DevNullStream, []*idl.Connection{}, 0, source, tablespaces)
 		if err != nil {
 			t.Errorf("unexpected error %#v", err)
 		}
@@ -58,7 +58,7 @@ func TestCheckDiskSpace_OnMaster(t *testing.T) {
 		hub.SetCheckDiskUsage(MasterHostErrorsWith(expected))
 		defer hub.ResetCheckDiskUsage()
 
-		err := hub.CheckDiskSpace(step.DevNullStream, []*hub.Connection{}, 0, source, tablespaces)
+		err := hub.CheckDiskSpace(step.DevNullStream, []*idl.Connection{}, 0, source, tablespaces)
 		if !errors.Is(err, expected) {
 			t.Errorf("got error %#v, want %#v", err, expected)
 		}
@@ -74,7 +74,7 @@ func TestCheckDiskSpace_OnMaster(t *testing.T) {
 		hub.SetCheckDiskUsage(MasterHostReturnsUsage(disk.FileSystemDiskUsage{&usage}))
 		defer hub.ResetCheckDiskUsage()
 
-		err := hub.CheckDiskSpace(step.DevNullStream, []*hub.Connection{}, 0, source, tablespaces)
+		err := hub.CheckDiskSpace(step.DevNullStream, []*idl.Connection{}, 0, source, tablespaces)
 		expected := disk.NewSpaceUsageErrorFromUsage(usage)
 		if !reflect.DeepEqual(err, expected) {
 			t.Errorf("returned %v want %v", err, expected)
@@ -130,7 +130,7 @@ func TestCheckDiskSpace_OnSegments(t *testing.T) {
 			},
 		).Return(&idl.CheckDiskSpaceReply{}, nil)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, smdw, "smdw", nil},
 			{nil, sdw1, "sdw1", nil},
 			{nil, sdw2, "sdw2", nil},
@@ -153,7 +153,7 @@ func TestCheckDiskSpace_OnSegments(t *testing.T) {
 			gomock.Any(),
 		).Return(nil, expected)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, failedClient, "sdw1", nil},
 		}
 
@@ -180,7 +180,7 @@ func TestCheckDiskSpace_OnSegments(t *testing.T) {
 			gomock.Any(),
 		).Return(&idl.CheckDiskSpaceReply{Usage: disk.FileSystemDiskUsage{&usage}}, nil)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, failedClient, "smdw", nil},
 		}
 
@@ -231,7 +231,7 @@ func TestCheckDiskSpace_OnSegments(t *testing.T) {
 			gomock.Any(),
 		).Return(&idl.CheckDiskSpaceReply{Usage: mirrorUsage}, nil)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{AgentClient: primary, Hostname: "primary"},
 			{AgentClient: mirror, Hostname: "mirror"},
 		}
@@ -273,7 +273,7 @@ func TestCheckDiskSpace_OnSegments(t *testing.T) {
 			gomock.Any(),
 		).Times(0) // expected to not be called for cluster with no segments
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, sdw2, "sdw2", nil},
 		}
 

--- a/hub/check_upgrade.go
+++ b/hub/check_upgrade.go
@@ -8,6 +8,7 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
@@ -29,7 +30,7 @@ func (upgradeChecker) UpgradePrimaries(args UpgradePrimaryArgs) error {
 
 var upgrader UpgradeChecker = upgradeChecker{}
 
-func (s *Server) CheckUpgrade(stream step.OutStreams, conns []*Connection) error {
+func (s *Server) CheckUpgrade(stream step.OutStreams, conns []*idl.Connection) error {
 	var wg sync.WaitGroup
 	checkErrs := make(chan error, 2)
 

--- a/hub/check_upgrade_test.go
+++ b/hub/check_upgrade_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
+	"github.com/greenplum-db/gpupgrade/idl"
 )
 
 type upgraderMock struct {
@@ -25,7 +26,7 @@ func (u upgraderMock) UpgradePrimaries(args UpgradePrimaryArgs) error {
 	return UpgradePrimariesMock(args, u.s)
 }
 
-var connections = []*Connection{{Conn: nil, Hostname: "bengie"}}
+var connections = []*idl.Connection{{Conn: nil, Hostname: "bengie"}}
 
 func setUpgrader(updated UpgradeChecker) {
 	upgrader = updated

--- a/hub/delete_data_directories_test.go
+++ b/hub/delete_data_directories_test.go
@@ -80,9 +80,9 @@ func TestDeleteSegmentDataDirs(t *testing.T) {
 			).Return(&idl.DeleteDataDirectoriesReply{}, nil)
 
 			agentConns := []*idl.Connection{
-				{nil, sdw1Client, "sdw1", nil},
-				{nil, sdw2Client, "sdw2", nil},
-				{nil, standbyClient, "standby", nil},
+				{AgentClient: sdw1Client, Hostname: "sdw1"},
+				{AgentClient: sdw2Client, Hostname: "sdw2"},
+				{AgentClient: standbyClient, Hostname: "standby"},
 			}
 
 			err := hub.DeleteMirrorAndStandbyDataDirectories(agentConns, c)
@@ -119,9 +119,9 @@ func TestDeleteSegmentDataDirs(t *testing.T) {
 			// NOTE: we expect no call to the standby
 
 			agentConns := []*idl.Connection{
-				{nil, sdw1Client, "sdw1", nil},
-				{nil, sdw2Client, "sdw2", nil},
-				{nil, standbyClient, "standby", nil},
+				{AgentClient: sdw1Client, Hostname: "sdw1"},
+				{AgentClient: sdw2Client, Hostname: "sdw2"},
+				{AgentClient: standbyClient, Hostname: "standby"},
 			}
 
 			source := hub.InitializeConfig{
@@ -153,8 +153,8 @@ func TestDeleteSegmentDataDirs(t *testing.T) {
 			).Return(nil, expected)
 
 			agentConns := []*idl.Connection{
-				{nil, sdw1Client, "sdw1", nil},
-				{nil, sdw2ClientFailed, "sdw2", nil},
+				{AgentClient: sdw1Client, Hostname: "sdw1"},
+				{AgentClient: sdw2ClientFailed, Hostname: "sdw2"},
 			}
 
 			source := hub.InitializeConfig{
@@ -310,10 +310,10 @@ func TestDeleteTablespaceDirectories(t *testing.T) {
 		standby := mock_idl.NewMockAgentClient(ctrl)
 
 		agentConns := []*idl.Connection{
-			{nil, sdw1, "sdw1", nil},
-			{nil, sdw2, "sdw2", nil},
-			{nil, master, "master", nil},
-			{nil, standby, "standby", nil},
+			{AgentClient: sdw1, Hostname: "sdw1"},
+			{AgentClient: sdw2, Hostname: "sdw2"},
+			{AgentClient: master, Hostname: "master"},
+			{AgentClient: standby, Hostname: "standby"},
 		}
 
 		err := hub.DeleteTargetTablespacesOnPrimaries(agentConns, target, tablespaces, "301908232")
@@ -340,8 +340,8 @@ func TestDeleteTablespaceDirectories(t *testing.T) {
 		).Return(nil, expected)
 
 		agentConns := []*idl.Connection{
-			{nil, sdw1, "sdw1", nil},
-			{nil, failedClient, "sdw2", nil},
+			{AgentClient: sdw1, Hostname: "sdw1"},
+			{AgentClient: failedClient, Hostname: "sdw2"},
 		}
 
 		err := hub.DeleteTargetTablespacesOnPrimaries(agentConns, target, nil, "")
@@ -359,8 +359,8 @@ func TestDeleteTablespaceDirectories(t *testing.T) {
 		sdw2 := mock_idl.NewMockAgentClient(ctrl)
 
 		agentConns := []*idl.Connection{
-			{nil, sdw1, "sdw1", nil},
-			{nil, sdw2, "sdw2", nil},
+			{AgentClient: sdw1, Hostname: "sdw1"},
+			{AgentClient: sdw2, Hostname: "sdw2"},
 		}
 
 		err := hub.DeleteTargetTablespacesOnPrimaries(agentConns, nil, nil, "")
@@ -464,12 +464,12 @@ func TestDeleteTablespacesOnMirrorsAndStandby(t *testing.T) {
 		sdw2 := mock_idl.NewMockAgentClient(ctrl)
 
 		agentConns := []*idl.Connection{
-			{nil, sdw1, "sdw1", nil},
-			{nil, msdw1, "msdw1", nil},
-			{nil, sdw2, "sdw2", nil},
-			{nil, msdw2, "msdw2", nil},
-			{nil, master, "master", nil},
-			{nil, standby, "standby", nil},
+			{AgentClient: sdw1, Hostname: "sdw1"},
+			{AgentClient: msdw1, Hostname: "msdw1"},
+			{AgentClient: sdw2, Hostname: "sdw2"},
+			{AgentClient: msdw2, Hostname: "msdw2"},
+			{AgentClient: master, Hostname: "master"},
+			{AgentClient: standby, Hostname: "standby"},
 		}
 
 		err := hub.DeleteSourceTablespacesOnMirrorsAndStandby(agentConns, source, tablespaces)
@@ -505,8 +505,8 @@ func TestDeleteTablespacesOnMirrorsAndStandby(t *testing.T) {
 		).Return(nil, expected)
 
 		agentConns := []*idl.Connection{
-			{nil, msdw1, "msdw1", nil},
-			{nil, failedClient, "msdw2", nil},
+			{AgentClient: msdw1, Hostname: "msdw1"},
+			{AgentClient: failedClient, Hostname: "msdw2"},
 		}
 
 		err := hub.DeleteSourceTablespacesOnMirrorsAndStandby(agentConns, source, tablespaces)

--- a/hub/delete_data_directories_test.go
+++ b/hub/delete_data_directories_test.go
@@ -79,7 +79,7 @@ func TestDeleteSegmentDataDirs(t *testing.T) {
 				&idl.DeleteDataDirectoriesRequest{Datadirs: []string{"/data/standby"}},
 			).Return(&idl.DeleteDataDirectoriesReply{}, nil)
 
-			agentConns := []*hub.Connection{
+			agentConns := []*idl.Connection{
 				{nil, sdw1Client, "sdw1", nil},
 				{nil, sdw2Client, "sdw2", nil},
 				{nil, standbyClient, "standby", nil},
@@ -118,7 +118,7 @@ func TestDeleteSegmentDataDirs(t *testing.T) {
 			standbyClient := mock_idl.NewMockAgentClient(ctrl)
 			// NOTE: we expect no call to the standby
 
-			agentConns := []*hub.Connection{
+			agentConns := []*idl.Connection{
 				{nil, sdw1Client, "sdw1", nil},
 				{nil, sdw2Client, "sdw2", nil},
 				{nil, standbyClient, "standby", nil},
@@ -152,7 +152,7 @@ func TestDeleteSegmentDataDirs(t *testing.T) {
 				gomock.Any(),
 			).Return(nil, expected)
 
-			agentConns := []*hub.Connection{
+			agentConns := []*idl.Connection{
 				{nil, sdw1Client, "sdw1", nil},
 				{nil, sdw2ClientFailed, "sdw2", nil},
 			}
@@ -309,7 +309,7 @@ func TestDeleteTablespaceDirectories(t *testing.T) {
 		master := mock_idl.NewMockAgentClient(ctrl)
 		standby := mock_idl.NewMockAgentClient(ctrl)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, sdw1, "sdw1", nil},
 			{nil, sdw2, "sdw2", nil},
 			{nil, master, "master", nil},
@@ -339,7 +339,7 @@ func TestDeleteTablespaceDirectories(t *testing.T) {
 			gomock.Any(),
 		).Return(nil, expected)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, sdw1, "sdw1", nil},
 			{nil, failedClient, "sdw2", nil},
 		}
@@ -358,7 +358,7 @@ func TestDeleteTablespaceDirectories(t *testing.T) {
 		sdw1 := mock_idl.NewMockAgentClient(ctrl)
 		sdw2 := mock_idl.NewMockAgentClient(ctrl)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, sdw1, "sdw1", nil},
 			{nil, sdw2, "sdw2", nil},
 		}
@@ -463,7 +463,7 @@ func TestDeleteTablespacesOnMirrorsAndStandby(t *testing.T) {
 		sdw1 := mock_idl.NewMockAgentClient(ctrl)
 		sdw2 := mock_idl.NewMockAgentClient(ctrl)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, sdw1, "sdw1", nil},
 			{nil, msdw1, "msdw1", nil},
 			{nil, sdw2, "sdw2", nil},
@@ -504,7 +504,7 @@ func TestDeleteTablespacesOnMirrorsAndStandby(t *testing.T) {
 				}}),
 		).Return(nil, expected)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, msdw1, "msdw1", nil},
 			{nil, failedClient, "msdw2", nil},
 		}

--- a/hub/delete_state_directories.go
+++ b/hub/delete_state_directories.go
@@ -9,8 +9,8 @@ import (
 	"github.com/greenplum-db/gpupgrade/idl"
 )
 
-func DeleteStateDirectories(agentConns []*Connection, excludeHostname string) error {
-	request := func(conn *Connection) error {
+func DeleteStateDirectories(agentConns []*idl.Connection, excludeHostname string) error {
+	request := func(conn *idl.Connection) error {
 		if conn.Hostname == excludeHostname {
 			return nil
 		}

--- a/hub/delete_state_directories_test.go
+++ b/hub/delete_state_directories_test.go
@@ -40,9 +40,9 @@ func TestDeleteStateDirectories(t *testing.T) {
 			// NOTE: we expect no call to the master
 
 			agentConns := []*idl.Connection{
-				{nil, sdw1Client, "sdw1", nil},
-				{nil, standbyClient, "standby", nil},
-				{nil, masterHostClient, excludeHostname, nil},
+				{AgentClient: sdw1Client, Hostname: "sdw1"},
+				{AgentClient: standbyClient, Hostname: "standby"},
+				{AgentClient: masterHostClient, Hostname: excludeHostname},
 			}
 
 			err := hub.DeleteStateDirectories(agentConns, excludeHostname)
@@ -69,8 +69,8 @@ func TestDeleteStateDirectories(t *testing.T) {
 			).Return(nil, expected)
 
 			agentConns := []*idl.Connection{
-				{nil, sdw1Client, "sdw1", nil},
-				{nil, sdw2ClientFailed, "sdw2", nil},
+				{AgentClient: sdw1Client, Hostname: "sdw1"},
+				{AgentClient: sdw2ClientFailed, Hostname: "sdw2"},
 			}
 
 			err := hub.DeleteStateDirectories(agentConns, "")

--- a/hub/delete_state_directories_test.go
+++ b/hub/delete_state_directories_test.go
@@ -39,7 +39,7 @@ func TestDeleteStateDirectories(t *testing.T) {
 			masterHostClient := mock_idl.NewMockAgentClient(ctrl)
 			// NOTE: we expect no call to the master
 
-			agentConns := []*hub.Connection{
+			agentConns := []*idl.Connection{
 				{nil, sdw1Client, "sdw1", nil},
 				{nil, standbyClient, "standby", nil},
 				{nil, masterHostClient, excludeHostname, nil},
@@ -68,7 +68,7 @@ func TestDeleteStateDirectories(t *testing.T) {
 				gomock.Any(),
 			).Return(nil, expected)
 
-			agentConns := []*hub.Connection{
+			agentConns := []*idl.Connection{
 				{nil, sdw1Client, "sdw1", nil},
 				{nil, sdw2ClientFailed, "sdw2", nil},
 			}

--- a/hub/execute.go
+++ b/hub/execute.go
@@ -22,7 +22,7 @@ const executeMasterBackupName = "upgraded-master.bak"
 func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_ExecuteServer) (err error) {
 	upgradedMasterBackupDir := filepath.Join(s.StateDir, executeMasterBackupName)
 
-	st, err := step.Begin(idl.Step_EXECUTE, stream)
+	st, err := step.Begin(idl.Step_EXECUTE, stream, s.AgentConns)
 	if err != nil {
 		return err
 	}
@@ -74,12 +74,6 @@ func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_Execut
 	})
 
 	st.Run(idl.Substep_UPGRADE_PRIMARIES, func(_ step.OutStreams) error {
-		agentConns, err := s.AgentConns()
-
-		if err != nil {
-			return xerrors.Errorf("connect to gpupgrade agent: %w", err)
-		}
-
 		dataDirPair, err := s.GetDataDirPairs()
 
 		if err != nil {
@@ -89,7 +83,7 @@ func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_Execut
 		return UpgradePrimaries(UpgradePrimaryArgs{
 			CheckOnly:              false,
 			MasterBackupDir:        upgradedMasterBackupDir,
-			AgentConns:             agentConns,
+			AgentConns:             s.agentConns,
 			DataDirPairMap:         dataDirPair,
 			Source:                 s.Source,
 			Target:                 s.Target,

--- a/hub/finalize.go
+++ b/hub/finalize.go
@@ -19,7 +19,7 @@ import (
 )
 
 func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeServer) (err error) {
-	st, err := step.Begin(idl.Step_FINALIZE, stream)
+	st, err := step.Begin(idl.Step_FINALIZE, stream, s.AgentConns)
 	if err != nil {
 		return err
 	}

--- a/hub/rename_data_directories.go
+++ b/hub/rename_data_directories.go
@@ -21,7 +21,7 @@ func (s *Server) UpdateDataDirectories() error {
 	return UpdateDataDirectories(s.Config, s.agentConns)
 }
 
-func UpdateDataDirectories(conf *Config, agentConns []*Connection) error {
+func UpdateDataDirectories(conf *Config, agentConns []*idl.Connection) error {
 	source := conf.Source.MasterDataDir()
 	target := conf.TargetInitializeConfig.Master.DataDir
 	if err := ArchiveSource(source, target, true); err != nil {
@@ -84,8 +84,8 @@ func getRenameMap(source *greenplum.Cluster, target InitializeConfig, onlyRename
 
 // e.g. for source /data/dbfast1/demoDataDir0 becomes /data/dbfast1/demoDataDir0_old
 // e.g. for target /data/dbfast1/demoDataDir0_123ABC becomes /data/dbfast1/demoDataDir0
-func RenameSegmentDataDirs(agentConns []*Connection, renames RenameMap) error {
-	request := func(conn *Connection) error {
+func RenameSegmentDataDirs(agentConns []*idl.Connection, renames RenameMap) error {
+	request := func(conn *idl.Connection) error {
 		if len(renames[conn.Hostname]) == 0 {
 			return nil
 		}

--- a/hub/rename_data_directories_test.go
+++ b/hub/rename_data_directories_test.go
@@ -79,7 +79,7 @@ func TestRenameSegmentDataDirs(t *testing.T) {
 		client3 := mock_idl.NewMockAgentClient(ctrl)
 		// NOTE: we expect no call to the standby
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, client1, "sdw1", nil},
 			{nil, client2, "sdw2", nil},
 			{nil, client3, "standby", nil},
@@ -108,7 +108,7 @@ func TestRenameSegmentDataDirs(t *testing.T) {
 			gomock.Any(),
 		).Return(nil, expected)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, client, "sdw1", nil},
 			{nil, failedClient, "sdw2", nil},
 		}
@@ -271,7 +271,7 @@ func TestUpdateDataDirectories(t *testing.T) {
 			RenameTarget: false,
 		}})
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, sdw1, "sdw1", nil},
 			{nil, sdw2, "sdw2", nil},
 			{nil, standby, "standby", nil},
@@ -326,7 +326,7 @@ func TestUpdateDataDirectories(t *testing.T) {
 			"/data/standby",
 		})
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, sdw1, "sdw1", nil},
 			{nil, sdw2, "sdw2", nil},
 			{nil, standby, "standby", nil},

--- a/hub/rename_data_directories_test.go
+++ b/hub/rename_data_directories_test.go
@@ -80,9 +80,9 @@ func TestRenameSegmentDataDirs(t *testing.T) {
 		// NOTE: we expect no call to the standby
 
 		agentConns := []*idl.Connection{
-			{nil, client1, "sdw1", nil},
-			{nil, client2, "sdw2", nil},
-			{nil, client3, "standby", nil},
+			{AgentClient: client1, Hostname: "sdw1"},
+			{AgentClient: client2, Hostname: "sdw2"},
+			{AgentClient: client3, Hostname: "standby"},
 		}
 
 		err := hub.RenameSegmentDataDirs(agentConns, m)
@@ -109,8 +109,8 @@ func TestRenameSegmentDataDirs(t *testing.T) {
 		).Return(nil, expected)
 
 		agentConns := []*idl.Connection{
-			{nil, client, "sdw1", nil},
-			{nil, failedClient, "sdw2", nil},
+			{AgentClient: client, Hostname: "sdw1"},
+			{AgentClient: failedClient, Hostname: "sdw2"},
 		}
 
 		err := hub.RenameSegmentDataDirs(agentConns, m)
@@ -272,9 +272,9 @@ func TestUpdateDataDirectories(t *testing.T) {
 		}})
 
 		agentConns := []*idl.Connection{
-			{nil, sdw1, "sdw1", nil},
-			{nil, sdw2, "sdw2", nil},
-			{nil, standby, "standby", nil},
+			{AgentClient: sdw1, Hostname: "sdw1"},
+			{AgentClient: sdw2, Hostname: "sdw2"},
+			{AgentClient: standby, Hostname: "standby"},
 		}
 
 		err := hub.UpdateDataDirectories(conf, agentConns)
@@ -327,9 +327,9 @@ func TestUpdateDataDirectories(t *testing.T) {
 		})
 
 		agentConns := []*idl.Connection{
-			{nil, sdw1, "sdw1", nil},
-			{nil, sdw2, "sdw2", nil},
-			{nil, standby, "standby", nil},
+			{AgentClient: sdw1, Hostname: "sdw1"},
+			{AgentClient: sdw2, Hostname: "sdw2"},
+			{AgentClient: standby, Hostname: "standby"},
 		}
 
 		err := hub.UpdateDataDirectories(conf, agentConns)

--- a/hub/restore_source_cluster.go
+++ b/hub/restore_source_cluster.go
@@ -30,7 +30,7 @@ var Excludes = []string{
 	"gp_dbid", "postgresql.conf", "backup_label.old", "postmaster.pid", "recovery.conf",
 }
 
-func RsyncMasterAndPrimaries(stream step.OutStreams, agentConns []*Connection, source *greenplum.Cluster) error {
+func RsyncMasterAndPrimaries(stream step.OutStreams, agentConns []*idl.Connection, source *greenplum.Cluster) error {
 	if !source.HasAllMirrorsAndStandby() {
 		return errors.New("Source cluster does not have mirrors and/or standby. Cannot restore source cluster. Please contact support.")
 	}
@@ -57,7 +57,7 @@ func RsyncMasterAndPrimaries(stream step.OutStreams, agentConns []*Connection, s
 	return err
 }
 
-func RsyncMasterAndPrimariesTablespaces(stream step.OutStreams, agentConns []*Connection, source *greenplum.Cluster, tablespaces greenplum.Tablespaces) error {
+func RsyncMasterAndPrimariesTablespaces(stream step.OutStreams, agentConns []*idl.Connection, source *greenplum.Cluster, tablespaces greenplum.Tablespaces) error {
 	if !source.HasAllMirrorsAndStandby() {
 		return ErrMissingMirrorsAndStandby
 	}
@@ -145,8 +145,8 @@ func RsyncMasterTablespaces(stream step.OutStreams, standbyHostname string, mast
 	return nil
 }
 
-func RsyncPrimaries(agentConns []*Connection, source *greenplum.Cluster) error {
-	request := func(conn *Connection) error {
+func RsyncPrimaries(agentConns []*idl.Connection, source *greenplum.Cluster) error {
+	request := func(conn *idl.Connection) error {
 		mirrors := source.SelectSegments(func(seg *greenplum.SegConfig) bool {
 			return seg.IsOnHost(conn.Hostname) && !seg.IsStandby() && seg.IsMirror()
 		})
@@ -178,8 +178,8 @@ func RsyncPrimaries(agentConns []*Connection, source *greenplum.Cluster) error {
 	return ExecuteRPC(agentConns, request)
 }
 
-func RsyncPrimariesTablespaces(agentConns []*Connection, source *greenplum.Cluster, tablespaces greenplum.Tablespaces) error {
-	request := func(conn *Connection) error {
+func RsyncPrimariesTablespaces(agentConns []*idl.Connection, source *greenplum.Cluster, tablespaces greenplum.Tablespaces) error {
+	request := func(conn *idl.Connection) error {
 		mirrors := source.SelectSegments(func(seg *greenplum.SegConfig) bool {
 			return seg.IsOnHost(conn.Hostname) && !seg.IsStandby() && seg.IsMirror()
 		})
@@ -221,7 +221,7 @@ func RsyncPrimariesTablespaces(agentConns []*Connection, source *greenplum.Clust
 	return ExecuteRPC(agentConns, request)
 }
 
-func RestoreMasterAndPrimariesPgControl(streams step.OutStreams, agentConns []*Connection, source *greenplum.Cluster) error {
+func RestoreMasterAndPrimariesPgControl(streams step.OutStreams, agentConns []*idl.Connection, source *greenplum.Cluster) error {
 	var wg sync.WaitGroup
 	errs := make(chan error, 2)
 
@@ -244,8 +244,8 @@ func RestoreMasterAndPrimariesPgControl(streams step.OutStreams, agentConns []*C
 	return err
 }
 
-func restorePrimariesPgControl(agentConns []*Connection, source *greenplum.Cluster) error {
-	request := func(conn *Connection) error {
+func restorePrimariesPgControl(agentConns []*idl.Connection, source *greenplum.Cluster) error {
+	request := func(conn *idl.Connection) error {
 		primaries := source.SelectSegments(func(seg *greenplum.SegConfig) bool {
 			return seg.IsOnHost(conn.Hostname) && !seg.IsStandby() && seg.IsPrimary()
 		})

--- a/hub/restore_source_cluster_test.go
+++ b/hub/restore_source_cluster_test.go
@@ -208,9 +208,9 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 		standby := mock_idl.NewMockAgentClient(ctrl)
 
 		agentConns := []*idl.Connection{
-			{nil, msdw1, "msdw1", nil},
-			{nil, msdw2, "msdw2", nil},
-			{nil, standby, "standby", nil},
+			{AgentClient: msdw1, Hostname: "msdw1"},
+			{AgentClient: msdw2, Hostname: "msdw2"},
+			{AgentClient: standby, Hostname: "standby"},
 		}
 
 		err := hub.RsyncPrimaries(agentConns, cluster)
@@ -254,9 +254,9 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 		standby := mock_idl.NewMockAgentClient(ctrl)
 
 		agentConns := []*idl.Connection{
-			{nil, msdw1, "msdw1", nil},
-			{nil, msdw2, "msdw2", nil},
-			{nil, standby, "standby", nil},
+			{AgentClient: msdw1, Hostname: "msdw1"},
+			{AgentClient: msdw2, Hostname: "msdw2"},
+			{AgentClient: standby, Hostname: "standby"},
 		}
 
 		err := hub.RsyncPrimariesTablespaces(agentConns, cluster, tablespaces)
@@ -328,8 +328,8 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 		).Return(nil, expected)
 
 		agentConns := []*idl.Connection{
-			{nil, msdw1, "msdw1", nil},
-			{nil, failedClient, "msdw2", nil},
+			{AgentClient: msdw1, Hostname: "msdw1"},
+			{AgentClient: failedClient, Hostname: "msdw2"},
 		}
 
 		err := hub.RsyncPrimaries(agentConns, cluster)
@@ -357,8 +357,8 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 		).Return(nil, expected)
 
 		agentConns := []*idl.Connection{
-			{nil, msdw1, "msdw1", nil},
-			{nil, failedClient, "msdw2", nil},
+			{AgentClient: msdw1, Hostname: "msdw1"},
+			{AgentClient: failedClient, Hostname: "msdw2"},
 		}
 
 		err := hub.RsyncPrimariesTablespaces(agentConns, cluster, tablespaces)
@@ -406,8 +406,8 @@ func TestRestoreMasterAndPrimariesPgControl(t *testing.T) {
 		).Return(nil, expectedError)
 
 		agentConns := []*idl.Connection{
-			{nil, sdw1, "sdw1", nil},
-			{nil, failedClient, "sdw2", nil},
+			{AgentClient: sdw1, Hostname: "sdw1"},
+			{AgentClient: failedClient, Hostname: "sdw2"},
 		}
 
 		err := hub.RestoreMasterAndPrimariesPgControl(step.DevNullStream, agentConns, cluster)
@@ -475,8 +475,8 @@ func TestRestoreMasterAndPrimariesPgControl(t *testing.T) {
 		).Return(&idl.RestorePgControlReply{}, nil)
 
 		agentConns := []*idl.Connection{
-			{nil, sdw1, "sdw1", nil},
-			{nil, sdw2, "sdw2", nil},
+			{AgentClient: sdw1, Hostname: "sdw1"},
+			{AgentClient: sdw2, Hostname: "sdw2"},
 		}
 
 		err = hub.RestoreMasterAndPrimariesPgControl(step.DevNullStream, agentConns, cluster)

--- a/hub/restore_source_cluster_test.go
+++ b/hub/restore_source_cluster_test.go
@@ -93,7 +93,7 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 			{ContentID: 1, Hostname: "sdw2", DataDir: "/data/dbfast2/seg2", Role: greenplum.PrimaryRole},
 		})
 
-		err := hub.RsyncMasterAndPrimariesTablespaces(&testutils.DevNullWithClose{}, []*hub.Connection{}, cluster, nil)
+		err := hub.RsyncMasterAndPrimariesTablespaces(&testutils.DevNullWithClose{}, []*idl.Connection{}, cluster, nil)
 		if !errors.Is(err, hub.ErrMissingMirrorsAndStandby) {
 			t.Errorf("got error %#v want %#v", err, hub.ErrMissingMirrorsAndStandby)
 		}
@@ -207,7 +207,7 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 
 		standby := mock_idl.NewMockAgentClient(ctrl)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, msdw1, "msdw1", nil},
 			{nil, msdw2, "msdw2", nil},
 			{nil, standby, "standby", nil},
@@ -253,7 +253,7 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 
 		standby := mock_idl.NewMockAgentClient(ctrl)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, msdw1, "msdw1", nil},
 			{nil, msdw2, "msdw2", nil},
 			{nil, standby, "standby", nil},
@@ -273,7 +273,7 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 			{ContentID: 1, Hostname: "sdw2", DataDir: "/data/dbfast2/seg2", Role: greenplum.PrimaryRole},
 		})
 
-		err := hub.RsyncMasterAndPrimaries(&testutils.DevNullWithClose{}, []*hub.Connection{}, cluster)
+		err := hub.RsyncMasterAndPrimaries(&testutils.DevNullWithClose{}, []*idl.Connection{}, cluster)
 		if err == nil {
 			t.Error("unexpected nil error")
 		}
@@ -327,7 +327,7 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 			gomock.Any(),
 		).Return(nil, expected)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, msdw1, "msdw1", nil},
 			{nil, failedClient, "msdw2", nil},
 		}
@@ -356,7 +356,7 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 			gomock.Any(),
 		).Return(nil, expected)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, msdw1, "msdw1", nil},
 			{nil, failedClient, "msdw2", nil},
 		}
@@ -405,7 +405,7 @@ func TestRestoreMasterAndPrimariesPgControl(t *testing.T) {
 			gomock.Any(),
 		).Return(nil, expectedError)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, sdw1, "sdw1", nil},
 			{nil, failedClient, "sdw2", nil},
 		}
@@ -474,7 +474,7 @@ func TestRestoreMasterAndPrimariesPgControl(t *testing.T) {
 			},
 		).Return(&idl.RestorePgControlReply{}, nil)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, sdw1, "sdw1", nil},
 			{nil, sdw2, "sdw2", nil},
 		}

--- a/hub/revert.go
+++ b/hub/revert.go
@@ -20,7 +20,7 @@ import (
 var ErrMissingMirrorsAndStandby = errors.New("Source cluster does not have mirrors and/or standby. Cannot restore source cluster. Please contact support.")
 
 func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) (err error) {
-	st, err := step.Begin(idl.Step_REVERT, stream)
+	st, err := step.Begin(idl.Step_REVERT, stream, s.AgentConns)
 	if err != nil {
 		return err
 	}
@@ -37,12 +37,6 @@ func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) 
 
 	if !s.Source.HasAllMirrorsAndStandby() {
 		return errors.New("Source cluster does not have mirrors and/or standby. Cannot restore source cluster. Please contact support.")
-	}
-
-	// ensure that agentConns is populated
-	_, err = s.AgentConns()
-	if err != nil {
-		return xerrors.Errorf("connect to gpupgrade agent: %w", err)
 	}
 
 	// If the target cluster is started, it must be stopped.

--- a/hub/rpc.go
+++ b/hub/rpc.go
@@ -6,10 +6,11 @@ package hub
 import (
 	"sync"
 
+	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
-func ExecuteRPC(agentConns []*Connection, executeRequest func(conn *Connection) error) error {
+func ExecuteRPC(agentConns []*idl.Connection, executeRequest func(conn *idl.Connection) error) error {
 	var wg sync.WaitGroup
 	errs := make(chan error, len(agentConns))
 

--- a/hub/rpc_test.go
+++ b/hub/rpc_test.go
@@ -16,8 +16,8 @@ import (
 func TestExecuteRPC(t *testing.T) {
 	t.Run("executes multiple requests", func(t *testing.T) {
 		agentConns := []*idl.Connection{
-			{nil, nil, "mdw", nil},
-			{nil, nil, "sdw", nil},
+			{Hostname: "mdw"},
+			{Hostname: "sdw"},
 		}
 
 		hosts := make(chan string, len(agentConns))
@@ -47,8 +47,8 @@ func TestExecuteRPC(t *testing.T) {
 
 	t.Run("bubbles up errors", func(t *testing.T) {
 		agentConns := []*idl.Connection{
-			{nil, nil, "mdw", nil},
-			{nil, nil, "sdw", nil},
+			{Hostname: "mdw"},
+			{Hostname: "sdw"},
 		}
 
 		expected := errors.New("permission denied")

--- a/hub/rpc_test.go
+++ b/hub/rpc_test.go
@@ -10,17 +10,18 @@ import (
 	"testing"
 
 	"github.com/greenplum-db/gpupgrade/hub"
+	"github.com/greenplum-db/gpupgrade/idl"
 )
 
 func TestExecuteRPC(t *testing.T) {
 	t.Run("executes multiple requests", func(t *testing.T) {
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, nil, "mdw", nil},
 			{nil, nil, "sdw", nil},
 		}
 
 		hosts := make(chan string, len(agentConns))
-		request := func(conn *hub.Connection) error {
+		request := func(conn *idl.Connection) error {
 			hosts <- conn.Hostname
 			return nil
 		}
@@ -45,13 +46,13 @@ func TestExecuteRPC(t *testing.T) {
 	})
 
 	t.Run("bubbles up errors", func(t *testing.T) {
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, nil, "mdw", nil},
 			{nil, nil, "sdw", nil},
 		}
 
 		expected := errors.New("permission denied")
-		request := func(conn *hub.Connection) error {
+		request := func(conn *idl.Connection) error {
 			if conn.Hostname == "mdw" {
 				return expected
 			}

--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/hub"
+	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/testutils/mock_agent"
 	"github.com/greenplum-db/gpupgrade/testutils/testlog"
@@ -287,7 +288,7 @@ func TestAgentConns(t *testing.T) {
 	})
 }
 
-func ensureAgentConnsReachState(t *testing.T, agentConns []*hub.Connection, state connectivity.State) {
+func ensureAgentConnsReachState(t *testing.T, agentConns []*idl.Connection, state connectivity.State) {
 	t.Helper()
 
 	for _, conn := range agentConns {

--- a/hub/upgrade_primaries.go
+++ b/hub/upgrade_primaries.go
@@ -19,7 +19,7 @@ import (
 type UpgradePrimaryArgs struct {
 	CheckOnly              bool
 	MasterBackupDir        string
-	AgentConns             []*Connection
+	AgentConns             []*idl.Connection
 	DataDirPairMap         map[string][]*idl.DataDirPair
 	Source                 *greenplum.Cluster
 	Target                 *greenplum.Cluster
@@ -28,7 +28,7 @@ type UpgradePrimaryArgs struct {
 }
 
 func UpgradePrimaries(args UpgradePrimaryArgs) error {
-	request := func(conn *Connection) error {
+	request := func(conn *idl.Connection) error {
 		_, err := conn.AgentClient.UpgradePrimaries(context.Background(), &idl.UpgradePrimariesRequest{
 			SourceBinDir:               filepath.Join(args.Source.GPHome, "bin"),
 			TargetBinDir:               filepath.Join(args.Target.GPHome, "bin"),

--- a/hub/upgrade_primaries_test.go
+++ b/hub/upgrade_primaries_test.go
@@ -100,8 +100,8 @@ func TestUpgradePrimaries(t *testing.T) {
 		).Return(&idl.UpgradePrimariesReply{}, nil)
 
 		agentConns := []*idl.Connection{
-			{nil, client1, "sdw1", nil},
-			{nil, client2, "sdw2", nil},
+			{AgentClient: client1, Hostname: "sdw1"},
+			{AgentClient: client2, Hostname: "sdw2"},
 		}
 
 		err := hub.UpgradePrimaries(hub.UpgradePrimaryArgs{
@@ -173,8 +173,8 @@ func TestUpgradePrimaries(t *testing.T) {
 				).Return(&idl.UpgradePrimariesReply{}, expected)
 
 				agentConns := []*idl.Connection{
-					{nil, client1, "sdw1", nil},
-					{nil, failedClient, "sdw2", nil},
+					{AgentClient: client1, Hostname: "sdw1"},
+					{AgentClient: failedClient, Hostname: "sdw2"},
 				}
 
 				err := hub.UpgradePrimaries(hub.UpgradePrimaryArgs{

--- a/hub/upgrade_primaries_test.go
+++ b/hub/upgrade_primaries_test.go
@@ -99,7 +99,7 @@ func TestUpgradePrimaries(t *testing.T) {
 			},
 		).Return(&idl.UpgradePrimariesReply{}, nil)
 
-		agentConns := []*hub.Connection{
+		agentConns := []*idl.Connection{
 			{nil, client1, "sdw1", nil},
 			{nil, client2, "sdw2", nil},
 		}
@@ -172,7 +172,7 @@ func TestUpgradePrimaries(t *testing.T) {
 					},
 				).Return(&idl.UpgradePrimariesReply{}, expected)
 
-				agentConns := []*hub.Connection{
+				agentConns := []*idl.Connection{
 					{nil, client1, "sdw1", nil},
 					{nil, failedClient, "sdw2", nil},
 				}

--- a/idl/connection.go
+++ b/idl/connection.go
@@ -1,0 +1,15 @@
+//  Copyright (c) 2017-2021 VMware, Inc. or its affiliates
+//  SPDX-License-Identifier: Apache-2.0
+
+package idl
+
+import (
+	"google.golang.org/grpc"
+)
+
+type Connection struct {
+	Conn          *grpc.ClientConn
+	AgentClient   AgentClient
+	Hostname      string
+	CancelContext func()
+}

--- a/step/step.go
+++ b/step/step.go
@@ -39,7 +39,16 @@ func New(name idl.Step, sender idl.MessageSender, substepStore SubstepStore, str
 	}
 }
 
-func Begin(step idl.Step, sender idl.MessageSender) (*Step, error) {
+func Begin(step idl.Step, sender idl.MessageSender, agentConns func() ([]*idl.Connection, error)) (*Step, error) {
+	// FIXME: Having s.agentConns() in the step framework is a heavy indication of
+	//  tech debt that needs to be addressed. However, for the time being ensure
+	//  agentConns are properly populated at the start of each step, otherwise
+	//  the agentConns member variable can be nil.
+	_, err := agentConns()
+	if err != nil {
+		return nil, xerrors.Errorf("ensuring agent connections are ready: %w", err)
+	}
+
 	logdir, err := utils.GetLogDir()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Centralize the location of ensuring agentConns are ready inside step.Begin as this ensures the s.agentConns member variable is not nil and safe to use.

However, having the s.agentConns inside the step framework indicates heavy tech debt which needs to be addressed. However, for the time being centrally call it here so that subsequent calls to s.agentConns are populated and updated.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:agentConns