### PR TITLE
pg_upgrade: update foreign key constraint tests

### DIFF
--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/foreign_key_constraint.out
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/foreign_key_constraint.out
@@ -57,7 +57,7 @@ Database: isolation2test
 --------------------------------------------------------------------------------
 -- Workaround to unblock upgrade
 --------------------------------------------------------------------------------
-ALTER TABLE public.pt DROP CONSTRAINT pt_fkey CASCADE;
+ALTER TABLE public.pt DROP CONSTRAINT pt_fkey;
 ALTER
-ALTER TABLE public.pt_another DROP CONSTRAINT pt_another_fkey CASCADE;
+ALTER TABLE public.pt_another DROP CONSTRAINT pt_another_fkey;
 ALTER

--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/foreign_key_constraint.sql
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/foreign_key_constraint.sql
@@ -42,5 +42,5 @@ INSERT INTO non_pt SELECT i FROM generate_series(1,2)i;
 --------------------------------------------------------------------------------
 -- Workaround to unblock upgrade
 --------------------------------------------------------------------------------
-ALTER TABLE public.pt DROP CONSTRAINT pt_fkey CASCADE;
-ALTER TABLE public.pt_another DROP CONSTRAINT pt_another_fkey CASCADE;
+ALTER TABLE public.pt DROP CONSTRAINT pt_fkey;
+ALTER TABLE public.pt_another DROP CONSTRAINT pt_another_fkey;


### PR DESCRIPTION
Remove CASCADE from the workaround.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:updateFKtests