### PR TITLE
CI: remove test_plcontainer and test_pxf

### DIFF
--- a/ci/scripts/ci-helpers.bash
+++ b/ci/scripts/ci-helpers.bash
@@ -10,12 +10,6 @@ is_GPDB5() {
     [[ $version =~ ^"postgres (Greenplum Database) 5." ]]
 }
 
-# Only test pxf when not centos6 since pxf5 for GPDB6 on centos6 is not supported.
-test_pxf() {
-    local os_version=$1
-    [ "$os_version" != "centos6" ]
-}
-
 # set the database gucs
 # 1. bytea_output: by default for bytea the output format is hex on GPDB 6,
 #    so change it to escape to match GPDB 5 representation

--- a/ci/scripts/ci-helpers.bash
+++ b/ci/scripts/ci-helpers.bash
@@ -16,12 +16,6 @@ test_pxf() {
     [ "$os_version" != "centos6" ]
 }
 
-# Don't test plcontainer on centos6 as its not supported.
-test_plcontainer() {
-    local os_version=$1
-    [ "$os_version" != "centos6" ]
-}
-
 # set the database gucs
 # 1. bytea_output: by default for bytea the output format is hex on GPDB 6,
 #    so change it to escape to match GPDB 5 representation

--- a/ci/scripts/upgrade-extensions.bash
+++ b/ci/scripts/upgrade-extensions.bash
@@ -21,10 +21,7 @@ echo "Copying extensions to the target cluster..."
 scp postgis_gppkg_target/postgis*.gppkg gpadmin@mdw:/tmp/postgis_target.gppkg
 scp madlib_gppkg_target/madlib*.gppkg gpadmin@mdw:/tmp/madlib_target.gppkg
 scp plr_gppkg_target/plr*.gppkg gpadmin@mdw:/tmp/plr_target.gppkg
-
-if test_plcontainer "$OS_VERSION"; then
-    scp plcontainer_gppkg_target/*.gppkg gpadmin@mdw:/tmp/plcontainer_target.gppkg
-fi
+scp plcontainer_gppkg_target/*.gppkg gpadmin@mdw:/tmp/plcontainer_target.gppkg
 
 if test_pxf "$OS_VERSION"; then
     # PXF SNAPSHOT builds are only available as an RPM inside a tar.gz
@@ -89,11 +86,7 @@ time ssh -n mdw "
     gppkg -i /tmp/postgis_target.gppkg
     gppkg -i /tmp/madlib_target.gppkg
     gppkg -i /tmp/plr_target.gppkg
-
-    $(typeset -f test_plcontainer) # allow local function on remote host
-    if test_plcontainer '$OS_VERSION'; then
-        gppkg -i /tmp/plcontainer_target.gppkg
-    fi
+    gppkg -i /tmp/plcontainer_target.gppkg
 
     $(typeset -f test_pxf) # allow local function on remote host
     if test_pxf '$OS_VERSION'; then


### PR DESCRIPTION
This PR is based off of https://github.com/greenplum-db/gpupgrade/pull/697 thus ignore the first commit.

After refactoring parse_template we no longer run the extensions job on both centos6 and centos7 to avoid exploding the text matrix. Thus, remove the conditionals for not testing plcontainer and pxf on centos6.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:refactorCIextensions