### PR TITLE
Enable revert operation on initialize for no mirror systems

### DIFF
--- a/cli/commands/confirmation_text.go
+++ b/cli/commands/confirmation_text.go
@@ -90,6 +90,8 @@ gpupgrade revert will perform a series of steps, including:
 
 gpupgrade log files can be found on all hosts in %s
 
+WARNING: You cannot revert if you do not have mirrors & standby configured, and execute has started.
+
 WARNING: Do not perform operations on the source and target clusters until gpupgrade revert
 has completed.
 `

--- a/hub/restore_source_cluster.go
+++ b/hub/restore_source_cluster.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
-	"github.com/pkg/errors"
 
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -31,9 +30,6 @@ var Excludes = []string{
 }
 
 func RsyncMasterAndPrimaries(stream step.OutStreams, agentConns []*idl.Connection, source *greenplum.Cluster) error {
-	if !source.HasAllMirrorsAndStandby() {
-		return errors.New("Source cluster does not have mirrors and/or standby. Cannot restore source cluster. Please contact support.")
-	}
 
 	var wg sync.WaitGroup
 	errs := make(chan error, 2)
@@ -58,10 +54,6 @@ func RsyncMasterAndPrimaries(stream step.OutStreams, agentConns []*idl.Connectio
 }
 
 func RsyncMasterAndPrimariesTablespaces(stream step.OutStreams, agentConns []*idl.Connection, source *greenplum.Cluster) error {
-	if !source.HasAllMirrorsAndStandby() {
-		return ErrMissingMirrorsAndStandby
-	}
-
 	var wg sync.WaitGroup
 	errs := make(chan error, 2)
 

--- a/hub/restore_source_cluster_test.go
+++ b/hub/restore_source_cluster_test.go
@@ -86,20 +86,6 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 		}
 	})
 
-	t.Run("errors in restoring tablespaces when source cluster does not have mirrors and standby", func(t *testing.T) {
-		cluster := hub.MustCreateCluster(t, greenplum.SegConfigs{
-			{ContentID: -1, Hostname: "master", DataDir: "/data/qddir", Role: greenplum.PrimaryRole},
-			{ContentID: 0, Hostname: "sdw1", DataDir: "/data/dbfast1/seg1", Role: greenplum.PrimaryRole},
-			{ContentID: 0, Hostname: "msdw1", DataDir: "/data/dbfast_mirror1/seg1", Role: greenplum.MirrorRole},
-			{ContentID: 1, Hostname: "sdw2", DataDir: "/data/dbfast2/seg2", Role: greenplum.PrimaryRole},
-		})
-
-		err := hub.RsyncMasterAndPrimariesTablespaces(&testutils.DevNullWithClose{}, []*idl.Connection{}, cluster)
-		if !errors.Is(err, hub.ErrMissingMirrorsAndStandby) {
-			t.Errorf("got error %#v want %#v", err, hub.ErrMissingMirrorsAndStandby)
-		}
-	})
-
 	t.Run("restores master tablespaces in link mode using correct rsync arguments", func(t *testing.T) {
 		defer rsync.ResetRsyncCommand()
 		rsync.SetRsyncCommand(exectest.NewCommandWithVerifier(hub.Success, func(utility string, args ...string) {
@@ -240,20 +226,6 @@ func TestRsyncMasterAndPrimaries(t *testing.T) {
 		err := hub.RsyncPrimariesTablespaces(agentConns, cluster, tablespaces)
 		if err != nil {
 			t.Errorf("unexpected err %#v", err)
-		}
-	})
-
-	t.Run("errors when source cluster does not have all mirrors and standby", func(t *testing.T) {
-		cluster := hub.MustCreateCluster(t, greenplum.SegConfigs{
-			{ContentID: -1, Hostname: "master", DataDir: "/data/qddir", Role: greenplum.PrimaryRole},
-			{ContentID: 0, Hostname: "sdw1", DataDir: "/data/dbfast1/seg1", Role: greenplum.PrimaryRole},
-			{ContentID: 0, Hostname: "msdw1", DataDir: "/data/dbfast_mirror1/seg1", Role: greenplum.MirrorRole},
-			{ContentID: 1, Hostname: "sdw2", DataDir: "/data/dbfast2/seg2", Role: greenplum.PrimaryRole},
-		})
-
-		err := hub.RsyncMasterAndPrimaries(&testutils.DevNullWithClose{}, []*idl.Connection{}, cluster)
-		if err == nil {
-			t.Error("unexpected nil error")
 		}
 	})
 

--- a/hub/revert.go
+++ b/hub/revert.go
@@ -34,7 +34,12 @@ func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) 
 		}
 	}()
 
-	if !s.Source.HasAllMirrorsAndStandby() {
+	hasExecuteStarted, err := step.HasStarted(idl.Step_EXECUTE)
+	if err != nil {
+		return err
+	}
+
+	if hasExecuteStarted && !s.Source.HasAllMirrorsAndStandby() {
 		return errors.New("Source cluster does not have mirrors and/or standby. Cannot restore source cluster. Please contact support.")
 	}
 

--- a/step/step.go
+++ b/step/step.go
@@ -83,6 +83,24 @@ func Begin(step idl.Step, sender idl.MessageSender, agentConns func() ([]*idl.Co
 	return New(step, sender, substepStore, streams), nil
 }
 
+func HasStarted(step idl.Step) (bool, error) {
+	substepStore, err := NewSubstepFileStore()
+	if err != nil {
+		return false, err
+	}
+
+	substepsMap, err := substepStore.ReadStep(step)
+	if err != nil {
+		return false, err
+	}
+
+	if substepsMap != nil {
+		return true, nil
+	}
+
+	return false, nil
+}
+
 func HasRun(step idl.Step, substep idl.Substep) (bool, error) {
 	return hasStatus(step, substep, func(status idl.Status) bool {
 		return status != idl.Status_UNKNOWN_STATUS


### PR DESCRIPTION
Current implementation of revert has a hard stop on systems without mirrors. While this is necessary for production systems, it hinders the ability to quickly test on dev environments for customers. This commit adds a new check to determine if we are at a stage before execute and allows the revert in such cases.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:revert-initialize