### PR TITLE
ci: use gcs for 5X release candidate rpms and only use -dev bucket when testing specific RC rpms

### DIFF
--- a/ci/generated/pipeline.yml
+++ b/ci/generated/pipeline.yml
@@ -72,22 +72,18 @@ resources:
     regexp: server/published/gpdb6/greenplum-db-(6.*)-rhel7-x86_64.debug.rpm
 
 - name: rpm_gpdb5_centos6
-  type: s3
+  type: gcs
   source:
-    access_key_id: ((bucket-access-key-id))
-    bucket: ((gpdb-stable-builds-bucket-name))
-    region_name: ((aws-region))
-    secret_access_key: ((bucket-secret-access-key))
-    regexp: release_candidates/gpdb_rpm_installer_centos6/gpdb5/greenplum-db-(5.*)-rhel6-x86_64.rpm
+    bucket: ((gcs-bucket))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: server/published/gpdb5/greenplum-db-(5.*)-rhel6-x86_64.debug.rpm
 
 - name: rpm_gpdb5_centos7
-  type: s3
+  type: gcs
   source:
-    access_key_id: ((bucket-access-key-id))
-    bucket: ((gpdb-stable-builds-bucket-name))
-    region_name: ((aws-region))
-    secret_access_key: ((bucket-secret-access-key))
-    regexp: release_candidates/gpdb_rpm_installer_centos7/gpdb5/greenplum-db-(5.*)-rhel7-x86_64.rpm
+    bucket: ((gcs-bucket))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: server/published/gpdb5/greenplum-db-(5.*)-rhel7-x86_64.debug.rpm
 
 
 - name: rpm_oss

--- a/ci/generated/pipeline.yml
+++ b/ci/generated/pipeline.yml
@@ -60,28 +60,32 @@ resources:
 - name: rpm_gpdb6_centos6
   type: gcs
   source:
-    bucket: ((gcs-bucket))
+    # Test release candidate rpms built from production pipelines are published to the -prod bucket.
+    bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: server/published/gpdb6/greenplum-db-(6.*)-rhel6-x86_64.debug.rpm
 
 - name: rpm_gpdb6_centos7
   type: gcs
   source:
-    bucket: ((gcs-bucket))
+    # Test release candidate rpms built from production pipelines are published to the -prod bucket.
+    bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: server/published/gpdb6/greenplum-db-(6.*)-rhel7-x86_64.debug.rpm
 
 - name: rpm_gpdb5_centos6
   type: gcs
   source:
-    bucket: ((gcs-bucket))
+    # Test release candidate rpms built from production pipelines are published to the -prod bucket.
+    bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: server/published/gpdb5/greenplum-db-(5.*)-rhel6-x86_64.debug.rpm
 
 - name: rpm_gpdb5_centos7
   type: gcs
   source:
-    bucket: ((gcs-bucket))
+    # Test release candidate rpms built from production pipelines are published to the -prod bucket.
+    bucket: pivotal-gpdb-concourse-resources-prod
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: server/published/gpdb5/greenplum-db-(5.*)-rhel7-x86_64.debug.rpm
 

--- a/ci/template.yml
+++ b/ci/template.yml
@@ -53,7 +53,13 @@ resources:
 - name: rpm_gpdb{{.GPVersion}}_centos{{.CentosVersion}}
   type: gcs
   source:
-    bucket: ((gcs-bucket))
+    {{- if .TestRCIdentifier }}
+    # Test release candidate rpms built with --build-test-rc are published to the -dev bucket.
+    bucket: pivotal-gpdb-concourse-resources-dev
+    {{- else }}
+    # Test release candidate rpms built from production pipelines are published to the -prod bucket.
+    bucket: pivotal-gpdb-concourse-resources-prod
+    {{- end }}
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: server/published/gpdb{{ majorVersion .GPVersion }}/greenplum-db-{{.TestRCIdentifier}}({{escapeVersion .GPVersion}}.*)-rhel{{.CentosVersion}}-x86_64.debug.rpm
 {{end}}

--- a/ci/template.yml
+++ b/ci/template.yml
@@ -50,23 +50,12 @@ resources:
 # source and target clusters. In order to test this scenario release candidate
 # builds are needed.
 {{range .Versions}}
-{{- if eq (majorVersion .GPVersion) "5" }}
-- name: rpm_gpdb{{.GPVersion}}_centos{{.CentosVersion}}
-  type: s3
-  source:
-    access_key_id: ((bucket-access-key-id))
-    bucket: ((gpdb-stable-builds-bucket-name))
-    region_name: ((aws-region))
-    secret_access_key: ((bucket-secret-access-key))
-    regexp: release_candidates/gpdb_rpm_installer_centos{{.CentosVersion}}/gpdb{{ majorVersion .GPVersion }}/greenplum-db-{{.TestRCIdentifier}}({{escapeVersion .GPVersion}}.*)-rhel{{.CentosVersion}}-x86_64.rpm
-{{- else }}
 - name: rpm_gpdb{{.GPVersion}}_centos{{.CentosVersion}}
   type: gcs
   source:
     bucket: ((gcs-bucket))
     json_key: ((concourse-gcs-resources-service-account-key))
     regexp: server/published/gpdb{{ majorVersion .GPVersion }}/greenplum-db-{{.TestRCIdentifier}}({{escapeVersion .GPVersion}}.*)-rhel{{.CentosVersion}}-x86_64.debug.rpm
-{{- end }}
 {{end}}
 
 - name: rpm_oss


### PR DESCRIPTION
1) The 5X_STABLE pipeline migrated from s3 to gcs for publishing release candidate rpms.
2) Only use -dev bucket when testing specific RC rpms

Associated 5X PR: https://github.com/greenplum-db/gpdb/pull/12368

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:template5X

**_Note:_** Will need to ~wait~ simply re-trigger the `Build_Release_Candidate_RPMs` job for 5X_STABLE to create new [release candidate RPMs containing `.debug` in the name](https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/5X_STABLE/jobs/Build_Release_Candidate_RPMs/builds/73) before merging.