### PR TITLE
Fix some bug during gp6 upgrade to gp7

### DIFF
--- a/greenplum/query_pg_stat_activity.go
+++ b/greenplum/query_pg_stat_activity.go
@@ -41,7 +41,7 @@ func (s StatActivities) Error() string {
 }
 
 func QueryPgStatActivity(db *sql.DB, cluster *Cluster) error {
-	query := `SELECT application_name, usename, datname, query FROM pg_stat_activity WHERE pid <> pg_backend_pid() ORDER BY application_name, usename, datname;`
+	query := `SELECT application_name, usename, datname, query FROM pg_stat_activity WHERE pid <> pg_backend_pid() AND datname <>'' ORDER BY application_name, usename, datname;`
 	if cluster.Version.Major < 6 {
 		query = `SELECT application_name, usename, datname, current_query FROM pg_stat_activity WHERE procpid <> pg_backend_pid() ORDER BY application_name, usename, datname;`
 	}

--- a/upgrade/run.go
+++ b/upgrade/run.go
@@ -62,7 +62,7 @@ func Run(stdout, stderr io.Writer, opts *idl.PgOptions) error {
 		args = append(args, "--old-options", opts.GetOldOptions())
 	}
 
-	if opts.Action != idl.PgOptions_check {
+	if opts.Action != idl.PgOptions_check && semver.MustParse(opts.TargetVersion).Major < 7 {
 		args = append(args, "--old-tablespaces-file", utils.GetTablespaceMappingFile())
 	}
 


### PR DESCRIPTION
1.  Fix check_active_connections_on_target_cluster during finalize phase during gp6 upgrade to gp7.
2.  Only add '--old-tablespaces-file' option for target major version less than 7. The option is not supported in gp7 for now.