### PR TITLE
ci: use rsync instead of scp to copy BATS to mdw

### DIFF
--- a/ci/scripts/multihost-gpupgrade-tests.bash
+++ b/ci/scripts/multihost-gpupgrade-tests.bash
@@ -31,7 +31,7 @@ main() {
     scp -rpq gpupgrade_src gpadmin@mdw:/home/gpadmin
 
     echo "Installing BATS..."
-    scp -rpq bats centos@mdw:~
+    rsync --archive bats centos@mdw:~
     ssh centos@mdw sudo ./bats/install.sh /usr/local
 
     echo "Running data migration scripts and tests..."


### PR DESCRIPTION
Use rsync to preserve symlinks when copying BATS to mdw to install for multi-host testing. This was causing the following error on the CI when BATS bumped their version from 1.3.0 to 1.4.1:

> + scp -rpq bats 'centos@mdw:~'
bats/test/fixtures/parallel/suite/helper.bash: No such file or directory
bats/test/fixtures/parallel/setup_file/helper.bash: No such file or directory

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixBATS