### PR TITLE
add CASCADE to __gpupgrade_tmp drop command

### DIFF
--- a/data-migration-scripts/create_find_view_dep_function.sql
+++ b/data-migration-scripts/create_find_view_dep_function.sql
@@ -9,7 +9,7 @@
 
 SET client_min_messages TO WARNING;
 
-DROP SCHEMA IF EXISTS __gpupgrade_tmp;
+DROP SCHEMA IF EXISTS __gpupgrade_tmp CASCADE;
 CREATE SCHEMA __gpupgrade_tmp;
 
 CREATE OR REPLACE FUNCTION  __gpupgrade_tmp.find_view_dependencies()

--- a/data-migration-scripts/gpupgrade-migration-sql-generator.bash
+++ b/data-migration-scripts/gpupgrade-migration-sql-generator.bash
@@ -125,7 +125,7 @@ execute_script_directory() {
         # Drop the temp schema
         records=$(PGOPTIONS='--client-min-messages=warning' \
             "$GPHOME"/bin/psql -X -q -d "$database" -p "$PGPORT" -Atc \
-            "DROP SCHEMA IF EXISTS __gpupgrade_tmp")
+            "DROP SCHEMA IF EXISTS __gpupgrade_tmp CASCADE")
     done
 
     echo "Output files are located in: $output_dir"


### PR DESCRIPTION
The data migration scripts drop and create a temporary schema
(__gpupgrade_tmp). If the process gets interrupted, we might end up
with a schema already in place as we try to drop and recreate it.
Adding CASCADE to the drop command ensures that this process works
as intended.