### PR TITLE
pg_upgrade: partitioned_heap_table_with_dropped_columns

### DIFF
--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/partitioned_heap_table_with_dropped_columns.out
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/partitioned_heap_table_with_dropped_columns.out
@@ -14,56 +14,131 @@
 -- Create and setup non-upgradeable objects
 --------------------------------------------------------------------------------
 
--- 1. Differently aligned dropped column
-CREATE TABLE p_different_aligned_column (a int, b aclitem, c int) DISTRIBUTED BY (a) PARTITION BY range(c) SUBPARTITION BY range(a) (PARTITION p_part_with_different_alignedd_dropped_columns START(0) END(42) (SUBPARTITION subpart_differnt_aligned_column START(0) END(22), SUBPARTITION p_subpart_with_different_alignedd_dropped_columns START(22) END(42)));
+-- 1. Heterogeneous partition table with dropped column
+--    The root and only a subset of children have the dropped column reference.
+CREATE TABLE dropped_column (a int, b int, c char, d varchar(50)) DISTRIBUTED BY (c) PARTITION BY RANGE (a) (PARTITION part_1 START(1) END(5), PARTITION part_2 START(5));
 CREATE
+ALTER TABLE dropped_column DROP COLUMN d;
+ALTER
+
+-- Splitting the subpartition leads to its rewrite, eliminating its dropped column
+-- reference. So, after this, only part_2 and the root partition will have a
+-- dropped column reference.
+ALTER TABLE dropped_column SPLIT PARTITION FOR(1) AT (2) INTO (PARTITION split_part_1, PARTITION split_part_2);
+ALTER
+INSERT INTO dropped_column VALUES(1, 2, 'a');
+INSERT 1
+
+-- 2. Root partitions do not have dropped column references, but some child partitions do
+CREATE TABLE child_has_dropped_column (a int, b int, c char, d varchar(50)) PARTITION BY RANGE (a) (PARTITION part_1 START(1) END(5), PARTITION part_2 START(5));
+CREATE
+
+CREATE TABLE intermediate_table (a int, b int, c char, d varchar(50), to_drop int);
+CREATE
+ALTER TABLE intermediate_table DROP COLUMN to_drop;
+ALTER
+
+ALTER TABLE child_has_dropped_column EXCHANGE PARTITION part_1 WITH TABLE intermediate_table;
+ALTER
+DROP TABLE intermediate_table;
+DROP
+
+-- 3. Root and child partitions have different number of dropped column references
+CREATE TABLE diff_no_dropped_columns (a int, b int, c char, to_drop varchar(50)) PARTITION BY RANGE (a) (PARTITION part_1 START(1) END(5), PARTITION part_2 START(5));
+CREATE
+ALTER TABLE diff_no_dropped_columns DROP COLUMN to_drop;
+ALTER
+
+CREATE TABLE intermediate_table (a int, b int, c char, to_drop varchar(50), to_drop_2 int);
+CREATE
+ALTER TABLE intermediate_table DROP COLUMN to_drop;
+ALTER
+ALTER TABLE intermediate_table DROP COLUMN to_drop_2;
+ALTER
+
+ALTER TABLE diff_no_dropped_columns EXCHANGE PARTITION part_1 WITH TABLE intermediate_table;
+ALTER
+DROP TABLE intermediate_table;
+DROP
+
+-- 4. Differently aligned dropped column
+CREATE TABLE differently_aligned_column (a int, b aclitem, c int) DISTRIBUTED BY (a) PARTITION BY range(c) SUBPARTITION BY range(a) (PARTITION differently_aligned_columns_part START(0) END(42) (SUBPARTITION subpart_1 START(0) END(22), SUBPARTITION subpart_2 START(22) END(42)));
+CREATE
+ALTER TABLE differently_aligned_column DROP COLUMN b;
+ALTER
+INSERT INTO differently_aligned_column VALUES(22, 22), (23, 23);
+INSERT 2
 
 -- 'b' column is intentionally differently aligned - aclitem has 'i' alignment
 -- and timetz has 'd' alignment. If we allow the upgrade then on the new cluster
 -- we will fetch column 'c' at the wrong offset.
-CREATE TABLE subpart_different_aligned_column(a int, b timetz, c int);
+CREATE TABLE intermediate_table (a int, b timetz, c int);
 CREATE
-ALTER TABLE p_different_aligned_column DROP COLUMN b;
-ALTER
-INSERT INTO subpart_different_aligned_column VALUES (1, '00:00:00-8', 1), (2, '00:00:00-8', 2);
+INSERT INTO intermediate_table VALUES (1, '00:00:00-8', 1), (2, '00:00:00-8', 2);
 INSERT 2
-ALTER TABLE subpart_different_aligned_column DROP COLUMN b;
-ALTER
-INSERT INTO p_different_aligned_column VALUES(22, 22), (23, 23);
-INSERT 2
-ALTER TABLE p_different_aligned_column ALTER PARTITION p_part_with_different_alignedd_dropped_columns EXCHANGE PARTITION subpart_differnt_aligned_column WITH TABLE subpart_different_aligned_column;
+ALTER TABLE intermediate_table DROP COLUMN b;
 ALTER
 
--- 2. Differently aligned dropped varlena column
-CREATE TABLE p_diff_aligned_varlena (a int, b float8[], c int) DISTRIBUTED BY (a) PARTITION BY range(c) SUBPARTITION BY range(a) (PARTITION varlena START(0) END(42) (SUBPARTITION varlena_first START(0) END(22), SUBPARTITION varlena_second START(22) END(42)));
+ALTER TABLE differently_aligned_column ALTER PARTITION differently_aligned_columns_part EXCHANGE PARTITION subpart_1 WITH TABLE intermediate_table;
+ALTER
+DROP TABLE intermediate_table;
+DROP
+
+-- 5. Differently aligned dropped varlena column
+CREATE TABLE differently_aligned_varlena (a int, b float8[], c int) DISTRIBUTED BY (a) PARTITION BY range(c) SUBPARTITION BY range(a) (PARTITION differently_aligned_varlena_part START(0) END(42) (SUBPARTITION subpart_1 START(0) END(22), SUBPARTITION subpart_2 START(22) END(42)));
 CREATE
+ALTER TABLE differently_aligned_varlena DROP COLUMN b;
+ALTER
 
 -- 'b' column is intentionally differently aligned - float8[] has 'd'
 -- alignment and numeric has 'i' alignment. If we allow the upgrade then on
 -- the new cluster we will fetch column 'c' at the wrong offset.
-CREATE TABLE varlena_first(a int, b numeric, c int);
+CREATE TABLE intermediate_table(a int, b numeric, c int);
 CREATE
-ALTER TABLE p_diff_aligned_varlena DROP COLUMN b;
-ALTER
-INSERT INTO varlena_first VALUES (1, 1.987654321, 1), (2, 2.3456789, 2);
+INSERT INTO intermediate_table VALUES (1, 1.987654321, 1), (2, 2.3456789, 2);
 INSERT 2
-ALTER TABLE varlena_first DROP COLUMN b;
-ALTER
-ALTER TABLE p_diff_aligned_varlena ALTER PARTITION varlena EXCHANGE PARTITION varlena_first WITH TABLE varlena_first;
+ALTER TABLE intermediate_table DROP COLUMN b;
 ALTER
 
--- 3. Differently sized dropped column
-CREATE TABLE p_different_size_column (a int, b int, c int) DISTRIBUTED BY (a) PARTITION BY range(c) SUBPARTITION BY range(a) (PARTITION p_part_with_different_sized_dropped_columns START(0) END(42) (SUBPARTITION subpart_differnt_size_column START(0) END(22), SUBPARTITION p_subpart_with_different_sized_dropped_columns START(22) END(42)));
-CREATE
+ALTER TABLE differently_aligned_varlena ALTER PARTITION differently_aligned_varlena_part EXCHANGE PARTITION subpart_1 WITH TABLE intermediate_table;
+ALTER
+DROP TABLE intermediate_table;
+DROP
 
-CREATE TABLE subpart_different_size_column(a int, b numeric, c int);
+-- 6. Differently sized dropped column
+CREATE TABLE differently_sized_column (a int, b int, c int) DISTRIBUTED BY (a) PARTITION BY range(c) SUBPARTITION BY range(a) (PARTITION differently_sized_column_part START(0) END(42) (SUBPARTITION subpart_1 START(0) END(22), SUBPARTITION subpart_2 START(22) END(42)));
 CREATE
-ALTER TABLE p_different_size_column DROP COLUMN b;
+ALTER TABLE differently_sized_column DROP COLUMN b;
 ALTER
-ALTER TABLE subpart_different_size_column DROP COLUMN b;
+
+CREATE TABLE intermediate_table(a int, b numeric, c int);
+CREATE
+ALTER TABLE intermediate_table DROP COLUMN b;
 ALTER
-ALTER TABLE p_different_size_column ALTER PARTITION p_part_with_different_sized_dropped_columns EXCHANGE PARTITION subpart_differnt_size_column WITH TABLE subpart_different_size_column;
+
+ALTER TABLE differently_sized_column ALTER PARTITION differently_sized_column_part EXCHANGE PARTITION subpart_1 WITH TABLE intermediate_table;
 ALTER
+DROP TABLE intermediate_table;
+DROP
+
+-- 7. Child having a different column order than the root
+-- At the end of the scenario the root will have cols (a, b, ..dropped) and part_1 will have cols (a, ..dropped, b)
+CREATE TABLE dropped_cols_out_of_order (a int, b int, to_drop int) PARTITION BY RANGE (a) (PARTITION part_1 START(1) END(5), PARTITION part_2 START(5));
+CREATE
+ALTER TABLE dropped_cols_out_of_order DROP COLUMN to_drop;
+ALTER
+
+CREATE TABLE intermediate_table(a int, to_drop int);
+CREATE
+ALTER TABLE intermediate_table DROP COLUMN to_drop;
+ALTER
+ALTER TABLE intermediate_table ADD COLUMN b int;
+ALTER
+
+ALTER TABLE dropped_cols_out_of_order EXCHANGE PARTITION part_1 WITH TABLE intermediate_table;
+ALTER
+DROP TABLE intermediate_table;
+DROP
 
 --------------------------------------------------------------------------------
 -- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
@@ -72,34 +147,203 @@ ALTER
 -- start_ignore
 -- end_ignore
 (exited with code 1)
-! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/heterogeneous_partitioned_tables.txt | LC_ALL=C sort -b;
-  column ........pg.dropped.2........ of parent table public.p_diff_aligned_varlena has type 0 of length -1 and alignment 'd', but it is type 0 of length -1 and alignment 'i' in child table public.p_diff_aligned_varlena_1_prt_varlena_2_prt_varlena_first
-  column ........pg.dropped.2........ of parent table public.p_different_aligned_column has type 0 of length 12 and alignment 'i', but it is type 0 of length 12 and alignment 'd' in child table public.p_differen_1_prt_p_part_w_2_prt_subpart_differnt_aligned_column
-  column ........pg.dropped.2........ of parent table public.p_different_size_column has type 0 of length 4 and alignment 'i', but it is type 0 of length -1 and alignment 'i' in child table public.p_different_s_1_prt_p_part_w_2_prt_subpart_differnt_size_column
+-- NOTE: We sort the output to ensure the test is deterministic. See commit b6a084c. However, this prevents asserting
+-- the correct tables were detected for the sub-checks "invalid dropped column references" and "misaligned columns".
+-- Thus, we split the file and sort the two sub-checks individually.
+! csplit -f parts ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/heterogeneous_partitioned_tables.txt '/Partitions with misaligned dropped column references:/';
+166
+379
+
+! cat parts00 | LC_ALL=C sort -b;
+Database: isolation2test
+  Partitions with invalid dropped column references:
+    public.child_has_dropped_column_1_prt_part_1
+    public.dropped_column_1_prt_part_2
+
+! cat parts01 | LC_ALL=C sort -b;
+  Partitions with misaligned dropped column references:
+    public.diff_no_dropped_columns_1_prt_part_1
+    public.differently_aligned_colu_1_prt_differently_alig_2_prt_subpart_1
+    public.differently_aligned_varl_1_prt_differently_alig_2_prt_subpart_1
+    public.differently_sized_column_1_prt_differently_size_2_prt_subpart_1
+    public.dropped_cols_out_of_order_1_prt_part_1
 
 
 --------------------------------------------------------------------------------
 -- Workaround to unblock upgrade
 --------------------------------------------------------------------------------
 
--- 1. Differently aligned dropped column
-ALTER TABLE p_different_aligned_column RENAME TO p_with_different_aligned_dropped_columns_broken;
-ALTER
-CREATE TABLE p_different_aligned_column AS SELECT * FROM p_with_different_aligned_dropped_columns_broken;
-CREATE 4
-DROP TABLE p_with_different_aligned_dropped_columns_broken CASCADE;
-DROP
-
--- 2. Differently aligned dropped varlena column
--- TODO: Add steps to recreate the table as a workaround
--- Drop the table for now
-DROP TABLE p_diff_aligned_varlena;
-DROP
-
--- 3. Differently sized dropped column
-ALTER TABLE p_different_size_column RENAME TO p_with_different_size_dropped_columns_broken;
-ALTER
-CREATE TABLE p_different_size_column AS SELECT * FROM p_with_different_size_dropped_columns_broken;
+-- 1. Heterogeneous partition table with dropped column
+--    The root and only a subset of children have the dropped column reference.
+-- Perform a CTAS on only the affected partitions.
+-- The root and sub-root partitions do not have any data and will be ignored
+-- by the pg_upgrade check.
+CREATE TABLE scratch_table AS SELECT * FROM dropped_column_1_prt_part_2;
 CREATE 0
-DROP TABLE p_with_different_size_dropped_columns_broken CASCADE;
+BEGIN;
+BEGIN
+ALTER TABLE dropped_column EXCHANGE PARTITION part_2 WITH TABLE scratch_table;
+ALTER
+COMMIT;
+COMMIT
+DROP TABLE scratch_table;
 DROP
+
+-- 2. Root partitions do not have dropped column references, but some child partitions do
+-- Perform a CTAS on only the affected partitions.
+-- The root and sub-root partitions do not have any data and will be ignored
+-- by the pg_upgrade check.
+CREATE TABLE scratch_table AS SELECT * FROM child_has_dropped_column_1_prt_part_1;
+CREATE 0
+BEGIN;
+BEGIN
+ALTER TABLE child_has_dropped_column EXCHANGE PARTITION part_1 WITH TABLE scratch_table;
+ALTER
+COMMIT;
+COMMIT
+DROP TABLE scratch_table;
+DROP
+
+-- 3. Root and child partitions have different number of dropped column references
+-- Perform a CTAS on only the affected partitions.
+-- The root and sub-root partitions do not have any data and will be ignored
+-- by the pg_upgrade check.
+CREATE TABLE scratch_table_part_1 AS SELECT * FROM diff_no_dropped_columns_1_prt_part_1;
+CREATE 0
+CREATE TABLE scratch_table_part_2 AS SELECT * FROM diff_no_dropped_columns_1_prt_part_2;
+CREATE 0
+BEGIN;
+BEGIN
+ALTER TABLE diff_no_dropped_columns EXCHANGE PARTITION part_1 WITH TABLE scratch_table_part_1;
+ALTER
+ALTER TABLE diff_no_dropped_columns EXCHANGE PARTITION part_2 WITH TABLE scratch_table_part_2;
+ALTER
+COMMIT;
+COMMIT
+DROP TABLE scratch_table_part_1;
+DROP
+DROP TABLE scratch_table_part_2;
+DROP
+
+-- 4. Differently aligned dropped column
+-- Fix the affected partitions by recreating them with the proper dropped column references.
+CREATE TABLE scratch_table_subpart_1 (a int, b aclitem, c int) DISTRIBUTED BY (a);
+CREATE
+ALTER TABLE scratch_table_subpart_1 DROP COLUMN b;
+ALTER
+INSERT INTO scratch_table_subpart_1 SELECT * FROM differently_aligned_colu_1_prt_differently_alig_2_prt_subpart_1;
+INSERT 2
+BEGIN;
+BEGIN
+ALTER TABLE differently_aligned_column ALTER PARTITION differently_aligned_columns_part EXCHANGE PARTITION subpart_1 WITH TABLE scratch_table_subpart_1;
+ALTER
+COMMIT;
+COMMIT
+DROP TABLE scratch_table_subpart_1;
+DROP
+
+-- 5. Differently aligned dropped varlena column
+-- Show an alternative way of fixing the affected partitions by performing a
+-- CTAS on all child partitions.
+-- The root and sub-root partitions do not have any data and will be ignored
+-- by the pg_upgrade check.
+CREATE TABLE scratch_table_subpart_1 AS SELECT * FROM differently_aligned_varl_1_prt_differently_alig_2_prt_subpart_1;
+CREATE 2
+CREATE TABLE scratch_table_subpart_2 AS SELECT * FROM differently_aligned_varl_1_prt_differently_alig_2_prt_subpart_2;
+CREATE 0
+BEGIN;
+BEGIN
+ALTER TABLE differently_aligned_varlena ALTER PARTITION differently_aligned_varlena_part EXCHANGE PARTITION subpart_1 WITH TABLE scratch_table_subpart_1;
+ALTER
+ALTER TABLE differently_aligned_varlena ALTER PARTITION differently_aligned_varlena_part EXCHANGE PARTITION subpart_2 WITH TABLE scratch_table_subpart_2;
+ALTER
+COMMIT;
+COMMIT
+DROP TABLE scratch_table_subpart_1;
+DROP
+DROP TABLE scratch_table_subpart_2;
+DROP
+
+-- 6. Differently sized dropped column
+-- Fix the affected partitions by recreating them with the proper dropped column references.
+CREATE TABLE scratch_table_subpart_1 (a int, b int, c int) DISTRIBUTED BY (a);
+CREATE
+ALTER TABLE scratch_table_subpart_1 DROP COLUMN b;
+ALTER
+INSERT INTO scratch_table_subpart_1 SELECT * FROM differently_sized_column_1_prt_differently_size_2_prt_subpart_1;
+INSERT 0
+BEGIN;
+BEGIN
+ALTER TABLE differently_sized_column ALTER PARTITION differently_sized_column_part EXCHANGE PARTITION subpart_1 WITH TABLE scratch_table_subpart_1;
+ALTER
+COMMIT;
+COMMIT
+DROP TABLE scratch_table_subpart_1;
+DROP
+
+-- 7. Child having a different column order than the root
+-- Fix the affected partitions by recreating them with the proper dropped column order.
+CREATE TABLE scratch_table (a int, b int, to_drop int);
+CREATE
+ALTER TABLE scratch_table DROP COLUMN to_drop;
+ALTER
+INSERT INTO scratch_table SELECT * FROM dropped_cols_out_of_order_1_prt_part_1;
+INSERT 0
+BEGIN;
+BEGIN
+ALTER TABLE dropped_cols_out_of_order EXCHANGE PARTITION part_1 WITH TABLE scratch_table;
+ALTER
+COMMIT;
+COMMIT
+DROP TABLE scratch_table;
+DROP
+
+-- To fix the entire partition table there are two options:
+-- 1) using gpbackup and gprestore, or 2) using pg_dump.
+--------------------------------------------------------------------------------
+-- To fix the entire table using gpbackup and gprestore:
+--------------------------------------------------------------------------------
+-- gpbackup --metadata-only --dbname postgres --include-table user_schema.table_part
+--
+-- Record the form the output above "Backup Timestamp = 20220126161009"
+--
+-- CREATE SCHEMA scratch;
+--
+-- gprestore --timestamp 20220126161009 --redirect-schema scratch --include-table user_schema.table_part
+--
+-- INSERT INTO scratch.table_part SELECT * FROM user_schema.table_part;
+--
+-- BEGIN;
+-- DROP TABLE user_schema.table_part;
+--
+-- ALTER TABLE scratch.table_part SET SCHEMA user_schema;
+-- ALTER TABLE scratch.table_part_1_prt_subpart SET SCHEMA user_schema;
+-- ALTER TABLE scratch.table_part_1_prt_subpart_2_prt_subpart_1 SET SCHEMA user_schema;
+-- ALTER TABLE scratch.table_part_1_prt_subpart_2_prt_subpart_2 SET SCHEMA user_schema;
+-- COMMIT;
+--
+-- DROP SCHEMA scratch;
+--------------------------------------------------------------------------------
+-- To fix the entire table using pg_dump:
+--------------------------------------------------------------------------------
+-- pg_dump --gp-syntax  --schema-only -t user_schema.table_part postgres > out.sql
+--
+-- Edit out.sql and update all object references to use the "scratch" schema name.
+-- For example, "CREATE TABLE scratch.table_part ..."
+--
+-- CREATE SCHEMA scratch;
+-- psql -d postgres -f out.sql
+--
+-- INSERT INTO scratch.table_part SELECT * FROM user_schema.table_part;
+--
+-- BEGIN;
+-- DROP TABLE user_schema.table_part;
+--
+-- ALTER TABLE scratch.table_part SET SCHEMA user_schema;
+-- ALTER TABLE scratch.table_part_1_prt_subpart SET SCHEMA user_schema;
+-- ALTER TABLE scratch.table_part_1_prt_subpart_2_prt_subpart_1 SET SCHEMA user_schema;
+-- ALTER TABLE scratch.table_part_1_prt_subpart_2_prt_subpart_2 SET SCHEMA user_schema;
+-- COMMIT;
+--
+-- DROP SCHEMA scratch;
+--------------------------------------------------------------------------------

--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/partitioned_heap_table_with_dropped_columns.sql
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/partitioned_heap_table_with_dropped_columns.sql
@@ -14,73 +14,254 @@
 -- Create and setup non-upgradeable objects
 --------------------------------------------------------------------------------
 
--- 1. Differently aligned dropped column
-CREATE TABLE p_different_aligned_column (a int, b aclitem, c int) DISTRIBUTED BY (a)
+-- 1. Heterogeneous partition table with dropped column
+--    The root and only a subset of children have the dropped column reference.
+CREATE TABLE dropped_column (a int, b int, c char, d varchar(50)) DISTRIBUTED BY (c)
+    PARTITION BY RANGE (a)
+        (PARTITION part_1 START(1) END(5),
+        PARTITION part_2 START(5));
+ALTER TABLE dropped_column DROP COLUMN d;
+
+-- Splitting the subpartition leads to its rewrite, eliminating its dropped column
+-- reference. So, after this, only part_2 and the root partition will have a
+-- dropped column reference.
+ALTER TABLE dropped_column SPLIT PARTITION FOR(1) AT (2) INTO (PARTITION split_part_1, PARTITION split_part_2);
+INSERT INTO dropped_column VALUES(1, 2, 'a');
+
+-- 2. Root partitions do not have dropped column references, but some child partitions do
+CREATE TABLE child_has_dropped_column (a int, b int, c char, d varchar(50))
+    PARTITION BY RANGE (a)
+        (PARTITION part_1 START(1) END(5),
+        PARTITION part_2 START(5));
+
+CREATE TABLE intermediate_table (a int, b int, c char, d varchar(50), to_drop int);
+ALTER TABLE intermediate_table DROP COLUMN to_drop;
+
+ALTER TABLE child_has_dropped_column EXCHANGE PARTITION part_1 WITH TABLE intermediate_table;
+DROP TABLE intermediate_table;
+
+-- 3. Root and child partitions have different number of dropped column references
+CREATE TABLE diff_no_dropped_columns (a int, b int, c char, to_drop varchar(50))
+    PARTITION BY RANGE (a)
+        (PARTITION part_1 START(1) END(5),
+        PARTITION part_2 START(5));
+ALTER TABLE diff_no_dropped_columns DROP COLUMN to_drop;
+
+CREATE TABLE intermediate_table (a int, b int, c char, to_drop varchar(50), to_drop_2 int);
+ALTER TABLE intermediate_table DROP COLUMN to_drop;
+ALTER TABLE intermediate_table DROP COLUMN to_drop_2;
+
+ALTER TABLE diff_no_dropped_columns EXCHANGE PARTITION part_1 WITH TABLE intermediate_table;
+DROP TABLE intermediate_table;
+
+-- 4. Differently aligned dropped column
+CREATE TABLE differently_aligned_column (a int, b aclitem, c int) DISTRIBUTED BY (a)
     PARTITION BY range(c)
-        SUBPARTITION BY range(a) (PARTITION p_part_with_different_alignedd_dropped_columns START(0) END(42)
-            (SUBPARTITION subpart_differnt_aligned_column START(0) END(22),
-            SUBPARTITION p_subpart_with_different_alignedd_dropped_columns START(22) END(42)));
+        SUBPARTITION BY range(a) (PARTITION differently_aligned_columns_part START(0) END(42)
+            (SUBPARTITION subpart_1 START(0) END(22),
+            SUBPARTITION subpart_2 START(22) END(42)));
+ALTER TABLE differently_aligned_column DROP COLUMN b;
+INSERT INTO differently_aligned_column VALUES(22, 22), (23, 23);
 
 -- 'b' column is intentionally differently aligned - aclitem has 'i' alignment
 -- and timetz has 'd' alignment. If we allow the upgrade then on the new cluster
 -- we will fetch column 'c' at the wrong offset.
-CREATE TABLE subpart_different_aligned_column(a int, b timetz, c int);
-ALTER TABLE p_different_aligned_column DROP COLUMN b;
-INSERT INTO subpart_different_aligned_column VALUES (1, '00:00:00-8', 1), (2, '00:00:00-8', 2);
-ALTER TABLE subpart_different_aligned_column DROP COLUMN b;
-INSERT INTO p_different_aligned_column VALUES(22, 22), (23, 23);
-ALTER TABLE p_different_aligned_column ALTER PARTITION p_part_with_different_alignedd_dropped_columns
-    EXCHANGE PARTITION subpart_differnt_aligned_column WITH TABLE subpart_different_aligned_column;
+CREATE TABLE intermediate_table (a int, b timetz, c int);
+INSERT INTO intermediate_table VALUES (1, '00:00:00-8', 1), (2, '00:00:00-8', 2);
+ALTER TABLE intermediate_table DROP COLUMN b;
 
--- 2. Differently aligned dropped varlena column
-CREATE TABLE p_diff_aligned_varlena (a int, b float8[], c int) DISTRIBUTED BY (a)
+ALTER TABLE differently_aligned_column ALTER PARTITION differently_aligned_columns_part
+    EXCHANGE PARTITION subpart_1 WITH TABLE intermediate_table;
+DROP TABLE intermediate_table;
+
+-- 5. Differently aligned dropped varlena column
+CREATE TABLE differently_aligned_varlena (a int, b float8[], c int) DISTRIBUTED BY (a)
     PARTITION BY range(c)
-        SUBPARTITION BY range(a) (PARTITION varlena START(0) END(42)
-            (SUBPARTITION varlena_first START(0) END(22),
-            SUBPARTITION varlena_second START(22) END(42)));
+        SUBPARTITION BY range(a) (PARTITION differently_aligned_varlena_part START(0) END(42)
+            (SUBPARTITION subpart_1 START(0) END(22),
+            SUBPARTITION subpart_2 START(22) END(42)));
+ALTER TABLE differently_aligned_varlena DROP COLUMN b;
 
 -- 'b' column is intentionally differently aligned - float8[] has 'd'
 -- alignment and numeric has 'i' alignment. If we allow the upgrade then on
 -- the new cluster we will fetch column 'c' at the wrong offset.
-CREATE TABLE varlena_first(a int, b numeric, c int);
-ALTER TABLE p_diff_aligned_varlena DROP COLUMN b;
-INSERT INTO varlena_first VALUES (1, 1.987654321, 1), (2, 2.3456789, 2);
-ALTER TABLE varlena_first DROP COLUMN b;
-ALTER TABLE p_diff_aligned_varlena ALTER PARTITION varlena EXCHANGE PARTITION varlena_first WITH TABLE varlena_first;
+CREATE TABLE intermediate_table(a int, b numeric, c int);
+INSERT INTO intermediate_table VALUES (1, 1.987654321, 1), (2, 2.3456789, 2);
+ALTER TABLE intermediate_table DROP COLUMN b;
 
--- 3. Differently sized dropped column
-CREATE TABLE p_different_size_column (a int, b int, c int) DISTRIBUTED BY (a)
+ALTER TABLE differently_aligned_varlena ALTER PARTITION differently_aligned_varlena_part
+    EXCHANGE PARTITION subpart_1 WITH TABLE intermediate_table;
+DROP TABLE intermediate_table;
+
+-- 6. Differently sized dropped column
+CREATE TABLE differently_sized_column (a int, b int, c int) DISTRIBUTED BY (a)
     PARTITION BY range(c)
-        SUBPARTITION BY range(a) (PARTITION p_part_with_different_sized_dropped_columns START(0) END(42)
-            (SUBPARTITION subpart_differnt_size_column START(0) END(22),
-            SUBPARTITION p_subpart_with_different_sized_dropped_columns START(22) END(42)));
+        SUBPARTITION BY range(a) (PARTITION differently_sized_column_part START(0) END(42)
+            (SUBPARTITION subpart_1 START(0) END(22),
+            SUBPARTITION subpart_2 START(22) END(42)));
+ALTER TABLE differently_sized_column DROP COLUMN b;
 
-CREATE TABLE subpart_different_size_column(a int, b numeric, c int);
-ALTER TABLE p_different_size_column DROP COLUMN b;
-ALTER TABLE subpart_different_size_column DROP COLUMN b;
-ALTER TABLE p_different_size_column ALTER PARTITION p_part_with_different_sized_dropped_columns EXCHANGE PARTITION subpart_differnt_size_column WITH TABLE subpart_different_size_column;
+CREATE TABLE intermediate_table(a int, b numeric, c int);
+ALTER TABLE intermediate_table DROP COLUMN b;
+
+ALTER TABLE differently_sized_column ALTER PARTITION differently_sized_column_part
+    EXCHANGE PARTITION subpart_1 WITH TABLE intermediate_table;
+DROP TABLE intermediate_table;
+
+-- 7. Child having a different column order than the root
+-- At the end of the scenario the root will have cols (a, b, ..dropped) and part_1 will have cols (a, ..dropped, b)
+CREATE TABLE dropped_cols_out_of_order (a int, b int, to_drop int)
+    PARTITION BY RANGE (a)
+        (PARTITION part_1 START(1) END(5),
+        PARTITION part_2 START(5));
+ALTER TABLE dropped_cols_out_of_order DROP COLUMN to_drop;
+
+CREATE TABLE intermediate_table(a int, to_drop int);
+ALTER TABLE intermediate_table DROP COLUMN to_drop;
+ALTER TABLE intermediate_table ADD COLUMN b int;
+
+ALTER TABLE dropped_cols_out_of_order EXCHANGE PARTITION part_1 WITH TABLE intermediate_table;
+DROP TABLE intermediate_table;
 
 --------------------------------------------------------------------------------
 -- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
 --------------------------------------------------------------------------------
 !\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --automatic;
-! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/heterogeneous_partitioned_tables.txt | LC_ALL=C sort -b;
+-- NOTE: We sort the output to ensure the test is deterministic. See commit b6a084c. However, this prevents asserting
+-- the correct tables were detected for the sub-checks "invalid dropped column references" and "misaligned columns".
+-- Thus, we split the file and sort the two sub-checks individually.
+! csplit -f parts ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/heterogeneous_partitioned_tables.txt '/Partitions with misaligned dropped column references:/';
+! cat parts00 | LC_ALL=C sort -b;
+! cat parts01 | LC_ALL=C sort -b;
 
 --------------------------------------------------------------------------------
 -- Workaround to unblock upgrade
 --------------------------------------------------------------------------------
 
--- 1. Differently aligned dropped column
-ALTER TABLE p_different_aligned_column RENAME TO p_with_different_aligned_dropped_columns_broken;
-CREATE TABLE p_different_aligned_column AS SELECT * FROM p_with_different_aligned_dropped_columns_broken;
-DROP TABLE p_with_different_aligned_dropped_columns_broken CASCADE;
+-- 1. Heterogeneous partition table with dropped column
+--    The root and only a subset of children have the dropped column reference.
+-- Perform a CTAS on only the affected partitions.
+-- The root and sub-root partitions do not have any data and will be ignored
+-- by the pg_upgrade check.
+CREATE TABLE scratch_table AS SELECT * FROM dropped_column_1_prt_part_2;
+BEGIN;
+ALTER TABLE dropped_column EXCHANGE PARTITION part_2 WITH TABLE scratch_table;
+COMMIT;
+DROP TABLE scratch_table;
 
--- 2. Differently aligned dropped varlena column
--- TODO: Add steps to recreate the table as a workaround
--- Drop the table for now
-DROP TABLE p_diff_aligned_varlena;
+-- 2. Root partitions do not have dropped column references, but some child partitions do
+-- Perform a CTAS on only the affected partitions.
+-- The root and sub-root partitions do not have any data and will be ignored
+-- by the pg_upgrade check.
+CREATE TABLE scratch_table AS SELECT * FROM child_has_dropped_column_1_prt_part_1;
+BEGIN;
+ALTER TABLE child_has_dropped_column EXCHANGE PARTITION part_1 WITH TABLE scratch_table;
+COMMIT;
+DROP TABLE scratch_table;
 
--- 3. Differently sized dropped column
-ALTER TABLE p_different_size_column RENAME TO p_with_different_size_dropped_columns_broken;
-CREATE TABLE p_different_size_column AS SELECT * FROM p_with_different_size_dropped_columns_broken;
-DROP TABLE p_with_different_size_dropped_columns_broken CASCADE;
+-- 3. Root and child partitions have different number of dropped column references
+-- Perform a CTAS on only the affected partitions.
+-- The root and sub-root partitions do not have any data and will be ignored
+-- by the pg_upgrade check.
+CREATE TABLE scratch_table_part_1 AS SELECT * FROM diff_no_dropped_columns_1_prt_part_1;
+CREATE TABLE scratch_table_part_2 AS SELECT * FROM diff_no_dropped_columns_1_prt_part_2;
+BEGIN;
+ALTER TABLE diff_no_dropped_columns EXCHANGE PARTITION part_1 WITH TABLE scratch_table_part_1;
+ALTER TABLE diff_no_dropped_columns EXCHANGE PARTITION part_2 WITH TABLE scratch_table_part_2;
+COMMIT;
+DROP TABLE scratch_table_part_1;
+DROP TABLE scratch_table_part_2;
+
+-- 4. Differently aligned dropped column
+-- Fix the affected partitions by recreating them with the proper dropped column references.
+CREATE TABLE scratch_table_subpart_1 (a int, b aclitem, c int) DISTRIBUTED BY (a);
+ALTER TABLE scratch_table_subpart_1 DROP COLUMN b;
+INSERT INTO scratch_table_subpart_1 SELECT * FROM differently_aligned_colu_1_prt_differently_alig_2_prt_subpart_1;
+BEGIN;
+ALTER TABLE differently_aligned_column ALTER PARTITION differently_aligned_columns_part EXCHANGE PARTITION subpart_1 WITH TABLE scratch_table_subpart_1;
+COMMIT;
+DROP TABLE scratch_table_subpart_1;
+
+-- 5. Differently aligned dropped varlena column
+-- Show an alternative way of fixing the affected partitions by performing a
+-- CTAS on all child partitions.
+-- The root and sub-root partitions do not have any data and will be ignored
+-- by the pg_upgrade check.
+CREATE TABLE scratch_table_subpart_1 AS SELECT * FROM differently_aligned_varl_1_prt_differently_alig_2_prt_subpart_1;
+CREATE TABLE scratch_table_subpart_2 AS SELECT * FROM differently_aligned_varl_1_prt_differently_alig_2_prt_subpart_2;
+BEGIN;
+ALTER TABLE differently_aligned_varlena ALTER PARTITION differently_aligned_varlena_part EXCHANGE PARTITION subpart_1 WITH TABLE scratch_table_subpart_1;
+ALTER TABLE differently_aligned_varlena ALTER PARTITION differently_aligned_varlena_part EXCHANGE PARTITION subpart_2 WITH TABLE scratch_table_subpart_2;
+COMMIT;
+DROP TABLE scratch_table_subpart_1;
+DROP TABLE scratch_table_subpart_2;
+
+-- 6. Differently sized dropped column
+-- Fix the affected partitions by recreating them with the proper dropped column references.
+CREATE TABLE scratch_table_subpart_1 (a int, b int, c int) DISTRIBUTED BY (a);
+ALTER TABLE scratch_table_subpart_1 DROP COLUMN b;
+INSERT INTO scratch_table_subpart_1 SELECT * FROM differently_sized_column_1_prt_differently_size_2_prt_subpart_1;
+BEGIN;
+ALTER TABLE differently_sized_column ALTER PARTITION differently_sized_column_part EXCHANGE PARTITION subpart_1 WITH TABLE scratch_table_subpart_1;
+COMMIT;
+DROP TABLE scratch_table_subpart_1;
+
+-- 7. Child having a different column order than the root
+-- Fix the affected partitions by recreating them with the proper dropped column order.
+CREATE TABLE scratch_table (a int, b int, to_drop int);
+ALTER TABLE scratch_table DROP COLUMN to_drop;
+INSERT INTO scratch_table SELECT * FROM dropped_cols_out_of_order_1_prt_part_1;
+BEGIN;
+ALTER TABLE dropped_cols_out_of_order EXCHANGE PARTITION part_1 WITH TABLE scratch_table;
+COMMIT;
+DROP TABLE scratch_table;
+
+-- To fix the entire partition table there are two options:
+-- 1) using gpbackup and gprestore, or 2) using pg_dump.
+--------------------------------------------------------------------------------
+-- To fix the entire table using gpbackup and gprestore:
+--------------------------------------------------------------------------------
+-- gpbackup --metadata-only --dbname postgres --include-table user_schema.table_part
+--
+-- Record the form the output above "Backup Timestamp = 20220126161009"
+--
+-- CREATE SCHEMA scratch;
+--
+-- gprestore --timestamp 20220126161009 --redirect-schema scratch --include-table user_schema.table_part
+--
+-- INSERT INTO scratch.table_part SELECT * FROM user_schema.table_part;
+--
+-- BEGIN;
+-- DROP TABLE user_schema.table_part;
+--
+-- ALTER TABLE scratch.table_part SET SCHEMA user_schema;
+-- ALTER TABLE scratch.table_part_1_prt_subpart SET SCHEMA user_schema;
+-- ALTER TABLE scratch.table_part_1_prt_subpart_2_prt_subpart_1 SET SCHEMA user_schema;
+-- ALTER TABLE scratch.table_part_1_prt_subpart_2_prt_subpart_2 SET SCHEMA user_schema;
+-- COMMIT;
+--
+-- DROP SCHEMA scratch;
+--------------------------------------------------------------------------------
+-- To fix the entire table using pg_dump:
+--------------------------------------------------------------------------------
+-- pg_dump --gp-syntax  --schema-only -t user_schema.table_part postgres > out.sql
+--
+-- Edit out.sql and update all object references to use the "scratch" schema name.
+-- For example, "CREATE TABLE scratch.table_part ..."
+--
+-- CREATE SCHEMA scratch;
+-- psql -d postgres -f out.sql
+--
+-- INSERT INTO scratch.table_part SELECT * FROM user_schema.table_part;
+--
+-- BEGIN;
+-- DROP TABLE user_schema.table_part;
+--
+-- ALTER TABLE scratch.table_part SET SCHEMA user_schema;
+-- ALTER TABLE scratch.table_part_1_prt_subpart SET SCHEMA user_schema;
+-- ALTER TABLE scratch.table_part_1_prt_subpart_2_prt_subpart_1 SET SCHEMA user_schema;
+-- ALTER TABLE scratch.table_part_1_prt_subpart_2_prt_subpart_2 SET SCHEMA user_schema;
+-- COMMIT;
+--
+-- DROP SCHEMA scratch;
+--------------------------------------------------------------------------------

--- a/test/acceptance/pg_upgrade/upgradeable_tests/source_cluster_regress/expected/partitioned_heap_table.out
+++ b/test/acceptance/pg_upgrade/upgradeable_tests/source_cluster_regress/expected/partitioned_heap_table.out
@@ -80,15 +80,56 @@ VACUUM
 
 
 --
+-- partitioned table with a dropped column
+--
+CREATE TABLE dropped_column (a int, b int, c int, d int) DISTRIBUTED BY (c) PARTITION BY RANGE (a) (PARTITION part_1 START(1) END(5), PARTITION part_2 START(5));
+CREATE
+INSERT INTO dropped_column SELECT i, i, i, i FROM generate_series(1, 10) i;
+INSERT 10
+ALTER TABLE dropped_column DROP COLUMN d;
+ALTER
+INSERT INTO dropped_column SELECT i, i, i FROM generate_series(10, 20) i;
+INSERT 11
+
+--
+-- partitioned table with the root partition has a dropped column reference but
+-- none of its child partitions do.
+--
+CREATE TABLE root_has_dropped_column (a int, b int, c int, d int) PARTITION BY RANGE (a) (PARTITION part_1 START(1) END(5), PARTITION part_2 START(5));
+CREATE
+INSERT INTO root_has_dropped_column SELECT i, i, i, i FROM generate_series(1, 10) i;
+INSERT 10
+ALTER TABLE root_has_dropped_column DROP COLUMN d;
+ALTER
+
+CREATE TABLE intermediate_table_1 (a int, b int, c int);
+CREATE
+ALTER TABLE root_has_dropped_column EXCHANGE PARTITION part_1 WITH TABLE intermediate_table_1;
+ALTER
+DROP TABLE intermediate_table_1;
+DROP
+
+CREATE TABLE intermediate_table_2 (a int, b int, c int);
+CREATE
+ALTER TABLE root_has_dropped_column EXCHANGE PARTITION part_2 WITH TABLE intermediate_table_2;
+ALTER
+DROP TABLE intermediate_table_2;
+DROP
+
+INSERT INTO root_has_dropped_column SELECT i, i, i FROM generate_series(10, 20) i;
+INSERT 11
+
+--
 -- partitioned table with a dropped and newly added column
 --
-CREATE TABLE p_dropcol (a int, b int, c int, d numeric) DISTRIBUTED BY (a) PARTITION BY RANGE(c) SUBPARTITION BY range(d) (PARTITION mama START(0) END(42) (SUBPARTITION chica START(0) END(42)));
+CREATE TABLE dropped_and_added_column (a int, b int, c int, d numeric) DISTRIBUTED BY (a) PARTITION BY RANGE(c) SUBPARTITION BY range(d) (PARTITION part_1 START(0) END(42) (SUBPARTITION subpart_1 START(0) END(42)));
 CREATE
-INSERT INTO p_dropcol SELECT i, i, i, i FROM generate_series(1, 10)i;
+
+INSERT INTO dropped_and_added_column SELECT i, i, i, i FROM generate_series(1, 10) i;
 INSERT 10
-ALTER TABLE p_dropcol DROP COLUMN b;
+ALTER TABLE dropped_and_added_column DROP COLUMN b;
 ALTER
-ALTER TABLE p_dropcol ADD COLUMN e int;
+ALTER TABLE dropped_and_added_column ADD COLUMN e int;
 ALTER
-INSERT INTO p_dropcol SELECT i, i, i, i FROM generate_series(10, 20)i;
+INSERT INTO dropped_and_added_column SELECT i, i, i, i FROM generate_series(10, 20) i;
 INSERT 11

--- a/test/acceptance/pg_upgrade/upgradeable_tests/target_cluster_regress/expected/partitioned_heap_table.out
+++ b/test/acceptance/pg_upgrade/upgradeable_tests/target_cluster_regress/expected/partitioned_heap_table.out
@@ -57,7 +57,20 @@ SELECT id, age FROM p_subpart_heap;
  2  | 20  
 (2 rows)
 
-SELECT c, d FROM p_dropcol WHERE a=10;
+SELECT b, c FROM dropped_column WHERE a=10;
+ b  | c  
+----+----
+ 10 | 10 
+ 10 | 10 
+(2 rows)
+
+SELECT b, c FROM root_has_dropped_column WHERE a=10;
+ b  | c  
+----+----
+ 10 | 10 
+(1 row)
+
+SELECT c, d FROM dropped_and_added_column WHERE a=10;
  c  | d  
 ----+----
  10 | 10 

--- a/test/acceptance/pg_upgrade/upgradeable_tests/target_cluster_regress/sql/partitioned_heap_table.sql
+++ b/test/acceptance/pg_upgrade/upgradeable_tests/target_cluster_regress/sql/partitioned_heap_table.sql
@@ -17,4 +17,8 @@ SELECT id, age FROM p_subpart_heap_1_prt_partition_id_2_prt_subpartition_age_fir
 SELECT id, age FROM p_subpart_heap_1_prt_partition_id_2_prt_subpartition_age_second;
 SELECT id, age FROM p_subpart_heap;
 
-SELECT c, d FROM p_dropcol WHERE a=10;
+SELECT b, c FROM dropped_column WHERE a=10;
+
+SELECT b, c FROM root_has_dropped_column WHERE a=10;
+
+SELECT c, d FROM dropped_and_added_column WHERE a=10;


### PR DESCRIPTION
These are the acceptance tests for PR https://github.com/greenplum-db/gpdb/pull/13028 which should be merged first before this PR.

Update tests for readability and maintainability. Test two workarounds 1) doing a CTAS for the individually affected partitions, and 2) doing a CTAS for the entire partition table.

Pipeline (using the above PR branch to test): https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:dropColTests?group=pg_upgrade
Using PR branch RPM: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:dropColTests/resources/gpdb6_centos7_rpm