### PR TITLE
ci: update gptext resource name to match sytle

### DIFF
--- a/ci/1_resources_anchors_groups.yml
+++ b/ci/1_resources_anchors_groups.yml
@@ -193,7 +193,7 @@ resources:
 # NOTE: The same gptext artifact is used for both gpdb5 and gpdb6. Also, the same
 # rhel6 artifact is used for both centos6 and centos7, since the rhel7 artifact
 # does not support gpdb5.
-- name: greenplum-text-dev-rhel{{.CentosVersion}}
+- name: greenplum_text_rhel{{.CentosVersion}}
   type: s3
   source:
     access_key_id: ((gptext_s3_access_key_id))

--- a/ci/6_upgrade_and_functional_jobs.yml
+++ b/ci/6_upgrade_and_functional_jobs.yml
@@ -39,7 +39,7 @@
         {{- end }}
         {{- if .ExtensionsJob }}
         - get: gptext_targz # NOTE: The same gptext artifact is used for both the source and target clusters.
-          resource: greenplum-text-dev-rhel{{.CentosVersion}}
+          resource: greenplum_text_rhel{{.CentosVersion}}
         - get: postgis_gppkg_source
           resource: postgis_2.1.5_gpdb{{.Source}}_centos{{.CentosVersion}}_gppkg
         - get: postgis_gppkg_target


### PR DESCRIPTION
Use underscores in resource names.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:gptextResourceName