### PR TITLE
Update initialize help text

### DIFF
--- a/cli/commands/confirmation_text.go
+++ b/cli/commands/confirmation_text.go
@@ -5,7 +5,6 @@ package commands
 
 const initializeConfirmationText = `
 You are about to initialize a major-version upgrade of Greenplum.
-This should be done only during a downtime window.
 
 gpupgrade initialize will perform a series of steps, including:
  - Check disk space

--- a/cli/commands/help_text.go
+++ b/cli/commands/help_text.go
@@ -83,7 +83,6 @@ func init() {
 
 const initializeHelp = `
 Runs pre-upgrade checks and prepares the cluster for upgrade.
-This command should be run only during a downtime window.
 
 Initialize will carry out the following steps:
 %s


### PR DESCRIPTION
Based on the [docs comment](https://github.com/pivotal/gp-docs-gpupgrade/pull/72#issuecomment-1148972274) update initialize help text.

We now would like customers to run initialize early on in the upgrade process to detect and fix any issues ahead of the upgrade window. Technically no downtime is needed, but is probably safe to run during a maintenance window. It depends on customers specific environment, and risk tolerance.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:initializeHelpText