### PR TITLE
Preserve view owners after post-finalize and post-revert

### DIFF
--- a/data-migration-scripts/create_find_view_dep_function.sql
+++ b/data-migration-scripts/create_find_view_dep_function.sql
@@ -14,37 +14,40 @@ RETURNS VOID AS
 $$
 import plpy
 
+
 # First find views that do not depend on other views (and directly on the table)
 
 leaf_view = plpy.execute("""
-SELECT schema, view
+SELECT
+    schema,
+    view
 FROM (
-SELECT DISTINCT nv.nspname AS schema, v.relname AS view
-FROM pg_depend d
-    JOIN pg_rewrite r ON r.oid = d.objid
-    JOIN pg_class v ON v.oid = r.ev_class
-    JOIN pg_catalog.pg_namespace nv ON v.relnamespace = nv.oid
-    JOIN pg_catalog.pg_attribute a ON (d.refobjid = a.attrelid AND d.refobjsubid = a.attnum)
-    JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
-    JOIN pg_catalog.pg_namespace nc ON c.relnamespace = nc.oid
-
-WHERE
-    v.relkind = 'v'
-    AND d.classid = 'pg_rewrite'::regclass
-    AND d.refclassid = 'pg_class'::regclass
-    AND d.deptype = 'n'
-    AND (a.atttypid = 'pg_catalog.tsquery'::pg_catalog.regtype OR a.atttypid = 'pg_catalog.name'::pg_catalog.regtype)
-    AND c.relkind = 'r'
-    AND NOT a.attisdropped
-    AND nv.nspname NOT LIKE 'pg_temp_%'
-    AND nv.nspname NOT LIKE 'pg_toast_temp_%'
-    AND nv.nspname NOT IN ('pg_catalog',
-    'information_schema')
-    AND nc.nspname NOT LIKE 'pg_temp_%'
-    AND nc.nspname NOT LIKE 'pg_toast_temp_%'
-    AND nc.nspname NOT IN ('pg_catalog',
-                        'information_schema')
-) subq;
+    SELECT DISTINCT
+        nv.nspname AS schema,
+        v.relname AS view
+    FROM
+        pg_depend d
+        JOIN pg_rewrite r ON r.oid = d.objid
+        JOIN pg_class v ON v.oid = r.ev_class
+        JOIN pg_catalog.pg_namespace nv ON v.relnamespace = nv.oid
+        JOIN pg_catalog.pg_attribute a ON (d.refobjid = a.attrelid AND d.refobjsubid = a.attnum)
+        JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
+        JOIN pg_catalog.pg_namespace nc ON c.relnamespace = nc.oid
+    WHERE
+        v.relkind = 'v'
+        AND d.classid = 'pg_rewrite'::regclass
+        AND d.refclassid = 'pg_class'::regclass
+        AND d.deptype = 'n'
+        AND (a.atttypid = 'pg_catalog.tsquery'::pg_catalog.regtype OR a.atttypid = 'pg_catalog.name'::pg_catalog.regtype)
+        AND c.relkind = 'r'
+        AND NOT a.attisdropped
+        AND nv.nspname NOT LIKE 'pg_temp_%'
+        AND nv.nspname NOT LIKE 'pg_toast_temp_%'
+        AND nv.nspname NOT IN ('pg_catalog', 'information_schema')
+        AND nc.nspname NOT LIKE 'pg_temp_%'
+        AND nc.nspname NOT LIKE 'pg_toast_temp_%'
+        AND nc.nspname NOT IN ('pg_catalog', 'information_schema')
+    ) subq;
 """)
 
 checklist = {}
@@ -53,47 +56,45 @@ for row in leaf_view:
     checklist[(row['schema'], row['view'])] = view_order
 
 rows = plpy.execute("""
-    SELECT
-        nsp1.nspname AS depender_schema,
-        depender,
-        nsp2.nspname AS dependee_schema,
-        dependee
-    FROM
-        pg_namespace AS nsp1,
-        pg_namespace AS nsp2,
-        (
-            SELECT
-                c.relname depender,
-                c.relnamespace AS depender_nsp,
-                c1.relname AS dependee,
-                c1.relnamespace AS dependee_nsp
-            FROM
-                pg_rewrite AS rw,
-                pg_depend AS d,
-                pg_class AS c,
-                pg_class AS c1
-            WHERE
-                rw.ev_class = c.oid AND
-                rw.oid = d.objid AND
-                d.classid = 'pg_rewrite'::regclass AND
-                d.refclassid = 'pg_class'::regclass AND
-                d.refobjid = c1.oid AND
-                c1.relkind = 'v' AND
-                c.relname <> c1.relname
-            GROUP BY
-                depender, depender_nsp, dependee, dependee_nsp
-        ) t1
-    WHERE
-        t1.depender_nsp = nsp1.oid AND
-        t1.dependee_nsp = nsp2.oid
-        AND nsp1.nspname NOT LIKE 'pg_temp_%'
-        AND nsp1.nspname NOT LIKE 'pg_toast_temp_%'
-        AND nsp1.nspname NOT IN ('pg_catalog',
-        'information_schema', 'gp_toolkit')
-        AND nsp2.nspname NOT LIKE 'pg_temp_%'
-        AND nsp2.nspname NOT LIKE 'pg_toast_temp_%'
-        AND nsp2.nspname NOT IN ('pg_catalog',
-                            'information_schema', 'gp_toolkit')
+SELECT
+    nsp1.nspname AS depender_schema,
+    depender,
+    nsp2.nspname AS dependee_schema,
+    dependee
+FROM
+    pg_namespace AS nsp1,
+    pg_namespace AS nsp2,
+    (
+        SELECT
+            c.relname depender,
+            c.relnamespace AS depender_nsp,
+            c1.relname AS dependee,
+            c1.relnamespace AS dependee_nsp
+        FROM
+            pg_rewrite AS rw,
+            pg_depend AS d,
+            pg_class AS c,
+            pg_class AS c1
+        WHERE
+            rw.ev_class = c.oid
+            AND rw.oid = d.objid
+            AND d.classid = 'pg_rewrite'::regclass
+            AND d.refclassid = 'pg_class'::regclass
+            AND d.refobjid = c1.oid
+            AND c1.relkind = 'v'
+            AND c.relname <> c1.relname
+        GROUP BY
+            depender, depender_nsp, dependee, dependee_nsp
+    ) t1
+WHERE
+    t1.depender_nsp = nsp1.oid
+    AND t1.dependee_nsp = nsp2.oid
+    AND nsp1.nspname NOT LIKE 'pg_temp_%'
+    AND nsp1.nspname NOT LIKE 'pg_toast_temp_%'
+    AND nsp1.nspname NOT IN ('pg_catalog', 'information_schema', 'gp_toolkit')
+    AND nsp2.nspname NOT LIKE 'pg_temp_%'
+    AND nsp2.nspname NOT LIKE 'pg_toast_temp_%'
+    AND nsp2.nspname NOT IN ('pg_catalog', 'information_schema', 'gp_toolkit')
 """)
 
 view2view = {}

--- a/data-migration-scripts/post-finalize/recreate_views_on_deprecated_built_in_types.sql
+++ b/data-migration-scripts/post-finalize/recreate_views_on_deprecated_built_in_types.sql
@@ -1,6 +1,7 @@
 -- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
 -- SPDX-License-Identifier: Apache-2.0
 
-SELECT $$CREATE VIEW $$|| full_view_name || $$ AS $$ ||
-    pg_catalog.pg_get_viewdef(full_view_name::regclass::oid, false) || $$;$$
+SELECT
+    $$CREATE VIEW $$ || full_view_name || $$ AS $$ || pg_catalog.pg_get_viewdef(full_view_name::regclass::oid, false) || $$;$$ || E'\n'||
+    $$ALTER VIEW $$ || full_view_name || $$ OWNER TO $$ || view_owner || $$;$$
 FROM __gpupgrade_tmp_generator.__temp_views_list ORDER BY view_order;

--- a/data-migration-scripts/post-revert/recreate_views_on_deprecated_built_in_types.sql
+++ b/data-migration-scripts/post-revert/recreate_views_on_deprecated_built_in_types.sql
@@ -1,6 +1,7 @@
 -- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
 -- SPDX-License-Identifier: Apache-2.0
 
-SELECT $$CREATE VIEW $$|| full_view_name || $$ AS $$ ||
-    pg_catalog.pg_get_viewdef(full_view_name::regclass::oid, false) || $$;$$
+SELECT
+    $$CREATE VIEW $$ || full_view_name || $$ AS $$ || pg_catalog.pg_get_viewdef(full_view_name::regclass::oid, false) || $$;$$ || E'\n'||
+    $$ALTER TABLE $$ || full_view_name || $$ OWNER TO $$ || view_owner || $$;$$
 FROM __gpupgrade_tmp_generator.__temp_views_list ORDER BY view_order;

--- a/data-migration-scripts/test/create_nonupgradable_objects.sql
+++ b/data-migration-scripts/test/create_nonupgradable_objects.sql
@@ -120,12 +120,13 @@ CREATE TABLE partition_table_partitioned_by_name_type(a int, b name) PARTITION B
 DROP TABLE IF EXISTS table_distributed_by_name_type;
 CREATE TABLE table_distributed_by_name_type(a int, b name) DISTRIBUTED BY (b);
 INSERT INTO table_distributed_by_name_type VALUES (1,'z'),(2,'x');
--- create table / views with name dataype
+-- create table / views with name datatype
 CREATE TABLE t1_with_name(a name, b name) DISTRIBUTED RANDOMLY;
 INSERT INTO t1_with_name SELECT 'aaa', 'bbb';
 CREATE TABLE t2_with_name(a int, b name) DISTRIBUTED RANDOMLY;
 INSERT INTO t2_with_name SELECT 1, 'bbb';
 CREATE VIEW v2_on_t2_with_name AS SELECT * FROM t2_with_name;
+ALTER TABLE v2_on_t2_with_name OWNER TO test_role1;
 -- multilevel partition table with partitioning keys using name datatype
 CREATE TABLE multilevel_part_with_partition_col_name_datatype (trans_id int, country name, amount decimal(9,2), region name)
 DISTRIBUTED BY (trans_id)
@@ -205,9 +206,10 @@ CREATE TABLE name_inherits (
     state      char(2)
 ) INHERITS (table_with_name_tsquery);
 
--- view on a view on a name column
+-- view on a view on a name column with owner different than the underlying table
 DROP VIEW IF EXISTS v3_on_v2_recursive;
 CREATE VIEW v3_on_v2_recursive AS SELECT * FROM v2_on_t2_with_name;
+ALTER TABLE v3_on_v2_recursive OWNER TO test_role2;
 
 -- Third level recursive view on a name column
 DROP VIEW IF EXISTS v4_on_v3_recursive;
@@ -269,7 +271,7 @@ CREATE TABLE dropped_column (a int CONSTRAINT positive_int CHECK (b > 0), b int 
         (PARTITION part_1 START(1) END(5),
         PARTITION part_2 START(5));
 ALTER TABLE dropped_column DROP COLUMN d;
-ALTER TABLE dropped_column OWNER TO testrole;
+ALTER TABLE dropped_column OWNER TO testrole1;
 
 -- Splitting the subpartition leads to its rewrite, eliminating its dropped column
 -- reference. So, after this, only part_2 and the root partition will have a

--- a/data-migration-scripts/test/setup_nonupgradable_objects.sql
+++ b/data-migration-scripts/test/setup_nonupgradable_objects.sql
@@ -4,4 +4,5 @@
 -- CREATE global objects
 CREATE DATABASE testdb;
 CREATE ROLE gphdfs_user CREATEEXTTABLE(protocol='gphdfs', type='writable') CREATEEXTTABLE(protocol='gphdfs', type='readable');
-CREATE ROLE test_role;
+CREATE ROLE test_role1;
+CREATE ROLE test_role2;

--- a/data-migration-scripts/test/teardown_nonupgradable_objects.sql
+++ b/data-migration-scripts/test/teardown_nonupgradable_objects.sql
@@ -4,4 +4,5 @@
 -- DROP global objects
 DROP DATABASE IF EXISTS testdb;
 DROP ROLE IF EXISTS gphdfs_user;
-DROP ROLE IF EXISTS test_role;
+DROP ROLE IF EXISTS test_role1;
+DROP ROLE IF EXISTS test_role2;


### PR DESCRIPTION
As part of gpupgrade views are manually recreated by us. This change
ensures the owners of the views are preserved after post-revert or
post-finalize is run.

pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:migration-script-view-owner