### PR TITLE
CI: use rhel 8 instead of centos

### DIFF
--- a/ci/5_multi_host_gpupgrade_jobs.yml
+++ b/ci/5_multi_host_gpupgrade_jobs.yml
@@ -51,7 +51,7 @@
         image_resource:
           type: registry-image
           source:
-            repository: centos
+            repository: registry.access.redhat.com/ubi8/ubi
             tag: latest
         inputs:
           - name: gpupgrade_src

--- a/ci/6_upgrade_and_functional_jobs.yml
+++ b/ci/6_upgrade_and_functional_jobs.yml
@@ -86,7 +86,7 @@
         image_resource:
           type: registry-image
           source:
-            repository: centos
+            repository: registry.access.redhat.com/ubi8/ubi
             tag: latest
         inputs:
           - name: gpupgrade_src

--- a/ci/scripts/prepare-installation.bash
+++ b/ci/scripts/prepare-installation.bash
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 #
 # Copyright (c) 2017-2021 VMware, Inc. or its affiliates
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Red Hat has terminated CentOS development and centos 8 was EOL’d. Thus,
the following error was according when performing a yum install:
```
yum install --quiet -y openssh-clients
Error: Failed to download metadata for repo 'appstream': Cannot prepare
internal mirrorlist: No URLs in mirrorlist
```

Use the official rhel 8 image.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixPipeline