### PR TITLE
finalize.bats: pass required mode after refactor

### DIFF
--- a/test/acceptance/gpupgrade/finalize.bats
+++ b/test/acceptance/gpupgrade/finalize.bats
@@ -130,7 +130,7 @@ upgrade_cluster() {
 # NOTE: To reduce overall test time we test --use-hba-hostnames in link mode, and without in copy mode.
 
 @test "in copy mode gpupgrade finalize should swap the target data directories and ports with the source cluster" {
-    upgrade_cluster
+    upgrade_cluster "copy"
 }
 
 @test "in link mode gpupgrade finalize should also delete mirror directories and honors --use-hba-hostnames" {


### PR DESCRIPTION
There was a recent refactor to the mode which is now required to be explicit. Specifying copy mode was accidentally forgotten.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixFinalizeBats