### PR TITLE
ci: allow GPDB test release candidate RPMs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,17 +201,23 @@ else
 endif
 
 .PHONY: set-pipeline expose-pipeline
-# TODO: Keep this in sync with the README at github.com/greenplum-db/continuous-integration
+set-pipeline: export 5X_GIT_USER=${5X_GIT_USER:-}
+set-pipeline: export 5X_GIT_BRANCH=${5X_GIT_BRANCH:-}
+set-pipeline: export 6X_GIT_USER=${6X_GIT_USER:-}
+set-pipeline: export 6X_GIT_BRANCH=${6X_GIT_BRANCH:-}
+set-pipeline: export 7X_GIT_USER=${7X_GIT_USER:-}
+set-pipeline: export 7X_GIT_BRANCH=${7X_GIT_BRANCH:-}
 set-pipeline:
 	# Keep pipeline.yml up to date
 	go generate ./ci
 	#NOTE-- make sure your gpupgrade-git-remote uses an https style git"
 	#NOTE-- such as https://github.com/greenplum-db/gpupgrade.git"
+	# TODO: Keep this in sync with the README at github.com/greenplum-db/continuous-integration
 	fly -t $(FLY_TARGET) set-pipeline -p $(PIPELINE_NAME) \
 		-c ci/generated/pipeline.yml \
 		-l ~/workspace/gp-continuous-integration/secrets/gpupgrade.$(TARGET).yml \
 		-l ~/workspace/gp-continuous-integration/secrets/gpdb_common-ci-secrets.yml \
-		-l ~/workspace/gp-continuous-integration/secrets/gpdb_master-ci-secrets.prod.yml \
+		-l ~/workspace/gp-continuous-integration/secrets/gpdb_master-ci-secrets.$(TARGET).yml \
 		-l ~/workspace/gp-continuous-integration/secrets/ccp_ci_secrets_$(FLY_TARGET).yml \
 		-l ~/workspace/gp-continuous-integration/secrets/gp-upgrade-packaging.dev.yml \
 		-v gpupgrade-git-remote=$(GIT_URI) \

--- a/ci/generated/pipeline.yml
+++ b/ci/generated/pipeline.yml
@@ -167,14 +167,24 @@ resources:
 - name: gpdb5_icw_planner_centos6_dump
   type: gcs
   source:
-    bucket: ((gcs-bucket-intermediates))
+    # FIXME: When flying a dev or prod pipeline we use the -dev or -prod bucket
+    # based on ccp_ci_secrets_$(FLY_TARGET).yml. However, for dev pipelines the
+    # -dev bucket does not have this artifact, causing all jobs that use this
+    # resource to hang. So for now hardcode it to the bucket with the artifact.
+    # bucket: ((gcs-bucket-intermediates))
+    bucket: pivotal-gpdb-concourse-resources-intermediates-prod
     json_key: ((concourse-gcs-resources-service-account-key))
     versioned_file: 5X_STABLE/icw_planner_centos6_dump/dump.sql.xz
 
 - name: dump_gpdb6_icw_gporca_centos6
   type: gcs
   source:
-    bucket: ((gcs-bucket-intermediates))
+    # FIXME: When flying a dev or prod pipeline we use the -dev or -prod bucket
+    # based on ccp_ci_secrets_$(FLY_TARGET).yml. However, for dev pipelines the
+    # -dev bucket does not have this artifact, causing all jobs that use this
+    # resource to hang. So for now hardcode it to the bucket with the artifact.
+    # bucket: ((gcs-bucket-intermediates))
+    bucket: pivotal-gpdb-concourse-resources-intermediates-prod
     json_key: ((concourse-gcs-resources-service-account-key))
     versioned_file: 6X_STABLE/icw_gporca_centos6_dump/dump.sql.xz
 

