### PR TITLE
test pg_upgrade check for root partitions with seg entries

### DIFF
--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/parent_partitions_with_seg_entries.out
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/expected/parent_partitions_with_seg_entries.out
@@ -1,0 +1,105 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Check for AO and AOCO parent partitions that contain entries in pg_aoseg
+-- or pg_aocsseg respectively. These tables should not contain any entries
+-- as parent partitions don't carry any data.
+--
+-- Running into such entries can cause unexpected failures during
+-- pg_upgrade (and possibly during post-upgrade activity). One such ERROR
+-- manifested when we were trying to run VACUUM FREEZE while upgrading
+-- primaries. In this case, there was a root AOCO table with a non-empty
+-- pg_aocsseg table on the master node.
+--
+--   "ERROR","58P01","could not open Append-Only segment file
+--   ""base/16410/20863.1665"": No such file or directory",,,,,,"VACUUM
+--     (FREEZE);",0,,"aomd.c"
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION insert_dummy_segentry(segrelfqname text) RETURNS void AS $func$ BEGIN /* in func */ EXECUTE 'INSERT INTO ' || segrelfqname || ' VALUES(null)'; /* in func */ END /* in func */ $func$  LANGUAGE plpgsql;
+CREATE
+
+-- Test AO partition table
+CREATE TABLE ao_root_partition (A INT, B INT) WITH (APPENDONLY=TRUE) DISTRIBUTED BY(A) PARTITION BY RANGE(A) SUBPARTITION BY RANGE(B) SUBPARTITION TEMPLATE (START(1) END (5) EVERY(1)) (START (1) END (2) EVERY (1));
+CREATE
+
+INSERT INTO ao_root_partition SELECT 1,i FROM GENERATE_SERIES(1,4) AS i;
+INSERT 4
+-- Create an artificial aoseg entry for the root and interior partition.
+SET allow_system_table_mods TO DML;
+SET
+SELECT insert_dummy_segentry(s.interior_segrelfqname) FROM (SELECT segrelid::regclass::text AS interior_segrelfqname FROM pg_appendonly WHERE relid IN ('ao_root_partition'::regclass, 'ao_root_partition_1_prt_1'::regclass)) AS s;
+ insert_dummy_segentry 
+-----------------------
+                       
+                       
+(2 rows)
+RESET allow_system_table_mods;
+RESET
+
+-- Test AOCO partition table
+CREATE TABLE aoco_root_partition (A INT, B INT) WITH (APPENDONLY=TRUE, ORIENTATION=COLUMN) DISTRIBUTED BY(A) PARTITION BY RANGE(A) SUBPARTITION BY RANGE(B) SUBPARTITION TEMPLATE (START(1) END (5) EVERY(1)) (START (1) END (2) EVERY (1));
+CREATE
+
+INSERT INTO aoco_root_partition SELECT 1,i FROM GENERATE_SERIES(1,4) AS i;
+INSERT 4
+-- Create an artificial aocsseg entry for the root and interior partition.
+SET allow_system_table_mods TO DML;
+SET
+SELECT insert_dummy_segentry(s.interior_segrelfqname) FROM (SELECT segrelid::regclass::text AS interior_segrelfqname FROM pg_appendonly WHERE relid IN ('aoco_root_partition'::regclass, 'aoco_root_partition_1_prt_1'::regclass)) AS s;
+ insert_dummy_segentry 
+-----------------------
+                       
+                       
+(2 rows)
+RESET allow_system_table_mods;
+RESET
+
+--------------------------------------------------------------------------------
+-- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+--------------------------------------------------------------------------------
+-- start_matchsubs
+--
+-- m/segrel pg_aoseg.pg_aoseg_\d+$/
+-- s/segrel pg_aoseg.pg_aoseg_\d+/segrel pg_aoseg.pg_aoseg_XXXXX/
+--
+-- m/segrel pg_aoseg.pg_aocsseg_\d+$/
+-- s/segrel pg_aoseg.pg_aocsseg_\d+/segrel pg_aoseg.pg_aocsseg_XXXXX/
+--
+-- end_matchsubs
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --automatic;
+-- start_ignore
+-- end_ignore
+(exited with code 1)
+! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/parent_partitions_with_seg_entries.txt | LC_ALL=C sort -b;
+Database: isolation2test
+  public.ao_root_partition has non empty segrel pg_aoseg.pg_aoseg_38240
+  public.ao_root_partition_1_prt_1 has non empty segrel pg_aoseg.pg_aoseg_38247
+  public.aoco_root_partition has non empty segrel pg_aoseg.pg_aocsseg_38303
+  public.aoco_root_partition_1_prt_1 has non empty segrel pg_aoseg.pg_aocsseg_38310
+
+
+--------------------------------------------------------------------------------
+-- Workaround to unblock upgrade
+--------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION truncate_segrel(segrelfqname text) RETURNS void AS $func$ BEGIN /* in func */ EXECUTE 'DELETE FROM ' || segrelfqname; /* in func */ END /* in func */ $func$  LANGUAGE plpgsql;
+CREATE
+
+SET allow_system_table_mods TO DML;
+SET
+
+-- Truncate the artificial aoseg entries.
+SELECT truncate_segrel(s.interior_segrelfqname) FROM (SELECT segrelid::regclass::text AS interior_segrelfqname FROM pg_appendonly WHERE relid IN ('ao_root_partition'::regclass, 'ao_root_partition_1_prt_1'::regclass, 'aoco_root_partition'::regclass, 'aoco_root_partition_1_prt_1'::regclass)) AS s;
+ truncate_segrel 
+-----------------
+                 
+                 
+                 
+                 
+(4 rows)
+
+RESET allow_system_table_mods;
+RESET

