### PR TITLE
CI: fix rsync issue when installing BATS for multihost tests

### DIFF
--- a/ci/scripts/multihost-gpupgrade-tests.bash
+++ b/ci/scripts/multihost-gpupgrade-tests.bash
@@ -30,7 +30,7 @@ main() {
     scp -rpq gpupgrade_src gpadmin@mdw:/home/gpadmin
 
     echo "Installing BATS..."
-    rsync --archive bats centos@mdw:~
+    rsync --archive bats centos@mdw:
     ssh centos@mdw sudo ./bats/install.sh /usr/local
 
     echo "Running data migration scripts and tests..."


### PR DESCRIPTION
The CI is failing when installing BATS with the following output:
```
Installing BATS...
+ rsync --archive bats 'centos@mdw:~'
+ ssh centos@mdw sudo ./bats/install.sh /usr/local
sudo: ./bats/install.sh: command not found
```

Logging into the failing job shows that rsync was creating a directory `~` such as `/home/centos/~/bats`, rather than `/home/centos/bats` as expected. I am not sure what caused the change. Perhaps rsync was updated to have a different default behavior?

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixRsyncIssueOnCI