### PR TITLE
CI: unset LD_LIBRARY_PATH

### DIFF
--- a/test/acceptance/gpupgrade/execute.bats
+++ b/test/acceptance/gpupgrade/execute.bats
@@ -183,7 +183,7 @@ ensure_hardlinks_for_relfilenode_on_master_and_segments() {
     restore_cluster
 
     # Put the source and target clusters back the way they were.
-    (source "$GPHOME_TARGET"/greenplum_path.sh && gpstop -a -d "$NEW_CLUSTER")
+    (unset LD_LIBRARY_PATH; source "$GPHOME_TARGET"/greenplum_path.sh && gpstop -a -d "$NEW_CLUSTER")
     start_source_cluster
 
     # Mark every substep in the status file as failed. Then re-execute.

--- a/test/acceptance/gpupgrade/finalize.bats
+++ b/test/acceptance/gpupgrade/finalize.bats
@@ -76,7 +76,7 @@ upgrade_cluster() {
 
         gpupgrade finalize --non-interactive --verbose
 
-        (source "${GPHOME_TARGET}"/greenplum_path.sh && "${GPHOME_TARGET}"/bin/gpstart -a)
+        (unset LD_LIBRARY_PATH; source "${GPHOME_TARGET}"/greenplum_path.sh && "${GPHOME_TARGET}"/bin/gpstart -a)
 
         if is_GPDB5 "$GPHOME_SOURCE"; then
             check_tablespace_data
@@ -120,7 +120,7 @@ upgrade_cluster() {
         # TODO: Query gp_stat_replication to check if the standby is in sync.
         #   That is a more accurate representation if the standby is running and
         #   in sync, since gpstate might simply check if the process is running.
-        local actual_standby_status=$(source "${GPHOME_TARGET}/greenplum_path.sh" && gpstate -d "${MASTER_DATA_DIRECTORY}")
+        local actual_standby_status=$(unset LD_LIBRARY_PATH; source "${GPHOME_TARGET}/greenplum_path.sh" && gpstate -d "${MASTER_DATA_DIRECTORY}")
         local standby_status_line=$(get_standby_status "$actual_standby_status")
         [[ $standby_status_line == *"Standby host passive"* ]] || fail "expected standby to be up and in passive mode, got **** ${actual_standby_status} ****"
 

--- a/test/acceptance/gpupgrade/gpinitsystem.bats
+++ b/test/acceptance/gpupgrade/gpinitsystem.bats
@@ -61,7 +61,7 @@ teardown() {
     # Sanity check the newly created master's location.
     [ "$newmasterdir" = $(expected_target_datadir "$masterdir") ]
 
-    (PGPORT=$newport source "$GPHOME_TARGET"/greenplum_path.sh && gpstart -a -d "$newmasterdir")
+    (unset LD_LIBRARY_PATH; PGPORT=$newport source "$GPHOME_TARGET"/greenplum_path.sh && gpstart -a -d "$newmasterdir")
 
     # Store the data directories for the new cluster.
     run get_segment_configuration "$GPHOME_TARGET" "$newport"
@@ -115,7 +115,7 @@ teardown() {
     local newmasterdir="$(gpupgrade config show --target-datadir)"
     NEW_CLUSTER="${newmasterdir}"
 
-    (PGPORT=$newport source "$GPHOME_TARGET"/greenplum_path.sh && gpstart -a -d "$newmasterdir")
+    (unset LD_LIBRARY_PATH; PGPORT=$newport source "$GPHOME_TARGET"/greenplum_path.sh && gpstart -a -d "$newmasterdir")
 
     # save the actual ports
     local actual_ports=$($PSQL -At -p $newport postgres -c "

--- a/test/acceptance/gpupgrade/initialize.bats
+++ b/test/acceptance/gpupgrade/initialize.bats
@@ -317,7 +317,7 @@ wait_for_port_change() {
     # To simulate an init cluster failure, stop a segment and remove a datadir
     local newmasterdir
     newmasterdir="$(gpupgrade config show --target-datadir)"
-    (PGPORT=$TARGET_PGPORT source "$GPHOME_TARGET"/greenplum_path.sh && gpstart -a -d "$newmasterdir")
+    (unset LD_LIBRARY_PATH; PGPORT=$TARGET_PGPORT source "$GPHOME_TARGET"/greenplum_path.sh && gpstart -a -d "$newmasterdir")
 
     local datadir=$(query_datadirs "$GPHOME_TARGET" $TARGET_PGPORT "content=1")
     pg_ctl -D "$datadir" stop

--- a/test/acceptance/gpupgrade/migration_scripts.bats
+++ b/test/acceptance/gpupgrade/migration_scripts.bats
@@ -84,7 +84,7 @@ teardown() {
     gpupgrade execute --non-interactive --verbose
     gpupgrade finalize --non-interactive --verbose
 
-    (source "${GPHOME_TARGET}"/greenplum_path.sh && "${GPHOME_TARGET}"/bin/gpstart -a)
+    (unset LD_LIBRARY_PATH; source "${GPHOME_TARGET}"/greenplum_path.sh && "${GPHOME_TARGET}"/bin/gpstart -a)
 
     "$SCRIPTS_DIR"/gpupgrade-migration-sql-executor.bash "$GPHOME_TARGET" "$PGPORT" "$MIGRATION_DIR"/post-finalize
 

--- a/test/acceptance/helpers/helpers.bash
+++ b/test/acceptance/helpers/helpers.bash
@@ -56,7 +56,7 @@ isready() {
 
 # start_source_cluster() ensures that database is up before returning
 start_source_cluster() {
-    isready || (source "$GPHOME_SOURCE"/greenplum_path.sh && "${GPHOME_SOURCE}"/bin/gpstart -a)
+    isready || (unset LD_LIBRARY_PATH; source "$GPHOME_SOURCE"/greenplum_path.sh && "${GPHOME_SOURCE}"/bin/gpstart -a)
 }
 
 # stop_any_cluster will attempt to stop the cluster defined by MASTER_DATA_DIRECTORY.
@@ -65,7 +65,7 @@ stop_any_cluster() {
     gphome=$(awk '{ split($0, parts, "/bin/postgres"); print parts[1] }' "$MASTER_DATA_DIRECTORY"/postmaster.opts) \
         || return $?
 
-    (source "$gphome"/greenplum_path.sh && gpstop -af) || return $?
+    (unset LD_LIBRARY_PATH; source "$gphome"/greenplum_path.sh && gpstop -af) || return $?
 }
 
 # Sanity check that the passed directory looks like a valid master data
@@ -109,7 +109,7 @@ __gpdeletesystem() {
 
     # XXX gpdeletesystem returns 1 if there are warnings. There are always
     # warnings. So we ignore the exit code...
-    (source $gphome/greenplum_path.sh && yes | PGPORT="$port" "$gpdeletesystem" -fd "$masterdir") || true
+    (unset LD_LIBRARY_PATH; source $gphome/greenplum_path.sh && yes | PGPORT="$port" "$gpdeletesystem" -fd "$masterdir") || true
 }
 
 delete_target_datadirs() {

--- a/test/acceptance/helpers/tablespace_helpers.bash
+++ b/test/acceptance/helpers/tablespace_helpers.bash
@@ -49,7 +49,7 @@ create_tablespace_with_tables() {
     echo "tablespace configuration:"
     cat "$TABLESPACE_CONFIG"
 
-    (source "${GPHOME_SOURCE}"/greenplum_path.sh && gpfilespace --config "${TABLESPACE_CONFIG}")
+    (unset LD_LIBRARY_PATH; source "${GPHOME_SOURCE}"/greenplum_path.sh && gpfilespace --config "${TABLESPACE_CONFIG}")
 
     # create a tablespace in said filespace and some databases in that tablespace
     "${GPHOME_SOURCE}"/bin/psql -d postgres -v ON_ERROR_STOP=1 <<- EOF


### PR DESCRIPTION
During teardown our BATS test call gpdeletesystem which stops the postgres processes. This was failing with:

> Error: unable to import module: /usr/local/greenplum-db-6.20.2+dev.3.g24b949d/lib/libpq.so.5: symbol gss_acquire_cred_from, version gssapi_krb5_2_MIT not defined in file libgssapi_krb5.so.2 with link time reference

This is most likely because the LD_LIBRARY_PATH is already set in the parent environment and when sourcing the target greenplum_path.sh this also sets the LD_LIBRARY_PATH causing it to be polluted with both the source and target cluster values. Thus, ensure LD_LIBRARY_PATH is unset before sourcing the target greenplum_path.sh.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixCI_5-to-6-cluster-tests