### PR TITLE
Transpose Active Connections Output

### DIFF
--- a/greenplum/query_pg_stat_activity.go
+++ b/greenplum/query_pg_stat_activity.go
@@ -16,7 +16,7 @@ import (
 )
 
 type StatActivity struct {
-	Usename          string
+	User             string
 	Application_name string
 	Datname          string
 	Query            string
@@ -43,7 +43,7 @@ func (s StatActivities) Error() string {
 func (s StatActivities) table() [][]string {
 	var rows [][]string
 	for _, activity := range s {
-		rows = append(rows, []string{activity.Application_name, activity.Usename, activity.Datname, activity.Query})
+		rows = append(rows, []string{activity.Application_name, activity.User, activity.Datname, activity.Query})
 	}
 
 	sort.Sort(utils.TableRows(rows))
@@ -67,7 +67,7 @@ func QueryPgStatActivity(db *sql.DB, cluster *Cluster) error {
 	var activities StatActivities
 	for rows.Next() {
 		var activity StatActivity
-		err := rows.Scan(&activity.Datname, &activity.Usename, &activity.Application_name, &activity.Query)
+		err := rows.Scan(&activity.Datname, &activity.User, &activity.Application_name, &activity.Query)
 		if err != nil {
 			return xerrors.Errorf("pg_stat_activity: %w", err)
 		}

--- a/greenplum/query_pg_stat_activity_test.go
+++ b/greenplum/query_pg_stat_activity_test.go
@@ -66,8 +66,8 @@ func TestQueryPgStatActivity(t *testing.T) {
 			AddRow("stats_db", "gpcc", "status_checker", "SELECT * FROM stats;"))
 
 		expected := greenplum.StatActivities{
-			{Usename: "gpadmin", Application_name: "etl_job", Datname: "postgres", Query: "SELECT * FROM my_table;"},
-			{Usename: "gpcc", Application_name: "status_checker", Datname: "stats_db", Query: "SELECT * FROM stats;"},
+			{User: "gpadmin", Application_name: "etl_job", Datname: "postgres", Query: "SELECT * FROM my_table;"},
+			{User: "gpcc", Application_name: "status_checker", Datname: "stats_db", Query: "SELECT * FROM stats;"},
 		}
 
 		err = greenplum.QueryPgStatActivity(db, target)


### PR DESCRIPTION
Reformat output of active connections to better handle multi-line queries.

Before:
```
Application:  User:    Database:  Query:
etl_job       gpadmin  postgres   SELECT
  clock_timestamp(),
  pg_sleep(1),
  clock_timestamp(),
  pg_sleep(30),
  clock_timestamp(),
  pg_sleep(60),
  clock_timestamp();
status_checker        gpcc  stats_db  SELECT
  clock_timestamp(),
  pg_sleep(1),
  clock_timestamp(),
  pg_sleep(30),
  clock_timestamp(),
  pg_sleep(60),
  clock_timestamp();
```

After:
```
Application:  etl_job
User:         gpadmin
Database:     postgres
Query:        SELECT
  clock_timestamp(),
  pg_sleep(1),
  clock_timestamp(),
  pg_sleep(30),
  clock_timestamp(),
  pg_sleep(60),
  clock_timestamp();

Application:  status_checker
User:         gpcc
Database:     stats_db
Query:        SELECT
  clock_timestamp(),
  pg_sleep(1),
  clock_timestamp(),
  pg_sleep(30),
  clock_timestamp(),
  pg_sleep(60),
  clock_timestamp();
```

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:activeConns