### PR TITLE
Update pxf-storage-service-account-key location

### DIFF
--- a/ci/1_resources_anchors_groups.yml
+++ b/ci/1_resources_anchors_groups.yml
@@ -210,7 +210,7 @@ resources:
 - name: pxf_6_gpdb{{.GPDBVersion}}_centos{{.CentosVersion}}_rpm
   type: gcs
   source:
-    json_key: ((ud/pxf/secrets/storage-service-account-key))
+    json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
     bucket: data-gpdb-ud-pxf-build
     versioned_file: prod/snapshots/pxf6/pxf-gp{{.GPDBVersion}}.el{{.CentosVersion}}.tar.gz
 


### PR DESCRIPTION
pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:update-pxf-key

must re-fly prod pipeline.