### PR TITLE
CI: pull only pxf6

### DIFF
--- a/ci/1_resources_anchors_groups.yml
+++ b/ci/1_resources_anchors_groups.yml
@@ -211,7 +211,7 @@ resources:
   source:
     json_key: ((pxf-storage-service-account-key))
     bucket: data-gpdb-ud-pxf-build
-    versioned_file: prod/snapshots/pxf-gp{{.GPVersion}}.el{{.CentosVersion}}.tar.gz
+    versioned_file: prod/snapshots/pxf6/pxf-gp{{.GPVersion}}.el{{.CentosVersion}}.tar.gz
 {{- end }}
 
 - name: plr_gpdb{{.GPVersion}}_rhel{{.CentosVersion}}_gppkg


### PR DESCRIPTION
Previously, the pxf pipelines were pushing both pxf5 and pxf6 snapshot builds to the same bucket with the same name. This did not allow downstream consumers such as gpupgrade the ability to differentiate between pxf versions. In PR https://github.com/greenplum-db/pxf/pull/801 pxf 6 snapshot builds are pushed to a different bucket allowing gpupgrade to pull only pxf 6 builds.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:pullSpecificPxfVersion/jobs/5-to-6-extensions-centos-7

**_Note:_** After merging un-pin the pxf resources in our prod CI.