### PR TITLE
Enable option ON_ERROR_STOP on psql calls

### DIFF
--- a/ci/scripts/load-dump.bash
+++ b/ci/scripts/load-dump.bash
@@ -19,7 +19,9 @@ time ssh -n gpadmin@mdw "
 
     source /usr/local/greenplum-db-source/greenplum_path.sh
     export PGOPTIONS='--client-min-messages=warning'
-    unxz < /tmp/dump.sql.xz | psql -f - postgres
+    # This is failing due to a number of errors.
+    # Disabling ON_ERROR_STOP until this is fixed.
+    unxz < /tmp/dump.sql.xz | psql -v ON_ERROR_STOP=0 -f - postgres
 "
 
 echo "Running the data migration scripts and workarounds on the source cluster..."
@@ -29,7 +31,7 @@ time ssh -n mdw "
     source /usr/local/greenplum-db-source/greenplum_path.sh
 
     echo 'Running data migration script workarounds...'
-    psql -d regression  <<SQL_EOF
+    psql -v ON_ERROR_STOP=1 -d regression  <<SQL_EOF
 
         -- gen_alter_name_type_columns.sql cannot drop the following index because
         -- its definition uses cast to deprecated name type but evaluates to integer
@@ -47,7 +49,7 @@ ssh -n mdw "
     source /usr/local/greenplum-db-source/greenplum_path.sh
 
     # Hardcode this view since it's the only one containing a column with type name.
-    psql regression -c 'DROP VIEW IF EXISTS redundantly_named_part;'
+    psql -v ON_ERROR_STOP=1 regression -c 'DROP VIEW IF EXISTS redundantly_named_part;'
 "
 
 echo "Dropping columns with abstime, reltime, tinterval user data types..."
