### PR TITLE
return early if gphome is incorrect

### DIFF
--- a/greenplum/allowed_gpdb_versions.go
+++ b/greenplum/allowed_gpdb_versions.go
@@ -85,19 +85,25 @@ func getMinVersion(version semver.Version, minVersions map[int]string) string {
 }
 
 func VerifyCompatibleGPDBVersions(sourceGPHome, targetGPHome string) error {
-	var err error
+	var errs error
 
-	sourceVersion, vErr := Version(sourceGPHome)
-	err = errorlist.Append(err, vErr)
-	vErr = validateVersion(sourceVersion, idl.ClusterDestination_SOURCE)
-	err = errorlist.Append(err, vErr)
+	sourceVersion, err := Version(sourceGPHome)
+	if err != nil {
+		return err
+	}
 
-	targetVersion, vErr := Version(targetGPHome)
-	err = errorlist.Append(err, vErr)
-	vErr = validateVersion(targetVersion, idl.ClusterDestination_TARGET)
-	err = errorlist.Append(err, vErr)
+	err = validateVersion(sourceVersion, idl.ClusterDestination_SOURCE)
+	errs = errorlist.Append(errs, err)
 
-	return err
+	targetVersion, err := Version(targetGPHome)
+	if err != nil {
+		return err
+	}
+
+	err = validateVersion(targetVersion, idl.ClusterDestination_TARGET)
+	errs = errorlist.Append(errs, err)
+
+	return errs
 }
 
 func validateVersion(versionStr string, destination idl.ClusterDestination) error {

--- a/greenplum/version.go
+++ b/greenplum/version.go
@@ -4,6 +4,7 @@
 package greenplum
 
 import (
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -36,7 +37,7 @@ func Version(gphome string) (string, error) {
 	gplog.Debug(cmd.String())
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", xerrors.Errorf("%q failed with %q: %w", cmd.String(), string(output), err)
+		return "", fmt.Errorf("%q failed with %q: %w", cmd.String(), string(output), err)
 	}
 
 	rawVersion := string(output)

--- a/greenplum/version_test.go
+++ b/greenplum/version_test.go
@@ -30,6 +30,16 @@ func PostgresGPVersion_11_341_31() {
 	fmt.Println("postgres (Greenplum Database) 11.341.31 build commit:a21de286045072d8d1df64fa48752b7dfac8c1b7")
 }
 
+func PostgresGPVersion_MultiLine() {
+	fmt.Println(`/usr/local/greenplum-db-6.18.2/bin/postgres: /usr/local/greenplum-db-5.29.1+dev.1.g0962183f78/lib/libxml2.so.2: no version information available (required by /usr/local/greenplum-db-6.18.2/bin/postgres)
+/usr/local/greenplum-db-6.18.2/bin/postgres: /usr/local/greenplum-db-5.29.1+dev.1.g0962183f78/lib/libxml2.so.2: no version information available (required by /usr/local/greenplum-db-6.18.2/bin/postgres)
+postgres (Greenplum Database) 6.18.2 build commit:1242aadf0137d3b26ee42c80e579e78bd7a805c7`)
+}
+
+func PostgresGPVersion_0_0_0() {
+	fmt.Println("postgres (Greenplum Database) 0.0.0 build commit:a21de286045072d8d1df64fa48752b7dfac8c1b7")
+}
+
 func EmptyString() {
 	fmt.Println("")
 }
@@ -48,6 +58,8 @@ func init() {
 		PostgresGPVersion_6_dev,
 		PostgresGPVersion_6_7_1,
 		PostgresGPVersion_11_341_31,
+		PostgresGPVersion_MultiLine,
+		PostgresGPVersion_0_0_0,
 		EmptyString,
 		MarkerOnly,
 		FailedMain,
@@ -66,6 +78,7 @@ func TestVersion_Parsing(t *testing.T) {
 		{name: "handles beta versions", versionCommand: PostgresGPVersion_5_27_0_beta, expected: "5.27.0"},
 		{name: "handles release versions", versionCommand: PostgresGPVersion_6_7_1, expected: "6.7.1"},
 		{name: "handles large versions", versionCommand: PostgresGPVersion_11_341_31, expected: "11.341.31"},
+		{name: "handles multi line versions", versionCommand: PostgresGPVersion_MultiLine, expected: "6.18.2"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
If a user passed an incorrect gphome path then VerifyCompatibleGPDBVersions would try and still call validateVersion which would return a stack trace. Instead return early if getting the version fails. And then bundle multiple errors if validateVersion fails.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:versionErr