### PR TITLE
Refactor: Remove deprecated PathExists function

### DIFF
--- a/greenplum/cluster.go
+++ b/greenplum/cluster.go
@@ -351,8 +351,13 @@ func runStartStopCmd(stream step.OutStreams, gphome, command string, env string)
 // IsMasterRunning returns whether the cluster's master process is running.
 func (c *Cluster) IsMasterRunning(stream step.OutStreams) (bool, error) {
 	path := filepath.Join(c.MasterDataDir(), "postmaster.pid")
-	if !upgrade.PathExists(path) {
-		return false, nil
+	exist, err := upgrade.PathExist(path)
+	if err != nil {
+		return false, err
+	}
+
+	if !exist {
+		return false, err
 	}
 
 	cmd := execCommand("pgrep", "-F", path)
@@ -362,7 +367,7 @@ func (c *Cluster) IsMasterRunning(stream step.OutStreams) (bool, error) {
 
 	gplog.Debug("checking if master process is running with %s", cmd.String())
 
-	err := cmd.Run()
+	err = cmd.Run()
 	var exitErr *exec.ExitError
 	if xerrors.As(err, &exitErr) {
 		if exitErr.ExitCode() == 1 {

--- a/hub/delete_data_directories_test.go
+++ b/hub/delete_data_directories_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/testutils/testlog"
-	"github.com/greenplum-db/gpupgrade/upgrade"
 )
 
 func TestDeleteSegmentDataDirs(t *testing.T) {
@@ -214,24 +213,17 @@ func TestDeleteTablespaceDirectories(t *testing.T) {
 
 		// verify user tablespace directories are deleted
 		for _, dir := range []string{tsDir1, tsDir2} {
-			if upgrade.PathExists(dir) {
-				t.Errorf("expected tablespace directory %q to be deleted", dir)
-			}
+
+			testutils.PathMustNotExist(t, dir)
 
 			dbIdDir := filepath.Dir(filepath.Clean(dir))
-			if upgrade.PathExists(dbIdDir) {
-				t.Errorf("expected parent dbid directory %q to be deleted", dbIdDir)
-			}
+			testutils.PathMustNotExist(t, dbIdDir)
 		}
 
 		// verify system tablespace directories are not deleted
-		if !upgrade.PathExists(systemTsDir) {
-			t.Errorf("expected system tablespace directory %q to not be deleted", systemTsDir)
-		}
+		testutils.PathMustExist(t, systemTsDir)
+		testutils.PathMustExist(t, systemDbIdDir)
 
-		if !upgrade.PathExists(systemDbIdDir) {
-			t.Errorf("expected system tablespace parent dbid directory %q to not be deleted", systemDbIdDir)
-		}
 	})
 
 	t.Run("deletes tablespace directories only on the primaries", func(t *testing.T) {

--- a/testutils/test_utils.go
+++ b/testutils/test_utils.go
@@ -211,17 +211,38 @@ func MustWriteToFile(t *testing.T, path string, contents string) {
 func VerifyRename(t *testing.T, source, target string) {
 	t.Helper()
 
-	if !upgrade.PathExists(source) {
-		t.Errorf("expected source %q to exist", source)
-	}
-
 	archive := target + upgrade.OldSuffix
-	if !upgrade.PathExists(archive) {
-		t.Errorf("expected archive %q to exist", archive)
+
+	PathMustExist(t, source)
+	PathMustExist(t, archive)
+	PathMustNotExist(t, target)
+
+}
+
+func PathMustExist(t *testing.T, path string){
+	t.Helper()
+	checkPath(t, path, true)
+}
+
+func PathMustNotExist(t *testing.T, path string){
+	t.Helper()
+	checkPath(t, path, false)
+}
+
+func checkPath(t *testing.T, path string, shouldExist bool) {
+	t.Helper()
+
+	exist, err := upgrade.PathExist(path)
+	if err != nil {
+		t.Fatalf("unexpected error checking path %q: %v", path, err)
 	}
 
-	if upgrade.PathExists(target) {
-		t.Errorf("expected target %q to not exist", target)
+	if shouldExist && !exist {
+		t.Fatalf("expected path %q to exist", path)
+	}
+
+	if !shouldExist && exist {
+		t.Fatalf("expected path %q to not exist", path)
 	}
 }
 

--- a/upgrade/directories.go
+++ b/upgrade/directories.go
@@ -101,7 +101,14 @@ func ArchiveSource(source, target string, renameTarget bool) error {
 	// Instead of manipulating the source to create the archive we append the
 	// old suffix to the target to achieve the same result.
 	archive := target + OldSuffix
-	if alreadyRenamed(archive, target) {
+
+	alreadyRenamed, err := AlreadyRenamed(target, archive)
+
+	if err != nil {
+		return err
+	}
+
+	if alreadyRenamed {
 		return nil
 	}
 
@@ -179,15 +186,6 @@ func VerifyDataDirectory(path ...string) error {
 	}
 
 	return err
-}
-
-// TODO: Remove alreadyRenamed and use AlreadyRenamed
-func alreadyRenamed(archive, target string) bool {
-
-	archiveExist, _ := PathExist(archive)
-	targetExist, _ := PathExist(target)
-
-	return archiveExist && !targetExist
 }
 
 // AlreadyRenamed infers if a successful rename has already occurred

--- a/upgrade/directories_test.go
+++ b/upgrade/directories_test.go
@@ -197,14 +197,8 @@ func TestArchiveSource(t *testing.T) {
 		if calls != 1 {
 			t.Errorf("expected rename to be called once")
 		}
-
-		if upgrade.PathExists(source) {
-			t.Errorf("expected source %q to not exist", source)
-		}
-
-		if !upgrade.PathExists(archive) {
-			t.Errorf("expected archive %q to exist", archive)
-		}
+		testutils.PathMustNotExist(t, source)
+		testutils.PathMustExist(t, archive)
 	})
 
 	t.Run("when renaming succeeds then a re-run succeeds", func(t *testing.T) {
@@ -245,18 +239,11 @@ func TestArchiveSource(t *testing.T) {
 			t.Errorf("got %#v want %#v", err, expected)
 		}
 
-		if !upgrade.PathExists(source) {
-			t.Errorf("expected source %q to exist", source)
-		}
-
 		archive := target + upgrade.OldSuffix
-		if upgrade.PathExists(archive) {
-			t.Errorf("expected archive %q to not exist", archive)
-		}
 
-		if !upgrade.PathExists(target) {
-			t.Errorf("expected target %q to exist", target)
-		}
+		testutils.PathMustExist(t, source)
+		testutils.PathMustNotExist(t, archive)
+		testutils.PathMustExist(t, target)
 
 		utils.System.Rename = os.Rename
 
@@ -287,18 +274,11 @@ func TestArchiveSource(t *testing.T) {
 			t.Errorf("got %#v want %#v", err, expected)
 		}
 
-		if upgrade.PathExists(source) {
-			t.Errorf("expected source %q to not exist", source)
-		}
-
 		archive := target + upgrade.OldSuffix
-		if !upgrade.PathExists(archive) {
-			t.Errorf("expected archive %q to exist", archive)
-		}
 
-		if !upgrade.PathExists(target) {
-			t.Errorf("expected target %q to exist", target)
-		}
+		testutils.PathMustNotExist(t, source)
+		testutils.PathMustExist(t, archive)
+		testutils.PathMustExist(t, target)
 
 		utils.System.Rename = os.Rename
 
@@ -536,13 +516,8 @@ func TestDeleteNewTablespaceDirectories(t *testing.T) {
 			t.Errorf("DeleteNewTablespaceDirectories returned error %+v", err)
 		}
 
-		if upgrade.PathExists(tablespaceDir) {
-			t.Errorf("expected directory %q to be deleted", tablespaceDir)
-		}
-
-		if upgrade.PathExists(dbIDDir) {
-			t.Errorf("expected parent dbID directory %q to be deleted", dbIDDir)
-		}
+		testutils.PathMustNotExist(t, tablespaceDir)
+		testutils.PathMustNotExist(t, dbIDDir)
 	})
 
 	t.Run("rerun of DeleteNewTablespaceDirectories after previous successful execution succeeds", func(t *testing.T) {
@@ -554,18 +529,13 @@ func TestDeleteNewTablespaceDirectories(t *testing.T) {
 			t.Errorf("DeleteNewTablespaceDirectories returned error %+v", err)
 		}
 
-		if upgrade.PathExists(tablespaceDir) {
-			t.Errorf("expected directory %q to be deleted", tablespaceDir)
-		}
-
-		if upgrade.PathExists(dbIdDir) {
-			t.Errorf("expected parent dbid directory %q to be deleted", dbIdDir)
-		}
-
 		err = upgrade.DeleteNewTablespaceDirectories(step.DevNullStream, []string{tablespaceDir})
 		if err != nil {
 			t.Errorf("rerun of DeleteNewTablespaceDirectories returned error %+v", err)
 		}
+
+		testutils.PathMustNotExist(t, tablespaceDir)
+		testutils.PathMustNotExist(t, dbIdDir)
 	})
 
 	t.Run("does not delete parent dbID directory when it's not empty", func(t *testing.T) {
@@ -580,13 +550,8 @@ func TestDeleteNewTablespaceDirectories(t *testing.T) {
 			t.Errorf("DeleteNewTablespaceDirectories returned error %+v", err)
 		}
 
-		if upgrade.PathExists(tablespaceDir) {
-			t.Errorf("expected directory %q to be deleted", tablespaceDir)
-		}
-
-		if !upgrade.PathExists(dbIDDir) {
-			t.Errorf("expected parent dbID directory %q to not be deleted", dbIDDir)
-		}
+		testutils.PathMustNotExist(t, tablespaceDir)
+		testutils.PathMustExist(t, dbIDDir)
 	})
 
 	t.Run("deletes multiple tablespace directories including their parent dbID directory when empty", func(t *testing.T) {
@@ -612,13 +577,8 @@ func TestDeleteNewTablespaceDirectories(t *testing.T) {
 		}
 
 		for _, dir := range dirs {
-			if upgrade.PathExists(dir.tablespaceDir) {
-				t.Errorf("expected directory %q to be deleted", dir.tablespaceDir)
-			}
-
-			if upgrade.PathExists(dir.dbIDDir) {
-				t.Errorf("expected parent dbID directory %q to be deleted", dir.dbIDDir)
-			}
+			testutils.PathMustNotExist(t, dir.tablespaceDir)
+			testutils.PathMustNotExist(t, dir.dbIDDir)
 		}
 	})
 
@@ -636,14 +596,9 @@ func TestDeleteNewTablespaceDirectories(t *testing.T) {
 		}
 
 		for _, dir := range dirs {
-			if !upgrade.PathExists(dir) {
-				t.Errorf("expected directory %q to not be deleted", dir)
-			}
-
 			dbIdDir := filepath.Dir(filepath.Clean(dir))
-			if !upgrade.PathExists(dbIdDir) {
-				t.Errorf("expected parent dbID directory %q to not be deleted", dbIdDir)
-			}
+			testutils.PathMustExist(t, dir)
+			testutils.PathMustExist(t, dbIdDir)
 		}
 	})
 
@@ -670,13 +625,8 @@ func TestDeleteNewTablespaceDirectories(t *testing.T) {
 			t.Errorf("got error %#v want %#v", err, os.ErrPermission)
 		}
 
-		if !upgrade.PathExists(tablespaceDir) {
-			t.Errorf("expected directory %q to not be deleted", tablespaceDir)
-		}
-
-		if !upgrade.PathExists(dbIDDir) {
-			t.Errorf("expected parent dbID directory %q to not be deleted", dbIDDir)
-		}
+		testutils.PathMustExist(t, tablespaceDir)
+		testutils.PathMustExist(t, dbIDDir)
 	})
 
 	t.Run("errors when failing to read parent dbID directory", func(t *testing.T) {
@@ -701,13 +651,8 @@ func TestDeleteNewTablespaceDirectories(t *testing.T) {
 			t.Errorf("got error %#v want %#v", err, os.ErrPermission)
 		}
 
-		if upgrade.PathExists(tablespaceDir) {
-			t.Errorf("expected directory %q to be deleted", tablespaceDir)
-		}
-
-		if !upgrade.PathExists(dbIDDir) {
-			t.Errorf("expected parent dbID directory %q to not be deleted", dbIDDir)
-		}
+		testutils.PathMustNotExist(t, tablespaceDir)
+		testutils.PathMustExist(t, dbIDDir)
 	})
 
 	t.Run("errors when failing to remove parent dbID directory", func(t *testing.T) {
@@ -732,13 +677,8 @@ func TestDeleteNewTablespaceDirectories(t *testing.T) {
 			t.Errorf("got error %#v want %#v", err, os.ErrPermission)
 		}
 
-		if upgrade.PathExists(tablespaceDir) {
-			t.Errorf("expected directory %q to be deleted", tablespaceDir)
-		}
-
-		if !upgrade.PathExists(dbIDDir) {
-			t.Errorf("expected parent dbid directory %q to not be deleted", dbIDDir)
-		}
+		testutils.PathMustNotExist(t, tablespaceDir)
+		testutils.PathMustExist(t, dbIDDir)
 	})
 
 	t.Run("rerun finishes successfully", func(t *testing.T) {
@@ -764,13 +704,8 @@ func TestDeleteNewTablespaceDirectories(t *testing.T) {
 		}
 
 		for _, dir := range dirs {
-			if upgrade.PathExists(dir.tablespaceDir) {
-				t.Errorf("expected directory %q to be deleted", dir.tablespaceDir)
-			}
-
-			if upgrade.PathExists(dir.dbIdDir) {
-				t.Errorf("expected parent dbid directory %q to be deleted", dir.dbIdDir)
-			}
+			testutils.PathMustNotExist(t, dir.tablespaceDir)
+			testutils.PathMustNotExist(t, dir.dbIdDir)
 		}
 
 		err = upgrade.DeleteNewTablespaceDirectories(step.DevNullStream, tsDirs)

--- a/utils/rsync/rsync_test.go
+++ b/utils/rsync/rsync_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/testutils/exectest"
 	"github.com/greenplum-db/gpupgrade/testutils/testlog"
-	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/greenplum-db/gpupgrade/utils/rsync"
 )
 
@@ -187,9 +186,7 @@ func TestRsync(t *testing.T) {
 			t.Errorf("Rsync() returned error %+v", err)
 		}
 
-		if pathExists(filepath.Join(destination, filename)) {
-			t.Errorf("destination directory file %q should not exist, but it does", filename)
-		}
+		testutils.PathMustNotExist(t, filepath.Join(destination, filename))
 	})
 
 	t.Run("does not copy files in the exclusion list from the source directory", func(t *testing.T) {
@@ -212,9 +209,7 @@ func TestRsync(t *testing.T) {
 			t.Errorf("Rsync() returned error %+v", err)
 		}
 
-		if pathExists(filepath.Join(destination, filename)) {
-			t.Errorf("destination directory file %q should not exist, but it does", filename)
-		}
+		testutils.PathMustNotExist(t, filepath.Join(destination, filename))
 	})
 
 	t.Run("preserves files in the exclusion list in the destination directory", func(t *testing.T) {
@@ -241,18 +236,9 @@ func TestRsync(t *testing.T) {
 			t.Errorf("Rsync() returned error %+v", err)
 		}
 
-		if !pathExists(filepath.Join(destination, filename1)) {
-			t.Errorf("file %q does not exist", filename1)
-		}
-
-		if !pathExists(filepath.Join(destination, filename2)) {
-			t.Errorf("file %q does not exist", filename2)
-		}
-
-		if !pathExists(filepath.Join(destination, filename3)) {
-			t.Errorf("file %q does not exist", filename3)
-		}
-
+		testutils.PathMustExist(t, filepath.Join(destination, filename1))
+		testutils.PathMustExist(t, filepath.Join(destination, filename2))
+		testutils.PathMustExist(t, filepath.Join(destination, filename3))
 	})
 
 	t.Run("when an input stream is provided, it returns an RsyncError that wraps an ExitError", func(t *testing.T) {
@@ -394,9 +380,4 @@ func TestRsync(t *testing.T) {
 			t.Errorf("got error '%#v' want '%#v'", err, rsync.ErrInvalidRsyncSourcePath)
 		}
 	})
-}
-
-func pathExists(path string) bool {
-	_, err := utils.System.Stat(path)
-	return err == nil
 }

--- a/utils/sys_utils_test.go
+++ b/utils/sys_utils_test.go
@@ -135,8 +135,6 @@ func TestAtomicallyWrite(t *testing.T) {
 			t.Errorf("returned error type %T want %T", err, expected)
 		}
 
-		if upgrade.PathExists(path) {
-			t.Errorf("expected file %q to not exist", path)
-		}
+		testutils.PathMustNotExist(t, path)
 	})
 }


### PR DESCRIPTION
In directories.go, PathExists function has been deprecated and
a PathExist function has been added prior to this commit. This
commit removes the references to that function and replaces
its usage with PathExist in proper format.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:refactor-path-exists