### PR TITLE
Set disk-free-ratio to 0 for tests

### DIFF
--- a/ci/scripts/upgrade-cluster.bash
+++ b/ci/scripts/upgrade-cluster.bash
@@ -35,7 +35,8 @@ time ssh -n mdw "
               --source-gphome $GPHOME_SOURCE \
               --source-master-port $PGPORT \
               --mode $MODE \
-              --temp-port-range 6020-6040
+              --temp-port-range 6020-6040 \
+              --disk-free-ratio 0
 
     gpupgrade execute --non-interactive
     gpupgrade finalize --non-interactive

--- a/test/acceptance/gpupgrade/args.bats
+++ b/test/acceptance/gpupgrade/args.bats
@@ -43,6 +43,7 @@ teardown() {
         --target-gphome "$GPHOME_TARGET" \
         --source-master-port "$PGPORT" \
         --stop-before-cluster-creation \
+        --disk-free-ratio 0 \
         --pg-upgrade-verbose
 
     [ "$status" -eq 1 ]
@@ -97,6 +98,7 @@ teardown() {
         --target-gphome "$GPHOME_TARGET" \
         --source-master-port "$PGPORT" \
         --stop-before-cluster-creation \
+        --disk-free-ratio 0 \
         --verbose
 
     run gpupgrade execute --non-interactive --pg-upgrade-verbose


### PR DESCRIPTION
This flag was ommitted for a couple tests, resulting in test failures in CI when the disk is >60% used.