### PR TITLE
Fix dynamic_library_path params in the CI

### DIFF
--- a/ci/scripts/upgrade-extensions.bash
+++ b/ci/scripts/upgrade-extensions.bash
@@ -63,7 +63,7 @@ time ssh -n mdw "
               --source-gphome $GPHOME_SOURCE \
               --source-master-port $PGPORT \
               --temp-port-range 6020-6040 \
-              --dynamic-library-path $GPHOME_TARGET'/madlib/Current/ports/greenplum/6/lib:/usr/local/greenplum-db-text/lib/gpdb6'
+              --dynamic-library-path ${GPHOME_TARGET}/madlib/Current/ports/greenplum/6/lib:/usr/local/greenplum-db-text/lib/gpdb6
     set -e
 
     # Remove the expected failure logs such that any legitimate errors can easily be identified.
@@ -106,7 +106,7 @@ time ssh -n mdw "
               --source-gphome $GPHOME_SOURCE \
               --source-master-port $PGPORT \
               --temp-port-range 6020-6040 \
-              --dynamic-library-path $GPHOME_TARGET'/madlib/Current/ports/greenplum/6/lib:/usr/local/greenplum-db-text/lib/gpdb6'
+              --dynamic-library-path ${GPHOME_TARGET}/madlib/Current/ports/greenplum/6/lib:/usr/local/greenplum-db-text/lib/gpdb6
 
     gpupgrade execute --non-interactive
     gpupgrade finalize --non-interactive

--- a/ci/scripts/upgrade-extensions.bash
+++ b/ci/scripts/upgrade-extensions.bash
@@ -63,7 +63,7 @@ time ssh -n mdw "
               --source-gphome $GPHOME_SOURCE \
               --source-master-port $PGPORT \
               --temp-port-range 6020-6040 \
-              --dynamic-library-path '$GPHOME_TARGET/madlib/Current/ports/greenplum/6/lib:/usr/local/greenplum-db-text/lib/gpdb6'
+              --dynamic-library-path '/usr/local/greenplum-db-target/madlib/Current/ports/greenplum/6/lib:/usr/local/greenplum-db-text/lib/gpdb6'
     set -e
 
     # Remove the expected failure logs such that any legitimate errors can easily be identified.
@@ -106,7 +106,7 @@ time ssh -n mdw "
               --source-gphome $GPHOME_SOURCE \
               --source-master-port $PGPORT \
               --temp-port-range 6020-6040 \
-              --dynamic-library-path '$GPHOME_TARGET/madlib/Current/ports/greenplum/6/lib:/usr/local/greenplum-db-text/lib/gpdb6'
+              --dynamic-library-path '/usr/local/greenplum-db-target/madlib/Current/ports/greenplum/6/lib:/usr/local/greenplum-db-text/lib/gpdb6'
 
     gpupgrade execute --non-interactive
     gpupgrade finalize --non-interactive

--- a/ci/scripts/upgrade-extensions.bash
+++ b/ci/scripts/upgrade-extensions.bash
@@ -63,7 +63,7 @@ time ssh -n mdw "
               --source-gphome $GPHOME_SOURCE \
               --source-master-port $PGPORT \
               --temp-port-range 6020-6040 \
-              --dynamic-library-path '/usr/local/greenplum-db-target/madlib/Current/ports/greenplum/6/lib:/usr/local/greenplum-db-text/lib/gpdb6'
+              --dynamic-library-path '$GPHOME_TARGET/madlib/Current/ports/greenplum/6/lib:/usr/local/greenplum-db-text/lib/gpdb6'
     set -e
 
     # Remove the expected failure logs such that any legitimate errors can easily be identified.
@@ -106,7 +106,7 @@ time ssh -n mdw "
               --source-gphome $GPHOME_SOURCE \
               --source-master-port $PGPORT \
               --temp-port-range 6020-6040 \
-              --dynamic-library-path '/usr/local/greenplum-db-target/madlib/Current/ports/greenplum/6/lib:/usr/local/greenplum-db-text/lib/gpdb6'
+              --dynamic-library-path '$GPHOME_TARGET/madlib/Current/ports/greenplum/6/lib:/usr/local/greenplum-db-text/lib/gpdb6'
 
     gpupgrade execute --non-interactive
     gpupgrade finalize --non-interactive

--- a/ci/scripts/upgrade-extensions.bash
+++ b/ci/scripts/upgrade-extensions.bash
@@ -63,7 +63,7 @@ time ssh -n mdw "
               --source-gphome $GPHOME_SOURCE \
               --source-master-port $PGPORT \
               --temp-port-range 6020-6040 \
-              --dynamic-library-path '$GPHOME_TARGET/madlib/Current/ports/greenplum/6/lib:/usr/local/greenplum-db-text/lib/gpdb6'
+              --dynamic-library-path $GPHOME_TARGET'/madlib/Current/ports/greenplum/6/lib:/usr/local/greenplum-db-text/lib/gpdb6'
     set -e
 
     # Remove the expected failure logs such that any legitimate errors can easily be identified.
@@ -106,7 +106,7 @@ time ssh -n mdw "
               --source-gphome $GPHOME_SOURCE \
               --source-master-port $PGPORT \
               --temp-port-range 6020-6040 \
-              --dynamic-library-path '$GPHOME_TARGET/madlib/Current/ports/greenplum/6/lib:/usr/local/greenplum-db-text/lib/gpdb6'
+              --dynamic-library-path $GPHOME_TARGET'/madlib/Current/ports/greenplum/6/lib:/usr/local/greenplum-db-text/lib/gpdb6'
 
     gpupgrade execute --non-interactive
     gpupgrade finalize --non-interactive


### PR DESCRIPTION
1- $GPHOME_TARGET does not resolve to the correct value because of the
quotes. This commit changes it to use the actual path.
2- gptext path is not needed any more once the GUC change is merged into
6X. This commit removes it to keep the code clean.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:gpdb-guc-defaults