### PR TITLE
Add child partition ownership tests for pg_upgrade.

### DIFF
--- a/test/acceptance/pg_upgrade/upgradeable_tests/source_cluster_regress/expected/partitioned_heap_table.out
+++ b/test/acceptance/pg_upgrade/upgradeable_tests/source_cluster_regress/expected/partitioned_heap_table.out
@@ -133,3 +133,14 @@ ALTER TABLE dropped_and_added_column ADD COLUMN e int;
 ALTER
 INSERT INTO dropped_and_added_column SELECT i, i, i, i FROM generate_series(10, 20) i;
 INSERT 11
+
+---
+--- partitioned table with alter owner
+---
+
+CREATE ROLE testrole;
+CREATE
+CREATE TABLE p_alter_owner (id INTEGER, name TEXT) DISTRIBUTED BY (id) PARTITION BY RANGE(id) (START(1) END(3) EVERY(1));
+CREATE
+ALTER TABLE p_alter_owner OWNER TO testrole;
+ALTER

--- a/test/acceptance/pg_upgrade/upgradeable_tests/source_cluster_regress/sql/partitioned_heap_table.sql
+++ b/test/acceptance/pg_upgrade/upgradeable_tests/source_cluster_regress/sql/partitioned_heap_table.sql
@@ -101,3 +101,11 @@ INSERT INTO dropped_and_added_column SELECT i, i, i, i FROM generate_series(1, 1
 ALTER TABLE dropped_and_added_column DROP COLUMN b;
 ALTER TABLE dropped_and_added_column ADD COLUMN e int;
 INSERT INTO dropped_and_added_column SELECT i, i, i, i FROM generate_series(10, 20) i;
+
+---
+--- partitioned table with alter owner
+---
+
+CREATE ROLE testrole;
+CREATE TABLE p_alter_owner (id INTEGER, name TEXT) DISTRIBUTED BY (id) PARTITION BY RANGE(id) (START(1) END(3) EVERY(1));
+ALTER TABLE p_alter_owner OWNER TO testrole;

--- a/test/acceptance/pg_upgrade/upgradeable_tests/target_cluster_regress/expected/partitioned_heap_table.out
+++ b/test/acceptance/pg_upgrade/upgradeable_tests/target_cluster_regress/expected/partitioned_heap_table.out
@@ -76,3 +76,11 @@ SELECT c, d FROM dropped_and_added_column WHERE a=10;
  10 | 10 
  10 | 10 
 (2 rows)
+
+SELECT c.relname, pg_catalog.pg_get_userbyid(c.relowner) as owner FROM pg_class c WHERE relname like 'p_alter_owner%';
+ relname               | owner    
+-----------------------+----------
+ p_alter_owner         | testrole 
+ p_alter_owner_1_prt_1 | testrole 
+ p_alter_owner_1_prt_2 | testrole 
+(3 rows)

--- a/test/acceptance/pg_upgrade/upgradeable_tests/target_cluster_regress/sql/partitioned_heap_table.sql
+++ b/test/acceptance/pg_upgrade/upgradeable_tests/target_cluster_regress/sql/partitioned_heap_table.sql
@@ -22,3 +22,7 @@ SELECT b, c FROM dropped_column WHERE a=10;
 SELECT b, c FROM root_has_dropped_column WHERE a=10;
 
 SELECT c, d FROM dropped_and_added_column WHERE a=10;
+
+SELECT c.relname, pg_catalog.pg_get_userbyid(c.relowner) as owner
+FROM pg_class c
+WHERE relname like 'p_alter_owner%';


### PR DESCRIPTION
https://github.com/greenplum-db/gpdb/pull/13622 resolves an issue where `ALTER TABLE ... OWNER TO` 
on a partition parent table was not propagating to child partitions during pg_upgrade. 

This PR adds tests to exercise the fix.