### PR TITLE
Use a custom bucket for madlib artifacts

### DIFF
--- a/ci/1_resources_anchors_groups.yml
+++ b/ci/1_resources_anchors_groups.yml
@@ -186,7 +186,7 @@ resources:
     access_key_id: ((madlib-s3-access_key_id))
     secret_access_key: ((madlib-s3-secret_access_key))
     region_name: us-west-2
-    bucket: madlib-artifacts  # FIXME: update to prod bucket once MADlib is released.
+    bucket: madlib-artifacts-gpupgrade  # FIXME: update to prod bucket once MADlib is released.
     versioned_file: bin_madlib_artifacts_centos{{.CentosVersion}}/madlib-master-gp{{.GPVersion}}-rhel{{.CentosVersion}}-x86_64.gppkg
 
 # NOTE: Skip creating the pxf resources for centos6 since pxf5 gpdb6 is not supported for centos6. Thus, we can only


### PR DESCRIPTION
This commit is a temporary fix for picking specific builds of madlib
to ensure gpupgrade works. Once the dynamic_library_path change is
merged, we should revert this commit.