### PR TITLE
lint: fix SA1019: "io/ioutil" has been deprecated

### DIFF
--- a/agent/upgrade_primaries.go
+++ b/agent/upgrade_primaries.go
@@ -6,7 +6,7 @@ package agent
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strconv"
@@ -74,7 +74,7 @@ func upgradePrimarySegment(host string, opt *idl.PgOptions) error {
 		}
 	}
 
-	err := upgrade.Run(ioutil.Discard, ioutil.Discard, opt)
+	err := upgrade.Run(io.Discard, io.Discard, opt)
 	if err != nil {
 		return xerrors.Errorf("%s primary on host %s with content %d: %w", opt.GetAction(), host, opt.GetContentID(), err)
 	}

--- a/cli/commanders/common_test.go
+++ b/cli/commanders/common_test.go
@@ -4,7 +4,7 @@
 package commanders
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"sync"
 	"testing"
@@ -57,7 +57,7 @@ func BufferStandardDescriptors(t *testing.T) *descriptors {
 	go func() {
 		defer d.wg.Done()
 
-		d.outBytes, err = ioutil.ReadAll(rOut)
+		d.outBytes, err = io.ReadAll(rOut)
 		if err != nil {
 			errChan <- xerrors.Errorf("reading from stdout pipe: %w", err)
 		}
@@ -65,7 +65,7 @@ func BufferStandardDescriptors(t *testing.T) *descriptors {
 	go func() {
 		defer d.wg.Done()
 
-		d.errBytes, err = ioutil.ReadAll(rErr)
+		d.errBytes, err = io.ReadAll(rErr)
 		if err != nil {
 			errChan <- xerrors.Errorf("reading from stderr pipe: %w", err)
 		}

--- a/cli/commanders/initialize_test.go
+++ b/cli/commanders/initialize_test.go
@@ -6,7 +6,6 @@ package commanders
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -161,7 +160,7 @@ func TestStartHub_FailsWhenStartingTheHubErrors(t *testing.T) {
 }
 
 func TestCreateStateDir(t *testing.T) {
-	home, err := ioutil.TempDir("", t.Name())
+	home, err := os.MkdirTemp("", t.Name())
 	if err != nil {
 		t.Fatalf("failed creating temp dir %#v", err)
 	}
@@ -225,7 +224,7 @@ func TestCreateStateDir(t *testing.T) {
 func TestCreateInitialClusterConfigs(t *testing.T) {
 	const port = -1
 
-	home, err := ioutil.TempDir("", t.Name())
+	home, err := os.MkdirTemp("", t.Name())
 	if err != nil {
 		t.Fatalf("failed creating temp dir %#v", err)
 	}

--- a/cli/commanders/step_store_test.go
+++ b/cli/commanders/step_store_test.go
@@ -5,7 +5,6 @@ package commanders_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -18,7 +17,7 @@ import (
 )
 
 func TestStepStore(t *testing.T) {
-	stateDir, err := ioutil.TempDir("", "")
+	stateDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +69,7 @@ func TestStepStore(t *testing.T) {
 	})
 
 	t.Run("write errors and read errors with unknown status when failing to get the steps status file", func(t *testing.T) {
-		stateDir, err := ioutil.TempDir("", "")
+		stateDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -111,7 +110,7 @@ func TestStepStore(t *testing.T) {
 	})
 
 	t.Run("HasStatus errors with false when failing to get the steps status file", func(t *testing.T) {
-		stateDir, err := ioutil.TempDir("", "")
+		stateDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -222,7 +221,7 @@ func TestStepStore(t *testing.T) {
 }
 
 func TestValidateStep(t *testing.T) {
-	stateDir, err := ioutil.TempDir("", "")
+	stateDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/commanders/step_test.go
+++ b/cli/commanders/step_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,7 +21,7 @@ import (
 )
 
 func TestSubstep(t *testing.T) {
-	stateDir, err := ioutil.TempDir("", "")
+	stateDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -450,7 +449,7 @@ func TestSubstep(t *testing.T) {
 }
 
 func TestStepStatus(t *testing.T) {
-	stateDir, err := ioutil.TempDir("", "")
+	stateDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/greenplum/cluster_test.go
+++ b/greenplum/cluster_test.go
@@ -5,7 +5,6 @@ package greenplum_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"reflect"
@@ -144,7 +143,7 @@ func TestGetSegmentConfiguration(t *testing.T) {
 }
 
 func TestPrimaryHostnames(t *testing.T) {
-	testStateDir, err := ioutil.TempDir("", "")
+	testStateDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Errorf("got error when creating tempdir: %+v", err)
 	}
@@ -169,7 +168,7 @@ func TestPrimaryHostnames(t *testing.T) {
 }
 
 func TestClusterFromDB(t *testing.T) {
-	testStateDir, err := ioutil.TempDir("", "")
+	testStateDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Errorf("got error when creating tempdir: %+v", err)
 	}

--- a/hub/init_target_cluster.go
+++ b/hub/init_target_cluster.go
@@ -7,7 +7,7 @@ import (
 	"bufio"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"reflect"
 	"strings"
@@ -148,7 +148,7 @@ func CreateInitialInitsystemConfig(targetCoordinatorDataDir string, useHbaHostna
 func WriteInitsystemFile(gpinitsystemConfig []string, gpinitsystemFilepath string) error {
 	gpinitsystemContents := []byte(strings.Join(gpinitsystemConfig, "\n"))
 
-	err := ioutil.WriteFile(gpinitsystemFilepath, gpinitsystemContents, 0644)
+	err := os.WriteFile(gpinitsystemFilepath, gpinitsystemContents, 0644)
 	if err != nil {
 		return xerrors.Errorf("write gpinitsystem_config file: %w", err)
 	}

--- a/hub/init_target_cluster_test.go
+++ b/hub/init_target_cluster_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"reflect"
@@ -543,5 +542,5 @@ func (s *stdoutBuffer) Stdout() io.Writer {
 }
 
 func (s *stdoutBuffer) Stderr() io.Writer {
-	return ioutil.Discard
+	return io.Discard
 }

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -6,7 +6,6 @@ package step_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -347,7 +346,7 @@ func TestStepRun(t *testing.T) {
 }
 
 func TestHasStarted(t *testing.T) {
-	stateDir, err := ioutil.TempDir("", "")
+	stateDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -436,7 +435,7 @@ func TestHasStarted(t *testing.T) {
 }
 
 func TestHasRun(t *testing.T) {
-	stateDir, err := ioutil.TempDir("", "")
+	stateDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -547,7 +546,7 @@ func TestHasRun(t *testing.T) {
 }
 
 func TestHasCompleted(t *testing.T) {
-	stateDir, err := ioutil.TempDir("", "")
+	stateDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/step/stream.go
+++ b/step/stream.go
@@ -6,7 +6,6 @@ package step
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"sync"
@@ -31,11 +30,11 @@ var DevNullStream = devNullStream{}
 type devNullStream struct{}
 
 func (_ devNullStream) Stdout() io.Writer {
-	return ioutil.Discard
+	return io.Discard
 }
 
 func (_ devNullStream) Stderr() io.Writer {
-	return ioutil.Discard
+	return io.Discard
 }
 
 // BufferedStreams provides an implementation of OutStreams that stores

--- a/step/stream_test.go
+++ b/step/stream_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -75,7 +75,7 @@ func TestMultiplexedStream(t *testing.T) {
 				Type:   idl.Chunk_stderr,
 			}}})
 
-		stream := newMultiplexedStream(mockStream, ioutil.Discard)
+		stream := newMultiplexedStream(mockStream, io.Discard)
 		fmt.Fprint(stream.Stdout(), expectedStdout)
 		fmt.Fprint(stream.Stderr(), expectedStderr)
 	})

--- a/step/substep_store.go
+++ b/step/substep_store.go
@@ -6,7 +6,7 @@ package step
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"golang.org/x/xerrors"
 
@@ -62,7 +62,7 @@ func (p *PrettyStatus) UnmarshalText(buf []byte) error {
 }
 
 func (f *SubstepFileStore) load() (prettyMap, error) {
-	data, err := ioutil.ReadFile(f.path)
+	data, err := os.ReadFile(f.path)
 	if err != nil {
 		return nil, err
 	}

--- a/step/substep_store_test.go
+++ b/step/substep_store_test.go
@@ -5,7 +5,6 @@ package step_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -17,7 +16,7 @@ import (
 )
 
 func TestFileStore(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/testutils/stream.go
+++ b/testutils/stream.go
@@ -5,7 +5,6 @@ package testutils
 
 import (
 	"io"
-	"io/ioutil"
 )
 
 // DevNullWithClose implements step.OutStreams
@@ -18,7 +17,7 @@ func (s DevNullSpy) Stdout() io.Writer {
 }
 
 func (s DevNullSpy) Stderr() io.Writer {
-	return ioutil.Discard
+	return io.Discard
 }
 
 // FailingStreams is an implementation of OutStreams for which every call to a
@@ -43,11 +42,11 @@ type DevNullWithClose struct {
 }
 
 func (DevNullWithClose) Stdout() io.Writer {
-	return ioutil.Discard
+	return io.Discard
 }
 
 func (DevNullWithClose) Stderr() io.Writer {
-	return ioutil.Discard
+	return io.Discard
 }
 
 func (d *DevNullWithClose) Close() error {

--- a/testutils/test_utils.go
+++ b/testutils/test_utils.go
@@ -4,7 +4,6 @@
 package testutils
 
 import (
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -139,7 +138,7 @@ func MustGetPort(t *testing.T) int {
 func GetTempDir(t *testing.T, prefix string) string {
 	t.Helper()
 
-	dir, err := ioutil.TempDir("", prefix+"-")
+	dir, err := os.MkdirTemp("", prefix+"-")
 	if err != nil {
 		t.Fatalf("creating temporary directory: %+v", err)
 	}
@@ -176,7 +175,7 @@ func MustCreateDataDirs(t *testing.T) (string, string, func(*testing.T)) {
 	for _, dir := range []string{source, target} {
 		for _, f := range upgrade.PostgresFiles {
 			path := filepath.Join(dir, f)
-			err := ioutil.WriteFile(path, []byte(""), 0600)
+			err := os.WriteFile(path, []byte(""), 0600)
 			if err != nil {
 				t.Fatalf("failed creating postgres file %q: %+v", path, err)
 			}
@@ -196,7 +195,7 @@ func MustCreateDataDirs(t *testing.T) (string, string, func(*testing.T)) {
 func MustReadFile(t *testing.T, path string) string {
 	t.Helper()
 
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("error reading file %q: %v", path, err)
 	}
@@ -207,7 +206,7 @@ func MustReadFile(t *testing.T, path string) string {
 func MustWriteToFile(t *testing.T, path string, contents string) {
 	t.Helper()
 
-	err := ioutil.WriteFile(path, []byte(contents), 0600)
+	err := os.WriteFile(path, []byte(contents), 0600)
 	if err != nil {
 		t.Fatalf("error writing file %q: %v", path, err)
 	}

--- a/upgrade/directories_test.go
+++ b/upgrade/directories_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -494,7 +493,7 @@ func TestPathExist(t *testing.T) {
 
 func setupDirs(t *testing.T, subdirectories []string, requiredPaths []string) (tmpDir string, createdDirectories []string) {
 	var err error
-	tmpDir, err = ioutil.TempDir("", "")
+	tmpDir, err = os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("error creating temporary directory: %v", err)
 	}

--- a/upgrade/tablespace_directories.go
+++ b/upgrade/tablespace_directories.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -91,7 +90,7 @@ func DeleteTablespaceDirectories(streams step.OutStreams, dirs []string) error {
 	for _, dir := range dirs {
 		parent := filepath.Dir(filepath.Clean(dir))
 
-		entries, err := ioutil.ReadDir(parent)
+		entries, err := os.ReadDir(parent)
 		if os.IsNotExist(err) {
 			// directory may have been already removed during previous execution
 			continue
@@ -220,7 +219,7 @@ func VerifyTablespaceDbIDDirectory(fsys fs.FS, dbID string) (bool, error) {
 // The expected tablespace directory layout is:
 //   /dir/<fsname>/<datadir>/<tablespaceOID>/<dbID>/GPDB_6_<catalogVersion>/<dbOID>/<relfilenode>
 func VerifyTablespaceDirectory(path string) (bool, error) {
-	entries, err := ioutil.ReadDir(path)
+	entries, err := os.ReadDir(path)
 	if err != nil {
 		return false, xerrors.Errorf("read tablespace directory %q: %w", path, err)
 	}

--- a/utils/sys_utils.go
+++ b/utils/sys_utils.go
@@ -6,7 +6,6 @@ package utils
 import (
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -76,8 +75,8 @@ func InitializeSystemFunctions() *SystemFunctions {
 		Rename:       os.Rename,
 		Stat:         os.Stat,
 		FilePathGlob: filepath.Glob,
-		ReadFile:     ioutil.ReadFile,
-		WriteFile:    ioutil.WriteFile,
+		ReadFile:     os.ReadFile,
+		WriteFile:    os.WriteFile,
 		Create:       os.Create,
 		Mkdir:        os.Mkdir,
 		Symlink:      os.Symlink,

--- a/utils/sys_utils_test.go
+++ b/utils/sys_utils_test.go
@@ -5,7 +5,6 @@ package utils_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,7 +17,7 @@ import (
 )
 
 func TestJSONFile(t *testing.T) {
-	stateDir, err := ioutil.TempDir("", "")
+	stateDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fix the following lint errors as of golangci-lint v1.48.0:
```
utils/sys_utils.go:9:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
	"io/ioutil"
	^
testutils/stream.go:8:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
	"io/ioutil"
	^
testutils/test_utils.go:7:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
	"io/ioutil"
	^
```

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixLint