### PR TITLE
fix flakey unit tests

### DIFF
--- a/cli/commands/version_test.go
+++ b/cli/commands/version_test.go
@@ -11,6 +11,10 @@ import (
 
 func TestVersion(t *testing.T) {
 	t.Run("returns empty values when version fields are not set", func(t *testing.T) {
+		commands.Version = ""
+		commands.Commit = ""
+		commands.Release = ""
+
 		actual := commands.VersionString("")
 		expected := `Version: 
 Commit: 

--- a/testutils/test_utils.go
+++ b/testutils/test_utils.go
@@ -329,39 +329,6 @@ func MustMakeTablespaceDir(t *testing.T, tablespaceOid int) (string, string, str
 	return tablespace, dbID, location
 }
 
-// MustMake5XTablespaceDir returns the parent tablespace location and dbOID
-// directory containing PG_VERSION and a relfile. The location should be removed
-// for cleanup. An optional tablespaceOid may be specified to construct unique
-// tablespace directories.
-func MustMake5XTablespaceDir(t *testing.T, tablespaceOID int) (string, string) {
-	t.Helper()
-
-	// ex: /filespace/demoDataDir0
-	filespace := os.TempDir()
-
-	// ex: /filespace/demoDataDir0/16386
-	if tablespaceOID == 0 {
-		tablespaceOID = 16386
-	}
-	location := filepath.Join(filespace, strconv.Itoa(tablespaceOID))
-	err := os.MkdirAll(location, 0700)
-	if err != nil {
-		t.Fatalf("creating 5x tablespace location directory: %v", err)
-	}
-
-	// ex: /filespace/demoDataDir0/16386/12094
-	dbOID := filepath.Join(location, "12094")
-	err = os.MkdirAll(dbOID, 0700)
-	if err != nil {
-		t.Fatalf("creating 5x tablespace dbOID directory: %v", err)
-	}
-
-	MustWriteToFile(t, filepath.Join(dbOID, upgrade.PGVersion), "")
-	MustWriteToFile(t, filepath.Join(dbOID, "16384"), "")
-
-	return dbOID, location
-}
-
 func MustGetExecutablePath(t *testing.T) string {
 	t.Helper()
 

--- a/testutils/test_utils.go
+++ b/testutils/test_utils.go
@@ -314,32 +314,18 @@ func MustMakeTablespaceDir(t *testing.T, tablespaceOid int) (string, string, str
 	t.Helper()
 
 	// ex: /filespace/demoDataDir0
-	filespace := os.TempDir()
+	filespace := GetTempDir(t, "")
 
-	// ex: /filespace/demoDataDir0/16386
 	if tablespaceOid == 0 {
 		tablespaceOid = 16386
 	}
-	location := filepath.Join(filespace, strconv.Itoa(tablespaceOid))
-	err := os.MkdirAll(location, 0700)
-	if err != nil {
-		t.Fatalf("creating tablespace location directory: %v", err)
-	}
 
-	// ex: /filespace/demoDataDir0/16386/1
-	dbID := filepath.Join(location, "1")
-	err = os.MkdirAll(dbID, 0700)
-	if err != nil {
-		t.Fatalf("creating tablespace dbID directory: %v", err)
-	}
+	// ex /filespace/demoDataDir0/16386/1/GPDB_6_301908232
+	tablespace := filepath.Join(filespace, strconv.Itoa(tablespaceOid), "1", "GPDB_6_301908232")
+	MustCreateDir(t, tablespace)
 
-	// ex: /filespace/demoDataDir0/16386/1/GPDB_6_301908232
-	tablespace := filepath.Join(dbID, "GPDB_6_301908232")
-	err = os.MkdirAll(tablespace, 0700)
-	if err != nil {
-		t.Fatalf("creating tablespace directory: %v", err)
-	}
-
+	dbID := filepath.Dir(tablespace) // ex: /filespace/demoDataDir0/16386/1
+	location := filepath.Dir(dbID)   // ex: /filespace/demoDataDir0/16386
 	return tablespace, dbID, location
 }
 

--- a/upgrade/directories.go
+++ b/upgrade/directories.go
@@ -6,6 +6,7 @@ package upgrade
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -169,6 +170,19 @@ func AlreadyRenamed(src, dst string) (bool, error) {
 	}
 
 	return !srcExist && dstExist, nil
+}
+
+func PathExistInFS(fsys fs.FS, path string) (bool, error) {
+	_, err := utils.System.StatFS(fsys, path)
+	if err == nil {
+		return true, nil
+	}
+
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	return false, err
 }
 
 func PathExist(path string) (bool, error) {

--- a/upgrade/tablespace_directories.go
+++ b/upgrade/tablespace_directories.go
@@ -62,7 +62,7 @@ func TablespacePath(tablespaceLocation string, dbID int, majorVersion uint64, ca
 //  GPDB 6X:  /dir/<fsname>/<datadir>/<tablespaceOID>/<dbID>/GPDB_6_<catalogVersion>/<dbOID>/<relfilenode>
 func DeleteTablespaceDirectories(streams step.OutStreams, dirs []string) error {
 	for _, dir := range dirs {
-		exist, err := VerifyTablespaceDirectory(filepath.Dir(dir))
+		validTSDir, err := VerifyTablespaceDirectory(filepath.Dir(dir))
 		if err != nil && errors.Is(err, os.ErrNotExist) {
 			continue
 		}
@@ -71,8 +71,8 @@ func DeleteTablespaceDirectories(streams step.OutStreams, dirs []string) error {
 			return err
 		}
 
-		if !exist {
-			return xerrors.Errorf("wat")
+		if !validTSDir {
+			return xerrors.Errorf("Invalid tablespace directory %q", dir)
 		}
 	}
 

--- a/utils/sys_utils.go
+++ b/utils/sys_utils.go
@@ -5,6 +5,7 @@ package utils
 
 import (
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"net"
 	"os"
@@ -54,6 +55,9 @@ type SystemFunctions struct {
 	Mkdir        func(name string, perm os.FileMode) error
 	Symlink      func(oldname, newname string) error
 	Lstat        func(name string) (os.FileInfo, error)
+	ReadDir      func(fsys fs.FS, name string) ([]fs.DirEntry, error)
+	StatFS       func(fsys fs.FS, name string) (fs.FileInfo, error)
+	DirFS        func(dir string) fs.FS
 }
 
 func InitializeSystemFunctions() *SystemFunctions {
@@ -79,6 +83,9 @@ func InitializeSystemFunctions() *SystemFunctions {
 		Mkdir:        os.Mkdir,
 		Symlink:      os.Symlink,
 		Lstat:        os.Lstat,
+		ReadDir:      fs.ReadDir,
+		StatFS:       fs.Stat,
+		DirFS:        os.DirFS,
 	}
 }
 


### PR DESCRIPTION
See individual commits.

The main commit is to use testfs.mapFS for tablespace unit testing.  This required refactoring upgrade.VerifyTablespaceLocation() and various tablespace helper functions to use fs.FS filesystem which enables use of testfs.mapFS a simple in-memory file system implementation for testing.
This greatly reduces unit test flakes and moves towards golang's idiomatic way of testing read-only file system operations.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixFlakeyUntTests