### PR TITLE
CI: add gptext

### DIFF
--- a/ci/1_resources_anchors_groups.yml
+++ b/ci/1_resources_anchors_groups.yml
@@ -189,6 +189,20 @@ resources:
     bucket: madlib-artifacts  # FIXME: update to prod bucket once MADlib is released.
     versioned_file: bin_madlib_artifacts_centos{{.CentosVersion}}/madlib-master-gp{{.GPVersion}}-rhel{{.CentosVersion}}-x86_64.gppkg
 
+{{- if ne .GPVersion "6" }}
+# NOTE: The same gptext artifact is used for both gpdb5 and gpdb6. Also, the same
+# rhel6 artifact is used for both centos6 and centos7, since the rhel7 artifact
+# does not support gpdb5.
+- name: greenplum-text-dev-rhel{{.CentosVersion}}
+  type: s3
+  source:
+    access_key_id: ((gptext_s3_access_key_id))
+    secret_access_key: ((gptext_s3_secret_access_key))
+    region_name: us-west-2
+    bucket: gptext-artifacts
+    versioned_file: greenplum-text-release-dev-rhel6_x86_64.tar.gz
+{{- end}}
+
 # NOTE: Skip creating the pxf resources for centos6 since pxf5 gpdb6 is not supported for centos6. Thus, we can only
 # test pxf upgrades on centos7.
 {{- if ne .CentosVersion "6" }}

--- a/ci/6_upgrade_and_functional_jobs.yml
+++ b/ci/6_upgrade_and_functional_jobs.yml
@@ -38,6 +38,8 @@
           {{- end }}
         {{- end }}
         {{- if .ExtensionsJob }}
+        - get: gptext_targz # NOTE: The same gptext artifact is used for both the source and target clusters.
+          resource: greenplum-text-dev-rhel{{.CentosVersion}}
         - get: postgis_gppkg_source
           resource: postgis_2.1.5_gpdb{{.Source}}_centos{{.CentosVersion}}_gppkg
         - get: postgis_gppkg_target
@@ -130,6 +132,7 @@
           - name: ccp_src
           - name: cluster_env_files
           - name: gpupgrade_src
+          - name: gptext_targz
           - name: postgis_gppkg_source
           - name: madlib_gppkg_source
           - name: sqldump


### PR DESCRIPTION
- GPText will officialy support gpupgrade with version 3.9.0.
- GPText is somewhat different compared to the other
extensions, it requires an external solr cluster to test its functionality.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:add-gptext