### PR TITLE
ci: fixups for extensions

### DIFF
--- a/ci/scripts/load-extensions.bash
+++ b/ci/scripts/load-extensions.bash
@@ -134,6 +134,10 @@ install_pxf() {
     done
 
     ssh -n mdw "
+        set -eux -o pipefail
+
+        source /usr/local/greenplum-db-source/greenplum_path.sh
+
         echo 'Initialize pxf...'
         export GPHOME=$GPHOME_SOURCE
         export PXF_CONF=$PXF_CONF

--- a/ci/scripts/upgrade-extensions.bash
+++ b/ci/scripts/upgrade-extensions.bash
@@ -138,6 +138,7 @@ ssh -n mdw "
     psql -d postgres -c 'DROP INDEX wmstest_geomidx CASCADE;'
     psql -d postgres -f /usr/local/greenplum-db-target/share/postgresql/contrib/postgis-*/postgis_enable_operators.sql
 
+    $(typeset -f test_pxf) # allow local function on remote host
     if test_pxf '$OS_VERSION'; then
         echo 'Starting pxf...'
         /usr/local/pxf-gp6/bin/pxf cluster start


### PR DESCRIPTION
Missed these few minor issues:
- When loading pxf data source greenplum_path.sh so that psql can be found.
- After upgrading pxf allow the text_pxf function on the remote machine, so it can be used.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:extensionFixups