@@ -56,7 +58,9 @@ columns=$(ssh -n mdw "
 
     source /usr/local/greenplum-db-source/greenplum_path.sh
 
-    psql -d regression --tuples-only --no-align --field-separator ' ' <<SQL_EOF
+    # Disable ON_ERROR_STOP due to 6X incompatibility. The
+    # gp_distrbution_policy's column attrnums was renamed to distkey
+    psql -v ON_ERROR_STOP=0 -d regression --tuples-only --no-align --field-separator ' ' <<SQL_EOF
         SELECT nspname, relname, attname
         FROM   pg_catalog.pg_class c,
             pg_catalog.pg_namespace n,
@@ -82,7 +86,7 @@ echo "${columns}" | while read -r schema table column; do
 
             source /usr/local/greenplum-db-source/greenplum_path.sh
 
-            psql regression -c 'SET SEARCH_PATH TO ${schema}; ALTER TABLE ${table} DROP COLUMN ${column} CASCADE;'
+            psql -v ON_ERROR_STOP=1 -d regression -c 'SET SEARCH_PATH TO ${schema}; ALTER TABLE ${table} DROP COLUMN ${column} CASCADE;'
         " || echo "Drop columns with abstime, reltime, tinterval user data types failed. Continuing..."
     fi
 done
@@ -93,7 +97,7 @@ databases=$(ssh -n mdw "
 
     source /usr/local/greenplum-db-source/greenplum_path.sh
 
-    psql -d regression --tuples-only --no-align --field-separator ' ' <<SQL_EOF
+    psql -v ON_ERROR_STOP=1 -d regression --tuples-only --no-align --field-separator ' ' <<SQL_EOF
         SELECT datname
         FROM	pg_database
         WHERE	datname != 'template0';
@@ -107,7 +111,7 @@ echo "${databases}" | while read -r database; do
 
             source /usr/local/greenplum-db-source/greenplum_path.sh
 
-            psql -d ${database} -c 'DROP EXTENSION IF EXISTS gp_inject_fault';
+            psql -v ON_ERROR_STOP=1 -d ${database} -c 'DROP EXTENSION IF EXISTS gp_inject_fault';
         " || echo "dropping gp_inject_fault extension failed. Continuing..."
     fi
 done
@@ -118,6 +122,6 @@ ssh -n mdw "
 
     source /usr/local/greenplum-db-source/greenplum_path.sh
 
-    psql -d regression -c 'DROP FUNCTION public.myfunc(integer);
+    psql -v ON_ERROR_STOP=1 -d regression -c 'DROP FUNCTION public.myfunc(integer);
     DROP AGGREGATE public.newavg(integer);'
 " || echo "Dropping unsupported functions failed. Continuing..."

--- a/data-migration-scripts/gpupgrade-migration-sql-executor.bash
+++ b/data-migration-scripts/gpupgrade-migration-sql-executor.bash
@@ -58,7 +58,9 @@ main(){
     fi
 
     for file in ${files[*]}; do
-        local cmd="${GPHOME}/bin/psql -X -d postgres -p ${PGPORT} -f ${file} --echo-queries --quiet"
+        # Disabled ON_ERROR_STOP due to incompatibilties of deprecated objects
+        # on 6->6 upgrade that can will some scripts to fail.
+        local cmd="${GPHOME}/bin/psql -v ON_ERROR_STOP=0 -d postgres -p ${PGPORT} -f ${file} -X --echo-queries --quiet"
         echo "Executing command: ${cmd}" | tee -a "$log_file"
         ${cmd} 2>&1 | tee -a "$log_file"
     done

--- a/data-migration-scripts/post-revert/recreate_gphdfs_external_tables.sh
+++ b/data-migration-scripts/post-revert/recreate_gphdfs_external_tables.sh
@@ -24,7 +24,7 @@ main() {
     # influencing these queries. For 8.3 this is undocumented but still true.
     while read -r table; do
         tables+=(-t "$table")
-    done < <($psql -d "$DBNAME" -p "$PGPORT" -Atc "
+    done < <($psql -v ON_ERROR_STOP=1 -d "$DBNAME" -p "$PGPORT" -Atc "
         SELECT d.objid::regclass
         FROM pg_catalog.pg_depend d
                JOIN pg_catalog.pg_exttable x ON ( d.objid = x.reloid )

--- a/data-migration-scripts/test/create_nonupgradable_objects.sql
+++ b/data-migration-scripts/test/create_nonupgradable_objects.sql
@@ -271,7 +271,7 @@ CREATE TABLE dropped_column (a int CONSTRAINT positive_int CHECK (b > 0), b int 
         (PARTITION part_1 START(1) END(5),
         PARTITION part_2 START(5));
 ALTER TABLE dropped_column DROP COLUMN d;
-ALTER TABLE dropped_column OWNER TO testrole1;
+ALTER TABLE dropped_column OWNER TO test_role1;
 
 -- Splitting the subpartition leads to its rewrite, eliminating its dropped column
 -- reference. So, after this, only part_2 and the root partition will have a

--- a/data-migration-scripts/test/create_nonupgradable_objects.sql
+++ b/data-migration-scripts/test/create_nonupgradable_objects.sql
@@ -49,7 +49,8 @@ CREATE INDEX sales_idx_bitmap on sales using bitmap(office_id);
 CREATE INDEX sales_1_prt_2_idx on sales_1_prt_2(office_id, region);
 CREATE INDEX sales_1_prt_3_2_prt_asia_idx on sales_1_prt_3_2_prt_asia(region);
 CREATE INDEX sales_1_prt_outlying_dates_idx on sales_1_prt_outlying_dates(trans_id);
-CREATE UNIQUE INDEX sales_unique_idx on sales(office_id);
+INSERT INTO sales VALUES (1, 2, 'usa');
+CREATE UNIQUE INDEX sales_unique_idx on sales(trans_id);
 
 -- create tables where the index relation name is not equal primary/unique key constraint name.
 -- we create a TYPE with the default name of the constraint that would have been created to force

--- a/test/acceptance/gpupgrade/execute.bats
+++ b/test/acceptance/gpupgrade/execute.bats
@@ -21,7 +21,7 @@ setup() {
 teardown() {
     skip_if_no_gpdb
 
-    $PSQL postgres -c "drop table if exists test_linking;"
+    $PSQL -v ON_ERROR_STOP=1 -d postgres -c "drop table if exists test_linking;"
 
     gpupgrade kill-services
     archive_state_dir "$STATE_DIR"
@@ -80,7 +80,7 @@ ensure_hardlinks_for_relfilenode_on_coordinator_and_segments() {
         AND c.relname = '$tablename';"
     fi
 
-    read -r -a relfilenodes <<< $("$gphome"/bin/psql postgres -p "$port" --tuples-only --no-align -c "$sql")
+    read -r -a relfilenodes <<< $("$gphome"/bin/psql -v ON_ERROR_STOP=1 -d postgres -p "$port" --tuples-only --no-align -c "$sql")
 
     for relfilenode in "${relfilenodes[@]}"; do
         local number_of_hardlinks=$($STAT --format "%h" "${relfilenode}")
@@ -95,7 +95,7 @@ ensure_hardlinks_for_relfilenode_on_coordinator_and_segments() {
 
     delete_target_datadirs "${MASTER_DATA_DIRECTORY}"
 
-    $PSQL postgres -c "drop table if exists test_linking; create table test_linking (a int);"
+    $PSQL -v ON_ERROR_STOP=1 -d postgres -c "drop table if exists test_linking; create table test_linking (a int);"
 
     ensure_hardlinks_for_relfilenode_on_coordinator_and_segments $GPHOME_SOURCE $PGPORT 'test_linking' 1
 

--- a/test/acceptance/gpupgrade/gpinitsystem.bats
+++ b/test/acceptance/gpupgrade/gpinitsystem.bats
@@ -119,7 +119,7 @@ teardown() {
     (unset LD_LIBRARY_PATH; PGPORT=$newport source "$GPHOME_TARGET"/greenplum_path.sh && gpstart -a -d "$new_coordinator_dir")
 
     # save the actual ports
-    local actual_ports=$($PSQL -At -p $newport postgres -c "
+    local actual_ports=$($PSQL -v ON_ERROR_STOP=1 -At -p $newport postgres -c "
         select string_agg(port::text, ',' order by content) from gp_segment_configuration
     ")
 

--- a/test/acceptance/gpupgrade/initialize.bats
+++ b/test/acceptance/gpupgrade/initialize.bats
@@ -51,14 +51,14 @@ delete_target_on_teardown() {
 }
 
 setup_check_upgrade_to_fail() {
-    $PSQL -d postgres -p $PGPORT -c "CREATE TABLE test_pg_upgrade(a int) DISTRIBUTED BY (a) PARTITION BY RANGE (a)(start (1) end(4) every(1));"
-    $PSQL -d postgres -p $PGPORT -c "CREATE UNIQUE INDEX fomo ON test_pg_upgrade (a);"
+    $PSQL -v ON_ERROR_STOP=1 -d postgres -p $PGPORT -c "CREATE TABLE test_pg_upgrade(a int) DISTRIBUTED BY (a) PARTITION BY RANGE (a)(start (1) end(4) every(1));"
+    $PSQL -v ON_ERROR_STOP=1 -d postgres -p $PGPORT -c "CREATE UNIQUE INDEX fomo ON test_pg_upgrade (a);"
 
     register_teardown teardown_check_upgrade_failure
 }
 
 teardown_check_upgrade_failure() {
-    $PSQL -d postgres -p $PGPORT -c "DROP TABLE IF EXISTS test_pg_upgrade CASCADE;"
+    $PSQL -v ON_ERROR_STOP=1 -d postgres -p $PGPORT -c "DROP TABLE IF EXISTS test_pg_upgrade CASCADE;"
 }
 
 release_held_port() {

--- a/test/acceptance/gpupgrade/pg_upgrade.bats
+++ b/test/acceptance/gpupgrade/pg_upgrade.bats
@@ -36,7 +36,7 @@ teardown() {
 
     start_source_cluster
 
-    $PSQL -d postgres -p $PGPORT -c "DROP TABLE IF EXISTS test_pg_upgrade CASCADE;"
+    $PSQL -v ON_ERROR_STOP=1 -d postgres -p $PGPORT -c "DROP TABLE IF EXISTS test_pg_upgrade CASCADE;"
 }
 
 # yes, this will fail once we allow an index on a partition table
@@ -44,8 +44,8 @@ teardown() {
     skip_if_no_gpdb
 
     # add in a index on a partition table, which causes pg_upgrade --check to fail
-    $PSQL -d postgres -p $PGPORT -c "CREATE TABLE test_pg_upgrade(a int) DISTRIBUTED BY (a) PARTITION BY RANGE (a)(start (1) end(4) every(1));"
-    $PSQL -d postgres -p $PGPORT -c "CREATE UNIQUE INDEX fomo ON test_pg_upgrade (a);"
+    $PSQL -v ON_ERROR_STOP=1 -d postgres -p $PGPORT -c "CREATE TABLE test_pg_upgrade(a int) DISTRIBUTED BY (a) PARTITION BY RANGE (a)(start (1) end(4) every(1));"
+    $PSQL -v ON_ERROR_STOP=1 -d postgres -p $PGPORT -c "CREATE UNIQUE INDEX fomo ON test_pg_upgrade (a);"
 
     # Use --verbose to help debug cases where the grep fails. run() will hide
     # that output, so manually store the status and ignore the expected failure.
@@ -65,7 +65,7 @@ teardown() {
     grep "Checking for indexes on partitioned tables                  fatal" "$GPUPGRADE_LOGDIR"/hub*.log
 
     # revert added index
-    $PSQL -d postgres -p $PGPORT -c "DROP TABLE test_pg_upgrade CASCADE;"
+    $PSQL -v ON_ERROR_STOP=1 -d postgres -p $PGPORT -c "DROP TABLE test_pg_upgrade CASCADE;"
 
     KEEP_STATE_DIR=0
 }


### PR DESCRIPTION
If a sql file is executed by psql without this option turned on, any
errors in sql execution will be ignored and psql will keep executing sql
statements. The resulting error code will be the status of the last SQL
statement executed. By forcing psql to stop if an error is encountered
we can stop SQL execution and return with a non zero error code.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:ON_ERROR_STOP2