### PR TITLE
give better error message for incorrect gpdb versions

### DIFF
--- a/greenplum/version.go
+++ b/greenplum/version.go
@@ -11,6 +11,9 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
+
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
 )
 
 var ErrUnknownVersion = errors.New("unknown GPDB version")
@@ -67,12 +70,14 @@ func version(gphome string, host string) (semver.Version, error) {
 	cmd := execCommand(name, args...)
 	cmd.Env = []string{} // explicitly clear the environment
 
-	stdout, err := cmd.Output()
+	gplog.Debug("running cmd %q", cmd.String())
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return semver.Version{}, err
+		return semver.Version{}, xerrors.Errorf("%q failed with %q: %w", cmd.String(), string(output), err)
 	}
 
-	version := string(stdout)
+	version := string(output)
+	gplog.Debug("version: %q", version)
 	return parseVersion(version)
 }
 

--- a/greenplum/version_test.go
+++ b/greenplum/version_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/golang/mock/gomock"
 
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 )
 
 func PostgresGPVersion_5_27_0_beta() {
@@ -51,6 +52,8 @@ const gphome = "/usr/local/my-gpdb-home"
 const remoteHost = "remote_host"
 
 func TestGPHomeVersion(t *testing.T) {
+	testlog.SetupLogger()
+
 	cases := []struct {
 		name     string
 		execMain exectest.Main // the postgres Main implementation to run


### PR DESCRIPTION
If the version value is not parsed correctly by
greenplum/version.go, record an error message via gpLog