### PR TITLE
finalize: fix tablespace rename bug in link mode

### DIFF
--- a/hub/upgrade_mirrors_using_rsync_test.go
+++ b/hub/upgrade_mirrors_using_rsync_test.go
@@ -157,16 +157,6 @@ func TestRsyncAndRenameMirrorTablespacesOnSegments(t *testing.T) {
 					}},
 			},
 		).Return(&idl.RsyncReply{}, nil)
-		sdw1.EXPECT().RenameTablespaces(
-			gomock.Any(),
-			&idl.RenameTablespacesRequest{
-				RenamePairs: []*idl.RenameTablespacesRequest_RenamePair{
-					{
-						Source:      "/tmp/user_ts/m1/16384/3",
-						Destination: "/tmp/user_ts/p1/16384/4",
-					}},
-			},
-		).Return(&idl.RenameTablespacesReply{}, nil)
 
 		sdw2 := mock_idl.NewMockAgentClient(ctrl)
 		sdw2.EXPECT().RsyncTablespaceDirectories(
@@ -181,23 +171,13 @@ func TestRsyncAndRenameMirrorTablespacesOnSegments(t *testing.T) {
 					}},
 			},
 		).Return(&idl.RsyncReply{}, nil)
-		sdw2.EXPECT().RenameTablespaces(
-			gomock.Any(),
-			&idl.RenameTablespacesRequest{
-				RenamePairs: []*idl.RenameTablespacesRequest_RenamePair{
-					{
-						Source:      "/tmp/user_ts/m2/16384/5",
-						Destination: "/tmp/user_ts/p2/16384/6",
-					}},
-			},
-		).Return(&idl.RenameTablespacesReply{}, nil)
 
 		agentConns := []*idl.Connection{
 			{AgentClient: sdw1, Hostname: "sdw1"},
 			{AgentClient: sdw2, Hostname: "sdw2"},
 		}
 
-		err := hub.RsyncAndRenameMirrorTablespacesOnSegments(agentConns, source, intermediate)
+		err := hub.RsyncMirrorTablespacesOnSegments(agentConns, source, intermediate)
 		if err != nil {
 			t.Errorf("unexpected err %#v", err)
 		}
@@ -227,25 +207,62 @@ func TestRsyncAndRenameMirrorTablespacesOnSegments(t *testing.T) {
 					}},
 			},
 		).Return(&idl.RsyncReply{}, nil)
-		sdw2.EXPECT().RenameTablespaces(
-			gomock.Any(),
-			&idl.RenameTablespacesRequest{
-				RenamePairs: []*idl.RenameTablespacesRequest_RenamePair{
-					{
-						Source:      "/tmp/user_ts/m2/16384/5",
-						Destination: "/tmp/user_ts/p2/16384/6",
-					}},
-			},
-		).Return(&idl.RenameTablespacesReply{}, nil)
 
 		agentConns := []*idl.Connection{
 			{AgentClient: sdw1, Hostname: "sdw1"},
 			{AgentClient: sdw2, Hostname: "sdw2"},
 		}
 
