### PR TITLE
Enable psql option ON_ERROR_STOP to bubble up errors

### DIFF
--- a/ci/scripts/load-dump.bash
+++ b/ci/scripts/load-dump.bash
@@ -19,7 +19,7 @@ time ssh -n gpadmin@mdw "
 
     source /usr/local/greenplum-db-source/greenplum_path.sh
     export PGOPTIONS='--client-min-messages=warning'
-    unxz < /tmp/dump.sql.xz | psql -f - postgres
+    unxz < /tmp/dump.sql.xz | psql -v ON_ERROR_STOP=0 -f - postgres
 "
 
 echo "Running the data migration scripts and workarounds on the source cluster..."
@@ -82,7 +82,7 @@ echo "${columns}" | while read -r schema table column; do
 
             source /usr/local/greenplum-db-source/greenplum_path.sh
 
-            psql regression -c 'SET SEARCH_PATH TO ${schema}; ALTER TABLE ${table} DROP COLUMN ${column} CASCADE;'
+            psql -v ON_ERROR_STOP=1 regression -c 'SET SEARCH_PATH TO ${schema}; ALTER TABLE ${table} DROP COLUMN ${column} CASCADE;'
         " || echo "Drop columns with abstime, reltime, tinterval user data types failed. Continuing..."
     fi
 done
@@ -118,6 +118,6 @@ ssh -n mdw "
 
     source /usr/local/greenplum-db-source/greenplum_path.sh
 
-    psql -d regression -c 'DROP FUNCTION public.myfunc(integer);
+    psql -v ON_ERROR_STOP=1 -d regression -c 'DROP FUNCTION public.myfunc(integer);
     DROP AGGREGATE public.newavg(integer);'
 " || echo "Dropping unsupported functions failed. Continuing..."

--- a/ci/scripts/load-extensions.bash
+++ b/ci/scripts/load-extensions.bash
@@ -71,7 +71,7 @@ SQL_EOF
     echo 'Installing PostGIS...'
     gppkg -i /tmp/postgis_source.gppkg
     /usr/local/greenplum-db-source/share/postgresql/contrib/postgis-*/postgis_manager.sh postgres install
-    psql postgres -f /tmp/postgis_dump.sql
+    psql -v ON_ERROR_STOP=0 postgres -f /tmp/postgis_dump.sql
     psql -v ON_ERROR_STOP=1 -d postgres <<SQL_EOF
         -- Drop postgis views containing deprecated name datatypes
         DROP VIEW geography_columns;
@@ -254,7 +254,7 @@ SQL_EOF
 SQL_EOF
 
     echo 'Installing Fuzzy String Match...'
-    psql -d postgres -f /usr/local/greenplum-db-source/share/postgresql/contrib/fuzzystrmatch.sql
+    psql -v ON_ERROR_STOP=1 -d postgres -f /usr/local/greenplum-db-source/share/postgresql/contrib/fuzzystrmatch.sql
     psql -v ON_ERROR_STOP=1 -d postgres <<SQL_EOF
         CREATE VIEW fuzzystrmatch_test_view AS SELECT soundex('a'::text);
 SQL_EOF
@@ -262,7 +262,7 @@ SQL_EOF
     echo 'Installing citext...'
     echo 'Create a new db to avoid potential function overlaps with postgis to simplify the diff when comparing before and after upgrade.'
     createdb citext_db
-    psql -d citext_db -f /usr/local/greenplum-db-source/share/postgresql/contrib/citext.sql
+    psql -v ON_ERROR_STOP=1 -d citext_db -f /usr/local/greenplum-db-source/share/postgresql/contrib/citext.sql
     psql -v ON_ERROR_STOP=1 -d citext_db <<SQL_EOF
         CREATE TABLE citext_test_type (
             id bigint PRIMARY KEY,

--- a/ci/scripts/load-extensions.bash
+++ b/ci/scripts/load-extensions.bash
@@ -71,7 +71,7 @@ SQL_EOF
     echo 'Installing PostGIS...'
     gppkg -i /tmp/postgis_source.gppkg
     /usr/local/greenplum-db-source/share/postgresql/contrib/postgis-*/postgis_manager.sh postgres install
-    psql -v ON_ERROR_STOP=0 postgres -f /tmp/postgis_dump.sql
+    psql -v ON_ERROR_STOP=1 postgres -f /tmp/postgis_dump.sql
     psql -v ON_ERROR_STOP=1 -d postgres <<SQL_EOF
         -- Drop postgis views containing deprecated name datatypes
         DROP VIEW geography_columns;

--- a/ci/scripts/load-retail-data.bash
+++ b/ci/scripts/load-retail-data.bash
@@ -59,8 +59,8 @@ ssh mdw <<EOF
 
     source ${GPHOME_SOURCE}/greenplum_path.sh
     cd /home/gpadmin/industry_demo
-    psql -d template1 -e -f data_generation/prep_database.sql
-    psql -d gpdb_demo -e -f data_generation/prep_external_tables.sql
+    psql -v ON_ERROR_STOP=1 -d template1 -e -f data_generation/prep_database.sql
+    psql -v ON_ERROR_STOP=1 -d gpdb_demo -e -f data_generation/prep_external_tables.sql
 EOF
 
 # copy extracted demo_data to segments and start gpfdist
@@ -88,24 +88,24 @@ time ssh mdw <<EOF
     gpstop -ar
 
     cd /home/gpadmin/industry_demo
-    psql -d gpdb_demo -e -f data_generation/prep_UDFs.sql
+    psql -v ON_ERROR_STOP=1 -d gpdb_demo -e -f data_generation/prep_UDFs.sql
 
     data_generation/prep_GUCs.sh
 
     # prepare data
-    psql -d gpdb_demo -e -f data_generation/prep_retail_xts_tables.sql
-    psql -d gpdb_demo -e -f data_generation/prep_dimensions.sql
-    psql -d gpdb_demo -e -f data_generation/prep_facts.sql
+    psql -v ON_ERROR_STOP=1 -d gpdb_demo -e -f data_generation/prep_retail_xts_tables.sql
+    psql -v ON_ERROR_STOP=1 -d gpdb_demo -e -f data_generation/prep_dimensions.sql
+    psql -v ON_ERROR_STOP=1 -d gpdb_demo -e -f data_generation/prep_facts.sql
 
     # generate data
-    psql -d gpdb_demo -e -f data_generation/gen_order_base.sql
-    psql -d gpdb_demo -e -f data_generation/gen_facts.sql
-    psql -d gpdb_demo -e -f data_generation/gen_load_files.sql
-    psql -d gpdb_demo -e -f data_generation/load_RFMT_Scores.sql
+    psql -v ON_ERROR_STOP=1 -d gpdb_demo -e -f data_generation/gen_order_base.sql
+    psql -v ON_ERROR_STOP=1 -d gpdb_demo -e -f data_generation/gen_facts.sql
+    psql -v ON_ERROR_STOP=0 -d gpdb_demo -e -f data_generation/gen_load_files.sql
+    psql -v ON_ERROR_STOP=1 -d gpdb_demo -e -f data_generation/load_RFMT_Scores.sql
 
     # verify data
     # TODO: assert on the output of verification script
-    psql -d gpdb_demo -e -f data_generation/verify_data.sql
+    psql -v ON_ERROR_STOP=1 -d gpdb_demo -e -f data_generation/verify_data.sql
 
     # XXX: This is a workaround for the following pg_upgrade check failure:
     # "ERROR: could not create relation
@@ -124,7 +124,7 @@ ssh mdw "
     gpupgrade-migration-sql-executor.bash "$GPHOME_SOURCE" "$PGPORT" /home/gpadmin/gpupgrade/pre-initialize || true
 
     # match root/child partition schemas
-    psql -d gpdb_demo <<SQL_EOF
+    psql -v ON_ERROR_STOP=1 -d gpdb_demo <<SQL_EOF
         ALTER TABLE retail_demo.order_lineitems SET SCHEMA retail_parts;
         ALTER TABLE retail_demo.shipment_lineitems SET SCHEMA retail_parts;
         ALTER TABLE retail_demo.orders SET SCHEMA retail_parts;

--- a/data-migration-scripts/gpupgrade-migration-sql-executor.bash
+++ b/data-migration-scripts/gpupgrade-migration-sql-executor.bash
@@ -58,7 +58,7 @@ main(){
     fi
 
     for file in ${files[*]}; do
-        local cmd="${GPHOME}/bin/psql -X -d postgres -p ${PGPORT} -f ${file} --echo-queries --quiet"
+        local cmd="${GPHOME}/bin/psql -v ON_ERROR_STOP=0 -X -d postgres -p ${PGPORT} -f ${file} --echo-queries --quiet"
         echo "Executing command: ${cmd}" | tee -a "$log_file"
         ${cmd} 2>&1 | tee -a "$log_file"
     done

--- a/data-migration-scripts/test/create_nonupgradable_objects.sql
+++ b/data-migration-scripts/test/create_nonupgradable_objects.sql
@@ -271,7 +271,7 @@ CREATE TABLE dropped_column (a int CONSTRAINT positive_int CHECK (b > 0), b int 
         (PARTITION part_1 START(1) END(5),
         PARTITION part_2 START(5));
 ALTER TABLE dropped_column DROP COLUMN d;
-ALTER TABLE dropped_column OWNER TO testrole1;
+ALTER TABLE dropped_column OWNER TO test_role1;
 
 -- Splitting the subpartition leads to its rewrite, eliminating its dropped column
 -- reference. So, after this, only part_2 and the root partition will have a

--- a/test/acceptance/gpupgrade/execute.bats
+++ b/test/acceptance/gpupgrade/execute.bats
@@ -80,7 +80,7 @@ ensure_hardlinks_for_relfilenode_on_coordinator_and_segments() {
         AND c.relname = '$tablename';"
     fi
 
-    read -r -a relfilenodes <<< $("$gphome"/bin/psql postgres -p "$port" --tuples-only --no-align -c "$sql")
+    read -r -a relfilenodes <<< $("$gphome"/bin/psql -v ON_ERROR_STOP=1 postgres -p "$port" --tuples-only --no-align -c "$sql")
 
     for relfilenode in "${relfilenodes[@]}"; do
         local number_of_hardlinks=$($STAT --format "%h" "${relfilenode}")
@@ -95,7 +95,7 @@ ensure_hardlinks_for_relfilenode_on_coordinator_and_segments() {
 
     delete_target_datadirs "${MASTER_DATA_DIRECTORY}"
 
-    $PSQL postgres -c "drop table if exists test_linking; create table test_linking (a int);"
+    $PSQL -v ON_ERROR_STOP=1 postgres -c "drop table if exists test_linking; create table test_linking (a int);"
 
     ensure_hardlinks_for_relfilenode_on_coordinator_and_segments $GPHOME_SOURCE $PGPORT 'test_linking' 1
 

--- a/test/acceptance/gpupgrade/migration_scripts.bats
+++ b/test/acceptance/gpupgrade/migration_scripts.bats
@@ -20,11 +20,11 @@ setup() {
 
     PSQL="$GPHOME_SOURCE/bin/psql -X --no-align --tuples-only"
 
-    $PSQL -d postgres -f "$SCRIPTS_DIR"/test/setup_nonupgradable_objects.sql
+    $PSQL -d postgres -v ON_ERROR_STOP=1 -f "$SCRIPTS_DIR"/test/setup_nonupgradable_objects.sql
 }
 
 teardown() {
-    $PSQL -d postgres -f "$SCRIPTS_DIR"/test/teardown_nonupgradable_objects.sql
+    $PSQL -d postgres -v ON_ERROR_STOP=1 -f "$SCRIPTS_DIR"/test/teardown_nonupgradable_objects.sql
 
     # XXX Beware, BATS_TEST_SKIPPED is not a documented export.
     if [ -n "${BATS_TEST_SKIPPED}" ]; then
@@ -37,7 +37,7 @@ teardown() {
 }
 
 @test "migration scripts generate sql to modify non-upgradeable objects and fix pg_upgrade check errors" {
-    PGOPTIONS='--client-min-messages=warning' $PSQL -d testdb -f "$SCRIPTS_DIR"/test/create_nonupgradable_objects.sql
+    PGOPTIONS='--client-min-messages=warning' $PSQL -d testdb -v ON_ERROR_STOP=1 -f "$SCRIPTS_DIR"/test/create_nonupgradable_objects.sql
     run gpupgrade initialize \
         --source-gphome="$GPHOME_SOURCE" \
         --target-gphome="$GPHOME_TARGET" \
@@ -52,7 +52,7 @@ teardown() {
     egrep "\"check_upgrade\": \"failed\"" $GPUPGRADE_HOME/substeps.json
     egrep "^Checking.*fatal$" ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/pg_upgrade_internal.log
 
-    PGOPTIONS='--client-min-messages=warning' $PSQL -d testdb -f "$SCRIPTS_DIR"/test/drop_unfixable_objects.sql
+    PGOPTIONS='--client-min-messages=warning' $PSQL -d testdb -v ON_ERROR_STOP=1 -f "$SCRIPTS_DIR"/test/drop_unfixable_objects.sql
 
     root_child_indexes_before=$(get_indexes "$GPHOME_SOURCE")
     tsquery_datatype_objects_before=$(get_tsquery_datatypes "$GPHOME_SOURCE")
@@ -108,8 +108,8 @@ teardown() {
 }
 
 @test "after reverting recreate scripts must restore non-upgradeable objects" {
-    $PSQL -d testdb -f "$SCRIPTS_DIR"/test/create_nonupgradable_objects.sql
-    $PSQL -d testdb -f "$SCRIPTS_DIR"/test/drop_unfixable_objects.sql
+    $PSQL -d testdb -v ON_ERROR_STOP=1 -f "$SCRIPTS_DIR"/test/create_nonupgradable_objects.sql
+    $PSQL -d testdb -v ON_ERROR_STOP=1 -f "$SCRIPTS_DIR"/test/drop_unfixable_objects.sql
 
     root_child_indexes_before=$(get_indexes "$GPHOME_SOURCE")
     tsquery_datatype_objects_before=$(get_tsquery_datatypes "$GPHOME_SOURCE")
@@ -164,7 +164,7 @@ teardown() {
         skip "GPDB 5 does not support alternative PSQLRC locations"
     fi
 
-    $PSQL -d testdb -f "$SCRIPTS_DIR"/test/create_nonupgradable_objects.sql
+    $PSQL -d testdb -v ON_ERROR_STOP=1 -f "$SCRIPTS_DIR"/test/create_nonupgradable_objects.sql
 
     MIGRATION_DIR=$(mktemp -d /tmp/migration.XXXXXX)
     register_teardown rm -r "$MIGRATION_DIR"
@@ -174,7 +174,7 @@ teardown() {
     printf '\! kill $PPID\n' > "$PSQLRC"
 
     "$SCRIPTS_DIR"/gpupgrade-migration-sql-generator.bash "$GPHOME_SOURCE" "$PGPORT" "$MIGRATION_DIR" "$SCRIPTS_DIR"
-    $PSQL -d testdb -f "$SCRIPTS_DIR"/test/drop_unfixable_objects.sql
+    $PSQL -d testdb -v ON_ERROR_STOP=1 -f "$SCRIPTS_DIR"/test/drop_unfixable_objects.sql
     "$SCRIPTS_DIR"/gpupgrade-migration-sql-executor.bash "$GPHOME_SOURCE" "$PGPORT" "$MIGRATION_DIR"/pre-initialize
 
     gpupgrade initialize \

--- a/test/acceptance/gpupgrade/migration_scripts.bats
+++ b/test/acceptance/gpupgrade/migration_scripts.bats
@@ -20,7 +20,7 @@ setup() {
 
     PSQL="$GPHOME_SOURCE/bin/psql -X --no-align --tuples-only"
 
-    $PSQL -d postgres -v ON_ERROR_STOP=1 -f "$SCRIPTS_DIR"/test/setup_nonupgradable_objects.sql
+    $PSQL -d postgres -v ON_ERROR_STOP=0 -f "$SCRIPTS_DIR"/test/setup_nonupgradable_objects.sql
 }
 
 teardown() {
@@ -37,7 +37,7 @@ teardown() {
 }
 
 @test "migration scripts generate sql to modify non-upgradeable objects and fix pg_upgrade check errors" {
-    PGOPTIONS='--client-min-messages=warning' $PSQL -d testdb -v ON_ERROR_STOP=1 -f "$SCRIPTS_DIR"/test/create_nonupgradable_objects.sql
+    PGOPTIONS='--client-min-messages=warning' $PSQL -d testdb -v ON_ERROR_STOP=0 -f "$SCRIPTS_DIR"/test/create_nonupgradable_objects.sql
     run gpupgrade initialize \
         --source-gphome="$GPHOME_SOURCE" \
         --target-gphome="$GPHOME_TARGET" \
@@ -52,7 +52,7 @@ teardown() {
     egrep "\"check_upgrade\": \"failed\"" $GPUPGRADE_HOME/substeps.json
     egrep "^Checking.*fatal$" ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/pg_upgrade_internal.log
 
-    PGOPTIONS='--client-min-messages=warning' $PSQL -d testdb -v ON_ERROR_STOP=1 -f "$SCRIPTS_DIR"/test/drop_unfixable_objects.sql
+    PGOPTIONS='--client-min-messages=warning' $PSQL -d testdb -v ON_ERROR_STOP=0 -f "$SCRIPTS_DIR"/test/drop_unfixable_objects.sql
 
     root_child_indexes_before=$(get_indexes "$GPHOME_SOURCE")
     tsquery_datatype_objects_before=$(get_tsquery_datatypes "$GPHOME_SOURCE")
@@ -108,7 +108,7 @@ teardown() {
 }
 
 @test "after reverting recreate scripts must restore non-upgradeable objects" {
-    $PSQL -d testdb -v ON_ERROR_STOP=1 -f "$SCRIPTS_DIR"/test/create_nonupgradable_objects.sql
+    $PSQL -d testdb -v ON_ERROR_STOP=0 -f "$SCRIPTS_DIR"/test/create_nonupgradable_objects.sql
     $PSQL -d testdb -v ON_ERROR_STOP=1 -f "$SCRIPTS_DIR"/test/drop_unfixable_objects.sql
 
     root_child_indexes_before=$(get_indexes "$GPHOME_SOURCE")
@@ -164,7 +164,7 @@ teardown() {
         skip "GPDB 5 does not support alternative PSQLRC locations"
     fi
 
-    $PSQL -d testdb -v ON_ERROR_STOP=1 -f "$SCRIPTS_DIR"/test/create_nonupgradable_objects.sql
+    $PSQL -d testdb -v ON_ERROR_STOP=0 -f "$SCRIPTS_DIR"/test/create_nonupgradable_objects.sql
 
     MIGRATION_DIR=$(mktemp -d /tmp/migration.XXXXXX)
     register_teardown rm -r "$MIGRATION_DIR"

--- a/test/acceptance/helpers/finalize_checks.bash
+++ b/test/acceptance/helpers/finalize_checks.bash
@@ -62,7 +62,7 @@ wait_can_start_transactions() {
     for i in {1..10}; do
         ssh -n "${host}" "
             source ${GPHOME_NEW}/greenplum_path.sh
-            psql -X -p $port -At -d postgres << EOF
+            psql -v ON_ERROR_STOP=1 -X -p $port -At -d postgres << EOF
                 SELECT gp_request_fts_probe_scan();
                 BEGIN; CREATE TEMP TABLE temp_test(a int) DISTRIBUTED RANDOMLY; COMMIT;
 EOF

--- a/test/acceptance/helpers/tablespace_helpers.bash
+++ b/test/acceptance/helpers/tablespace_helpers.bash
@@ -53,7 +53,7 @@ create_tablespace_with_tables() {
     (unset LD_LIBRARY_PATH; source "${GPHOME_SOURCE}"/greenplum_path.sh && gpfilespace --config "${TABLESPACE_CONFIG}")
 
     # create a tablespace in said filespace and some databases in that tablespace
-    "${GPHOME_SOURCE}"/bin/psql -d postgres -v ON_ERROR_STOP=1 <<- EOF
+    "${GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -d postgres -v ON_ERROR_STOP=1 <<- EOF
         CREATE TABLESPACE batsTbsp FILESPACE batsFS;
 
         CREATE DATABASE foodb TABLESPACE batsTbsp;
@@ -61,7 +61,7 @@ create_tablespace_with_tables() {
 EOF
 
     # create various tables in the tablespace
-    "${GPHOME_SOURCE}"/bin/psql -d postgres -v ON_ERROR_STOP=1 <<- EOF
+    "${GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -d postgres -v ON_ERROR_STOP=1 <<- EOF
         CREATE TABLE "${tablespace_table_prefix}_0" (a int) TABLESPACE batsTbsp;
         INSERT INTO "${tablespace_table_prefix}_0" SELECT i from generate_series(1,100)i;
 


### PR DESCRIPTION
If a sql file is executed by psql without this option turned on, any
errors in sql execution will be ignored and psql will keep executing sql
statements. The resulting error code will be the status of the last SQL
statement executed. By forcing psql to stop if an error is encountered
we can stop SQL execution and return with a non zero error code.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:ON_ERROR_STOP