### PR TITLE
lint: fix strings.Title deprecated lint errors

### DIFF
--- a/cli/commanders/step.go
+++ b/cli/commanders/step.go
@@ -7,6 +7,8 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"os"
 	"strings"
 
@@ -74,7 +76,7 @@ func NewStep(currentStep idl.Step, streams *step.BufferedStreams, verbose bool, 
 		return &Step{}, err
 	}
 
-	stepName := strings.Title(strings.ToLower(currentStep.String()))
+	stepName := cases.Title(language.English).String(strings.ToLower(currentStep.String()))
 
 	fmt.Println()
 	fmt.Println(stepName + " in progress.")

--- a/step/step.go
+++ b/step/step.go
@@ -6,6 +6,8 @@ package step
 import (
 	"errors"
 	"fmt"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"os"
 	"path/filepath"
 	"strings"
@@ -69,7 +71,7 @@ func Begin(step idl.Step, sender idl.MessageSender, agentConns func() ([]*idl.Co
 		return nil, xerrors.Errorf(`step "%s": %w`, step, err)
 	}
 
-	_, err = fmt.Fprintf(log, "\n%s in progress.\n", strings.Title(step.String()))
+	_, err = fmt.Fprintf(log, "\n%s in progress.\n", cases.Title(language.English).String(step.String()))
 	if err != nil {
 		log.Close()
 		return nil, xerrors.Errorf(`logging step "%s": %w`, step, err)


### PR DESCRIPTION
This fixes the following error from the recent version of golangci-lint
v1.45.2: SA1019:
```
strings.Title is deprecated: The rule Title uses for
word boundaries does not handle Unicode punctuation properly. Use
golang.org/x/text/cases instead.
```

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixLinkIssues