### PR TITLE
Add gptext to CI testing

### DIFF
--- a/ci/1_resources_anchors_groups.yml
+++ b/ci/1_resources_anchors_groups.yml
@@ -189,6 +189,18 @@ resources:
     bucket: madlib-artifacts  # FIXME: update to prod bucket once MADlib is released.
     versioned_file: bin_madlib_artifacts_centos{{.CentosVersion}}/madlib-master-gp{{.GPVersion}}-rhel{{.CentosVersion}}-x86_64.gppkg
 
+{{- if ne .GPVersion "6" }}
+# NOTE: The same gptext artifact is used for both gpdb5 and gpdb6.
+- name: gptext-3.7.42-rhel{{.CentosVersion}}
+  type: s3
+  source:
+    access_key_id: ((gptext_s3_access_key_id))
+    secret_access_key: ((gptext_s3_secret_access_key))
+    region_name: us-west-2
+    bucket: gptext-artifacts
+    versioned_file: greenplum-text-3.7.42-rhel{{.CentosVersion}}_x86_64.tar.gz
+{{- end}}
+
 # NOTE: Skip creating the pxf resources for centos6 since pxf5 gpdb6 is not supported for centos6. Thus, we can only
 # test pxf upgrades on centos7.
 {{- if ne .CentosVersion "6" }}

--- a/ci/6_upgrade_and_functional_jobs.yml
+++ b/ci/6_upgrade_and_functional_jobs.yml
@@ -46,6 +46,8 @@
           resource: madlib_1.19.0_gpdb{{.Source}}_centos{{.CentosVersion}}_gppkg
         - get: madlib_gppkg_target
           resource: madlib_1.19.0_gpdb{{.Target}}_centos{{.CentosVersion}}_gppkg
+        - get: gptext_targz_source
+          resource: gptext-3.7.42-rhel{{.CentosVersion}}
         {{- if ne .CentosVersion "6" }}
         - get: pxf_rpm_source
           resource: pxf_5_gpdb{{.Source}}_centos{{.CentosVersion}}_rpm
@@ -132,6 +134,7 @@
           - name: gpupgrade_src
           - name: postgis_gppkg_source
           - name: madlib_gppkg_source
+          - name: gptext_targz_source
           - name: sqldump
           {{- if ne .CentosVersion "6" }}
           - name: pxf_rpm_source

--- a/ci/scripts/load-extensions.bash
+++ b/ci/scripts/load-extensions.bash
@@ -63,7 +63,8 @@ time ssh -n mdw "
         SELECT * FROM gptext.index(table(SELECT * FROM t1), 'gptext_db.public.t1');
         SELECT * FROM gptext.commit_index('gptext_db.public.t1');
 
-        SELECT * FROM gptext.search(table(SELECT 1 SCATTER BY 1), 'gptext_db.public.t1', 'greenplum', NULL);
+        -- TODO: Add a dependency on the gptext function by creating a view.
+        CREATE VIEW gptext_test_view AS SELECT * FROM gptext.search(table(SELECT 1 SCATTER BY 1), 'gptext_db.public.t1', 'greenplum', NULL);
 SQL_EOF
 
     echo 'Installing PostGIS...'


### PR DESCRIPTION
- GPText will officialy support gpupgrade with version 3.8.0.
- GPText is somewhat different compared to the other
extensions, it requires an external solr cluster to test its
functionality.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:add-gptext