### PR TITLE
lint: fix errorsas: second argument to errors.As should not be *error

### DIFF
--- a/agent/rsync_test.go
+++ b/agent/rsync_test.go
@@ -112,9 +112,16 @@ func TestRsync(t *testing.T) {
 			t.Errorf("expected an error")
 		}
 
-		var invalid *upgrade.InvalidDataDirectoryError
-		if !errors.As(invalid, &err) {
-			t.Errorf("got type %T want %T", err, invalid)
+		var errs errorlist.Errors
+		if !errors.As(err, &errs) {
+			t.Fatalf("got error %#v, want type %T", err, errs)
+		}
+
+		for _, err := range errs {
+			var invalid *upgrade.InvalidDataDirectoryError
+			if !errors.As(err, &invalid) {
+				t.Errorf("got type %T want %T", err, invalid)
+			}
 		}
 	})
 
@@ -141,9 +148,16 @@ func TestRsync(t *testing.T) {
 			t.Errorf("expected an error")
 		}
 
-		var invalid *upgrade.InvalidDataDirectoryError
-		if !errors.As(invalid, &err) {
-			t.Errorf("got type %T want %T", err, invalid)
+		var errs errorlist.Errors
+		if !errors.As(err, &errs) {
+			t.Fatalf("got error %#v, want type %T", err, errs)
+		}
+
+		for _, err := range errs {
+			var invalid *upgrade.InvalidDataDirectoryError
+			if !errors.As(err, &invalid) {
+				t.Errorf("got type %T want %T", err, invalid)
+			}
 		}
 	})
 


### PR DESCRIPTION
The [CI is failing](https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade/jobs/lint/builds/372#L62ba8233:52:58) since it pulls the latest golangci-lint which just released a new version 1.47.1. This version is now detecting the following error:
> errorsas: second argument to errors.As should not be *error

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixLint