### PR TITLE
add "export" to completed text

### DIFF
--- a/cli/commands/execute.go
+++ b/cli/commands/execute.go
@@ -70,8 +70,8 @@ Execute completed successfully.
 The target cluster is now running. You may now run queries against the target 
 database and perform any other validation desired prior to finalizing your upgrade.
 source %s
-MASTER_DATA_DIRECTORY=%s
-PGPORT=%d
+export MASTER_DATA_DIRECTORY=%s
+export PGPORT=%d
 
 WARNING: If any queries modify the target database prior to gpupgrade finalize, 
 it will be inconsistent with the source database. 

--- a/cli/commands/finalize.go
+++ b/cli/commands/finalize.go
@@ -100,8 +100,8 @@ To use the upgraded cluster:
    install location: %s -> %s
 3. In a new shell start the upgraded cluster.
    source %s
-   MASTER_DATA_DIRECTORY=%s
-   PGPORT=%d
+   export MASTER_DATA_DIRECTORY=%s
+   export PGPORT=%d
    gpstart -a
 
    Execute the “post-finalize” data migration scripts, and recreate any 

--- a/cli/commands/revert.go
+++ b/cli/commands/revert.go
@@ -79,8 +79,8 @@ func revert() *cobra.Command {
 Revert completed successfully.
 
 The source cluster is now running version %s.
-PGPORT=%d
-MASTER_DATA_DIRECTORY=%s
+export PGPORT=%d
+export MASTER_DATA_DIRECTORY=%s
 
 The gpupgrade logs can be found on the master and segment hosts in
 %s


### PR DESCRIPTION
add "export" to completed text. This allows one to easily copy and paste into their terminal.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:completedText