### PR TITLE
ci: create data migration scripts in /home/gpadmin/gpupgrade

### DIFF
--- a/ci/scripts/cluster-tests.bash
+++ b/ci/scripts/cluster-tests.bash
@@ -22,8 +22,8 @@ function run_migration_scripts_and_tests() {
         export GOFLAGS="-mod=readonly" # do not update dependencies during build
 
         cd gpupgrade_src
-        data-migration-scripts/gpupgrade-migration-sql-generator.bash "$GPHOME_SOURCE" "$PGPORT" /tmp/migration data-migration-scripts
-        data-migration-scripts/gpupgrade-migration-sql-executor.bash "$GPHOME_SOURCE" "$PGPORT" /tmp/migration/pre-initialize || true
+        data-migration-scripts/gpupgrade-migration-sql-generator.bash "$GPHOME_SOURCE" "$PGPORT" /home/gpadmin/gpupgrade ./data-migration-scripts
+        data-migration-scripts/gpupgrade-migration-sql-executor.bash "$GPHOME_SOURCE" "$PGPORT" /home/gpadmin/gpupgrade/pre-initialize || true
 
         make
         make check --keep-going

--- a/ci/scripts/load-dump.bash
+++ b/ci/scripts/load-dump.bash
@@ -36,8 +36,8 @@ time ssh -n mdw "
         DROP INDEX onek2_u2_prtl CASCADE;
 SQL_EOF
 
-    gpupgrade-migration-sql-generator.bash $GPHOME_SOURCE $PGPORT /tmp/migration
-    gpupgrade-migration-sql-executor.bash $GPHOME_SOURCE $PGPORT /tmp/migration/pre-initialize || true
+    gpupgrade-migration-sql-generator.bash $GPHOME_SOURCE $PGPORT /home/gpadmin/gpupgrade
+    gpupgrade-migration-sql-executor.bash $GPHOME_SOURCE $PGPORT /home/gpadmin/gpupgrade/pre-initialize || true
 "
 
 echo "Dropping views referencing deprecated objects..."

--- a/ci/scripts/load-extensions.bash
+++ b/ci/scripts/load-extensions.bash
@@ -280,6 +280,6 @@ ssh -n mdw "
 
     source /usr/local/greenplum-db-source/greenplum_path.sh
 
-    gpupgrade-migration-sql-generator.bash $GPHOME_SOURCE $PGPORT /tmp/migration
-    gpupgrade-migration-sql-executor.bash $GPHOME_SOURCE $PGPORT /tmp/migration/pre-initialize || true
+    gpupgrade-migration-sql-generator.bash $GPHOME_SOURCE $PGPORT /home/gpadmin/gpupgrade
+    gpupgrade-migration-sql-executor.bash $GPHOME_SOURCE $PGPORT /home/gpadmin/gpupgrade/pre-initialize || true
 "

--- a/ci/scripts/load-retail-data.bash
+++ b/ci/scripts/load-retail-data.bash
@@ -120,8 +120,8 @@ ssh mdw "
     source ${GPHOME_SOURCE}/greenplum_path.sh
     export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1
 
-    gpupgrade-migration-sql-generator.bash "$GPHOME_SOURCE" "$PGPORT" /tmp/migration
-    gpupgrade-migration-sql-executor.bash "$GPHOME_SOURCE" "$PGPORT" /tmp/migration/pre-initialize || true
+    gpupgrade-migration-sql-generator.bash "$GPHOME_SOURCE" "$PGPORT" /home/gpadmin/gpupgrade
+    gpupgrade-migration-sql-executor.bash "$GPHOME_SOURCE" "$PGPORT" /home/gpadmin/gpupgrade/pre-initialize || true
 
     # match root/child partition schemas
     psql -d gpdb_demo <<SQL_EOF

--- a/ci/scripts/multihost-gpupgrade-tests.bash
+++ b/ci/scripts/multihost-gpupgrade-tests.bash
@@ -15,8 +15,8 @@ function run_migration_scripts_and_tests() {
         export PGPORT=5432
 
         echo "Running data migration scripts to ensure a clean cluster..."
-        gpupgrade-migration-sql-generator.bash "$GPHOME_SOURCE" "$PGPORT" /tmp/migration gpupgrade_src/data-migration-scripts
-        gpupgrade-migration-sql-executor.bash "$GPHOME_SOURCE" "$PGPORT" /tmp/migration/pre-initialize || true
+        gpupgrade-migration-sql-generator.bash "$GPHOME_SOURCE" "$PGPORT" /home/gpadmin/gpupgrade gpupgrade_src/data-migration-scripts
+        gpupgrade-migration-sql-executor.bash "$GPHOME_SOURCE" "$PGPORT" /home/gpadmin/gpupgrade/pre-initialize || true
 
         ./gpupgrade_src/test/acceptance/gpupgrade/revert.bats
   '


### PR DESCRIPTION
Test more closely what we public document to customers which is to create the data migration scripts in ~/gpupgrade.

https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:ciMigrationScripts