### PR TITLE
ci: use centos instead of alpine

### DIFF
--- a/ci/5_multi_host_gpupgrade_jobs.yml
+++ b/ci/5_multi_host_gpupgrade_jobs.yml
@@ -51,7 +51,7 @@
         image_resource:
           type: registry-image
           source:
-            repository: alpine
+            repository: centos
             tag: latest
         inputs:
           - name: gpupgrade_src
@@ -61,7 +61,7 @@
           - name: rpm_gpdb_target
           {{- end }}
         run:
-          path: gpupgrade_src/ci/scripts/prepare-installation.sh
+          path: gpupgrade_src/ci/scripts/prepare-installation.bash
           args:
             - greenplum-db-{{majorVersion .Source}}
             - greenplum-db-{{majorVersion .Target}}

--- a/ci/6_upgrade_and_functional_jobs.yml
+++ b/ci/6_upgrade_and_functional_jobs.yml
@@ -84,7 +84,7 @@
         image_resource:
           type: registry-image
           source:
-            repository: alpine
+            repository: centos
             tag: latest
         inputs:
           - name: gpupgrade_src
@@ -94,7 +94,7 @@
           - name: rpm_gpdb_target
           {{- end }}
         run:
-          path: gpupgrade_src/ci/scripts/prepare-installation.sh
+          path: gpupgrade_src/ci/scripts/prepare-installation.bash
           args:
             - greenplum-db-{{majorVersion .Source}}
             - greenplum-db-{{majorVersion .Target}}

--- a/ci/scripts/prepare-installation.bash
+++ b/ci/scripts/prepare-installation.bash
@@ -17,7 +17,7 @@ set -eux -o pipefail
 source_package=$1
 target_package=$2
 
-apk add --no-progress openssh-client
+yum install --quiet -y openssh-clients
 
 echo "Enabling ssh to the ccp cluster..."
 cp -R cluster_env_files/.ssh /root/.ssh


### PR DESCRIPTION
For prepare_installation task use centos:latest instead of alpine since alpine has recently updated OpenSSH version from 8.6 to 8.8 which causes incompatible when connecting to older SSH implementations such as those on CCP centos6 VMs used during our tests. That is, the default cryptographic algorithms were changed to not send older algorithms that have been found to be weak.

Since OpenSSH is already updated to the latest version on the CCP centos6 VMs and still does not support newer cryptographic algorithms now being sent by alpine's OpenSSH version we switch to a different base image.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixCI
**Note:** Still waiting for full pipeline to finish, but problematic tasks are now passing.