### PR TITLE
use IntermediateTarget and remove InitializeConfig

### DIFF
--- a/cli/commands/commands_test.go
+++ b/cli/commands/commands_test.go
@@ -8,10 +8,13 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 )
 
 func TestGetHubPort(t *testing.T) {
+	testlog.SetupLogger()
+
 	t.Run("correctly pulls the port from the stored config", func(t *testing.T) {
 		stateDir := testutils.GetTempDir(t, "")
 		defer testutils.MustRemoveAll(t, stateDir)

--- a/greenplum/cluster_test.go
+++ b/greenplum/cluster_test.go
@@ -278,8 +278,8 @@ func TestClusterFromDB(t *testing.T) {
 		if err == nil {
 			t.Errorf("Expected an error, but got nil")
 		}
-		if actualCluster != nil {
-			t.Errorf("Expected cluster to be nil, but got %#v", actualCluster)
+		if !reflect.DeepEqual(actualCluster, greenplum.Cluster{}) {
+			t.Errorf("got: %#v want empty cluster: %#v", actualCluster, &greenplum.Cluster{})
 		}
 		if !strings.Contains(err.Error(), connErr.Error()) {
 			t.Errorf("Expected error: %+v got: %+v", connErr.Error(), err.Error())
@@ -298,8 +298,8 @@ func TestClusterFromDB(t *testing.T) {
 		if err == nil {
 			t.Errorf("Expected an error, but got nil")
 		}
-		if actualCluster != nil {
-			t.Errorf("Expected cluster to be nil, but got %#v", actualCluster)
+		if !reflect.DeepEqual(actualCluster, greenplum.Cluster{}) {
+			t.Errorf("Expected cluster to be empty, but got %#v", actualCluster)
 		}
 		if !strings.Contains(err.Error(), queryErr.Error()) {
 			t.Errorf("Expected error: %+v got: %+v", queryErr.Error(), err.Error())
@@ -323,8 +323,8 @@ func TestClusterFromDB(t *testing.T) {
 		expectedCluster.Version = dbconn.NewVersion("5.3.4")
 		expectedCluster.GPHome = gphome
 
-		if !reflect.DeepEqual(actualCluster, expectedCluster) {
-			t.Errorf("expected: %#v got: %#v", expectedCluster, actualCluster)
+		if !reflect.DeepEqual(&actualCluster, expectedCluster) {
+			t.Errorf("got: %#v want: %#v ", &actualCluster, expectedCluster)
 		}
 	})
 }

--- a/greenplum/common_test.go
+++ b/greenplum/common_test.go
@@ -42,5 +42,5 @@ func MustCreateCluster(t *testing.T, segs []SegConfig) *Cluster {
 		t.Fatalf("%+v", err)
 	}
 
-	return cluster
+	return &cluster
 }

--- a/hub/check_upgrade.go
+++ b/hub/check_upgrade.go
@@ -38,12 +38,12 @@ func (s *Server) CheckUpgrade(stream step.OutStreams, conns []*idl.Connection) e
 	go func() {
 		defer wg.Done()
 		checkErrs <- upgrader.UpgradeMaster(UpgradeMasterArgs{
-			Source:      s.Source,
-			Target:      s.Target,
-			StateDir:    s.StateDir,
-			Stream:      stream,
-			CheckOnly:   true,
-			UseLinkMode: s.UseLinkMode,
+			Source:             s.Source,
+			IntermediateTarget: s.IntermediateTarget,
+			StateDir:           s.StateDir,
+			Stream:             stream,
+			CheckOnly:          true,
+			UseLinkMode:        s.UseLinkMode,
 		})
 	}()
 
@@ -58,13 +58,13 @@ func (s *Server) CheckUpgrade(stream step.OutStreams, conns []*idl.Connection) e
 		}
 
 		checkErrs <- upgrader.UpgradePrimaries(UpgradePrimaryArgs{
-			CheckOnly:       true,
-			MasterBackupDir: "",
-			AgentConns:      conns,
-			DataDirPairMap:  dataDirPairMap,
-			Source:          s.Source,
-			Target:          s.Target,
-			UseLinkMode:     s.UseLinkMode,
+			CheckOnly:          true,
+			MasterBackupDir:    "",
+			AgentConns:         conns,
+			DataDirPairMap:     dataDirPairMap,
+			Source:             s.Source,
+			IntermediateTarget: s.IntermediateTarget,
+			UseLinkMode:        s.UseLinkMode,
 		})
 	}()
 

--- a/hub/check_upgrade_test.go
+++ b/hub/check_upgrade_test.go
@@ -36,12 +36,12 @@ func resetUpgrader() {
 }
 
 func TestMasterIsCheckedLinkModeTrue(t *testing.T) {
-	sourceCluster := MustCreateCluster(t, []greenplum.SegConfig{
+	source := MustCreateCluster(t, []greenplum.SegConfig{
 		{ContentID: -1, DbID: 1, Port: 15432, Hostname: "localhost", DataDir: "/data/qddir/seg-1", Role: "p"},
 		{ContentID: 0, DbID: 2, Port: 25432, Hostname: "host1", DataDir: "/data/dbfast1/seg1", Role: "p"},
 		{ContentID: 1, DbID: 3, Port: 25433, Hostname: "host2", DataDir: "/data/dbfast2/seg2", Role: "p"},
 	})
-	targetCluster := MustCreateCluster(t, []greenplum.SegConfig{
+	intermediateTarget := MustCreateCluster(t, []greenplum.SegConfig{
 		{ContentID: -1, DbID: 1, Port: 15432, Hostname: "localhost", DataDir: "/data/qddir/seg-1", Role: "p"},
 		{ContentID: 0, DbID: 2, Port: 25432, Hostname: "host1", DataDir: "/data/dbfast1/seg1", Role: "p"},
 		{ContentID: 1, DbID: 3, Port: 25433, Hostname: "host2", DataDir: "/data/dbfast2/seg2", Role: "p"},
@@ -51,9 +51,9 @@ func TestMasterIsCheckedLinkModeTrue(t *testing.T) {
 	for _, linkMode := range []bool{true, false} {
 		t.Run(fmt.Sprintf("check upgrade correctly passes useLinkMode is %v", linkMode), func(t *testing.T) {
 			conf := &Config{
-				Source:      sourceCluster,
-				Target:      targetCluster,
-				UseLinkMode: linkMode,
+				Source:             source,
+				IntermediateTarget: intermediateTarget,
+				UseLinkMode:        linkMode,
 			}
 			s := New(conf, grpc.DialContext, stateDirExpected)
 			testUpgraderMock := upgraderMock{s}
@@ -74,8 +74,8 @@ func UpgradeMasterMock(result UpgradeMasterArgs, expected *Server) error {
 	if !reflect.DeepEqual(result.Source, expected.Source) {
 		return fmt.Errorf("got %#v, expected %#v", result.Source, expected.Source)
 	}
-	if !reflect.DeepEqual(result.Target, expected.Target) {
-		return fmt.Errorf("got %#v, expected %#v", result.Target, expected.Target)
+	if !reflect.DeepEqual(result.IntermediateTarget, expected.IntermediateTarget) {
+		return fmt.Errorf("got %#v, expected %#v", result.IntermediateTarget, expected.IntermediateTarget)
 	}
 	if result.StateDir != expected.StateDir {
 		return fmt.Errorf("got %#v expected %#v", result.StateDir, expected.StateDir)
@@ -107,8 +107,8 @@ func UpgradePrimariesMock(result UpgradePrimaryArgs, expected *Server) error {
 	if !reflect.DeepEqual(result.Source, expected.Source) {
 		return fmt.Errorf("got %#v, expected %#v", result.Source, expected.Source)
 	}
-	if !reflect.DeepEqual(result.Target, expected.Target) {
-		return fmt.Errorf("got %#v, expected %#v", result.Target, expected.Target)
+	if !reflect.DeepEqual(result.IntermediateTarget, expected.IntermediateTarget) {
+		return fmt.Errorf("got %#v, expected %#v", result.IntermediateTarget, expected.IntermediateTarget)
 	}
 	if result.UseLinkMode != expected.UseLinkMode {
 		return fmt.Errorf("got %#v expected %#v", result.UseLinkMode, expected.UseLinkMode)

--- a/hub/common_test.go
+++ b/hub/common_test.go
@@ -45,5 +45,5 @@ func MustCreateCluster(t *testing.T, segs []greenplum.SegConfig) *greenplum.Clus
 		t.Fatalf("%+v", err)
 	}
 
-	return cluster
+	return &cluster
 }

--- a/hub/config.go
+++ b/hub/config.go
@@ -24,7 +24,7 @@ func (s *Server) GetConfig(ctx context.Context, in *idl.GetConfigRequest) (*idl.
 			resp.Value = s.Source.GPHome
 		}
 	case "target-gphome":
-		resp.Value = s.TargetGPHome
+		resp.Value = s.IntermediateTarget.GPHome
 	case "target-datadir":
 		if s.Target != nil {
 			resp.Value = s.IntermediateTarget.MasterDataDir()

--- a/hub/config.go
+++ b/hub/config.go
@@ -30,8 +30,8 @@ func (s *Server) GetConfig(ctx context.Context, in *idl.GetConfigRequest) (*idl.
 			resp.Value = s.Target.MasterDataDir()
 		}
 	case "target-port":
-		if s.IntermediateTarget.Master.Port != 0 {
-			resp.Value = strconv.Itoa(s.IntermediateTarget.Master.Port)
+		if s.IntermediateTarget.MasterPort() != 0 {
+			resp.Value = strconv.Itoa(s.IntermediateTarget.MasterPort())
 		}
 	default:
 		return nil, status.Errorf(codes.NotFound, "%s is not a valid configuration key", in.Name)

--- a/hub/config.go
+++ b/hub/config.go
@@ -27,7 +27,7 @@ func (s *Server) GetConfig(ctx context.Context, in *idl.GetConfigRequest) (*idl.
 		resp.Value = s.TargetGPHome
 	case "target-datadir":
 		if s.Target != nil {
-			resp.Value = s.Target.MasterDataDir()
+			resp.Value = s.IntermediateTarget.MasterDataDir()
 		}
 	case "target-port":
 		if s.IntermediateTarget.MasterPort() != 0 {

--- a/hub/config.go
+++ b/hub/config.go
@@ -30,8 +30,8 @@ func (s *Server) GetConfig(ctx context.Context, in *idl.GetConfigRequest) (*idl.
 			resp.Value = s.Target.MasterDataDir()
 		}
 	case "target-port":
-		if s.TargetInitializeConfig.Master.Port != 0 {
-			resp.Value = strconv.Itoa(s.TargetInitializeConfig.Master.Port)
+		if s.IntermediateTarget.Master.Port != 0 {
+			resp.Value = strconv.Itoa(s.IntermediateTarget.Master.Port)
 		}
 	default:
 		return nil, status.Errorf(codes.NotFound, "%s is not a valid configuration key", in.Name)

--- a/hub/copy_master.go
+++ b/hub/copy_master.go
@@ -81,8 +81,8 @@ func Copy(streams step.OutStreams, destinationDir string, sourceDirs, hosts []st
 func (s *Server) CopyMasterDataDir(streams step.OutStreams, destination string) error {
 	// Make sure sourceDir ends with a trailing slash so that rsync will
 	// transfer the directory contents and not the directory itself.
-	source := []string{filepath.Clean(s.Target.MasterDataDir()) + string(filepath.Separator)}
-	return Copy(streams, destination, source, s.Target.PrimaryHostnames())
+	source := []string{filepath.Clean(s.IntermediateTarget.MasterDataDir()) + string(filepath.Separator)}
+	return Copy(streams, destination, source, s.IntermediateTarget.PrimaryHostnames())
 }
 
 func (s *Server) CopyMasterTablespaces(streams step.OutStreams, destinationDir string) error {
@@ -94,5 +94,5 @@ func (s *Server) CopyMasterTablespaces(streams step.OutStreams, destinationDir s
 	sourcePaths := []string{s.TablespacesMappingFilePath}
 	sourcePaths = append(sourcePaths, s.Tablespaces.GetMasterTablespaces().UserDefinedTablespacesLocations()...)
 
-	return Copy(streams, destinationDir, sourcePaths, s.Target.PrimaryHostnames())
+	return Copy(streams, destinationDir, sourcePaths, s.IntermediateTarget.PrimaryHostnames())
 }

--- a/hub/delete_data_directories.go
+++ b/hub/delete_data_directories.go
@@ -16,7 +16,7 @@ import (
 
 func DeleteMirrorAndStandbyDataDirectories(agentConns []*idl.Connection, cluster *greenplum.Cluster) error {
 	segs := cluster.SelectSegments(func(seg *greenplum.SegConfig) bool {
-		return seg.Role == greenplum.MirrorRole
+		return seg.IsMirror() || seg.IsStandby()
 	})
 	return deleteDataDirectories(agentConns, segs)
 }

--- a/hub/delete_data_directories_test.go
+++ b/hub/delete_data_directories_test.go
@@ -124,12 +124,9 @@ func TestDeleteSegmentDataDirs(t *testing.T) {
 				{AgentClient: standbyClient, Hostname: "standby"},
 			}
 
-			source := hub.InitializeConfig{
-				Master:    greenplum.SegConfig{ContentID: -1, DbID: 0, Port: 25431, Hostname: "master", DataDir: "/data/qddir", Role: greenplum.PrimaryRole},
-				Primaries: primarySegConfigs,
-			}
+			intermediateTarget := hub.MustCreateCluster(t, append(primarySegConfigs, greenplum.SegConfig{ContentID: -1, DbID: 0, Port: 25431, Hostname: "master", DataDir: "/data/qddir", Role: greenplum.PrimaryRole}))
 
-			err := hub.DeleteMasterAndPrimaryDataDirectories(step.DevNullStream, agentConns, source)
+			err := hub.DeleteMasterAndPrimaryDataDirectories(step.DevNullStream, agentConns, intermediateTarget)
 			if err != nil {
 				t.Errorf("unexpected err %#v", err)
 			}
@@ -157,12 +154,9 @@ func TestDeleteSegmentDataDirs(t *testing.T) {
 				{AgentClient: sdw2ClientFailed, Hostname: "sdw2"},
 			}
 
-			source := hub.InitializeConfig{
-				Master:    greenplum.SegConfig{ContentID: -1, DbID: 0, Port: 25431, Hostname: "master", DataDir: "/data/qddir", Role: greenplum.PrimaryRole},
-				Primaries: primarySegConfigs,
-			}
+			intermediateTarget := hub.MustCreateCluster(t, append(primarySegConfigs, greenplum.SegConfig{ContentID: -1, DbID: 0, Port: 25431, Hostname: "master", DataDir: "/data/qddir", Role: greenplum.PrimaryRole}))
 
-			err := hub.DeleteMasterAndPrimaryDataDirectories(step.DevNullStream, agentConns, source)
+			err := hub.DeleteMasterAndPrimaryDataDirectories(step.DevNullStream, agentConns, intermediateTarget)
 
 			if !errors.Is(err, expected) {
 				t.Errorf("got error %#v, want %#v", err, expected)

--- a/hub/execute.go
+++ b/hub/execute.go
@@ -50,12 +50,12 @@ func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_Execut
 	st.Run(idl.Substep_UPGRADE_MASTER, func(streams step.OutStreams) error {
 		stateDir := s.StateDir
 		return UpgradeMaster(UpgradeMasterArgs{
-			Source:      s.Source,
-			Target:      s.Target,
-			StateDir:    stateDir,
-			Stream:      streams,
-			CheckOnly:   false,
-			UseLinkMode: s.UseLinkMode,
+			Source:             s.Source,
+			IntermediateTarget: s.IntermediateTarget,
+			StateDir:           stateDir,
+			Stream:             streams,
+			CheckOnly:          false,
+			UseLinkMode:        s.UseLinkMode,
 		})
 	})
 
@@ -86,14 +86,14 @@ func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_Execut
 			AgentConns:             s.agentConns,
 			DataDirPairMap:         dataDirPair,
 			Source:                 s.Source,
-			Target:                 s.Target,
+			IntermediateTarget:     s.IntermediateTarget,
 			UseLinkMode:            s.UseLinkMode,
 			TablespacesMappingFile: s.TablespacesMappingFilePath,
 		})
 	})
 
 	st.Run(idl.Substep_START_TARGET_CLUSTER, func(streams step.OutStreams) error {
-		err := s.Target.Start(streams)
+		err := s.IntermediateTarget.Start(streams)
 
 		if err != nil {
 			return xerrors.Errorf("failed to start target cluster: %w", err)
@@ -105,8 +105,8 @@ func (s *Server) Execute(request *idl.ExecuteRequest, stream idl.CliToHub_Execut
 	message := &idl.Message{Contents: &idl.Message_Response{Response: &idl.Response{Contents: &idl.Response_ExecuteResponse{
 		ExecuteResponse: &idl.ExecuteResponse{
 			Target: &idl.Cluster{
-				Port:                int32(s.Target.MasterPort()),
-				MasterDataDirectory: s.Target.MasterDataDir(),
+				Port:                int32(s.IntermediateTarget.MasterPort()),
+				MasterDataDirectory: s.IntermediateTarget.MasterDataDir(),
 			}},
 	}}}}
 

--- a/hub/fill_cluster_configs.go
+++ b/hub/fill_cluster_configs.go
@@ -53,12 +53,12 @@ func FillConfiguration(config *Config, conn *sql.DB, _ step.OutStreams, request 
 		ports = append(ports, int(p))
 	}
 
-	config.TargetInitializeConfig, err = AssignDatadirsAndPorts(config.Source, ports, config.UpgradeID)
+	config.IntermediateTarget, err = AssignDatadirsAndPorts(config.Source, ports, config.UpgradeID)
 	if err != nil {
 		return err
 	}
 
-	if err := ensureTempPortRangeDoesNotOverlapWithSourceClusterPorts(config.Source, config.TargetInitializeConfig); err != nil {
+	if err := ensureTempPortRangeDoesNotOverlapWithSourceClusterPorts(config.Source, config.IntermediateTarget); err != nil {
 		return err
 	}
 

--- a/hub/fill_cluster_configs.go
+++ b/hub/fill_cluster_configs.go
@@ -48,7 +48,6 @@ func FillConfiguration(config *Config, conn *sql.DB, _ step.OutStreams, request 
 	target := source // create target cluster based off source cluster
 	config.Source = &source
 	config.Target = &target
-	config.TargetGPHome = request.TargetGPHome // delete me in favor of config.Target.GPHome
 	config.Target.GPHome = request.TargetGPHome
 	config.UseLinkMode = request.UseLinkMode
 

--- a/hub/fill_cluster_configs.go
+++ b/hub/fill_cluster_configs.go
@@ -42,7 +42,9 @@ func FillConfiguration(config *Config, conn *sql.DB, _ step.OutStreams, request 
 		return xerrors.Errorf("retrieve source configuration: %w", err)
 	}
 
-	config.Source = source
+	target := source // create target cluster based off source cluster
+	config.Source = &source
+	config.Target = &target
 	config.TargetGPHome = request.TargetGPHome
 	config.UseLinkMode = request.UseLinkMode
 

--- a/hub/fill_cluster_configs_test.go
+++ b/hub/fill_cluster_configs_test.go
@@ -24,7 +24,7 @@ func TestAssignDataDirsAndPorts(t *testing.T) {
 
 		cluster  *greenplum.Cluster
 		ports    []int
-		expected InitializeConfig
+		expected *greenplum.Cluster
 	}{{
 		name: "sorts and deduplicates provided port range",
 		cluster: MustCreateCluster(t, []greenplum.SegConfig{
@@ -33,129 +33,120 @@ func TestAssignDataDirsAndPorts(t *testing.T) {
 			{ContentID: 1, DbID: 3, Hostname: "mdw", DataDir: "/data/dbfast2/seg2", Role: "p"},
 		}),
 		ports: []int{10, 9, 10, 9, 10, 8},
-		expected: InitializeConfig{
-			Master: greenplum.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDir("/data/qddir/seg-1"), Role: "p", Port: 8},
-			Primaries: []greenplum.SegConfig{
-				{ContentID: 0, DbID: 2, Hostname: "mdw", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 9},
-				{ContentID: 1, DbID: 3, Hostname: "mdw", DataDir: expectedDataDir("/data/dbfast2/seg2"), Role: "p", Port: 10},
-			}},
-	}, {
-		name: "gives master its own port regardless of host layout",
-		cluster: MustCreateCluster(t, []greenplum.SegConfig{
-			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p"},
-			{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1/seg1", Role: "p"},
-			{ContentID: 1, DbID: 3, Hostname: "sdw1", DataDir: "/data/dbfast2/seg2", Role: "p"},
-			{ContentID: 2, DbID: 4, Hostname: "sdw1", DataDir: "/data/dbfast3/seg3", Role: "p"},
+		expected: MustCreateCluster(t, []greenplum.SegConfig{
+			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDir("/data/qddir/seg-1"), Role: "p", Port: 8},
+			{ContentID: 0, DbID: 2, Hostname: "mdw", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 9},
+			{ContentID: 1, DbID: 3, Hostname: "mdw", DataDir: expectedDataDir("/data/dbfast2/seg2"), Role: "p", Port: 10},
 		}),
-		ports: []int{50432, 50433, 50434, 50435, 50436, 50437, 50438, 50439, 50440},
-		expected: InitializeConfig{
-			Master: greenplum.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDir("/data/qddir/seg-1"), Role: "p", Port: 50432},
-			Primaries: []greenplum.SegConfig{
+	},
+		{
+			name: "gives master its own port regardless of host layout",
+			cluster: MustCreateCluster(t, []greenplum.SegConfig{
+				{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p"},
+				{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1/seg1", Role: "p"},
+				{ContentID: 1, DbID: 3, Hostname: "sdw1", DataDir: "/data/dbfast2/seg2", Role: "p"},
+				{ContentID: 2, DbID: 4, Hostname: "sdw1", DataDir: "/data/dbfast3/seg3", Role: "p"},
+			}),
+			ports: []int{50432, 50433, 50434, 50435, 50436, 50437, 50438, 50439, 50440},
+			expected: MustCreateCluster(t, []greenplum.SegConfig{
+				{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDir("/data/qddir/seg-1"), Role: "p", Port: 50432},
 				{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 50433},
 				{ContentID: 1, DbID: 3, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast2/seg2"), Role: "p", Port: 50434},
 				{ContentID: 2, DbID: 4, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast3/seg3"), Role: "p", Port: 50435},
-			}},
-	}, {
-		name: "when using default ports, it sets up mirrors as expected in the InitializeConfig",
-		cluster: MustCreateCluster(t, []greenplum.SegConfig{
-			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p"},
-			{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1/seg1", Role: "p"},
-			{ContentID: 1, DbID: 3, Hostname: "sdw1", DataDir: "/data/dbfast2/seg2", Role: "p"},
-			{ContentID: 0, DbID: 4, Hostname: "sdw1", DataDir: "/data/dbfast_mirror1/seg1", Role: "m"},
-			{ContentID: 1, DbID: 5, Hostname: "sdw1", DataDir: "/data/dbfast_mirror2/seg2", Role: "m"},
-		}),
-		ports: []int{50432, 50433, 50434, 50435, 50436, 50437, 50438, 50439, 50440},
-		expected: InitializeConfig{
-			Master: greenplum.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDir("/data/qddir/seg-1"), Role: "p", Port: 50432},
-			Primaries: []greenplum.SegConfig{
+			}),
+		}, {
+			name: "when using default ports, it sets up mirrors as expected in the InitializeConfig",
+			cluster: MustCreateCluster(t, []greenplum.SegConfig{
+				{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p"},
+				{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1/seg1", Role: "p"},
+				{ContentID: 1, DbID: 3, Hostname: "sdw1", DataDir: "/data/dbfast2/seg2", Role: "p"},
+				{ContentID: 0, DbID: 4, Hostname: "sdw1", DataDir: "/data/dbfast_mirror1/seg1", Role: "m"},
+				{ContentID: 1, DbID: 5, Hostname: "sdw1", DataDir: "/data/dbfast_mirror2/seg2", Role: "m"},
+			}),
+			ports: []int{50432, 50433, 50434, 50435, 50436, 50437, 50438, 50439, 50440},
+			expected: MustCreateCluster(t, []greenplum.SegConfig{
+				{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDir("/data/qddir/seg-1"), Role: "p", Port: 50432},
 				{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 50433},
 				{ContentID: 1, DbID: 3, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast2/seg2"), Role: "p", Port: 50434},
-			},
-			Mirrors: []greenplum.SegConfig{
 				{ContentID: 0, DbID: 4, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast_mirror1/seg1"), Role: "m", Port: 50435},
 				{ContentID: 1, DbID: 5, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast_mirror2/seg2"), Role: "m", Port: 50436},
-			},
-		},
-	}, {
-		name: "provides a standby port",
-		cluster: MustCreateCluster(t, []greenplum.SegConfig{
-			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p"},
-			{ContentID: -1, DbID: 2, Hostname: "smdw", DataDir: "/data/standby", Role: "m"},
-			{ContentID: 0, DbID: 3, Hostname: "sdw1", DataDir: "/data/dbfast1/seg1", Role: "p"},
-		}),
-		ports: []int{50432, 50433, 50434, 50435, 50436, 50437, 50438, 50439, 50440},
-		expected: InitializeConfig{
-			Master:    greenplum.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDir("/data/qddir/seg-1"), Role: "p", Port: 50432},
-			Standby:   greenplum.SegConfig{ContentID: -1, DbID: 2, Hostname: "smdw", DataDir: expectedDataDir("/data/standby"), Role: "m", Port: 50433},
-			Primaries: []greenplum.SegConfig{{ContentID: 0, DbID: 3, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 50434}},
-		},
-	}, {
-		name: "deals with master and standby on the same host",
-		cluster: MustCreateCluster(t, []greenplum.SegConfig{
-			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p"},
-			{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: "/data/standby", Role: "m"},
-			{ContentID: 0, DbID: 3, Hostname: "sdw1", DataDir: "/data/dbfast1/seg1", Role: "p"},
-		}),
-		ports: []int{50432, 50433, 50434, 50435, 50436, 50437, 50438, 50439, 50440},
-		expected: InitializeConfig{
-			Master:    greenplum.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDir("/data/qddir/seg-1"), Role: "p", Port: 50432},
-			Standby:   greenplum.SegConfig{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: expectedDataDir("/data/standby"), Role: "m", Port: 50433},
-			Primaries: []greenplum.SegConfig{{ContentID: 0, DbID: 3, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 50434}},
-		},
-	}, {
-		name: "deals with master and standby on the same host as other segments",
-		cluster: MustCreateCluster(t, []greenplum.SegConfig{
-			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p"},
-			{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: "/data/standby", Role: "m"},
-			{ContentID: 0, DbID: 3, Hostname: "mdw", DataDir: "/data/dbfast1/seg1", Role: "p"},
-		}),
-		ports: []int{50432, 50433, 50434, 50435, 50436, 50437, 50438, 50439, 50440},
-		expected: InitializeConfig{
-			Master:    greenplum.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDir("/data/qddir/seg-1"), Role: "p", Port: 50432},
-			Standby:   greenplum.SegConfig{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: expectedDataDir("/data/standby"), Role: "m", Port: 50433},
-			Primaries: []greenplum.SegConfig{{ContentID: 0, DbID: 3, Hostname: "mdw", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 50434}},
-		},
-	}, {
-		name: "assigns provided ports to the standby",
-		cluster: MustCreateCluster(t, []greenplum.SegConfig{
-			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p"},
-			{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: "/data/standby", Role: "m"},
-			{ContentID: 0, DbID: 3, Hostname: "mdw", DataDir: "/data/dbfast1/seg1", Role: "p"},
-		}),
-		ports: []int{1, 2, 3},
-		expected: InitializeConfig{
-			Master:    greenplum.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDir("/data/qddir/seg-1"), Role: "p", Port: 1},
-			Standby:   greenplum.SegConfig{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: expectedDataDir("/data/standby"), Role: "m", Port: 2},
-			Primaries: []greenplum.SegConfig{{ContentID: 0, DbID: 3, Hostname: "mdw", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 3}},
-		},
-	}, {
-		name: "assigns provided ports to cluster with standby and multiple primaries and multiple mirrors",
-		cluster: MustCreateCluster(t, []greenplum.SegConfig{
-			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p"},
-			{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: "/data/standby", Role: "m"},
-			{ContentID: 0, DbID: 3, Hostname: "sdw1", DataDir: "/data/dbfast1/seg1", Role: "p"},
-			{ContentID: 1, DbID: 4, Hostname: "sdw2", DataDir: "/data/dbfast2/seg2", Role: "p"},
-			{ContentID: 2, DbID: 5, Hostname: "sdw3", DataDir: "/data/dbfast3/seg3", Role: "p"},
-			{ContentID: 0, DbID: 6, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg1", Role: "m"},
-			{ContentID: 1, DbID: 7, Hostname: "sdw3", DataDir: "/data/dbfast_mirror2/seg2", Role: "m"},
-			{ContentID: 2, DbID: 8, Hostname: "sdw1", DataDir: "/data/dbfast_mirror3/seg3", Role: "m"},
-		}),
-		ports: []int{1, 2, 3, 4, 5},
-		expected: InitializeConfig{
-			Master:  greenplum.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDir("/data/qddir/seg-1"), Role: "p", Port: 1},
-			Standby: greenplum.SegConfig{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: expectedDataDir("/data/standby"), Role: "m", Port: 2},
-			Primaries: []greenplum.SegConfig{
+			}),
+		}, {
+			name: "provides a standby port",
+			cluster: MustCreateCluster(t, []greenplum.SegConfig{
+				{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p"},
+				{ContentID: -1, DbID: 2, Hostname: "smdw", DataDir: "/data/standby", Role: "m"},
+				{ContentID: 0, DbID: 3, Hostname: "sdw1", DataDir: "/data/dbfast1/seg1", Role: "p"},
+			}),
+			ports: []int{50432, 50433, 50434, 50435, 50436, 50437, 50438, 50439, 50440},
+			expected: MustCreateCluster(t, []greenplum.SegConfig{
+				{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDir("/data/qddir/seg-1"), Role: "p", Port: 50432},
+				{ContentID: -1, DbID: 2, Hostname: "smdw", DataDir: expectedDataDir("/data/standby"), Role: "m", Port: 50433},
+				{ContentID: 0, DbID: 3, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 50434},
+			}),
+		}, {
+			name: "deals with master and standby on the same host",
+			cluster: MustCreateCluster(t, []greenplum.SegConfig{
+				{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p"},
+				{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: "/data/standby", Role: "m"},
+				{ContentID: 0, DbID: 3, Hostname: "sdw1", DataDir: "/data/dbfast1/seg1", Role: "p"},
+			}),
+			ports: []int{50432, 50433, 50434, 50435, 50436, 50437, 50438, 50439, 50440},
+			expected: MustCreateCluster(t, []greenplum.SegConfig{
+				{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDir("/data/qddir/seg-1"), Role: "p", Port: 50432},
+				{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: expectedDataDir("/data/standby"), Role: "m", Port: 50433},
+				{ContentID: 0, DbID: 3, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 50434},
+			}),
+		}, {
+			name: "deals with master and standby on the same host as other segments",
+			cluster: MustCreateCluster(t, []greenplum.SegConfig{
+				{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p"},
+				{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: "/data/standby", Role: "m"},
+				{ContentID: 0, DbID: 3, Hostname: "mdw", DataDir: "/data/dbfast1/seg1", Role: "p"},
+			}),
+			ports: []int{50432, 50433, 50434, 50435, 50436, 50437, 50438, 50439, 50440},
+			expected: MustCreateCluster(t, []greenplum.SegConfig{
+				{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDir("/data/qddir/seg-1"), Role: "p", Port: 50432},
+				{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: expectedDataDir("/data/standby"), Role: "m", Port: 50433},
+				{ContentID: 0, DbID: 3, Hostname: "mdw", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 50434},
+			}),
+		}, {
+			name: "assigns provided ports to the standby",
+			cluster: MustCreateCluster(t, []greenplum.SegConfig{
+				{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p"},
+				{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: "/data/standby", Role: "m"},
+				{ContentID: 0, DbID: 3, Hostname: "mdw", DataDir: "/data/dbfast1/seg1", Role: "p"},
+			}),
+			ports: []int{1, 2, 3},
+			expected: MustCreateCluster(t, []greenplum.SegConfig{
+				{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDir("/data/qddir/seg-1"), Role: "p", Port: 1},
+				{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: expectedDataDir("/data/standby"), Role: "m", Port: 2},
+				{ContentID: 0, DbID: 3, Hostname: "mdw", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 3},
+			}),
+		}, {
+			name: "assigns provided ports to cluster with standby and multiple primaries and multiple mirrors",
+			cluster: MustCreateCluster(t, []greenplum.SegConfig{
+				{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p"},
+				{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: "/data/standby", Role: "m"},
+				{ContentID: 0, DbID: 3, Hostname: "sdw1", DataDir: "/data/dbfast1/seg1", Role: "p"},
+				{ContentID: 1, DbID: 4, Hostname: "sdw2", DataDir: "/data/dbfast2/seg2", Role: "p"},
+				{ContentID: 2, DbID: 5, Hostname: "sdw3", DataDir: "/data/dbfast3/seg3", Role: "p"},
+				{ContentID: 0, DbID: 6, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg1", Role: "m"},
+				{ContentID: 1, DbID: 7, Hostname: "sdw3", DataDir: "/data/dbfast_mirror2/seg2", Role: "m"},
+				{ContentID: 2, DbID: 8, Hostname: "sdw1", DataDir: "/data/dbfast_mirror3/seg3", Role: "m"},
+			}),
+			ports: []int{1, 2, 3, 4, 5},
+			expected: MustCreateCluster(t, []greenplum.SegConfig{
+				{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: expectedDataDir("/data/qddir/seg-1"), Role: "p", Port: 1},
+				{ContentID: -1, DbID: 2, Hostname: "mdw", DataDir: expectedDataDir("/data/standby"), Role: "m", Port: 2},
 				{ContentID: 0, DbID: 3, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast1/seg1"), Role: "p", Port: 3},
 				{ContentID: 1, DbID: 4, Hostname: "sdw2", DataDir: expectedDataDir("/data/dbfast2/seg2"), Role: "p", Port: 3},
 				{ContentID: 2, DbID: 5, Hostname: "sdw3", DataDir: expectedDataDir("/data/dbfast3/seg3"), Role: "p", Port: 3},
-			},
-			Mirrors: []greenplum.SegConfig{
 				{ContentID: 0, DbID: 6, Hostname: "sdw2", DataDir: expectedDataDir("/data/dbfast_mirror1/seg1"), Role: "m", Port: 4},
 				{ContentID: 1, DbID: 7, Hostname: "sdw3", DataDir: expectedDataDir("/data/dbfast_mirror2/seg2"), Role: "m", Port: 4},
 				{ContentID: 2, DbID: 8, Hostname: "sdw1", DataDir: expectedDataDir("/data/dbfast_mirror3/seg3"), Role: "m", Port: 4},
-			},
-		},
-	}}
+			}),
+		}}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -252,114 +243,99 @@ func TestEnsureTempPortRangeDoesNotOverlapWithSourceClusterPorts(t *testing.T) {
 		{ContentID: 0, DbID: 5, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg0", Role: "m", Port: 25435},
 	})
 
-	target := InitializeConfig{
-		Master:  greenplum.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p", Port: 6000},
-		Standby: greenplum.SegConfig{ContentID: -1, DbID: 8, Hostname: "smdw", DataDir: "/data/qddir/seg-1", Role: "m", Port: 6001},
-		Primaries: []greenplum.SegConfig{
-			{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1/seg0", Role: "p", Port: 6002},
-		},
-		Mirrors: []greenplum.SegConfig{
-			{ContentID: 0, DbID: 5, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg0", Role: "m", Port: 6005},
-		}}
+	intermediateTarget := MustCreateCluster(t, []greenplum.SegConfig{
+		{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p", Port: 6000},
+		{ContentID: -1, DbID: 8, Hostname: "smdw", DataDir: "/data/qddir/seg-1", Role: "m", Port: 6001},
+		{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1/seg0", Role: "p", Port: 6002},
+		{ContentID: 0, DbID: 5, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg0", Role: "m", Port: 6005},
+	})
 
 	t.Run("ensureTempPortRangeDoesNotOverlapWithSourceClusterPorts succeeds", func(t *testing.T) {
-		err := ensureTempPortRangeDoesNotOverlapWithSourceClusterPorts(source, target)
+		err := ensureTempPortRangeDoesNotOverlapWithSourceClusterPorts(source, intermediateTarget)
 		if err != nil {
 			t.Errorf("unexpected error %#v", err)
 		}
 	})
 
 	t.Run("allow the same port on different hosts", func(t *testing.T) {
-		target.Standby.Port = source.MasterPort()
+		intermediateTarget.Mirrors[-1] = greenplum.SegConfig{ContentID: -1, DbID: 8, Hostname: "smdw", DataDir: "/data/qddir/seg-1", Role: "m", Port: source.MasterPort()}
 
-		err := ensureTempPortRangeDoesNotOverlapWithSourceClusterPorts(source, target)
+		err := ensureTempPortRangeDoesNotOverlapWithSourceClusterPorts(source, intermediateTarget)
 		if err != nil {
 			t.Errorf("unexpected error %#v", err)
 		}
 	})
 
 	errCases := []struct {
-		name            string
-		source          *greenplum.Cluster
-		target          InitializeConfig
-		conflictingPort int
+		name               string
+		source             *greenplum.Cluster
+		intermediateTarget *greenplum.Cluster
+		conflictingPort    int
 	}{{
-		name: "errors when source master port overlaps with temp target cluster ports",
+		name: "errors when source master port overlaps with intermediate target cluster ports",
 		source: MustCreateCluster(t, []greenplum.SegConfig{
 			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p", Port: 15432},
 			{ContentID: -1, DbID: 8, Hostname: "smdw", DataDir: "/data/qddir/seg-1", Role: "m", Port: 16432},
 			{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1/seg0", Role: "p", Port: 25432},
 			{ContentID: 0, DbID: 5, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg0", Role: "m", Port: 25435},
 		}),
-		target: InitializeConfig{
-			Master:  greenplum.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p", Port: 15432},
-			Standby: greenplum.SegConfig{ContentID: -1, DbID: 8, Hostname: "smdw", DataDir: "/data/qddir/seg-1", Role: "m", Port: 6001},
-			Primaries: []greenplum.SegConfig{
-				{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1/seg0", Role: "p", Port: 6002},
-			},
-			Mirrors: []greenplum.SegConfig{
-				{ContentID: 0, DbID: 5, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg0", Role: "m", Port: 6005},
-			}},
+		intermediateTarget: MustCreateCluster(t, []greenplum.SegConfig{
+			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p", Port: 15432},
+			{ContentID: -1, DbID: 8, Hostname: "smdw", DataDir: "/data/qddir/seg-1", Role: "m", Port: 6001},
+			{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1/seg0", Role: "p", Port: 6002},
+			{ContentID: 0, DbID: 5, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg0", Role: "m", Port: 6005},
+		}),
 		conflictingPort: 15432,
 	}, {
-		name: "errors when source standby port overlaps with temp target cluster ports",
+		name: "errors when source standby port overlaps with intermediate target cluster ports",
 		source: MustCreateCluster(t, []greenplum.SegConfig{
 			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p", Port: 15432},
 			{ContentID: -1, DbID: 8, Hostname: "smdw", DataDir: "/data/qddir/seg-1", Role: "m", Port: 16432},
 			{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1/seg0", Role: "p", Port: 25432},
 			{ContentID: 0, DbID: 5, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg0", Role: "m", Port: 25435},
 		}),
-		target: InitializeConfig{
-			Master:  greenplum.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p", Port: 6000},
-			Standby: greenplum.SegConfig{ContentID: -1, DbID: 8, Hostname: "smdw", DataDir: "/data/qddir/seg-1", Role: "m", Port: 16432},
-			Primaries: []greenplum.SegConfig{
-				{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1/seg0", Role: "p", Port: 6002},
-			},
-			Mirrors: []greenplum.SegConfig{
-				{ContentID: 0, DbID: 5, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg0", Role: "m", Port: 6005},
-			}},
+		intermediateTarget: MustCreateCluster(t, []greenplum.SegConfig{
+			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p", Port: 6000},
+			{ContentID: -1, DbID: 8, Hostname: "smdw", DataDir: "/data/qddir/seg-1", Role: "m", Port: 16432},
+			{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1/seg0", Role: "p", Port: 6002},
+			{ContentID: 0, DbID: 5, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg0", Role: "m", Port: 6005},
+		}),
 		conflictingPort: 16432,
 	}, {
-		name: "errors when source primary port overlaps with temp target cluster ports",
+		name: "errors when source primary port overlaps with intermediate target cluster ports",
 		source: MustCreateCluster(t, []greenplum.SegConfig{
 			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p", Port: 15432},
 			{ContentID: -1, DbID: 8, Hostname: "smdw", DataDir: "/data/qddir/seg-1", Role: "m", Port: 16432},
 			{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1/seg0", Role: "p", Port: 25432},
 			{ContentID: 0, DbID: 5, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg0", Role: "m", Port: 25435},
 		}),
-		target: InitializeConfig{
-			Master:  greenplum.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p", Port: 6000},
-			Standby: greenplum.SegConfig{ContentID: -1, DbID: 8, Hostname: "smdw", DataDir: "/data/qddir/seg-1", Role: "m", Port: 6001},
-			Primaries: []greenplum.SegConfig{
-				{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1/seg0", Role: "p", Port: 25432},
-			},
-			Mirrors: []greenplum.SegConfig{
-				{ContentID: 0, DbID: 5, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg0", Role: "m", Port: 6005},
-			}},
+		intermediateTarget: MustCreateCluster(t, []greenplum.SegConfig{
+			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p", Port: 6000},
+			{ContentID: -1, DbID: 8, Hostname: "smdw", DataDir: "/data/qddir/seg-1", Role: "m", Port: 6001},
+			{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1/seg0", Role: "p", Port: 25432},
+			{ContentID: 0, DbID: 5, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg0", Role: "m", Port: 6005},
+		}),
 		conflictingPort: 25432,
 	}, {
-		name: "errors when source mirror port overlaps with temp target cluster ports",
+		name: "errors when source mirror port overlaps with intermediate target cluster ports",
 		source: MustCreateCluster(t, []greenplum.SegConfig{
 			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p", Port: 15432},
 			{ContentID: -1, DbID: 8, Hostname: "smdw", DataDir: "/data/qddir/seg-1", Role: "m", Port: 16432},
 			{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1/seg0", Role: "p", Port: 25432},
 			{ContentID: 0, DbID: 5, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg0", Role: "m", Port: 25435},
 		}),
-		target: InitializeConfig{
-			Master:  greenplum.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p", Port: 6000},
-			Standby: greenplum.SegConfig{ContentID: -1, DbID: 8, Hostname: "smdw", DataDir: "/data/qddir/seg-1", Role: "m", Port: 6001},
-			Primaries: []greenplum.SegConfig{
-				{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1/seg0", Role: "p", Port: 6002},
-			},
-			Mirrors: []greenplum.SegConfig{
-				{ContentID: 0, DbID: 5, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg0", Role: "m", Port: 25435},
-			}},
+		intermediateTarget: MustCreateCluster(t, []greenplum.SegConfig{
+			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: "p", Port: 6000},
+			{ContentID: -1, DbID: 8, Hostname: "smdw", DataDir: "/data/qddir/seg-1", Role: "m", Port: 6001},
+			{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1/seg0", Role: "p", Port: 6002},
+			{ContentID: 0, DbID: 5, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg0", Role: "m", Port: 25435},
+		}),
 		conflictingPort: 25435,
 	}}
 
 	for _, c := range errCases {
 		t.Run(c.name, func(t *testing.T) {
-			err := ensureTempPortRangeDoesNotOverlapWithSourceClusterPorts(c.source, c.target)
+			err := ensureTempPortRangeDoesNotOverlapWithSourceClusterPorts(c.source, c.intermediateTarget)
 			var invalidPortErr *InvalidTempPortRangeError
 			if !errors.As(err, &invalidPortErr) {
 				t.Fatalf("got %T, want %T", err, invalidPortErr)

--- a/hub/finalize.go
+++ b/hub/finalize.go
@@ -56,7 +56,7 @@ func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeSe
 		return UpdateConfFiles(streams,
 			semver.MustParse(s.Target.Version.SemVer.String()),
 			s.Target.MasterDataDir(),
-			s.IntermediateTarget.Master.Port,
+			s.IntermediateTarget.MasterPort(),
 			s.Source.MasterPort(),
 		)
 	})
@@ -124,7 +124,7 @@ func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeSe
 		FinalizeResponse: &idl.FinalizeResponse{
 			TargetVersion:                     s.Target.Version.VersionString,
 			LogArchiveDirectory:               logArchiveDir,
-			ArchivedSourceMasterDataDirectory: s.Config.IntermediateTarget.Master.DataDir + upgrade.OldSuffix,
+			ArchivedSourceMasterDataDirectory: s.Config.IntermediateTarget.MasterDataDir() + upgrade.OldSuffix,
 			UpgradeID:                         s.Config.UpgradeID.String(),
 			Target: &idl.Cluster{
 				Port:                int32(s.Target.MasterPort()),

--- a/hub/finalize.go
+++ b/hub/finalize.go
@@ -56,7 +56,7 @@ func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeSe
 		return UpdateConfFiles(streams,
 			semver.MustParse(s.Target.Version.SemVer.String()),
 			s.Target.MasterDataDir(),
-			s.TargetInitializeConfig.Master.Port,
+			s.IntermediateTarget.Master.Port,
 			s.Source.MasterPort(),
 		)
 	})
@@ -73,7 +73,7 @@ func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeSe
 
 	st.RunConditionally(idl.Substep_UPGRADE_STANDBY, s.Source.HasStandby(), func(streams step.OutStreams) error {
 		// TODO: once the temporary standby upgrade is fixed, switch to
-		// using the TargetInitializeConfig's temporary assignments, and
+		// using the IntermediateTarget's temporary assignments, and
 		// move this upgrade step back to before the target shutdown.
 		standby := s.Source.Mirrors[-1]
 		return UpgradeStandby(greenplum.NewRunner(s.Target, streams), StandbyConfig{
@@ -86,7 +86,7 @@ func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeSe
 
 	st.RunConditionally(idl.Substep_UPGRADE_MIRRORS, s.Source.HasMirrors(), func(streams step.OutStreams) error {
 		// TODO: once the temporary mirror upgrade is fixed, switch to using
-		// the TargetInitializeConfig's temporary assignments, and move this
+		// the IntermediateTarget's temporary assignments, and move this
 		// upgrade step back to before the target shutdown.
 		mirrors := func(seg *greenplum.SegConfig) bool {
 			return seg.IsMirror()
@@ -124,7 +124,7 @@ func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeSe
 		FinalizeResponse: &idl.FinalizeResponse{
 			TargetVersion:                     s.Target.Version.VersionString,
 			LogArchiveDirectory:               logArchiveDir,
-			ArchivedSourceMasterDataDirectory: s.Config.TargetInitializeConfig.Master.DataDir + upgrade.OldSuffix,
+			ArchivedSourceMasterDataDirectory: s.Config.IntermediateTarget.Master.DataDir + upgrade.OldSuffix,
 			UpgradeID:                         s.Config.UpgradeID.String(),
 			Target: &idl.Cluster{
 				Port:                int32(s.Target.MasterPort()),

--- a/hub/finalize.go
+++ b/hub/finalize.go
@@ -60,7 +60,7 @@ func (s *Server) Finalize(_ *idl.FinalizeRequest, stream idl.CliToHub_FinalizeSe
 			}
 		}
 
-		return s.UpdateDataDirectories()
+		return RenameDataDirectories(s.agentConns, s.Source, s.IntermediateTarget, s.UseLinkMode)
 	})
 
 	st.Run(idl.Substep_UPDATE_TARGET_CONF_FILES, func(streams step.OutStreams) error {

--- a/hub/init_target_cluster.go
+++ b/hub/init_target_cluster.go
@@ -43,7 +43,7 @@ func (s *Server) writeConf(sourceDBConn *dbconn.DBConn) error {
 	}
 	defer sourceDBConn.Close()
 
-	gpinitsystemConfig, err := CreateInitialInitsystemConfig(s.TargetInitializeConfig.Master.DataDir, s.UseHbaHostnames)
+	gpinitsystemConfig, err := CreateInitialInitsystemConfig(s.IntermediateTarget.Master.DataDir, s.UseHbaHostnames)
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func (s *Server) writeConf(sourceDBConn *dbconn.DBConn) error {
 		return err
 	}
 
-	gpinitsystemConfig, err = WriteSegmentArray(gpinitsystemConfig, s.TargetInitializeConfig)
+	gpinitsystemConfig, err = WriteSegmentArray(gpinitsystemConfig, s.IntermediateTarget)
 	if err != nil {
 		return xerrors.Errorf("generating segment array: %w", err)
 	}
@@ -77,7 +77,7 @@ func (s *Server) RemoveTargetCluster(streams step.OutStreams) error {
 		}
 	}
 
-	err = DeleteMasterAndPrimaryDataDirectories(streams, s.agentConns, s.TargetInitializeConfig)
+	err = DeleteMasterAndPrimaryDataDirectories(streams, s.agentConns, s.IntermediateTarget)
 	if err != nil {
 		return xerrors.Errorf("deleting target cluster data directories: %w", err)
 	}

--- a/hub/init_target_cluster.go
+++ b/hub/init_target_cluster.go
@@ -87,13 +87,13 @@ func (s *Server) RemoveIntermediateTargetCluster(streams step.OutStreams) error 
 }
 
 func (s *Server) InitTargetCluster(stream step.OutStreams) error {
-	version, err := greenplum.LocalVersion(s.TargetGPHome)
+	version, err := greenplum.LocalVersion(s.IntermediateTarget.GPHome)
 	if err != nil {
 		return err
 	}
 
 	return RunInitsystemForTargetCluster(stream,
-		s.TargetGPHome, s.initsystemConfPath(), version)
+		s.IntermediateTarget.GPHome, s.initsystemConfPath(), version)
 }
 
 func GetCheckpointSegmentsAndEncoding(gpinitsystemConfig []string, version dbconn.GPDBVersion, dbConnector *dbconn.DBConn) ([]string, error) {

--- a/hub/init_target_cluster.go
+++ b/hub/init_target_cluster.go
@@ -85,30 +85,6 @@ func (s *Server) RemoveTargetCluster(streams step.OutStreams) error {
 	return nil
 }
 
-// CreateTargetCluster runs gpinitsystem using the server's
-// TargetInitializeConfig, then fills in the Target cluster and persists it to
-// disk.
-func (s *Server) CreateTargetCluster(stream step.OutStreams) error {
-	err := s.InitTargetCluster(stream)
-	if err != nil {
-		return err
-	}
-
-	conn := db.NewDBConn("localhost", s.TargetInitializeConfig.Master.Port, "template1")
-	defer conn.Close()
-
-	s.Target, err = greenplum.ClusterFromDB(conn, s.TargetGPHome)
-	if err != nil {
-		return xerrors.Errorf("retrieve target configuration: %w", err)
-	}
-
-	if err := s.SaveConfig(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (s *Server) InitTargetCluster(stream step.OutStreams) error {
 	version, err := greenplum.LocalVersion(s.TargetGPHome)
 	if err != nil {

--- a/hub/init_target_cluster.go
+++ b/hub/init_target_cluster.go
@@ -29,7 +29,7 @@ import (
 var ErrUnknownCatalogVersion = errors.New("pg_controldata output is missing catalog version")
 
 func (s *Server) GenerateInitsystemConfig() error {
-	sourceDBConn := db.NewDBConn("localhost", int(s.Source.MasterPort()), "template1")
+	sourceDBConn := db.NewDBConn("localhost", s.Source.MasterPort(), "template1")
 	return s.writeConf(sourceDBConn)
 }
 
@@ -67,13 +67,13 @@ func (s *Server) RemoveIntermediateTargetCluster(streams step.OutStreams) error 
 		return nil
 	}
 
-	running, err := s.Target.IsMasterRunning(streams)
+	running, err := s.IntermediateTarget.IsMasterRunning(streams)
 	if err != nil {
 		return err
 	}
 
 	if running {
-		if err := s.Target.Stop(streams); err != nil {
+		if err := s.IntermediateTarget.Stop(streams); err != nil {
 			return xerrors.Errorf("stopping target cluster: %w", err)
 		}
 	}

--- a/hub/init_target_cluster_test.go
+++ b/hub/init_target_cluster_test.go
@@ -160,10 +160,10 @@ func TestGetCheckpointSegmentsAndEncoding(t *testing.T) {
 }
 
 func TestWriteSegmentArray(t *testing.T) {
-	test := func(t *testing.T, initializeConfig InitializeConfig, expected []string) {
+	test := func(t *testing.T, intermediateTarget *greenplum.Cluster, expected []string) {
 		t.Helper()
 
-		actual, err := WriteSegmentArray([]string{}, initializeConfig)
+		actual, err := WriteSegmentArray([]string{}, intermediateTarget)
 		if err != nil {
 			t.Errorf("got %#v", err)
 		}
@@ -186,13 +186,11 @@ func TestWriteSegmentArray(t *testing.T) {
 	}
 
 	t.Run("renders the config file as expected", func(t *testing.T) {
-		config := InitializeConfig{
-			Master: greenplum.SegConfig{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir_upgrade/seg-1", Role: "p", Port: 15433},
-			Primaries: []greenplum.SegConfig{
-				{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1_upgrade/seg1", Role: "p", Port: 15434},
-				{ContentID: 1, DbID: 3, Hostname: "sdw2", DataDir: "/data/dbfast2_upgrade/seg2", Role: "p", Port: 15434},
-			},
-		}
+		config := MustCreateCluster(t, []greenplum.SegConfig{
+			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir_upgrade/seg-1", Role: "p", Port: 15433},
+			{ContentID: 0, DbID: 2, Hostname: "sdw1", DataDir: "/data/dbfast1_upgrade/seg1", Role: "p", Port: 15434},
+			{ContentID: 1, DbID: 3, Hostname: "sdw2", DataDir: "/data/dbfast2_upgrade/seg2", Role: "p", Port: 15434},
+		})
 
 		test(t, config, []string{
 			"QD_PRIMARY_ARRAY=mdw~mdw~15433~/data/qddir_upgrade/seg-1~1~-1",
@@ -201,14 +199,6 @@ func TestWriteSegmentArray(t *testing.T) {
 			"\tsdw2~sdw2~15434~/data/dbfast2_upgrade/seg2~3~1",
 			")",
 		})
-	})
-
-	t.Run("errors when source cluster contains no master segment", func(t *testing.T) {
-		_, err := WriteSegmentArray([]string{}, InitializeConfig{})
-
-		if err == nil {
-			t.Errorf("expected error got nil")
-		}
 	})
 }
 

--- a/hub/init_target_cluster_test.go
+++ b/hub/init_target_cluster_test.go
@@ -168,6 +168,8 @@ func TestWriteSegmentArray(t *testing.T) {
 			t.Errorf("got %#v", err)
 		}
 
+		sort.Strings(actual)
+		sort.Strings(expected)
 		if !reflect.DeepEqual(actual, expected) {
 			// Help developers see differences between the lines.
 			pretty := func(lines []string) string {

--- a/hub/initialize.go
+++ b/hub/initialize.go
@@ -121,7 +121,7 @@ func (s *Server) InitializeCreateCluster(in *idl.InitializeCreateClusterRequest,
 			return err
 		}
 
-		err = s.CreateTargetCluster(stream)
+		err = s.InitTargetCluster(stream)
 		if err != nil {
 			return err
 		}

--- a/hub/rename_data_directories.go
+++ b/hub/rename_data_directories.go
@@ -17,18 +17,14 @@ var ArchiveSource = upgrade.ArchiveSource
 
 type RenameMap = map[string][]*idl.RenameDirectories
 
-func (s *Server) UpdateDataDirectories() error {
-	return UpdateDataDirectories(s.Config, s.agentConns)
-}
-
-func UpdateDataDirectories(conf *Config, agentConns []*idl.Connection) error {
-	source := conf.Source.MasterDataDir()
-	intermediateTarget := conf.IntermediateTarget.MasterDataDir()
-	if err := ArchiveSource(source, intermediateTarget, true); err != nil {
+func RenameDataDirectories(agentConns []*idl.Connection, source *greenplum.Cluster, intermediateTarget *greenplum.Cluster, linkMode bool) error {
+	src := source.MasterDataDir()
+	dst := intermediateTarget.MasterDataDir()
+	if err := ArchiveSource(src, dst, true); err != nil {
 		return xerrors.Errorf("renaming master data directories: %w", err)
 	}
 
-	renameMap := getRenameMap(conf.Source, conf.IntermediateTarget, conf.UseLinkMode)
+	renameMap := getRenameMap(source, intermediateTarget, linkMode)
 	if err := RenameSegmentDataDirs(agentConns, renameMap); err != nil {
 		return xerrors.Errorf("renaming segment data directories: %w", err)
 	}

--- a/hub/rename_data_directories.go
+++ b/hub/rename_data_directories.go
@@ -28,18 +28,6 @@ func UpdateDataDirectories(conf *Config, agentConns []*idl.Connection) error {
 		return xerrors.Errorf("renaming master data directories: %w", err)
 	}
 
-	// in link mode, remove the source mirror and standby data directories; otherwise we create a second copy
-	//  of them for the intermediate target cluster. That might take too much disk space.
-	if conf.UseLinkMode {
-		if err := DeleteMirrorAndStandbyDataDirectories(agentConns, conf.Source); err != nil {
-			return xerrors.Errorf("removing source cluster standby and mirror segment data directories: %w", err)
-		}
-
-		if err := DeleteSourceTablespacesOnMirrorsAndStandby(agentConns, conf.Source, conf.Tablespaces); err != nil {
-			return xerrors.Errorf("removing source cluster standby and mirror tablespace data directories: %w", err)
-		}
-	}
-
 	renameMap := getRenameMap(conf.Source, conf.IntermediateTarget, conf.UseLinkMode)
 	if err := RenameSegmentDataDirs(agentConns, renameMap); err != nil {
 		return xerrors.Errorf("renaming segment data directories: %w", err)

--- a/hub/rename_data_directories.go
+++ b/hub/rename_data_directories.go
@@ -23,7 +23,7 @@ func (s *Server) UpdateDataDirectories() error {
 
 func UpdateDataDirectories(conf *Config, agentConns []*idl.Connection) error {
 	source := conf.Source.MasterDataDir()
-	target := conf.TargetInitializeConfig.Master.DataDir
+	target := conf.IntermediateTarget.Master.DataDir
 	if err := ArchiveSource(source, target, true); err != nil {
 		return xerrors.Errorf("renaming master data directories: %w", err)
 	}
@@ -40,7 +40,7 @@ func UpdateDataDirectories(conf *Config, agentConns []*idl.Connection) error {
 		}
 	}
 
-	renameMap := getRenameMap(conf.Source, conf.TargetInitializeConfig, conf.UseLinkMode)
+	renameMap := getRenameMap(conf.Source, conf.IntermediateTarget, conf.UseLinkMode)
 	if err := RenameSegmentDataDirs(agentConns, renameMap); err != nil {
 		return xerrors.Errorf("renaming segment data directories: %w", err)
 	}

--- a/hub/rename_data_directories_test.go
+++ b/hub/rename_data_directories_test.go
@@ -287,10 +287,6 @@ func TestUpdateDataDirectories(t *testing.T) {
 		// Similar to copy mode, but we want deletion requests on the mirrors
 		// and standby as opposed to archive requests.
 		sdw1 := mock_idl.NewMockAgentClient(ctrl)
-		expectDeletes(sdw1, []string{
-			"/data/dbfast_mirror1/seg1",
-			"/data/dbfast_mirror1/seg3",
-		})
 		expectRenames(sdw1, []*idl.RenameDirectories{{
 			Source:       "/data/dbfast1/seg1",
 			Target:       "/data/dbfast1/seg1_123ABC",
@@ -302,10 +298,6 @@ func TestUpdateDataDirectories(t *testing.T) {
 		}})
 
 		sdw2 := mock_idl.NewMockAgentClient(ctrl)
-		expectDeletes(sdw2, []string{
-			"/data/dbfast_mirror2/seg2",
-			"/data/dbfast_mirror2/seg4",
-		})
 		expectRenames(sdw2, []*idl.RenameDirectories{{
 			Source:       "/data/dbfast2/seg2",
 			Target:       "/data/dbfast2/seg2_123ABC",
@@ -316,15 +308,9 @@ func TestUpdateDataDirectories(t *testing.T) {
 			RenameTarget: true,
 		}})
 
-		standby := mock_idl.NewMockAgentClient(ctrl)
-		expectDeletes(standby, []string{
-			"/data/standby",
-		})
-
 		agentConns := []*idl.Connection{
 			{AgentClient: sdw1, Hostname: "sdw1"},
 			{AgentClient: sdw2, Hostname: "sdw2"},
-			{AgentClient: standby, Hostname: "standby"},
 		}
 
 		err := hub.UpdateDataDirectories(conf, agentConns)
@@ -341,15 +327,6 @@ func expectRenames(client *mock_idl.MockAgentClient, pairs []*idl.RenameDirector
 		gomock.Any(),
 		equivalentRenameDirsRequest(&idl.RenameDirectoriesRequest{Dirs: pairs}),
 	).Return(&idl.RenameDirectoriesReply{}, nil)
-}
-
-// expectDeletes is syntactic sugar for setting up an expectation on
-// AgentClient.DeleteDirectories().
-func expectDeletes(client *mock_idl.MockAgentClient, datadirs []string) {
-	client.EXPECT().DeleteDataDirectories(
-		gomock.Any(),
-		&idl.DeleteDataDirectoriesRequest{Datadirs: datadirs},
-	).Return(&idl.DeleteDataDirectoriesReply{}, nil)
 }
 
 // equivalentRequest is a Matcher that can handle differences in order between

--- a/hub/rename_data_directories_test.go
+++ b/hub/rename_data_directories_test.go
@@ -124,7 +124,7 @@ func TestRenameSegmentDataDirs(t *testing.T) {
 func TestUpdateDataDirectories(t *testing.T) {
 	// Prerequisites:
 	// - a valid Source cluster
-	// - a valid TargetInitializeConfig (XXX should be Target once we fix it)
+	// - a valid IntermediateTarget (XXX should be Target once we fix it)
 	// - agentConns pointing to each host (set up per test)
 
 	conf := new(hub.Config)
@@ -144,7 +144,7 @@ func TestUpdateDataDirectories(t *testing.T) {
 		{ContentID: 3, Hostname: "sdw2", DataDir: "/data/dbfast_mirror2/seg4", Role: greenplum.MirrorRole},
 	})
 
-	conf.TargetInitializeConfig = hub.InitializeConfig{
+	conf.IntermediateTarget = hub.InitializeConfig{
 		Master: greenplum.SegConfig{
 			ContentID: -1, Hostname: "sdw1", DataDir: "/data/qddir/seg-1_123ABC-1", Role: greenplum.PrimaryRole,
 		},
@@ -179,7 +179,7 @@ func TestUpdateDataDirectories(t *testing.T) {
 			{ContentID: -1, Hostname: "sdw1", DataDir: sourceDataDir, Role: greenplum.PrimaryRole},
 		})
 
-		conf.TargetInitializeConfig = hub.InitializeConfig{
+		conf.IntermediateTarget = hub.InitializeConfig{
 			Master: greenplum.SegConfig{
 				ContentID: -1, Hostname: "sdw1", DataDir: targetDataDir, Role: greenplum.PrimaryRole,
 			},

--- a/hub/rename_data_directories_test.go
+++ b/hub/rename_data_directories_test.go
@@ -187,7 +187,7 @@ func TestUpdateDataDirectories(t *testing.T) {
 			}
 		}()
 
-		err := hub.UpdateDataDirectories(conf, nil)
+		err := hub.RenameDataDirectories(nil, conf.Source, conf.IntermediateTarget, conf.UseLinkMode)
 		if err != nil {
 			t.Errorf("UpdateDataDirectories() returned error: %+v", err)
 		}
@@ -206,7 +206,7 @@ func TestUpdateDataDirectories(t *testing.T) {
 			}
 		}()
 
-		err := hub.UpdateDataDirectories(conf, nil)
+		err := hub.RenameDataDirectories(nil, conf.Source, conf.IntermediateTarget, conf.UseLinkMode)
 		if !errors.Is(err, expected) {
 			t.Errorf("got %#v want %#v", err, expected)
 		}
@@ -272,9 +272,9 @@ func TestUpdateDataDirectories(t *testing.T) {
 			{AgentClient: standby, Hostname: "standby"},
 		}
 
-		err := hub.UpdateDataDirectories(conf, agentConns)
+		err := hub.RenameDataDirectories(agentConns, conf.Source, conf.IntermediateTarget, conf.UseLinkMode)
 		if err != nil {
-			t.Errorf("UpdateDataDirectories() returned error: %+v", err)
+			t.Errorf("RenameDataDirectories() returned error: %+v", err)
 		}
 	})
 
@@ -313,9 +313,9 @@ func TestUpdateDataDirectories(t *testing.T) {
 			{AgentClient: sdw2, Hostname: "sdw2"},
 		}
 
-		err := hub.UpdateDataDirectories(conf, agentConns)
+		err := hub.RenameDataDirectories(agentConns, conf.Source, conf.IntermediateTarget, conf.UseLinkMode)
 		if err != nil {
-			t.Errorf("UpdateDataDirectories() returned error: %+v", err)
+			t.Errorf("RenameDataDirectories() returned error: %+v", err)
 		}
 	})
 }

--- a/hub/revert.go
+++ b/hub/revert.go
@@ -60,13 +60,13 @@ func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) 
 	}
 
 	st.RunConditionally(idl.Substep_DELETE_TARGET_CLUSTER_DATADIRS,
-		s.TargetInitializeConfig.Primaries != nil && s.TargetInitializeConfig.Master.DataDir != "",
+		s.IntermediateTarget.Primaries != nil && s.IntermediateTarget.Master.DataDir != "",
 		func(streams step.OutStreams) error {
-			return DeleteMasterAndPrimaryDataDirectories(streams, s.agentConns, s.TargetInitializeConfig)
+			return DeleteMasterAndPrimaryDataDirectories(streams, s.agentConns, s.IntermediateTarget)
 		})
 
 	st.RunConditionally(idl.Substep_DELETE_TABLESPACES,
-		s.TargetInitializeConfig.Primaries != nil && s.TargetInitializeConfig.Master.DataDir != "",
+		s.IntermediateTarget.Primaries != nil && s.IntermediateTarget.Master.DataDir != "",
 		func(streams step.OutStreams) error {
 			return DeleteTargetTablespaces(streams, s.agentConns, s.Config.Target, s.TargetCatalogVersion, s.Tablespaces)
 		})

--- a/hub/revert.go
+++ b/hub/revert.go
@@ -60,13 +60,13 @@ func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) 
 	}
 
 	st.RunConditionally(idl.Substep_DELETE_TARGET_CLUSTER_DATADIRS,
-		s.IntermediateTarget.Primaries != nil && s.IntermediateTarget.Master.DataDir != "",
+		s.IntermediateTarget.Primaries != nil && s.IntermediateTarget.MasterDataDir() != "",
 		func(streams step.OutStreams) error {
 			return DeleteMasterAndPrimaryDataDirectories(streams, s.agentConns, s.IntermediateTarget)
 		})
 
 	st.RunConditionally(idl.Substep_DELETE_TABLESPACES,
-		s.IntermediateTarget.Primaries != nil && s.IntermediateTarget.Master.DataDir != "",
+		s.IntermediateTarget.Primaries != nil && s.IntermediateTarget.MasterDataDir() != "",
 		func(streams step.OutStreams) error {
 			return DeleteTargetTablespaces(streams, s.agentConns, s.Config.Target, s.TargetCatalogVersion, s.Tablespaces)
 		})

--- a/hub/server.go
+++ b/hub/server.go
@@ -344,13 +344,6 @@ func (s *Server) closeAgentConns() {
 	}
 }
 
-type InitializeConfig struct {
-	Standby   greenplum.SegConfig
-	Master    greenplum.SegConfig
-	Primaries []greenplum.SegConfig
-	Mirrors   []greenplum.SegConfig
-}
-
 // Config contains all the information that will be persisted to/loaded from
 // from disk during calls to Save() and Load().
 type Config struct {
@@ -364,7 +357,7 @@ type Config struct {
 	// IntermediateTarget represents the initialized target cluster that is
 	// upgraded based on the source and later renamed to match the source
 	// cluster.
-	IntermediateTarget InitializeConfig
+	IntermediateTarget *greenplum.Cluster
 
 	// Target is the upgraded GPDB cluster. It is populated during the target
 	// gpinitsystem execution in the initialize step; before that, it is nil.

--- a/hub/server.go
+++ b/hub/server.go
@@ -361,6 +361,11 @@ type Config struct {
 	// it is nil.
 	Source *greenplum.Cluster
 
+	// IntermediateTarget represents the initialized target cluster that is
+	// upgraded based on the source and later renamed to match the source
+	// cluster.
+	IntermediateTarget InitializeConfig
+
 	// Target is the upgraded GPDB cluster. It is populated during the target
 	// gpinitsystem execution in the initialize step; before that, it is nil.
 	Target *greenplum.Cluster
@@ -369,10 +374,6 @@ type Config struct {
 	// source or target databases.  It also contains the Source.Version and
 	// Target.Version internally.
 	Connection *connURI.Conn
-
-	// TargetInitializeConfig contains all the info needed to initialize the
-	// target cluster's master, standby, primaries and mirrors.
-	TargetInitializeConfig InitializeConfig
 
 	Port            int
 	AgentPort       int

--- a/hub/server_internal_test.go
+++ b/hub/server_internal_test.go
@@ -18,7 +18,7 @@ func TestConfig(t *testing.T) {
 	// "stream" refers to the io.Writer/Reader interfaces.
 	t.Run("saves itself to the provided stream", func(t *testing.T) {
 		source, target := testutils.CreateMultinodeSampleClusterPair("/tmp")
-		targetInitializeConfig := InitializeConfig{Master: greenplum.SegConfig{Hostname: "mdw"}}
+		intermediateTarget := source
 
 		// NOTE: we explicitly do not name the struct members here, to ensure
 		// that the test fails to compile if you add new members to Config but
@@ -27,7 +27,7 @@ func TestConfig(t *testing.T) {
 		original := &Config{
 			"logArchiveDir",
 			source,
-			targetInitializeConfig,
+			intermediateTarget,
 			target,
 			&connURI.Conn{},
 			12345,           // Port

--- a/hub/server_internal_test.go
+++ b/hub/server_internal_test.go
@@ -27,9 +27,9 @@ func TestConfig(t *testing.T) {
 		original := &Config{
 			"logArchiveDir",
 			source,
+			targetInitializeConfig,
 			target,
 			&connURI.Conn{},
-			targetInitializeConfig,
 			12345,           // Port
 			54321,           // AgentPort
 			false,           // UseLinkMode

--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -46,13 +46,13 @@ func TestHubStart(t *testing.T) {
 	})
 
 	conf := &hub.Config{
-		Source:                 source,
-		Target:                 target,
-		TargetInitializeConfig: hub.InitializeConfig{},
-		Port:                   testutils.MustGetPort(t),
-		AgentPort:              testutils.MustGetPort(t),
-		UseLinkMode:            false,
-		UpgradeID:              0,
+		Source:             source,
+		Target:             target,
+		IntermediateTarget: hub.InitializeConfig{},
+		Port:               testutils.MustGetPort(t),
+		AgentPort:          testutils.MustGetPort(t),
+		UseLinkMode:        false,
+		UpgradeID:          0,
 	}
 
 	t.Run("start correctly errors if stop is called first", func(t *testing.T) {
@@ -174,13 +174,13 @@ func TestAgentConns(t *testing.T) {
 	defer agentServer.Stop()
 
 	conf := &hub.Config{
-		Source:                 source,
-		Target:                 target,
-		TargetInitializeConfig: hub.InitializeConfig{},
-		Port:                   testutils.MustGetPort(t),
-		AgentPort:              agentPort,
-		UseLinkMode:            false,
-		UpgradeID:              0,
+		Source:             source,
+		Target:             target,
+		IntermediateTarget: hub.InitializeConfig{},
+		Port:               testutils.MustGetPort(t),
+		AgentPort:          agentPort,
+		UseLinkMode:        false,
+		UpgradeID:          0,
 	}
 
 	testlog.SetupLogger()
@@ -322,13 +322,13 @@ func doesStateEventuallyReach(conn *grpc.ClientConn, state connectivity.State) (
 func TestHubSaveConfig(t *testing.T) {
 	source, target := testutils.CreateMultinodeSampleClusterPair("/tmp")
 	conf := &hub.Config{
-		Source:                 source,
-		Target:                 target,
-		TargetInitializeConfig: hub.InitializeConfig{},
-		Port:                   12345,
-		AgentPort:              54321,
-		UseLinkMode:            false,
-		UpgradeID:              0,
+		Source:             source,
+		Target:             target,
+		IntermediateTarget: hub.InitializeConfig{},
+		Port:               12345,
+		AgentPort:          54321,
+		UseLinkMode:        false,
+		UpgradeID:          0,
 	}
 
 	h := hub.New(conf, nil, "")
@@ -372,13 +372,13 @@ func TestGetArchiveDir(t *testing.T) {
 
 	source, target := testutils.CreateMultinodeSampleClusterPair("/data")
 	conf := &hub.Config{
-		Source:                 source,
-		Target:                 target,
-		TargetInitializeConfig: hub.InitializeConfig{},
-		Port:                   12345,
-		AgentPort:              54321,
-		UseLinkMode:            false,
-		UpgradeID:              0,
+		Source:             source,
+		Target:             target,
+		IntermediateTarget: hub.InitializeConfig{},
+		Port:               12345,
+		AgentPort:          54321,
+		UseLinkMode:        false,
+		UpgradeID:          0,
 	}
 
 	server := hub.New(conf, nil, "")

--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -48,7 +48,7 @@ func TestHubStart(t *testing.T) {
 	conf := &hub.Config{
 		Source:             source,
 		Target:             target,
-		IntermediateTarget: hub.InitializeConfig{},
+		IntermediateTarget: &greenplum.Cluster{},
 		Port:               testutils.MustGetPort(t),
 		AgentPort:          testutils.MustGetPort(t),
 		UseLinkMode:        false,
@@ -176,7 +176,7 @@ func TestAgentConns(t *testing.T) {
 	conf := &hub.Config{
 		Source:             source,
 		Target:             target,
-		IntermediateTarget: hub.InitializeConfig{},
+		IntermediateTarget: &greenplum.Cluster{},
 		Port:               testutils.MustGetPort(t),
 		AgentPort:          agentPort,
 		UseLinkMode:        false,
@@ -324,7 +324,7 @@ func TestHubSaveConfig(t *testing.T) {
 	conf := &hub.Config{
 		Source:             source,
 		Target:             target,
-		IntermediateTarget: hub.InitializeConfig{},
+		IntermediateTarget: &greenplum.Cluster{},
 		Port:               12345,
 		AgentPort:          54321,
 		UseLinkMode:        false,
@@ -374,7 +374,7 @@ func TestGetArchiveDir(t *testing.T) {
 	conf := &hub.Config{
 		Source:             source,
 		Target:             target,
-		IntermediateTarget: hub.InitializeConfig{},
+		IntermediateTarget: &greenplum.Cluster{},
 		Port:               12345,
 		AgentPort:          54321,
 		UseLinkMode:        false,

--- a/hub/update_catalog.go
+++ b/hub/update_catalog.go
@@ -187,25 +187,6 @@ func (s *Server) UpdateGpSegmentConfiguration(db *sql.DB) (err error) {
 	}
 	defer func() {
 		err = commitOrRollback(tx, err)
-		if err == nil {
-			// After successfully changing the catalog, update the source and
-			// target cluster objects to match the catalog and persist to
-			// disk.
-			origConf := &Config{}
-			err = LoadConfig(origConf, upgrade.GetConfigFile())
-			if err != nil {
-				err = xerrors.Errorf("loading config: %w", err)
-				return
-			}
-
-			// TODO: this is out of sync now, as the standby/mirrors are added later.
-			//   replace with one without standby/mirrors
-			s.Target = origConf.Source
-			s.Target.GPHome = origConf.Target.GPHome
-			s.Target.Version = origConf.Target.Version
-
-			err = s.SaveConfig()
-		}
 	}()
 
 	// Make sure the content IDs in gp_segment_configuration match the source

--- a/hub/update_catalog_test.go
+++ b/hub/update_catalog_test.go
@@ -28,7 +28,7 @@ var (
 )
 
 func TestUpdateCatalog(t *testing.T) {
-	src, err := greenplum.NewCluster([]greenplum.SegConfig{
+	src := MustCreateCluster(t, []greenplum.SegConfig{
 		{ContentID: -1, Port: 123, Role: greenplum.PrimaryRole},
 		{ContentID: -1, Port: 789, Role: greenplum.MirrorRole},
 		{ContentID: 0, Port: 234, Role: greenplum.PrimaryRole},
@@ -38,10 +38,6 @@ func TestUpdateCatalog(t *testing.T) {
 		{ContentID: 2, Port: 456, Role: greenplum.PrimaryRole},
 		{ContentID: 2, Port: 333, Role: greenplum.MirrorRole},
 	})
-
-	if err != nil {
-		t.Fatalf("constructing test cluster: %+v", err)
-	}
 
 	tempDir, err := ioutil.TempDir("", "gpupgrade")
 	if err != nil {

--- a/hub/upgrade_master_test.go
+++ b/hub/upgrade_master_test.go
@@ -203,12 +203,12 @@ func TestUpgradeMaster(t *testing.T) {
 		defer rsync.ResetRsyncCommand()
 
 		err := UpgradeMaster(UpgradeMasterArgs{
-			Source:      source,
-			Target:      target,
-			StateDir:    tempDir,
-			Stream:      step.DevNullStream,
-			CheckOnly:   false,
-			UseLinkMode: false,
+			Source:             source,
+			IntermediateTarget: target,
+			StateDir:           tempDir,
+			Stream:             step.DevNullStream,
+			CheckOnly:          false,
+			UseLinkMode:        false,
 		})
 		if err != nil {
 			t.Errorf("returned error %+v", err)
@@ -228,12 +228,12 @@ func TestUpgradeMaster(t *testing.T) {
 		defer ResetExecCommand()
 
 		err := UpgradeMaster(UpgradeMasterArgs{
-			Source:      source,
-			Target:      target,
-			StateDir:    tempDir,
-			Stream:      new(step.BufferedStreams),
-			CheckOnly:   false,
-			UseLinkMode: false,
+			Source:             source,
+			IntermediateTarget: target,
+			StateDir:           tempDir,
+			Stream:             new(step.BufferedStreams),
+			CheckOnly:          false,
+			UseLinkMode:        false,
 		})
 		if err == nil {
 			t.Errorf("expected error, returned nil")
@@ -259,12 +259,12 @@ func TestUpgradeMaster(t *testing.T) {
 		stream := new(step.BufferedStreams)
 
 		err := UpgradeMaster(UpgradeMasterArgs{
-			Source:      source,
-			Target:      target,
-			StateDir:    tempDir,
-			Stream:      stream,
-			CheckOnly:   false,
-			UseLinkMode: false,
+			Source:             source,
+			IntermediateTarget: target,
+			StateDir:           tempDir,
+			Stream:             stream,
+			CheckOnly:          false,
+			UseLinkMode:        false,
 		})
 		if err != nil {
 			t.Errorf("returned error %+v", err)
@@ -297,12 +297,12 @@ func TestUpgradeMaster(t *testing.T) {
 		source.Version = dbconn.NewVersion("5.28.0")
 
 		err := UpgradeMaster(UpgradeMasterArgs{
-			Source:      source,
-			Target:      target,
-			StateDir:    tempDir,
-			Stream:      step.DevNullStream,
-			CheckOnly:   false,
-			UseLinkMode: false,
+			Source:             source,
+			IntermediateTarget: target,
+			StateDir:           tempDir,
+			Stream:             step.DevNullStream,
+			CheckOnly:          false,
+			UseLinkMode:        false,
 		})
 		if err != nil {
 			t.Errorf("returned error %+v", err)
@@ -326,12 +326,12 @@ func TestUpgradeMaster(t *testing.T) {
 		source.Version = dbconn.NewVersion("6.10.0")
 
 		err := UpgradeMaster(UpgradeMasterArgs{
-			Source:      source,
-			Target:      target,
-			StateDir:    tempDir,
-			Stream:      step.DevNullStream,
-			CheckOnly:   false,
-			UseLinkMode: false,
+			Source:             source,
+			IntermediateTarget: target,
+			StateDir:           tempDir,
+			Stream:             step.DevNullStream,
+			CheckOnly:          false,
+			UseLinkMode:        false,
 		})
 		if err != nil {
 			t.Errorf("returned error %+v", err)
@@ -348,12 +348,12 @@ func TestUpgradeMaster(t *testing.T) {
 
 		expectedErr := errors.New("write failed!")
 		err := UpgradeMaster(UpgradeMasterArgs{
-			Source:      source,
-			Target:      target,
-			StateDir:    tempDir,
-			Stream:      testutils.FailingStreams{Err: expectedErr},
-			CheckOnly:   false,
-			UseLinkMode: false,
+			Source:             source,
+			IntermediateTarget: target,
+			StateDir:           tempDir,
+			Stream:             testutils.FailingStreams{Err: expectedErr},
+			CheckOnly:          false,
+			UseLinkMode:        false,
 		})
 		if !errors.Is(err, expectedErr) {
 			t.Errorf("returned error %+v, want %+v", err, expectedErr)
@@ -370,12 +370,12 @@ func TestUpgradeMaster(t *testing.T) {
 		stream := new(step.BufferedStreams)
 
 		err := UpgradeMaster(UpgradeMasterArgs{
-			Source:      source,
-			Target:      target,
-			StateDir:    tempDir,
-			Stream:      stream,
-			CheckOnly:   false,
-			UseLinkMode: false,
+			Source:             source,
+			IntermediateTarget: target,
+			StateDir:           tempDir,
+			Stream:             stream,
+			CheckOnly:          false,
+			UseLinkMode:        false,
 		})
 		if err == nil {
 			t.Errorf("expected error, returned nil")
@@ -437,12 +437,12 @@ Failure, exiting
 					})
 
 				err := UpgradeMaster(UpgradeMasterArgs{
-					Source:      source,
-					Target:      target,
-					StateDir:    tempDir,
-					Stream:      stream,
-					CheckOnly:   true,
-					UseLinkMode: false,
+					Source:             source,
+					IntermediateTarget: target,
+					StateDir:           tempDir,
+					Stream:             stream,
+					CheckOnly:          true,
+					UseLinkMode:        false,
 				})
 				if err == nil {
 					t.Errorf("expected error, returned nil")

--- a/hub/upgrade_primaries_test.go
+++ b/hub/upgrade_primaries_test.go
@@ -110,7 +110,7 @@ func TestUpgradePrimaries(t *testing.T) {
 			AgentConns:             agentConns,
 			DataDirPairMap:         pairs,
 			Source:                 source,
-			Target:                 target,
+			IntermediateTarget:     target,
 			UseLinkMode:            false,
 			TablespacesMappingFile: "/tmp/tablespaces_mapping.txt",
 		})
@@ -183,7 +183,7 @@ func TestUpgradePrimaries(t *testing.T) {
 					AgentConns:             agentConns,
 					DataDirPairMap:         pairs,
 					Source:                 source,
-					Target:                 target,
+					IntermediateTarget:     target,
 					UseLinkMode:            false,
 					TablespacesMappingFile: "",
 				})
@@ -211,13 +211,13 @@ func TestGetDataDirPairs(t *testing.T) {
 			{ContentID: 1, DbID: 3, Hostname: "mdw", DataDir: "/data/dbfast2/seg2", Role: greenplum.PrimaryRole},
 		})
 
-		target := hub.MustCreateCluster(t, []greenplum.SegConfig{
+		intermediateTarget := hub.MustCreateCluster(t, []greenplum.SegConfig{
 			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: greenplum.PrimaryRole},
 		})
 
 		conf := &hub.Config{
-			Source: source,
-			Target: target,
+			Source:             source,
+			IntermediateTarget: intermediateTarget,
 		}
 		server := hub.New(conf, nil, "")
 
@@ -234,15 +234,15 @@ func TestGetDataDirPairs(t *testing.T) {
 			{ContentID: 1, DbID: 3, Hostname: "mdw", DataDir: "/data/dbfast2/seg2", Role: greenplum.PrimaryRole},
 		})
 
-		target := hub.MustCreateCluster(t, []greenplum.SegConfig{
+		interemediateTarget := hub.MustCreateCluster(t, []greenplum.SegConfig{
 			{ContentID: -1, DbID: 1, Hostname: "mdw", DataDir: "/data/qddir/seg-1", Role: greenplum.PrimaryRole},
 			{ContentID: 0, DbID: 2, Hostname: "mdw", DataDir: "/data/dbfast1/seg1", Role: greenplum.PrimaryRole},
 			{ContentID: 2, DbID: 3, Hostname: "mdw", DataDir: "/data/dbfast2/seg2", Role: greenplum.PrimaryRole},
 		})
 
 		conf := &hub.Config{
-			Source: source,
-			Target: target,
+			Source:             source,
+			IntermediateTarget: interemediateTarget,
 		}
 		server := hub.New(conf, nil, "")
 
@@ -259,15 +259,15 @@ func TestGetDataDirPairs(t *testing.T) {
 			{ContentID: 1, DbID: 3, Hostname: "mdw", DataDir: "/data/dbfast2/seg2", Role: greenplum.PrimaryRole},
 		})
 
-		target := hub.MustCreateCluster(t, []greenplum.SegConfig{
+		intermedaiteTarget := hub.MustCreateCluster(t, []greenplum.SegConfig{
 			{ContentID: -1, DbID: 1, Hostname: "localhost", DataDir: "/data/qddir/seg-1", Role: greenplum.PrimaryRole},
 			{ContentID: 0, DbID: 2, Hostname: "localhost", DataDir: "/data/dbfast1/seg1", Role: greenplum.PrimaryRole},
 			{ContentID: 1, DbID: 3, Hostname: "localhost", DataDir: "/data/dbfast2/seg2", Role: greenplum.PrimaryRole},
 		})
 
 		conf := &hub.Config{
-			Source: source,
-			Target: target,
+			Source:             source,
+			IntermediateTarget: intermedaiteTarget,
 		}
 		server := hub.New(conf, nil, "")
 

--- a/test/acceptance/gpupgrade/config.bats
+++ b/test/acceptance/gpupgrade/config.bats
@@ -19,7 +19,7 @@ setup() {
         --automatic \
         --source-gphome "$GPHOME_SOURCE" \
         --target-gphome "$GPHOME_TARGET" \
-        --source-master-port ${PGPORT} \
+        --source-master-port "$PGPORT" \
         --temp-port-range "$TARGET_PGPORT"-6040 \
         --stop-before-cluster-creation \
         --disk-free-ratio 0 3>&-
@@ -49,7 +49,7 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "${lines[0]}" = "id - "* ]] # this is randomly generated; we could replace * with a base64 regex matcher
     [ "${lines[1]}" = "source-gphome - $GPHOME_SOURCE" ]
-    [ "${lines[2]}" = "target-datadir - " ] # This isn't populated until cluster creation, but it's still displayed here
+    [[ "${lines[2]}" = "target-datadir - "* ]]
     [ "${lines[3]}" = "target-gphome - $GPHOME_TARGET" ]
     [ "${lines[4]}" = "target-port - $TARGET_PGPORT" ]
 }

--- a/test/acceptance/gpupgrade/revert.bats
+++ b/test/acceptance/gpupgrade/revert.bats
@@ -89,7 +89,7 @@ query_host_datadirs() {
         --verbose 3>&-
 
     # grab cluster data before revert destroys it
-    target_hosts_dirs=$(jq -r '.Target.Primaries[] | .Hostname + " " + .DataDir' "${GPUPGRADE_HOME}/config.json")
+    target_hosts_dirs=$(jq -r '.IntermediateTarget.Primaries[] | .Hostname + " " + .DataDir' "${GPUPGRADE_HOME}/config.json")
     upgradeID=$(gpupgrade config show --id)
 
     gpupgrade revert --non-interactive --verbose

--- a/testutils/sql.go
+++ b/testutils/sql.go
@@ -56,7 +56,7 @@ func MockCluster() *greenplum.Cluster {
 		panic(fmt.Sprintf("unexpected error %+v", err))
 	}
 
-	return c
+	return &c
 }
 
 // CreateMockDBConn is just like testhelper.CreateAndConnectMockDB(), but it


### PR DESCRIPTION
Create the following cluster objects: Source, IntermediateTarget, and Target.

This is far more accurate and readable as we use intermediateTarget cluster up until we swap the intermediateTarget with the source when updating the catalog and on disk data directories. This, at any point in time callers can refer to the correct data directory and port. Visually this is represented as something like:

**Source Cluster:**
dataDir:  '/data/dbfast1/demoDataDir0'


**IntermediateTarget:**
dataDir: '/data/dbfast1/demoDataDir.123ABC.0'  
which gets renamed to  '/data/dbfast1/demoDataDir.123ABC.0.old, which we don't need to store as its simply  dataDir + oldSuffix.


**Target:**
dataDir:  '/data/dbfast1/demoDataDir0'

**InitializeConfig:** 
removed in favor of IntermediateTarget using the greenplum.Cluster data type.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:sourceTargetIntermediateTarget