### PR TITLE
6->7 and 7->7 Fixes for Fill cluster configs and WaitForSegments

### DIFF
--- a/greenplum/wait_for_segments.go
+++ b/greenplum/wait_for_segments.go
@@ -72,7 +72,12 @@ WHERE content > -1 AND status = 'u' AND (role = preferred_role) ` + whereClause)
 		return true, nil
 	}
 
-	row = db.QueryRow("SELECT COUNT(*) FROM gp_stat_replication WHERE gp_segment_id = -1 AND state = 'streaming' AND sent_location = flush_location;")
+	whereClause = "sent_location = flush_location;"
+	if cluster.Version.Major > 6 {
+		whereClause = "sent_lsn = flush_lsn;"
+	}
+
+	row = db.QueryRow("SELECT COUNT(*) FROM gp_stat_replication WHERE gp_segment_id = -1 AND state = 'streaming' AND " + whereClause)
 	if err := row.Scan(&segments); err != nil {
 		if err == sql.ErrNoRows {
 			log.Printf("no rows found when querying gp_stat_replication")

--- a/hub/fill_cluster_configs.go
+++ b/hub/fill_cluster_configs.go
@@ -25,7 +25,14 @@ func FillConfiguration(config *Config, request *idl.InitializeRequest, saveConfi
 		return err
 	}
 
+	// Need greenplum version to use correct utility mode parameter when making the database connection URI.
+	sourceVersion, err := greenplum.Version(request.GetSourceGPHome())
+	if err != nil {
+		return err
+	}
+
 	tempSource.Destination = idl.ClusterDestination_source
+	tempSource.Version = sourceVersion
 	conn := tempSource.Connection([]greenplum.Option{greenplum.Port(int(request.GetSourcePort())), greenplum.UtilityMode()}...)
 
 	db, err := sql.Open("pgx", conn)


### PR DESCRIPTION
Below are some fixes for 6->7 and 7->7 upgrades. As we are starting some initial testing on 7->7 upgrades these were discovered.

1) Fill cluster configs needs the version in order to correctly set the utility mode parameter.

2) WaitForSegments needs to use the correct fields when querying gp_stat_replication which were renamed in GPDB 7.


Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:6to7Fixes