### PR TITLE
pg_upgrade: set PYTHONPATH for local testing

### DIFF
--- a/test/acceptance/pg_upgrade/pg_upgrade.bats
+++ b/test/acceptance/pg_upgrade/pg_upgrade.bats
@@ -21,6 +21,11 @@ setup() {
 
     gpupgrade kill-services
 
+    # Set PYTHONPATH directly since it is needed when running the pg_upgrade tests locally. Normally one would source
+    # greenplum_path.sh, but that causes the following issues:
+    # https://web.archive.org/web/20220506055918/https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/JN-YwjCCReY/m/0L9wBOvlAQAJ
+    export PYTHONPATH=${GPHOME_TARGET}/lib/python
+
     # Ensure that the cluster contains no non-upgradeable objects before the test
     # Note: This is especially important with a 5X demo cluster which contains
     # the gphdfs role by default.
@@ -36,6 +41,7 @@ teardown() {
 
     run_teardowns
     gpupgrade kill-services
+    unset PYTHONPATH
 }
 
 @test "pg_upgrade --check detects non-upgradeable objects" {


### PR DESCRIPTION
Set PYTHONPATH directly since it is needed when running the pg_upgrade
tests locally. Normally one would source greenplum_path.sh, but that
causes the following issues:
https://web.archive.org/web/20220506055918/https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/JN-YwjCCReY/m/0L9wBOvlAQAJ

Without setting this locally one will see the following error:
```
  File "./sql_isolation_testcase.py", line 18, in <module>
    import pygresql.pg
ImportError: No module named pygresql.pg
```

Or if one sourced greenplum_path.sh:
```
 /usr/local/gpdb6/bin/psql: symbol lookup error: /usr/local/gpdb6/bin/psql: undefined symbol: PQencryptPasswordConn
```

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:pgupgradeBats