-		err := hub.RsyncAndRenameMirrorTablespacesOnSegments(agentConns, source, intermediate)
+		err := hub.RsyncMirrorTablespacesOnSegments(agentConns, source, intermediate)
 		if !errors.Is(err, expected) {
 			t.Errorf("got error %#v, want %#v", err, expected)
+		}
+	})
+}
+
+func TestRenameMirrorTablespacesOnSegments(t *testing.T) {
+	source := hub.MustCreateCluster(t, greenplum.SegConfigs{
+		{DbID: 1, ContentID: -1, Hostname: "master", DataDir: "/data/qddir/seg-1", Port: 15432, Role: greenplum.PrimaryRole},
+		{DbID: 2, ContentID: -1, Hostname: "standby", DataDir: "/data/standby", Port: 16432, Role: greenplum.MirrorRole},
+		{DbID: 3, ContentID: 0, Hostname: "sdw1", DataDir: "/data/dbfast1/seg1", Port: 25433, Role: greenplum.PrimaryRole},
+		{DbID: 4, ContentID: 0, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg1", Port: 25434, Role: greenplum.MirrorRole},
+		{DbID: 5, ContentID: 1, Hostname: "sdw2", DataDir: "/data/dbfast2/seg2", Port: 25435, Role: greenplum.PrimaryRole},
+		{DbID: 6, ContentID: 1, Hostname: "sdw1", DataDir: "/data/dbfast_mirror2/seg2", Port: 25436, Role: greenplum.MirrorRole},
+	})
+	source.Tablespaces = testutils.CreateTablespaces()
+
+	intermediate := hub.MustCreateCluster(t, greenplum.SegConfigs{
+		{DbID: 1, ContentID: -1, Hostname: "master", DataDir: "/data/qddir/seg.HqtFHX54y0o.-1", Port: 50432, Role: greenplum.PrimaryRole},
+		{DbID: 2, ContentID: -1, Hostname: "standby", DataDir: "/data/standby.HqtFHX54y0o", Port: 50433, Role: greenplum.MirrorRole},
+		{DbID: 3, ContentID: 0, Hostname: "sdw1", DataDir: "/data/dbfast1/seg.HqtFHX54y0o.1", Port: 50434, Role: greenplum.PrimaryRole},
+		{DbID: 4, ContentID: 0, Hostname: "sdw2", DataDir: "/data/dbfast_mirror1/seg.HqtFHX54y0o.1", Port: 50435, Role: greenplum.MirrorRole},
+		{DbID: 5, ContentID: 1, Hostname: "sdw2", DataDir: "/data/dbfast2/seg.HqtFHX54y0o.2", Port: 50436, Role: greenplum.PrimaryRole},
+		{DbID: 6, ContentID: 1, Hostname: "sdw1", DataDir: "/data/dbfast_mirror2/seg.HqtFHX54y0o.2", Port: 50437, Role: greenplum.MirrorRole},
+	})
+
+	t.Run("succeeds", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		sdw2 := mock_idl.NewMockAgentClient(ctrl)
+		sdw2.EXPECT().RenameTablespaces(
+			gomock.Any(),
+			&idl.RenameTablespacesRequest{
+				RenamePairs: []*idl.RenameTablespacesRequest_RenamePair{
+					{
+						Source:      "/tmp/user_ts/m1/16384/3",
+						Destination: "/tmp/user_ts/p1/16384/4",
+					}},
+			},
+		).Return(&idl.RenameTablespacesReply{}, nil)
+
+		agentConns := []*idl.Connection{
+			{AgentClient: sdw2, Hostname: "sdw2"},
+		}
+
+		err := hub.RenameMirrorTablespacesOnSegments(agentConns, source, intermediate)
+		if err != nil {
+			t.Errorf("unexpected err %#v", err)
 		}
 	})
 
@@ -254,54 +271,23 @@ func TestRsyncAndRenameMirrorTablespacesOnSegments(t *testing.T) {
 		defer ctrl.Finish()
 
 		expected := errors.New("permission denied")
-		sdw1 := mock_idl.NewMockAgentClient(ctrl)
-		sdw1.EXPECT().RsyncTablespaceDirectories(
-			gomock.Any(),
-			&idl.RsyncRequest{
-				Options: []*idl.RsyncRequest_RsyncOptions{
-					{
-						Sources:         []string{"/tmp/user_ts/p1/16384/"},
-						Destination:     "/tmp/user_ts/m1/16384",
-						DestinationHost: "sdw2",
-						Options:         []string{"--archive", "--delete", "--hard-links", "--size-only", "--no-inc-recursive"},
-					}},
-			},
-		).Return(&idl.RsyncReply{}, nil)
-		sdw1.EXPECT().RenameTablespaces(
-			gomock.Any(),
-			gomock.Any(),
-		).Return(nil, expected)
-
 		sdw2 := mock_idl.NewMockAgentClient(ctrl)
-		sdw2.EXPECT().RsyncTablespaceDirectories(
-			gomock.Any(),
-			&idl.RsyncRequest{
-				Options: []*idl.RsyncRequest_RsyncOptions{
-					{
-						Sources:         []string{"/tmp/user_ts/p2/16384/"},
-						Destination:     "/tmp/user_ts/m2/16384",
-						DestinationHost: "sdw1",
-						Options:         []string{"--archive", "--delete", "--hard-links", "--size-only", "--no-inc-recursive"},
-					}},
-			},
-		).Return(&idl.RsyncReply{}, nil)
 		sdw2.EXPECT().RenameTablespaces(
 			gomock.Any(),
 			&idl.RenameTablespacesRequest{
 				RenamePairs: []*idl.RenameTablespacesRequest_RenamePair{
 					{
-						Source:      "/tmp/user_ts/m2/16384/5",
-						Destination: "/tmp/user_ts/p2/16384/6",
+						Source:      "/tmp/user_ts/m1/16384/3",
+						Destination: "/tmp/user_ts/p1/16384/4",
 					}},
 			},
-		).Return(&idl.RenameTablespacesReply{}, nil)
+		).Return(&idl.RenameTablespacesReply{}, expected)
 
 		agentConns := []*idl.Connection{
-			{AgentClient: sdw1, Hostname: "sdw1"},
 			{AgentClient: sdw2, Hostname: "sdw2"},
 		}
 
-		err := hub.RsyncAndRenameMirrorTablespacesOnSegments(agentConns, source, intermediate)
+		err := hub.RenameMirrorTablespacesOnSegments(agentConns, source, intermediate)
 		if !errors.Is(err, expected) {
 			t.Errorf("got error %#v, want %#v", err, expected)
 		}


### PR DESCRIPTION
In link mode finalize would fail with the following error when tablespaces mirror directories where a subdirectory of the primary such as /tmp/testfs/gpseg0 and /tmp/testfs/mirror/gpseg0:

Error: Finalize: rpc error: code = Unknown desc = substep "UPGRADE_MIRRORS": 4
errors occurred:
* rpc error: code = Unknown desc = 2 errors occurred:
* rename
/tmp/testfs/mirror/gpseg3/25260/5 /tmp/testfs/gpseg3/25260/14: no such file or
directory
* rename /tmp/testfs/mirror/gpseg3/25259/5
/tmp/testfs/gpseg3/25259/14: no such file or directory

Previously, the code was renaming on the wrong host. Rather the rename needs to occur on the mirror tablespace host, which for link mode is the intermediate mirror host.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixTablespaceRenameBugInLinkMode