### PR TITLE
data-migration-script to drop parent partitions with seg entries

### DIFF
--- a/data-migration-scripts/pre-initialize/gen_drop_parent_partitions_with_seg_entries.sql
+++ b/data-migration-scripts/pre-initialize/gen_drop_parent_partitions_with_seg_entries.sql
@@ -1,0 +1,19 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Generates a script to truncate non-empty segrels for AO and AOCO parent
+-- partitions.
+
+SELECT 'SET allow_system_table_mods TO DML;';
+
+SELECT 'DELETE FROM ' || segrelid::regclass || ';'
+FROM pg_appendonly a JOIN pg_class c ON a.relid = c.oid
+WHERE c.oid IN (SELECT parrelid FROM pg_partition
+                 UNION SELECT parchildrelid
+                 FROM pg_partition_rule)
+      AND c.relhassubclass = true
+      AND a.relid IS NOT NULL
+      AND a.segrelid IS NOT NULL
+ORDER BY 1;
+
+SELECT 'RESET allow_system_table_mods;';


### PR DESCRIPTION
data-migration-script to drop parent partitions with seg entries

Turns out the ICW regression database has more AO and AOCO parent partitions with seg entries which is currently causing the 5 to 6 upgrade jobs to fail. Thus, the easiest way to address all these tables seems to add a pre-initialize data migration script. There is no need for a post-finalize or post-revert script since the seg entries are not needed.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixParentPartitionsWithSegEntries