### PR TITLE
CI: Remove orafce tests

### DIFF
--- a/ci/scripts/load-extensions.bash
+++ b/ci/scripts/load-extensions.bash
@@ -87,29 +87,20 @@ SQL_EOF
 SQL_EOF
 
     echo 'Installing hstore...'
-    psql -d postgres <<SQL_EOF
+    psql -v ON_ERROR_STOP=1 -d postgres <<SQL_EOF
         \i /usr/local/greenplum-db-source/share/postgresql/contrib/hstore.sql
 
-        CREATE TABLE hstore_test_type AS
-        SELECT 'a=>1,a=>2'::hstore as c1;
-        CREATE VIEW hstore_test_view AS SELECT c1 -> 'a' as c2 FROM foo;
+        CREATE TABLE hstore_test_type AS SELECT 'a=>1,a=>2'::hstore as c1;
+        CREATE VIEW hstore_test_view AS SELECT c1 -> 'a' as c2 FROM hstore_test_type;
 SQL_EOF
 
     echo 'Installing pgcrypto...'
-    psql -d postgres <<SQL_EOF
+    psql -v ON_ERROR_STOP=1 -d postgres <<SQL_EOF
         CREATE EXTENSION pgcrypto;
 
         CREATE VIEW pgcrypto_test_view AS SELECT crypt('new password', gen_salt('md5'));
 SQL_EOF
 
-    echo 'Installing orafce...'
-    psql -d postgres <<SQL_EOF
-        CREATE EXTENSION orafce;
-
-        CREATE TABLE orafce_test_type (a VARCHAR2(5), b NVARCHAR2(5));
-        INSERT INTO orafce_test_type VALUES ('abc'::VARCHAR2(5), 'abcdef'::NVARCHAR2(5));
-        CREATE VIEW orafce_test_view AS SELECT add_months('2003-08-01', 3);
-SQL_EOF
 "
 
 install_pxf() {

--- a/ci/scripts/load-extensions.bash
+++ b/ci/scripts/load-extensions.bash
@@ -30,7 +30,7 @@ time ssh -n mdw "
     gppkg -i /tmp/postgis_source.gppkg
     /usr/local/greenplum-db-source/share/postgresql/contrib/postgis-*/postgis_manager.sh postgres install
     psql postgres -f /tmp/postgis_dump.sql
-    psql -d postgres <<SQL_EOF
+    psql -v ON_ERROR_STOP=1 -d postgres <<SQL_EOF
         -- Drop postgis views containing deprecated name datatypes
         DROP VIEW geography_columns;
         DROP VIEW raster_columns;
@@ -40,7 +40,7 @@ SQL_EOF
     echo 'Installing MADlib...'
     gppkg -i /tmp/madlib_source.gppkg
     /usr/local/greenplum-db-source/madlib/bin/madpack -p greenplum -c /postgres install
-    psql -d postgres <<SQL_EOF
+    psql -v ON_ERROR_STOP=1 -d postgres <<SQL_EOF
         DROP TABLE IF EXISTS madlib_test_type;
         CREATE TABLE madlib_test_type(id int, value madlib.svec);
         INSERT INTO madlib_test_type VALUES(1, '{1,2,3}'::float8[]::madlib.svec);
@@ -59,7 +59,7 @@ time ssh -n mdw "
     source /usr/local/greenplum-db-source/greenplum_path.sh
 
     echo 'Installing amcheck...'
-    psql -d postgres <<SQL_EOF
+    psql -v ON_ERROR_STOP=1 -d postgres <<SQL_EOF
         CREATE EXTENSION amcheck;
 
         CREATE VIEW amcheck_test_view AS
@@ -76,7 +76,7 @@ time ssh -n mdw "
 SQL_EOF
 
     echo 'Installing dblink...'
-    psql -d postgres <<SQL_EOF
+    psql -v ON_ERROR_STOP=1 -d postgres <<SQL_EOF
         \i /usr/local/greenplum-db-source/share/postgresql/contrib/dblink.sql
 
         CREATE TABLE foo(f1 int, f2 text, primary key (f1,f2));
@@ -143,7 +143,7 @@ install_pxf() {
         /usr/local/pxf-*/bin/pxf cluster start
 
         echo 'Load PXF data...'
-        psql -d postgres <<SQL_EOF
+        psql -v ON_ERROR_STOP=1 -d postgres <<SQL_EOF
             CREATE EXTENSION pxf;
 
             CREATE EXTERNAL TABLE pxf_read_test (a TEXT, b TEXT, c TEXT)

--- a/ci/scripts/upgrade-extensions.bash
+++ b/ci/scripts/upgrade-extensions.bash
@@ -72,7 +72,7 @@ time ssh -n mdw "
 
     gpstart -a
 
-    psql -d postgres <<SQL_EOF
+    psql -v ON_ERROR_STOP=1 -d postgres <<SQL_EOF
         CREATE EXTENSION amcheck;
         CREATE EXTENSION dblink;
         CREATE EXTENSION hstore;
@@ -89,7 +89,7 @@ SQL_EOF
         export JAVA_HOME=/usr/lib/jvm/jre
 
         /usr/local/pxf-gp6/bin/pxf cluster init
-        psql -d postgres -c 'CREATE EXTENSION pxf;'
+        psql -v ON_ERROR_STOP=1 -d postgres -c 'CREATE EXTENSION pxf;'
     fi
 
     gpstop -a
@@ -131,11 +131,11 @@ ssh -n mdw "
     source /usr/local/greenplum-db-source/greenplum_path.sh
 
     echo 'Recreating dropped views that contained the deprecated name datatype...'
-    psql -d postgres -f /usr/local/greenplum-db-target/share/postgresql/contrib/postgis-*/postgis_replace_views.sql
+    psql -v ON_ERROR_STOP=1 -d postgres -f /usr/local/greenplum-db-target/share/postgresql/contrib/postgis-*/postgis_replace_views.sql
 
     echo 'Dropping operator dependent objects in order to successfully drop and recreate postgis operators...'
-    psql -d postgres -c 'DROP INDEX wmstest_geomidx CASCADE;'
-    psql -d postgres -f /usr/local/greenplum-db-target/share/postgresql/contrib/postgis-*/postgis_enable_operators.sql
+    psql -v ON_ERROR_STOP=1 -d postgres -c 'DROP INDEX wmstest_geomidx CASCADE;'
+    psql -v ON_ERROR_STOP=1 -d postgres -f /usr/local/greenplum-db-target/share/postgresql/contrib/postgis-*/postgis_enable_operators.sql
 
     $(typeset -f test_pxf) # allow local function on remote host
     if test_pxf '$OS_VERSION'; then

--- a/ci/scripts/upgrade-extensions.bash
+++ b/ci/scripts/upgrade-extensions.bash
@@ -77,7 +77,6 @@ time ssh -n mdw "
         CREATE EXTENSION dblink;
         CREATE EXTENSION hstore;
         CREATE EXTENSION pgcrypto;
-        CREATE EXTENSION orafce;
 SQL_EOF
 
     gppkg -i /tmp/postgis_target.gppkg


### PR DESCRIPTION
The orafce extension has been updated in GPDB6 and the versions
are incompatible with each other. This commit removes
its tests since we suggest the users to uninstall/reinstall.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:ci-remove-orafce?group=extensions