### PR TITLE
Split generator and executor temp schemas

### DIFF
--- a/data-migration-scripts/create_find_view_dep_function.sql
+++ b/data-migration-scripts/create_find_view_dep_function.sql
@@ -9,10 +9,7 @@
 
 SET client_min_messages TO WARNING;
 
-DROP SCHEMA IF EXISTS __gpupgrade_tmp CASCADE;
-CREATE SCHEMA __gpupgrade_tmp;
-
-CREATE OR REPLACE FUNCTION  __gpupgrade_tmp.find_view_dependencies()
+CREATE OR REPLACE FUNCTION  __gpupgrade_tmp_generator.find_view_dependencies()
 RETURNS VOID AS
 $$
 import plpy
@@ -116,13 +113,13 @@ while True:
     else:
         checklist.update(new_checklist)
 
-plpy.execute("DROP TABLE IF EXISTS  __gpupgrade_tmp.__temp_views_list")
-plpy.execute("CREATE TABLE  __gpupgrade_tmp.__temp_views_list (full_view_name TEXT, view_order INTEGER)")
+plpy.execute("DROP TABLE IF EXISTS  __gpupgrade_tmp_generator.__temp_views_list")
+plpy.execute("CREATE TABLE  __gpupgrade_tmp_generator.__temp_views_list (full_view_name TEXT, view_order INTEGER)")
 for v, view_order in checklist.items():
-    sql = "INSERT INTO  __gpupgrade_tmp.__temp_views_list VALUES('{0}.{1}', {2})".format(v[0],v[1],view_order)
+    sql = "INSERT INTO  __gpupgrade_tmp_generator.__temp_views_list VALUES('{0}.{1}', {2})".format(v[0],v[1],view_order)
     plpy.execute(sql)
 $$ LANGUAGE plpythonu;
 
-SELECT  __gpupgrade_tmp.find_view_dependencies();
+SELECT __gpupgrade_tmp_generator.find_view_dependencies();
 
-DROP FUNCTION  __gpupgrade_tmp.find_view_dependencies();
+DROP FUNCTION __gpupgrade_tmp_generator.find_view_dependencies();

--- a/data-migration-scripts/post-finalize/recreate_views_on_deprecated_built_in_types.sql
+++ b/data-migration-scripts/post-finalize/recreate_views_on_deprecated_built_in_types.sql
@@ -3,4 +3,4 @@
 
 SELECT $$CREATE VIEW $$|| full_view_name || $$ AS $$ ||
     pg_catalog.pg_get_viewdef(full_view_name::regclass::oid, false) || $$;$$
-FROM __gpupgrade_tmp.__temp_views_list ORDER BY view_order;
+FROM __gpupgrade_tmp_generator.__temp_views_list ORDER BY view_order;

--- a/data-migration-scripts/post-finalize/remove_gpupgrade_tmp_schema.sql
+++ b/data-migration-scripts/post-finalize/remove_gpupgrade_tmp_schema.sql
@@ -1,4 +1,0 @@
--- Copyright (c) 2017-2021 VMware, Inc. or its affiliates
--- SPDX-License-Identifier: Apache-2.0
-
-SELECT 'DROP SCHEMA IF EXISTS __gpupgrade_tmp CASCADE;';

--- a/data-migration-scripts/post-revert/recreate_views_on_deprecated_built_in_types.sql
+++ b/data-migration-scripts/post-revert/recreate_views_on_deprecated_built_in_types.sql
@@ -3,4 +3,4 @@
 
 SELECT $$CREATE VIEW $$|| full_view_name || $$ AS $$ ||
     pg_catalog.pg_get_viewdef(full_view_name::regclass::oid, false) || $$;$$
-FROM __gpupgrade_tmp.__temp_views_list ORDER BY view_order;
+FROM __gpupgrade_tmp_generator.__temp_views_list ORDER BY view_order;

--- a/data-migration-scripts/post-revert/remove_gpupgrade_tmp_schema.sql
+++ b/data-migration-scripts/post-revert/remove_gpupgrade_tmp_schema.sql
@@ -1,4 +1,0 @@
--- Copyright (c) 2017-2021 VMware, Inc. or its affiliates
--- SPDX-License-Identifier: Apache-2.0
-
-SELECT 'DROP SCHEMA IF EXISTS __gpupgrade_tmp CASCADE;';

--- a/data-migration-scripts/pre-initialize/gen_drop_depr_built_in_type_dependent_views.sql
+++ b/data-migration-scripts/pre-initialize/gen_drop_depr_built_in_type_dependent_views.sql
@@ -2,4 +2,4 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 SELECT 'DROP VIEW '|| full_view_name || ';'
-FROM  __gpupgrade_tmp.__temp_views_list ORDER BY view_order DESC;
+FROM  __gpupgrade_tmp_generator.__temp_views_list ORDER BY view_order DESC;


### PR DESCRIPTION
Using the same temporary schema name for both generating the data
migration scripts and executing them creates potential errors during
create/drop steps. This commit uses two different schemas to avoid such
potential issues.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:add-schema-msg