### PR TITLE
ci: use centos:7 instead of rhel8

### DIFF
--- a/ci/5_multi_host_gpupgrade_jobs.yml
+++ b/ci/5_multi_host_gpupgrade_jobs.yml
@@ -51,8 +51,8 @@
         image_resource:
           type: registry-image
           source:
-            repository: registry.access.redhat.com/ubi8/ubi
-            tag: latest
+            repository: centos
+            tag: 7
         inputs:
           - name: gpupgrade_src
           - name: cluster_env_files

--- a/ci/6_upgrade_and_functional_jobs.yml
+++ b/ci/6_upgrade_and_functional_jobs.yml
@@ -86,8 +86,8 @@
         image_resource:
           type: registry-image
           source:
-            repository: registry.access.redhat.com/ubi8/ubi
-            tag: latest
+            repository: centos
+            tag: 7
         inputs:
           - name: gpupgrade_src
           - name: cluster_env_files


### PR DESCRIPTION
Red Hat has terminated CentOS development and centos 8 was EOL’d. The
following timeout errors started occurring after moving to rhel8:
```
http://vault.centos.org/6.10/os/x86_64/repodata/1aa8754bde2f3921d67cca4bb70d9f587fb858a24cc3d1f66d3315292a89fc20-primary.sqlite.bz2: [Errno 12] Timeout on http://vault.centos.org/6.10/os/x86_64/repodata/1aa8754bde2f3921d67cca4bb70d9f587fb858a24cc3d1f66d3315292a89fc20-primary.sqlite.bz2: (28, 'connect() timed out!')
Trying other mirror.
http://vault.centos.org/6.10/os/x86_64/repodata/1aa8754bde2f3921d67cca4bb70d9f587fb858a24cc3d1f66d3315292a89fc20-primary.sqlite.bz2: [Errno 12] Timeout on http://vault.centos.org/6.10/os/x86_64/repodata/1aa8754bde2f3921d67cca4bb70d9f587fb858a24cc3d1f66d3315292a89fc20-primary.sqlite.bz2: (28, 'connect() timed out!')
Trying other mirror.
Error: failure: repodata/1aa8754bde2f3921d67cca4bb70d9f587fb858a24cc3d1f66d3315292a89fc20-primary.sqlite.bz2 from C6.10-base: [Errno 256] No more mirrors to try.
```

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixPipeline2