### PR TITLE
gpupgrade_config: comment out defaults

### DIFF
--- a/cli/commands/initialize.go
+++ b/cli/commands/initialize.go
@@ -264,23 +264,23 @@ To return the cluster to its original state, run "gpupgrade revert".`,
 		},
 	}
 
+	subInit.Flags().BoolVarP(&verbose, "verbose", "v", false, "print the output stream from all substeps")
 	subInit.Flags().StringVarP(&file, "file", "f", "", "the configuration file to use")
 	subInit.Flags().BoolVarP(&nonInteractive, "automatic", "a", false, "do not prompt for confirmation to proceed")
 	subInit.Flags().BoolVar(&nonInteractive, "non-interactive", false, "do not prompt for confirmation to proceed")
 	subInit.Flags().MarkHidden("non-interactive") //nolint
+	subInit.Flags().IntVar(&sourcePort, "source-master-port", 0, "master port for source gpdb cluster")
 	subInit.Flags().StringVar(&sourceGPHome, "source-gphome", "", "path for the source Greenplum installation")
 	subInit.Flags().StringVar(&targetGPHome, "target-gphome", "", "path for the target Greenplum installation")
-	subInit.Flags().IntVar(&sourcePort, "source-master-port", 5432, "master port for source gpdb cluster")
+	subInit.Flags().StringVar(&mode, "mode", "copy", "performs upgrade in either copy or link mode. Default is copy.")
+	subInit.Flags().Float64Var(&diskFreeRatio, "disk-free-ratio", 0.60, "percentage of disk space that must be available (from 0.0 - 1.0)")
+	subInit.Flags().BoolVar(&useHbaHostnames, "use-hba-hostnames", false, "use hostnames in pg_hba.conf")
+	subInit.Flags().StringVar(&dynamicLibraryPath, "dynamic-library-path", upgrade.DefaultDynamicLibraryPath, "sets the dynamic_library_path GUC to correctly find extensions installed outside their default location. Defaults to '$dynamic_library_path'.")
+	subInit.Flags().StringVar(&ports, "temp-port-range", "50432-65535", "set of ports to use when initializing the target cluster")
 	subInit.Flags().IntVar(&hubPort, "hub-port", upgrade.DefaultHubPort, "the port gpupgrade hub uses to listen for commands on")
 	subInit.Flags().IntVar(&agentPort, "agent-port", upgrade.DefaultAgentPort, "the port gpupgrade agent uses to listen for commands on")
 	subInit.Flags().BoolVar(&stopBeforeClusterCreation, "stop-before-cluster-creation", false, "only run up to pre-init")
 	subInit.Flags().MarkHidden("stop-before-cluster-creation") //nolint
-	subInit.Flags().Float64Var(&diskFreeRatio, "disk-free-ratio", 0.60, "percentage of disk space that must be available (from 0.0 - 1.0)")
-	subInit.Flags().BoolVarP(&verbose, "verbose", "v", false, "print the output stream from all substeps")
-	subInit.Flags().StringVar(&ports, "temp-port-range", "50432-65535", "set of ports to use when initializing the target cluster")
-	subInit.Flags().StringVar(&mode, "mode", "copy", "performs upgrade in either copy or link mode. Default is copy.")
-	subInit.Flags().BoolVar(&useHbaHostnames, "use-hba-hostnames", false, "use hostnames in pg_hba.conf")
-	subInit.Flags().StringVar(&dynamicLibraryPath, "dynamic-library-path", upgrade.DefaultDynamicLibraryPath, "sets the dynamic_library_path GUC to correctly find extensions installed outside their default location. Defaults to '$dynamic_library_path'.")
 	subInit.Flags().BoolVar(&skipVersionCheck, "skip-version-check", false, "disable source and target version check")
 	subInit.Flags().MarkHidden("skip-version-check") //nolint
 	return addHelpToCommand(subInit, InitializeHelp)

--- a/gpupgrade_config
+++ b/gpupgrade_config
@@ -17,32 +17,32 @@ target_gphome =
 # The copy method creates a copy of the primary segments and performs the
 # upgrade on the copies.
 # The link method directly upgrades the primary segments.
-mode = copy
+# mode = copy
 
 # The disk free ratio specifies what fraction of disk space must be free on
 # every host in order for gpupgrade to run. The ratio ranges from 0.0 to 1.0.
 # Recommended values are 0.6 [60%] for copy mode, and 0.2 [20%] for link mode.
-disk_free_ratio = 0.6
+# disk_free_ratio = 0.6
 
 # Whether to populate pg_hba.conf with hostnames or IP addresses during
 # execution of gpinitsystem and other utilities.
 # Choose "true" to use host names, or "false" to use IP addresses.
-use_hba_hostnames = false
+# use_hba_hostnames = false
 
 # For extensions installed outside of target_gphome include the extension’s
 # path in the dynamic_library_path value. For example, if pxf was installed in
 # /opt then set dynamic_library_path to "$libdir:/opt/greenplum/pxf-gp6".
-dynamic_library_path = $libdir
+# dynamic_library_path = $libdir
 
 # The temporary port range for the target Greenplum installation.
 # The temporary port range should be reserved prior to initializaton.
 # The format is a comma separated list of ports and port ranges, e.g.
 # “6000,6002-6005,6012.” The ports will be reconfigured to use the source
 # Greenplum installation port range once upgrade is complete.
-temp_port_range = 50432-65535
+# temp_port_range = 50432-65535
 
 # The port where the gpupgrade process will be running.
-hub_port = 7527
+# hub_port = 7527
 
 # The port where the agent process will be running on all hosts.
-agent_port = 6416
+# agent_port = 6416


### PR DESCRIPTION
Also re-order flag definitions in cli/commands/initialize.go to match the order in gpupgrade_config.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:commentDefaultConfigValues