--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/non_upgradeable_schedule
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/non_upgradeable_schedule
@@ -13,3 +13,4 @@ test: tsquery_col
 test: views_referencing_deprecated_tables
 test: views_with_lag_lead_functions
 test: views_referencing_deprecated_columns
+test: parent_partitions_with_seg_entries

--- a/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/parent_partitions_with_seg_entries.sql
+++ b/test/acceptance/pg_upgrade/non_upgradeable_tests/sql/parent_partitions_with_seg_entries.sql
@@ -1,0 +1,91 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Check for AO and AOCO parent partitions that contain entries in pg_aoseg
+-- or pg_aocsseg respectively. These tables should not contain any entries
+-- as parent partitions don't carry any data.
+--
+-- Running into such entries can cause unexpected failures during
+-- pg_upgrade (and possibly during post-upgrade activity). One such ERROR
+-- manifested when we were trying to run VACUUM FREEZE while upgrading
+-- primaries. In this case, there was a root AOCO table with a non-empty
+-- pg_aocsseg table on the master node.
+--
+--   "ERROR","58P01","could not open Append-Only segment file
+--   ""base/16410/20863.1665"": No such file or directory",,,,,,"VACUUM
+--     (FREEZE);",0,,"aomd.c"
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION insert_dummy_segentry(segrelfqname text)
+    RETURNS void AS
+$func$
+BEGIN /* in func */
+    EXECUTE 'INSERT INTO ' || segrelfqname || ' VALUES(null)'; /* in func */
+END /* in func */
+$func$  LANGUAGE plpgsql;
+
+-- Test AO partition table
+CREATE TABLE ao_root_partition (A INT, B INT) WITH (APPENDONLY=TRUE) DISTRIBUTED BY(A)
+    PARTITION BY RANGE(A)
+        SUBPARTITION BY RANGE(B)
+        SUBPARTITION TEMPLATE (START(1) END (5) EVERY(1)) (START (1) END (2) EVERY (1));
+
+INSERT INTO ao_root_partition SELECT 1,i FROM GENERATE_SERIES(1,4) AS i;
+-- Create an artificial aoseg entry for the root and interior partition.
+SET allow_system_table_mods TO DML;
+SELECT insert_dummy_segentry(s.interior_segrelfqname) FROM
+    (SELECT segrelid::regclass::text AS interior_segrelfqname FROM pg_appendonly
+     WHERE relid IN ('ao_root_partition'::regclass, 'ao_root_partition_1_prt_1'::regclass)) AS s;
+RESET allow_system_table_mods;
+
+-- Test AOCO partition table
+CREATE TABLE aoco_root_partition (A INT, B INT) WITH (APPENDONLY=TRUE, ORIENTATION=COLUMN) DISTRIBUTED BY(A)
+    PARTITION BY RANGE(A)
+        SUBPARTITION BY RANGE(B)
+        SUBPARTITION TEMPLATE (START(1) END (5) EVERY(1)) (START (1) END (2) EVERY (1));
+
+INSERT INTO aoco_root_partition SELECT 1,i FROM GENERATE_SERIES(1,4) AS i;
+-- Create an artificial aocsseg entry for the root and interior partition.
+SET allow_system_table_mods TO DML;
+SELECT insert_dummy_segentry(s.interior_segrelfqname) FROM
+    (SELECT segrelid::regclass::text AS interior_segrelfqname FROM pg_appendonly
+     WHERE relid IN ('aoco_root_partition'::regclass, 'aoco_root_partition_1_prt_1'::regclass)) AS s;
+RESET allow_system_table_mods;
+
+--------------------------------------------------------------------------------
+-- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+--------------------------------------------------------------------------------
+-- start_matchsubs
+--
+-- m/segrel pg_aoseg.pg_aoseg_\d+$/
+-- s/segrel pg_aoseg.pg_aoseg_\d+/segrel pg_aoseg.pg_aoseg_XXXXX/
+--
+-- m/segrel pg_aoseg.pg_aocsseg_\d+$/
+-- s/segrel pg_aoseg.pg_aocsseg_\d+/segrel pg_aoseg.pg_aocsseg_XXXXX/
+--
+-- end_matchsubs
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --automatic;
+! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/parent_partitions_with_seg_entries.txt | LC_ALL=C sort -b;
+
+--------------------------------------------------------------------------------
+-- Workaround to unblock upgrade
+--------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION truncate_segrel(segrelfqname text)
+    RETURNS void AS
+$func$
+BEGIN /* in func */
+    EXECUTE 'DELETE FROM ' || segrelfqname; /* in func */
+END /* in func */
+$func$  LANGUAGE plpgsql;
+
+SET allow_system_table_mods TO DML;
+
+-- Truncate the artificial aoseg entries.
+SELECT truncate_segrel(s.interior_segrelfqname) FROM
+    (SELECT segrelid::regclass::text AS interior_segrelfqname FROM pg_appendonly
+     WHERE relid IN ('ao_root_partition'::regclass, 'ao_root_partition_1_prt_1'::regclass, 'aoco_root_partition'::regclass, 'aoco_root_partition_1_prt_1'::regclass)) AS s;
+
+RESET allow_system_table_mods;


### PR DESCRIPTION
Check for AO and AOCO root partitions that contain entries in pg_aocsseg without a corresponding relfile. When upgrading the primaries pg_upgrade performs a vacuum freeze of the database before restoring the AO segment tables. Since the segment catalog is copied from the master pg_aocsseg may contain entries without a corresponding relfile causing pg_upgrade to fail with:
```
  "ERROR","58P01","could not open Append-Only segment file
  ""base/16410/20863.1665"": No such file or directory",,,,,,"VACUUM
  (FREEZE);",0,,"aomd.c"
  ```

pg_upgrade check PR: https://github.com/greenplum-db/gpdb/pull/13779
Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:upgradeCheckAocsRootParts