--- a/ci/scripts/install-tests.bash
+++ b/ci/scripts/install-tests.bash
@@ -22,7 +22,7 @@ time ./gpdb_src_source/concourse/scripts/setup_gpadmin_user.bash "centos"
 # install source packages
 yum install -y rpm_gpdb_source/*.rpm
 
-version=$(rpm -q --qf '%{version}' "$SOURCE_PACKAGE")
+version=$(rpm -q --qf '%{version}' "$SOURCE_PACKAGE" | tr _ -)
 sudo ln -s /usr/local/greenplum-db-${version} "$GPHOME_SOURCE"
 
 chown -R gpadmin:gpadmin "$GPHOME_SOURCE"
@@ -35,7 +35,7 @@ if [ "$SOURCE_PACKAGE" != "$TARGET_PACKAGE" ]; then
     yum install -y rpm_gpdb_target/*.rpm
 fi
 
-version=$(rpm -q --qf '%{version}' "$TARGET_PACKAGE")
+version=$(rpm -q --qf '%{version}' "$TARGET_PACKAGE" | tr _ -)
 sudo ln -s /usr/local/greenplum-db-${version} "$GPHOME_TARGET"
 
 chown -R gpadmin:gpadmin "$GPHOME_TARGET"

--- a/ci/scripts/pg-upgrade-tests.bash
+++ b/ci/scripts/pg-upgrade-tests.bash
@@ -31,7 +31,7 @@ yum install -y rpm_enterprise/gpupgrade-*.rpm
 # install source packages
 yum install -y rpm_gpdb_source/*.rpm
 
-version=$(rpm -q --qf '%{version}' "$SOURCE_PACKAGE")
+version=$(rpm -q --qf '%{version}' "$SOURCE_PACKAGE" | tr _ -)
 ln -s /usr/local/greenplum-db-${version} "$GPHOME_SOURCE"
 
 chown -R gpadmin:gpadmin "$GPHOME_SOURCE"
@@ -44,7 +44,7 @@ if [ "$SOURCE_PACKAGE" != "$TARGET_PACKAGE" ]; then
   yum install -y rpm_gpdb_target/*.rpm
 fi
 
-version=$(rpm -q --qf '%{version}' "$TARGET_PACKAGE")
+version=$(rpm -q --qf '%{version}' "$TARGET_PACKAGE" | tr _ -)
 ln -s /usr/local/greenplum-db-${version} "$GPHOME_TARGET"
 
 chown -R gpadmin:gpadmin "$GPHOME_TARGET"

--- a/ci/scripts/prepare-installation.sh
+++ b/ci/scripts/prepare-installation.sh
@@ -30,10 +30,10 @@ for host in `cat cluster_env_files/hostfile_all`; do
     ssh -n centos@"$host" "
         set -eux
 
-        version=\$(rpm -q --qf '%{version}' '$source_package')
+        version=\$(rpm -q --qf '%{version}' '$source_package' | tr _ -)
         sudo ln -s /usr/local/greenplum-db-\${version} /usr/local/greenplum-db-source
 
-        version=\$(rpm -q --qf '%{version}' '$target_package')
+        version=\$(rpm -q --qf '%{version}' '$target_package' | tr _ -)
         sudo ln -s /usr/local/greenplum-db-\${version} /usr/local/greenplum-db-target
     "
 

--- a/ci/template.yml
+++ b/ci/template.yml
@@ -58,14 +58,14 @@ resources:
     bucket: ((gpdb-stable-builds-bucket-name))
     region_name: ((aws-region))
     secret_access_key: ((bucket-secret-access-key))
-    regexp: release_candidates/gpdb_rpm_installer_centos{{.CentosVersion}}/gpdb{{ majorVersion .GPVersion }}/greenplum-db-({{escapeVersion .GPVersion}}.*)-rhel{{.CentosVersion}}-x86_64.rpm
+    regexp: release_candidates/gpdb_rpm_installer_centos{{.CentosVersion}}/gpdb{{ majorVersion .GPVersion }}/greenplum-db-{{.TestRCIdentifier}}({{escapeVersion .GPVersion}}.*)-rhel{{.CentosVersion}}-x86_64.rpm
 {{- else }}
 - name: rpm_gpdb{{.GPVersion}}_centos{{.CentosVersion}}
   type: gcs
   source:
     bucket: ((gcs-bucket))
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/gpdb{{ majorVersion .GPVersion }}/greenplum-db-({{escapeVersion .GPVersion}}.*)-rhel{{.CentosVersion}}-x86_64.debug.rpm
+    regexp: server/published/gpdb{{ majorVersion .GPVersion }}/greenplum-db-{{.TestRCIdentifier}}({{escapeVersion .GPVersion}}.*)-rhel{{.CentosVersion}}-x86_64.debug.rpm
 {{- end }}
 {{end}}
 
@@ -146,14 +146,24 @@ resources:
 - name: gpdb5_icw_planner_centos6_dump
   type: gcs
   source:
-    bucket: ((gcs-bucket-intermediates))
+    # FIXME: When flying a dev or prod pipeline we use the -dev or -prod bucket
+    # based on ccp_ci_secrets_$(FLY_TARGET).yml. However, for dev pipelines the
+    # -dev bucket does not have this artifact, causing all jobs that use this
+    # resource to hang. So for now hardcode it to the bucket with the artifact.
+    # bucket: ((gcs-bucket-intermediates))
+    bucket: pivotal-gpdb-concourse-resources-intermediates-prod
     json_key: ((concourse-gcs-resources-service-account-key))
     versioned_file: 5X_STABLE/icw_planner_centos6_dump/dump.sql.xz
 
 - name: dump_gpdb6_icw_gporca_centos6
   type: gcs
   source:
-    bucket: ((gcs-bucket-intermediates))
+    # FIXME: When flying a dev or prod pipeline we use the -dev or -prod bucket
+    # based on ccp_ci_secrets_$(FLY_TARGET).yml. However, for dev pipelines the
+    # -dev bucket does not have this artifact, causing all jobs that use this
+    # resource to hang. So for now hardcode it to the bucket with the artifact.
+    # bucket: ((gcs-bucket-intermediates))
+    bucket: pivotal-gpdb-concourse-resources-intermediates-prod
     json_key: ((concourse-gcs-resources-service-account-key))
     versioned_file: 6X_STABLE/icw_gporca_centos6_dump/dump.sql.xz
 

--- a/test/README.md
+++ b/test/README.md
@@ -3,6 +3,7 @@
 <!-- TOC -->
 - [Performance and Scale Testing](#performance-and-scale-testing)
 - [Acceptance Tests](#acceptance-tests)
+    - [Testing GPDB changes against gpupgrade](#testing-gpdb-changes-against-gpupgrade) 
     - [1) gpupgrade Acceptance Tests](#1-gpupgrade-acceptance-tests)
     - [2) pg_upgrade Acceptance Tests](#2-pg_upgrade-acceptance-tests)
         - [pg_upgrade non-upgradeable tests (negative tests)](#2a-pg_upgrade-non-upgradeable-tests-negative-tests)
@@ -21,6 +22,29 @@ Acceptance tests are "end-to-end" tests that exercise the binary of gpupgrade an
 the overall Greenplum upgrade process. There are two types of acceptance tests:
 1) gpupgrade, and 2) pg_upgrade. And within the pg_upgrade acceptance tests
 there are two sub-types: a) non-upgradeable, and b) upgradeable.
+
+---
+
+## Testing GPDB changes against gpupgrade
+
+1. Each developer will need to sync the latest origin tags with their remote. This will allow the GPDB test rpm to have 
+   the correct version number. For your GPDB branch run the following:
+
+```
+$ git fetch --tags origin
+$ git push --tags <yourRemoteName>
+```
+*Note:* If you already flew a pipeline *before* pushing tags you will likely need to delete it, push tags, and re-fly as 
+Concourse has some weird caching issues.
+
+2. Fly a GPDB test pipeline to build a test release candidate RPM based on your branch using the `--build-test-rc` flag.  
+Example gen_pipeline commands: 
+- For 5X: `./gen_pipeline.py -t cm --build-test-rc -o /tmp/5X_rc.yml`
+- For 6X: `./gen_pipeline.py -t cm --build-test-rc -O 'centos6' 'centos7' 'photon3' -o /tmp/6X_rc.yml`
+- For 7X: `./gen_pipeline.py -t cm --build-test-rc -O centos7 -o /tmp/7X_rc.yml`
+
+3. Finally, generate a gpupgrade pipeline to use those test GPDB RPMs using the appropriate environment variables.
+`make 5X_GIT_USER=alice 5X_GIT_BRANCH=5X_rc 6X_GIT_USER=bob 6X_GIT_BRANCH=6X_rc set-pipeline`
 
 ---
 


### PR DESCRIPTION
Allow gpupgrade to test against GPDB test branch release candidate RPMs. This is especially useful for pg_upgrade acceptance tests to verify tests and pg_upgrade behavior before merging into GPDB.

Test Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:test_rc