### PR TITLE
Update rsync requirement in the spec file to >= 3.0

### DIFF
--- a/gpupgrade.spec
+++ b/gpupgrade.spec
@@ -10,7 +10,7 @@ URL: https://github.com/greenplum-db/gpupgrade
 Source0: %{name}.tar.gz
 # Allow the RPM to be relocatable by setting prefix to "/".
 Prefix: /
-Requires: openssh rsync
+Requires: openssh rsync >= 3.0
 
 %description
 The gpupgrade package contains gpupgrade which performs in-place upgrades


### PR DESCRIPTION
Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:spec-rsync-version