### PR TITLE
add initial 6-to-7 data migration seed scripts

### DIFF
--- a/data-migration-scripts/6-to-7-seed-scripts/create_find_view_dep_function.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/create_find_view_dep_function.sql
@@ -1,0 +1,132 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- This script assumes that the plpython language is already enabled
+-- The generator should enable it if necessary on each database prior to this point
+
+-- TODO: This implementation can be greatly simplified using recursive CTEs
+-- They will be supported for 6X -> 7X upgrades
+
+SET client_min_messages TO WARNING;
+
+CREATE OR REPLACE FUNCTION  __gpupgrade_tmp_generator.find_view_dependencies()
+RETURNS VOID AS
+$$
+import plpy
+
+
+# First find views that do not depend on other views (and directly on the table)
+
+leaf_view = plpy.execute("""
+SELECT
+    schema,
+    view,
+    owner
+FROM (
+    SELECT DISTINCT
+        nv.nspname AS schema,
+        v.relname AS view,
+        pg_catalog.pg_get_userbyid(v.relowner) AS owner
+    FROM
+        pg_depend d
+        JOIN pg_rewrite r ON r.oid = d.objid
+        JOIN pg_class v ON v.oid = r.ev_class
+        JOIN pg_catalog.pg_namespace nv ON v.relnamespace = nv.oid
+        JOIN pg_catalog.pg_attribute a ON (d.refobjid = a.attrelid AND d.refobjsubid = a.attnum)
+        JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
+        JOIN pg_catalog.pg_namespace nc ON c.relnamespace = nc.oid
+    WHERE
+        v.relkind = 'v'
+        AND d.classid = 'pg_rewrite'::regclass
+        AND d.refclassid = 'pg_class'::regclass
+        AND d.deptype = 'n'
+        AND (a.atttypid = 'pg_catalog.tsquery'::pg_catalog.regtype OR a.atttypid = 'pg_catalog.name'::pg_catalog.regtype)
+        AND c.relkind = 'r'
+        AND NOT a.attisdropped
+        AND nv.nspname NOT LIKE 'pg_temp_%'
+        AND nv.nspname NOT LIKE 'pg_toast_temp_%'
+        AND nv.nspname NOT IN ('pg_catalog', 'information_schema')
+        AND nc.nspname NOT LIKE 'pg_temp_%'
+        AND nc.nspname NOT LIKE 'pg_toast_temp_%'
+        AND nc.nspname NOT IN ('pg_catalog', 'information_schema')
+    ) subq;
+""")
+
+checklist = {}
+view_order = 1
+for row in leaf_view:
+    checklist[(row['schema'], row['view'], row['owner'])] = view_order
+
+rows = plpy.execute("""
+SELECT
+    nsp1.nspname AS depender_schema,
+    depender,
+    depender_owner,
+    nsp2.nspname AS dependee_schema,
+    dependee,
+    dependee_owner
+FROM
+    pg_namespace AS nsp1,
+    pg_namespace AS nsp2,
+    (
+        SELECT
+            c.relname depender,
+            c.relnamespace AS depender_nsp,
+            pg_catalog.pg_get_userbyid(c.relowner) as depender_owner,
+            c1.relname AS dependee,
+            c1.relnamespace AS dependee_nsp,
+            pg_catalog.pg_get_userbyid(c1.relowner) as dependee_owner
+        FROM
+            pg_rewrite AS rw,
+            pg_depend AS d,
+            pg_class AS c,
+            pg_class AS c1
+        WHERE
+            rw.ev_class = c.oid
+            AND rw.oid = d.objid
+            AND d.classid = 'pg_rewrite'::regclass
+            AND d.refclassid = 'pg_class'::regclass
+            AND d.refobjid = c1.oid
+            AND c1.relkind = 'v'
+            AND c.relname <> c1.relname
+        GROUP BY
+            depender, depender_nsp, depender_owner, dependee, dependee_nsp, dependee_owner
+    ) t1
+WHERE
+    t1.depender_nsp = nsp1.oid
+    AND t1.dependee_nsp = nsp2.oid
+    AND nsp1.nspname NOT LIKE 'pg_temp_%'
+    AND nsp1.nspname NOT LIKE 'pg_toast_temp_%'
+    AND nsp1.nspname NOT IN ('pg_catalog', 'information_schema', 'gp_toolkit')
+    AND nsp2.nspname NOT LIKE 'pg_temp_%'
+    AND nsp2.nspname NOT LIKE 'pg_toast_temp_%'
+    AND nsp2.nspname NOT IN ('pg_catalog', 'information_schema', 'gp_toolkit')
+""")
+
+view2view = {}
+for row in rows:
+    key = (row['depender_schema'], row['depender'], row['depender_owner'])
+    val = (row['dependee_schema'], row['dependee'], row['dependee_owner'])
+    view2view[key]=val
+
+while True:
+    view_order += 1
+    new_checklist = {}
+    for depender, dependee in view2view.iteritems():
+        if dependee in checklist and depender not in checklist:
+            new_checklist[depender] = view_order
+    if len(new_checklist) == 0:
+        break
+    else:
+        checklist.update(new_checklist)
+
+plpy.execute("DROP TABLE IF EXISTS  __gpupgrade_tmp_generator.__temp_views_list")
+plpy.execute("CREATE TABLE  __gpupgrade_tmp_generator.__temp_views_list (full_view_name TEXT, view_owner TEXT, view_order INTEGER)")
+for v, view_order in checklist.items():
+    sql = "INSERT INTO  __gpupgrade_tmp_generator.__temp_views_list VALUES('{0}.{1}', '{2}', {3})".format(v[0],v[1],v[2],view_order)
+    plpy.execute(sql)
+$$ LANGUAGE plpythonu;
+
+SELECT __gpupgrade_tmp_generator.find_view_dependencies();
+
+DROP FUNCTION __gpupgrade_tmp_generator.find_view_dependencies();

--- a/data-migration-scripts/6-to-7-seed-scripts/finalize/partitioned_tables_indexes/recreate_partition_indexes_step_1.header
+++ b/data-migration-scripts/6-to-7-seed-scripts/finalize/partitioned_tables_indexes/recreate_partition_indexes_step_1.header
@@ -1,0 +1,3 @@
+-- The below CREATE INDEX statement will create the indexes on the leaf
+-- partitions only. Indexes on the root partition will be created via a
+-- separate step which must be executed after these SQL statements.

--- a/data-migration-scripts/6-to-7-seed-scripts/finalize/partitioned_tables_indexes/recreate_partition_indexes_step_1.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/finalize/partitioned_tables_indexes/recreate_partition_indexes_step_1.sql
@@ -1,0 +1,104 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- generates SQL statement to create indexes on child partition tables that do
+-- not correspond to primary or unique constraints.
+
+WITH child_partitions (relid) AS
+(
+   SELECT DISTINCT
+      parchildrelid
+   FROM
+      pg_partition_rule
+)
+,
+part_constraints AS
+(
+   SELECT
+      conname,
+      c.relname conrel,
+      n.nspname relschema,
+      cc.relname rel
+   FROM
+      pg_constraint con
+      JOIN
+         pg_depend dep
+         ON (dep.refclassid, dep.classid, dep.objsubid) =
+         (
+            'pg_constraint'::regclass,
+            'pg_class'::regclass,
+            0
+         )
+         AND dep.refobjid = con.oid
+         AND dep.deptype = 'i'
+         AND con.contype IN
+         (
+            'u',
+            'p'
+         )
+      JOIN
+         pg_class c
+         ON dep.objid = c.oid
+         AND c.relkind = 'i'
+      JOIN
+         child_partitions
+         ON con.conrelid = child_partitions.relid
+      JOIN
+         pg_class cc
+         ON cc.oid = con.conrelid
+      JOIN
+         pg_namespace n
+         ON (n.oid = cc.relnamespace)
+)
+,
+indexes AS
+(
+   SELECT
+      n.nspname AS schemaname,
+      c.relname AS tablename,
+      i.relname AS indexname,
+      t.spcname AS tablespace,
+      pg_get_indexdef(i.oid) AS indexdef
+   FROM
+      pg_index x
+      JOIN
+         child_partitions np
+         on np.relid = x.indrelid
+      JOIN
+         pg_class c
+         ON c.oid = x.indrelid
+      JOIN
+         pg_class i
+         ON i.oid = x.indexrelid
+      LEFT JOIN
+         pg_namespace n
+         ON n.oid = c.relnamespace
+      LEFT JOIN
+         pg_tablespace t
+         ON t.oid = i.reltablespace
+   WHERE
+      c.relkind = 'r'::"char"
+      AND i.relkind = 'i'::"char"
+      AND c.relhassubclass = 'f'
+      AND x.indisunique = 'f'
+)
+SELECT
+$$SET SEARCH_PATH=$$ || schemaname || $$; $$ || indexdef || $$ ;$$
+FROM
+   indexes
+WHERE
+   (
+      indexname,
+      schemaname,
+      tablename
+   )
+   NOT IN
+   (
+      SELECT
+         conrel,
+         relschema,
+         rel
+      FROM
+         part_constraints
+   )
+;

--- a/data-migration-scripts/6-to-7-seed-scripts/finalize/partitioned_tables_indexes/recreate_partition_indexes_step_2.header
+++ b/data-migration-scripts/6-to-7-seed-scripts/finalize/partitioned_tables_indexes/recreate_partition_indexes_step_2.header
@@ -1,0 +1,18 @@
+-- The below CREATE INDEX statement will create the indexes on the root
+-- partitions, which get cascaded to the child partitions. Prior to execution of
+-- the CREATE INDEX statement on root, CREATE INDEX statement on the child
+-- partitions must be executed for non-unique indexes. When CREATE INDEX on
+-- root is created and cascaded, it will identify that an index on the child partition
+-- already exists on the desired column, so it will adopt it, instead of creating a new one.
+-- 
+-- Note:
+-- 1. There may be cases where an index was dropped on child partition in
+-- source cluster explicitly as it was allowed with Greenplum Database 5.x
+-- version, but with Greenplum Database 6.x since a CREATE INDEX will be executed
+-- on the root, indexes will be created on all the child partitions.
+--
+-- 2. If there were any indexes only on the mid-level partitions in source cluster,
+-- they will not be created, as they don't serve any functional purpose
+--
+-- 3. The name of the unique indexes on the child partitions created in target cluster
+-- may have a different name in source cluster.

--- a/data-migration-scripts/6-to-7-seed-scripts/finalize/partitioned_tables_indexes/recreate_partition_indexes_step_2.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/finalize/partitioned_tables_indexes/recreate_partition_indexes_step_2.sql
@@ -1,0 +1,103 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- generates SQL statement to create indexes on root partition tables
+-- that don't correspond to unique or primary key constraints
+
+-- cte to get all the unique and primary key constraints
+WITH root_partitions (relid) AS
+(
+   SELECT DISTINCT
+      parrelid
+   FROM
+      pg_partition
+)
+,
+root_constraints AS
+(
+   SELECT
+      conname,
+      c.relname conrel,
+      n.nspname relschema,
+      cc.relname rel
+   FROM
+      pg_constraint con
+      JOIN
+         pg_depend dep
+         ON (dep.refclassid, dep.classid, dep.objsubid) =
+         (
+            'pg_constraint'::regclass,
+            'pg_class'::regclass,
+            0
+         )
+         AND dep.refobjid = con.oid
+         AND dep.deptype = 'i'
+         AND con.contype IN
+         (
+            'u',
+            'p'
+         )
+      JOIN
+         pg_class c
+         ON dep.objid = c.oid
+         AND c.relkind = 'i'
+      JOIN
+         root_partitions
+         ON con.conrelid = root_partitions.relid
+      JOIN
+         pg_class cc
+         ON cc.oid = con.conrelid
+      JOIN
+         pg_namespace n
+         ON (n.oid = cc.relnamespace)
+)
+,
+indexes AS
+(
+   SELECT
+      n.nspname AS schemaname,
+      c.relname AS tablename,
+      i.relname AS indexname,
+      t.spcname AS tablespace,
+      pg_get_indexdef(i.oid) AS indexdef
+   FROM
+      pg_index x
+      JOIN
+         root_partitions rp
+         on rp.relid = x.indrelid
+      JOIN
+         pg_class c
+         ON c.oid = x.indrelid
+      JOIN
+         pg_class i
+         ON i.oid = x.indexrelid
+      LEFT JOIN
+         pg_namespace n
+         ON n.oid = c.relnamespace
+      LEFT JOIN
+         pg_tablespace t
+         ON t.oid = i.reltablespace
+   WHERE
+      c.relkind = 'r'::"char"
+      AND i.relkind = 'i'::"char"
+)
+SELECT
+$$SET SEARCH_PATH=$$ || schemaname || $$; $$ || indexdef || $$;$$
+FROM
+   indexes
+WHERE
+   (
+      indexname,
+      schemaname,
+      tablename
+   )
+   NOT IN
+   (
+      SELECT
+         conrel,
+         relschema,
+         rel
+      FROM
+         root_constraints
+   )
+;

--- a/data-migration-scripts/6-to-7-seed-scripts/finalize/tables_using_name_and_tsquery/gen_change_text_to_name.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/finalize/tables_using_name_and_tsquery/gen_change_text_to_name.sql
@@ -1,0 +1,58 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+WITH distcols as
+(
+   SELECT
+      localoid,
+      numsegments
+   from
+      gp_distribution_policy
+),
+partitionedKeys as
+(
+   SELECT
+      DISTINCT parrelid, unnest(paratts) att_num
+   FROM
+      pg_catalog.pg_partition p
+)
+SELECT 'DO $$ BEGIN ALTER TABLE ' || c.oid::pg_catalog.regclass ||
+       ' ALTER COLUMN ' || pg_catalog.quote_ident(a.attname) ||
+       ' TYPE NAME; EXCEPTION WHEN feature_not_supported THEN PERFORM pg_temp.notsupported(''' || c.oid::pg_catalog.regclass || '''); END $$;'
+FROM
+   pg_catalog.pg_class c
+   JOIN
+      pg_catalog.pg_namespace n
+      ON c.relnamespace = n.oid
+      AND c.relkind = 'r'
+      AND n.nspname !~ '^pg_temp_'
+      AND n.nspname !~ '^pg_toast_temp_'
+      AND n.nspname NOT IN
+      (
+         'pg_catalog',
+         'information_schema',
+         'gp_toolkit'
+      )
+   JOIN
+      pg_catalog.pg_attribute a
+      ON c.oid = a.attrelid
+      AND a.attnum > 1
+      AND NOT a.attisdropped
+      AND a.atttypid = 'pg_catalog.name'::pg_catalog.regtype
+   LEFT JOIN distcols
+      ON a.attnum = distcols.numsegments
+      AND a.attrelid = distcols.localoid
+   LEFT JOIN partitionedKeys
+      ON a.attnum = partitionedKeys.att_num
+      AND a.attrelid = partitionedKeys.parrelid
+WHERE
+    -- exclude table entries which has a distribution key using name data type
+    distcols.numsegments is NULL
+    -- exclude partition tables entries which has partition columns using name data type
+    AND partitionedKeys.parrelid is NULL
+    -- exclude child partitions
+    AND c.oid NOT IN
+        (SELECT DISTINCT parchildrelid
+         FROM pg_catalog.pg_partition_rule)
+    -- exclude inherited columns
+    AND a.attinhcount = 0;

--- a/data-migration-scripts/6-to-7-seed-scripts/finalize/tables_using_name_and_tsquery/gen_change_text_to_tsquery.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/finalize/tables_using_name_and_tsquery/gen_change_text_to_tsquery.sql
@@ -1,0 +1,25 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- generates alter statement to modify text datatype to tsquery datatype
+SELECT $$ALTER TABLE $$ || pg_catalog.quote_ident(n.nspname) || '.' || pg_catalog.quote_ident(c.relname) ||
+       $$ ALTER COLUMN $$ || pg_catalog.quote_ident(a.attname) ||
+       $$ TYPE TSQUERY USING $$ || pg_catalog.quote_ident(a.attname) || $$::tsquery;$$
+FROM pg_catalog.pg_class c,
+     pg_catalog.pg_namespace n,
+     pg_catalog.pg_attribute a
+WHERE c.relkind = 'r'
+    AND c.oid = a.attrelid
+    AND NOT a.attisdropped
+    AND a.atttypid = 'pg_catalog.tsquery'::pg_catalog.regtype
+    AND c.relnamespace = n.oid
+    AND n.nspname NOT LIKE 'pg_temp_%'
+    AND n.nspname NOT LIKE 'pg_toast_temp_%'
+    AND n.nspname NOT IN ('pg_catalog',
+                        'information_schema')
+    AND c.oid NOT IN
+        (SELECT DISTINCT parchildrelid
+         FROM pg_catalog.pg_partition_rule)
+
+    -- exclude inherited columns
+    AND a.attinhcount = 0;

--- a/data-migration-scripts/6-to-7-seed-scripts/finalize/tables_using_name_and_tsquery/recreate_indexes_on_deprecated_built_in_types.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/finalize/tables_using_name_and_tsquery/recreate_indexes_on_deprecated_built_in_types.sql
@@ -1,0 +1,52 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Combine both name and tsquery scripts into the same subdirectory since both
+-- reply on this single recreate index script.
+
+-- generates create index statement to re-create indexes on deprecated types.
+
+SELECT pg_get_indexdef(xc.oid) || ';'
+           ||
+       CASE WHEN x.indisclustered
+                THEN
+                    chr(10) ||
+                    $$ALTER TABLE $$ ||
+        pg_catalog.quote_ident(n.nspname) || '.' || pg_catalog.quote_ident(c.relname) ||
+        $$ CLUSTER ON $$ || pg_catalog.quote_ident(xc.relname) || ';'
+    ELSE
+    ''
+END
+||
+CASE WHEN d.description IS NOT NULL
+THEN
+    chr(10) ||
+    $$COMMENT ON INDEX $$ ||
+    pg_catalog.quote_ident(n.nspname) || '.' || pg_catalog.quote_ident(xc.relname) ||
+    $$ IS '$$ || d.description || $$';$$
+ELSE
+''
+END
+FROM
+    pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+    JOIN pg_index x ON c.oid = x.indrelid
+    JOIN pg_class xc ON x.indexrelid = xc.oid
+    LEFT JOIN pg_description d ON xc.oid = d.objoid
+WHERE
+    EXISTS (
+            SELECT 1 FROM pg_catalog.pg_attribute
+            WHERE attrelid = c.oid
+              AND attnum = ANY(x.indkey)
+              AND (atttypid = 'pg_catalog.tsquery'::pg_catalog.regtype OR
+                   atttypid = 'pg_catalog.name'::pg_catalog.regtype)
+              AND NOT attisdropped
+        )
+    AND c.relkind = 'r'
+    AND xc.relkind = 'i'
+    AND n.nspname NOT LIKE 'pg_temp_%'
+    AND n.nspname NOT LIKE 'pg_toast_temp_%'
+    AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND c.oid NOT IN
+        (SELECT DISTINCT parchildrelid
+         FROM pg_catalog.pg_partition_rule);

--- a/data-migration-scripts/6-to-7-seed-scripts/finalize/tables_using_name_and_tsquery/recreate_views_on_deprecated_built_in_types.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/finalize/tables_using_name_and_tsquery/recreate_views_on_deprecated_built_in_types.sql
@@ -1,0 +1,9 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Combine both name and tsquery scripts into the same subdirectory since both
+-- reply on this single recreate views script.
+SELECT
+    $$CREATE VIEW $$ || full_view_name || $$ AS $$ || pg_catalog.pg_get_viewdef(full_view_name::regclass::oid, false) || $$;$$ || E'\n'||
+    $$ALTER VIEW $$ || full_view_name || $$ OWNER TO $$ || view_owner || $$;$$
+FROM __gpupgrade_tmp_generator.__temp_views_list ORDER BY view_order;

--- a/data-migration-scripts/6-to-7-seed-scripts/finalize/unique_primary_foreign_key_constraint/recreate_constraints_1_primary_unique.header
+++ b/data-migration-scripts/6-to-7-seed-scripts/finalize/unique_primary_foreign_key_constraint/recreate_constraints_1_primary_unique.header
@@ -1,0 +1,7 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- The below ALTER TABLE statement will recreate primary and unique constraints
+-- on non-partitioned tables. Note that we primary and unique constraints need
+-- to be created before foreign key constraints such that they can be properly
+-- referenced referenced. Thus, we place them in the same subdirectory.

--- a/data-migration-scripts/6-to-7-seed-scripts/finalize/unique_primary_foreign_key_constraint/recreate_constraints_1_primary_unique.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/finalize/unique_primary_foreign_key_constraint/recreate_constraints_1_primary_unique.sql
@@ -1,0 +1,49 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Generate a script to recreate unique/primary key constraints for
+-- non-child partition tables. Exclude all the child partitions as their
+-- constraints get created by their parent tables.
+
+-- cte to get oids of all tables that are not child partition tables
+WITH CTE as (
+    SELECT oid, *
+    FROM pg_class
+    WHERE
+            oid NOT IN (
+            SELECT DISTINCT parchildrelid
+            FROM pg_partition_rule
+        )
+)
+SELECT
+    $$ALTER TABLE $$ || pg_catalog.quote_ident(n.nspname) || $$.$$ ||
+    pg_catalog.quote_ident(cc.relname) ||
+    $$ ADD CONSTRAINT $$ || pg_catalog.quote_ident(conname) || $$ $$ ||
+    pg_catalog.pg_get_constraintdef(con.oid, false)  || $$;$$
+FROM
+    pg_constraint con
+        JOIN
+    pg_depend dep
+    ON (refclassid, classid, objsubid) =
+       (
+        'pg_constraint'::regclass,
+        'pg_class'::regclass,
+        0
+           )
+        AND refobjid = con.oid
+        AND deptype = 'i'
+        AND contype IN
+            (
+             'u',
+             'p'
+                )
+        JOIN
+    CTE c
+    ON objid = c.oid
+        AND relkind = 'i'
+        JOIN
+    CTE cc
+    ON cc.oid = con.conrelid
+        JOIN
+    pg_namespace n
+    ON (n.oid = cc.relnamespace);

--- a/data-migration-scripts/6-to-7-seed-scripts/finalize/unique_primary_foreign_key_constraint/recreate_constraints_2_fk.header
+++ b/data-migration-scripts/6-to-7-seed-scripts/finalize/unique_primary_foreign_key_constraint/recreate_constraints_2_fk.header
@@ -1,0 +1,4 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- The below ALTER TABLE statement will recreate foreign key constraints.

--- a/data-migration-scripts/6-to-7-seed-scripts/finalize/unique_primary_foreign_key_constraint/recreate_constraints_2_fk.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/finalize/unique_primary_foreign_key_constraint/recreate_constraints_2_fk.sql
@@ -1,0 +1,30 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- We have to create foreign key constraints after primary/unique constraints to make sure that
+-- we can successfully reference them.
+SELECT
+    $$ALTER TABLE $$ || pg_catalog.quote_ident(nspname) || $$.$$ || pg_catalog.quote_ident(relname) ||
+    $$ ADD CONSTRAINT $$ || pg_catalog.quote_ident(conname) || $$ $$ ||
+    pg_catalog.pg_get_constraintdef(cc.oid, false)  || $$;$$
+FROM
+    pg_constraint cc
+        JOIN
+    (
+        SELECT DISTINCT
+            c.oid,
+            n.nspname,
+            c.relname
+        FROM
+            pg_catalog.pg_partition p
+                JOIN
+            pg_catalog.pg_class c
+            ON (p.parrelid = c.oid)
+                JOIN
+            pg_catalog.pg_namespace n
+            ON (n.oid = c.relnamespace)
+    )
+        as sub
+    ON sub.oid = cc.conrelid
+WHERE
+    cc.contype = 'f';

--- a/data-migration-scripts/6-to-7-seed-scripts/initialize/gphdfs_external_tables/gen_drop_external_tables.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/initialize/gphdfs_external_tables/gen_drop_external_tables.sql
@@ -1,0 +1,12 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- generates a sql script to drop external tables in the cluster
+SELECT 'DROP EXTERNAL TABLE ' || d.objid::regclass || ';'
+FROM pg_catalog.pg_depend d
+       JOIN pg_catalog.pg_exttable x ON ( d.objid = x.reloid )
+       JOIN pg_catalog.pg_extprotocol p ON ( p.oid = d.refobjid )
+       JOIN pg_catalog.pg_class c ON ( c.oid = d.objid )
+       JOIN pg_catalog.pg_namespace n ON (c.relnamespace = n.oid)
+WHERE d.refclassid = 'pg_extprotocol'::regclass
+    AND p.ptcname = 'gphdfs';

--- a/data-migration-scripts/6-to-7-seed-scripts/initialize/heterogeneous_partitioned_tables/fix_heterogeneous_partition_tables.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/initialize/heterogeneous_partitioned_tables/fix_heterogeneous_partition_tables.sql
@@ -1,0 +1,121 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Detect heterogenous partition tables and CTAS the affected leaf tables
+-- The detection query is based on the GPDB pg_upgrade code at:
+-- contrib/pg_upgrade/greenplum/check_gp.h
+-- check_heterogeneous_partition() in contrib/pg_upgrade/greenplum/check_gp.c
+-- We only handle scenario 1 referenced in check_heterogeneous_partition().
+-- Detection query used: CHECK_PARTITION_TABLE_DROPPED_COLUMN_REFERENCES
+
+SET client_min_messages TO WARNING;
+
+-- Use CREATE SCHEMA IF NOT EXISTS once it is supported
+CREATE OR REPLACE FUNCTION  __gpupgrade_tmp_generator.fix_het()
+RETURNS VARCHAR AS
+$$
+import plpy
+
+swap_sql = ""
+
+res1 = plpy.execute("""
+SELECT cp1.childnamespace, cp1.childrelname, rp.parrelname, p3.schemaname, p3.partitionname, p3.partitionrank, p3.partitionposition, p3.parentpartitiontablename, cp1.childrelowner
+    FROM (
+            SELECT p.parrelid, rule.parchildrelid, n.nspname AS childnamespace, c.relname AS childrelname, c.relnatts AS childnatts,
+                   sum(CASE WHEN a.attisdropped THEN 1 ELSE 0 END) AS childnumattisdropped, r.rolname AS childrelowner
+            FROM pg_catalog.pg_partition p
+                JOIN pg_catalog.pg_partition_rule rule ON p.oid=rule.paroid AND NOT p.paristemplate
+                JOIN pg_catalog.pg_class c ON rule.parchildrelid = c.oid AND NOT c.relhassubclass
+                JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+                JOIN pg_catalog.pg_attribute a ON rule.parchildrelid = a.attrelid AND a.attnum > 0
+                JOIN pg_roles r ON c.relowner = r.oid
+            GROUP BY p.parrelid, rule.parchildrelid, n.nspname, c.relname, c.relnatts, r.rolname
+        ) cp1
+        JOIN (
+            SELECT p.parrelid, min(c.relnatts) AS minchildnatts, max(c.relnatts) AS maxchildnatts
+            FROM pg_catalog.pg_partition p
+                JOIN pg_catalog.pg_partition_rule rule ON p.oid=rule.paroid AND NOT p.paristemplate
+                JOIN pg_catalog.pg_class c ON rule.parchildrelid = c.oid AND NOT c.relhassubclass
+            GROUP BY p.parrelid
+        ) cp2 ON cp2.parrelid = cp1.parrelid
+        JOIN (
+            SELECT c.oid, n.nspname AS parnamespace, c.relname AS parrelname, c.relnatts AS parnatts,
+                   sum(CASE WHEN a.attisdropped THEN 1 ELSE 0 END) AS parnumattisdropped
+            FROM pg_catalog.pg_partition p
+                JOIN pg_catalog.pg_class c ON p.parrelid = c.oid AND NOT p.paristemplate AND p.parlevel = 0
+                JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+                JOIN pg_catalog.pg_attribute a ON c.oid = a.attrelid AND a.attnum > 0
+            GROUP BY c.oid, n.nspname, c.relname, c.relnatts
+        ) rp ON rp.oid = cp1.parrelid
+        JOIN pg_partitions p3 ON cp1.childrelname = p3.partitiontablename
+    WHERE NOT (rp.parnumattisdropped = 0 AND rp.parnatts = cp1.childnatts) AND
+          NOT (rp.parnumattisdropped > 0 AND cp2.minchildnatts = cp2.maxchildnatts AND
+               (rp.parnatts = cp1.childnatts OR cp1.childnumattisdropped = 0)) AND
+          NOT (rp.parnumattisdropped > 0 AND cp2.minchildnatts != cp2.maxchildnatts AND
+               cp2.minchildnatts < rp.parnatts AND cp1.childnumattisdropped = 0) AND
+          NOT (rp.parnumattisdropped > 0 AND cp2.minchildnatts != cp2.maxchildnatts AND
+               cp2.minchildnatts >= rp.parnatts)
+    ORDER BY rp.oid, cp1.parchildrelid;
+    """)
+if res1 is not None:
+    for i in res1:
+        schemaname = i["schemaname"]
+        partitionname = i["partitionname"]
+        partitionrank = i["partitionrank"]
+        parrelname = i["parrelname"]
+        childrelname = i["childrelname"]
+        childrelowner = i["childrelowner"]
+        partitionposition = i["partitionposition"]
+        parentpartitiontablename = i["parentpartitiontablename"]
+
+        partition_sql = ""
+        local_parentpartitiontablename = parentpartitiontablename
+        while local_parentpartitiontablename is not None:
+            local_vars = plpy.execute("""
+                SELECT parentpartitiontablename, partitionrank, partitionname
+                FROM pg_partitions
+                WHERE partitiontablename = '{local_parentpartitiontablename}' """.format(**locals()))[0]
+            local_partitionname = local_vars["partitionname"]
+            local_partitionrank = local_vars["partitionrank"]
+            if local_partitionname:
+                partition_sql = " ALTER PARTITION {local_partitionname} ".format(**locals()) + partition_sql
+            elif local_partitionrank:
+                partition_sql = " ALTER PARTITION FOR (RANK({local_partitionrank})) ".format(**locals()) + partition_sql
+            else:
+                plpy.error("Cannot read partition name or rank {local_parentpartitiontablename}".format(**locals()))
+
+            local_parentpartitiontablename = local_vars["parentpartitiontablename"]
+
+        exchange_sql = ""
+        if partitionname:
+            exchange_sql = " EXCHANGE PARTITION {partitionname} ".format(**locals())
+        elif partitionrank:
+            exchange_sql = " EXCHANGE PARTITION FOR (RANK({partitionrank})) ".format(**locals())
+        else:
+            plpy.error("Cannot read partition name or rank {0}".format(parentpartitiontablename))
+
+        swap_sql = swap_sql + """
+CREATE TABLE __gpupgrade_tmp_executor.scratch_table (LIKE {schemaname}.{childrelname} INCLUDING CONSTRAINTS INCLUDING DEFAULTS);
+ALTER TABLE __gpupgrade_tmp_executor.scratch_table OWNER TO {childrelowner};
+ALTER TABLE {schemaname}.{parrelname} {partition_sql} {exchange_sql} WITH TABLE __gpupgrade_tmp_executor.scratch_table;
+DROP TABLE __gpupgrade_tmp_executor.scratch_table;
+""".format(**locals())
+
+# We create a schema during the executor runtime for the temporary scratch tables.
+# This schema has a different name than the generator temp schema to avoid potential double create and/or premature
+# drop commands.
+if swap_sql is not "":
+    swap_sql = """
+SET gp_enable_exchange_default_partition = on;
+SET optimizer_enable_ctas = off;
+CREATE SCHEMA __gpupgrade_tmp_executor;
+DROP TABLE IF EXISTS __gpupgrade_tmp_executor.scratch_table;
+{0}
+DROP SCHEMA __gpupgrade_tmp_executor CASCADE;
+RESET gp_enable_exchange_default_partition;
+RESET optimizer_enable_ctas;
+""".format(swap_sql)
+return swap_sql
+
+$$ LANGUAGE plpythonu;
+SELECT __gpupgrade_tmp_generator.fix_het();

--- a/data-migration-scripts/6-to-7-seed-scripts/initialize/parent_partitions_with_seg_entries/gen_drop_parent_partitions_with_seg_entries.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/initialize/parent_partitions_with_seg_entries/gen_drop_parent_partitions_with_seg_entries.sql
@@ -1,0 +1,19 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Generates a script to truncate non-empty segrels for AO and AOCO parent
+-- partitions.
+
+SELECT 'SET allow_system_table_mods TO DML;';
+
+SELECT 'DELETE FROM ' || segrelid::regclass || ';'
+FROM pg_appendonly a JOIN pg_class c ON a.relid = c.oid
+WHERE c.oid IN (SELECT parrelid FROM pg_partition
+                 UNION SELECT parchildrelid
+                 FROM pg_partition_rule)
+      AND c.relhassubclass = true
+      AND a.relid IS NOT NULL
+      AND a.segrelid IS NOT NULL
+ORDER BY 1;
+
+SELECT 'RESET allow_system_table_mods;';

--- a/data-migration-scripts/6-to-7-seed-scripts/initialize/partitioned_tables_indexes/gen_drop_partition_indexes.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/initialize/partitioned_tables_indexes/gen_drop_partition_indexes.sql
@@ -1,0 +1,97 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- generates a script to drop partition indexes that do not correspond to unique or primary
+-- constraints
+
+-- cte to hold the oid from all the root and child partition table
+WITH partitions (relid) AS
+(
+   SELECT DISTINCT
+      parrelid
+   FROM
+      pg_partition
+   UNION ALL
+   SELECT DISTINCT
+      parchildrelid
+   FROM
+      pg_partition_rule
+)
+,
+-- cte to hold the unique and primary key constraint on all the root and child partition table
+part_constraint AS
+(
+   SELECT
+      conname,
+      c.relname connrel,
+      n.nspname relschema,
+      cc.relname rel
+   FROM
+      pg_constraint con
+      JOIN
+         pg_depend dep
+         ON (refclassid, classid, objsubid) =
+         (
+            'pg_constraint'::regclass,
+            'pg_class'::regclass,
+            0
+         )
+         AND refobjid = con.oid
+         AND deptype = 'i'
+         AND contype IN
+         (
+            'u',
+            'p'
+         )
+      JOIN
+         pg_class c
+         ON objid = c.oid
+         AND relkind = 'i'
+      JOIN
+         partitions
+         ON con.conrelid = partitions.relid
+      JOIN
+         pg_class cc
+         ON cc.oid = partitions.relid
+      JOIN
+         pg_namespace n
+         ON (n.oid = cc.relnamespace)
+)
+SELECT
+   $$ DROP INDEX IF EXISTS $$ || pg_catalog.quote_ident(n.nspname) ||'.'|| pg_catalog.quote_ident(i.relname) || $$ ;$$
+FROM
+   pg_index x
+   JOIN
+      partitions c
+      ON c.relid = x.indrelid
+   JOIN
+      pg_class y
+      ON c.relid = y.oid
+   JOIN
+      pg_class i
+      ON i.oid = x.indexrelid
+   LEFT JOIN
+      pg_namespace n
+      ON n.oid = y.relnamespace
+   LEFT JOIN
+      pg_tablespace t
+      ON t.oid = i.reltablespace
+WHERE
+   y.relkind = 'r'::"char"
+   AND i.relkind = 'i'::"char"
+   AND
+   (
+      i.relname,
+      n.nspname,
+      y.relname
+   )
+   NOT IN
+   (
+      SELECT
+         connrel,
+         relschema,
+         rel
+      FROM
+         part_constraint
+   )
+;

--- a/data-migration-scripts/6-to-7-seed-scripts/initialize/tables_using_name_and_tsquery/gen_drop_depr_built_in_type_dependent_views.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/initialize/tables_using_name_and_tsquery/gen_drop_depr_built_in_type_dependent_views.sql
@@ -1,0 +1,8 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Combine both name and tsquery scripts into the same subdirectory since both
+-- reply on this single drop views script.
+
+SELECT 'DROP VIEW '|| full_view_name || ';'
+FROM  __gpupgrade_tmp_generator.__temp_views_list ORDER BY view_order DESC;

--- a/data-migration-scripts/6-to-7-seed-scripts/initialize/tables_using_name_and_tsquery/gen_fix_name_type_columns.header
+++ b/data-migration-scripts/6-to-7-seed-scripts/initialize/tables_using_name_and_tsquery/gen_fix_name_type_columns.header
@@ -1,0 +1,27 @@
+-- The below SQL alters, where possible, the name data type to varchar(63)
+-- in columns other than the first.
+-- For a partition table, SQL is only generated for root partitions as that
+-- cascades to the child partitions.
+-- SQL statements are not generated for distribution columns with name data type,
+-- one can alter the datatype using the below steps:
+--   1. ALTER TABLE <tablename> SET DISTRIBUTED RANDOMLY;
+--   2. ALTER TABLE <tablename> ALTER COLUMN <columnname> TYPE VARCHAR(63);
+--   3. ALTER TABLE <tablename> SET DISTRIBUTED BY (columnname);
+-- SQL statements are not generated for partitioning columns with name data type, one
+-- has to manually recreate the table with datatype other than name such as varchar(63).
+-- Where not possible, a message is logged, and such tables must be manually
+-- modified to remove the name data type prior to running gpugprade.
+
+\set VERBOSITY terse
+
+\unset ECHO
+CREATE OR REPLACE FUNCTION pg_temp.notsupported(text) RETURNS VOID AS $$
+BEGIN
+    RAISE WARNING '---------------------------------------------------------------------------------';
+    RAISE WARNING 'Removing the name datatype column failed on table ''%''.  You must resolve it manually.',$1;
+    RAISE WARNING '---------------------------------------------------------------------------------';
+END
+$$ LANGUAGE plpgsql;
+\set ECHO queries
+
+

--- a/data-migration-scripts/6-to-7-seed-scripts/initialize/tables_using_name_and_tsquery/gen_fix_name_type_columns.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/initialize/tables_using_name_and_tsquery/gen_fix_name_type_columns.sql
@@ -1,0 +1,127 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Portions Copyright © 1996-2020, The PostgreSQL Global Development Group
+--
+-- Portions Copyright © 1994, The Regents of the University of California
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice
+-- and this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+-- BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+-- A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS,
+-- AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE,
+-- SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+-- generate ALTER TABLE ALTER COLUMN commands for tables with name datatype attributes
+-- The DDL command to alter the name datatype is executed on root partitions and
+-- non-partitioned tables. The ALTER command executed on root partitions cascades
+-- to child partitions, and thus are excluded here.
+
+-- A column cannot be altered if it has an index on it, so generate a drop statement for them
+WITH distcols AS
+(
+    SELECT localoid, numsegments
+    FROM gp_distribution_policy
+),
+partitionedKeys AS
+(
+    SELECT DISTINCT parrelid, unnest(paratts) att_num
+    FROM pg_catalog.pg_partition p
+)
+SELECT $$DROP INDEX IF EXISTS $$ || pg_catalog.quote_ident(n.nspname) || '.' || pg_catalog.quote_ident(xc.relname) || ';'
+FROM
+    pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+    JOIN pg_index x ON c.oid = x.indrelid
+    JOIN pg_class xc ON x.indexrelid = xc.oid
+WHERE
+    EXISTS (
+        SELECT 1 FROM pg_catalog.pg_attribute a
+            LEFT JOIN distcols
+                ON a.attnum = distcols.numsegments
+                AND a.attrelid = distcols.localoid
+            LEFT JOIN partitionedKeys
+                ON a.attnum = partitionedKeys.att_num
+                AND a.attrelid = partitionedKeys.parrelid
+        WHERE a.attrelid = c.oid
+            AND a.attnum = ANY(x.indkey)
+            AND a.atttypid = 'pg_catalog.name'::pg_catalog.regtype
+            AND NOT a.attisdropped
+            -- exclude table entries which has a distribution key using name data type
+            AND distcols.numsegments IS NULL
+            -- exclude partition tables entries which has partition columns using name data type
+            AND partitionedKeys.parrelid IS NULL
+            -- exclude inherited columns
+            AND a.attinhcount = 0
+        )
+  AND c.relkind = 'r'
+  AND xc.relkind = 'i'
+  AND n.nspname NOT LIKE 'pg_temp_%'
+  AND n.nspname NOT LIKE 'pg_toast_temp_%'
+  AND n.nspname NOT IN ('pg_catalog',
+                        'information_schema')
+  AND c.oid NOT IN
+      (SELECT DISTINCT parchildrelid
+       FROM pg_catalog.pg_partition_rule);
+
+WITH distcols AS
+(
+    SELECT localoid, numsegments
+    FROM gp_distribution_policy
+),
+partitionedKeys AS
+(
+   SELECT DISTINCT parrelid, unnest(paratts) att_num
+   FROM pg_catalog.pg_partition p
+)
+SELECT
+    'DO $$ BEGIN ALTER TABLE ' || c.oid::pg_catalog.regclass ||
+    ' ALTER COLUMN ' || pg_catalog.quote_ident(a.attname) ||
+    ' TYPE VARCHAR(63); EXCEPTION WHEN feature_not_supported THEN PERFORM pg_temp.notsupported(''' ||
+    c.oid::pg_catalog.regclass || '''); END $$;'
+FROM
+    pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n
+        ON c.relnamespace = n.oid
+        AND c.relkind = 'r'
+        AND n.nspname !~ '^pg_temp_'
+        AND n.nspname !~ '^pg_toast_temp_'
+        AND n.nspname NOT IN
+        (
+           'pg_catalog',
+           'information_schema',
+           'gp_toolkit'
+        )
+    JOIN pg_catalog.pg_attribute a
+        ON c.oid = a.attrelid
+        AND a.attnum > 1
+        AND NOT a.attisdropped
+        AND a.atttypid = 'pg_catalog.name'::pg_catalog.regtype
+    LEFT JOIN distcols
+        ON a.attnum = distcols.numsegments
+        AND a.attrelid = distcols.localoid
+    LEFT JOIN partitionedKeys
+        ON a.attnum = partitionedKeys.att_num
+        AND a.attrelid = partitionedKeys.parrelid
+WHERE
+    -- exclude table entries which has a distribution key using name data type
+    distcols.numsegments IS NULL
+    -- exclude partition tables entries which has partition columns using name data type
+    AND partitionedKeys.parrelid IS NULL
+    -- exclude inherited columns
+    AND a.attinhcount = 0
+    -- exclude child partitions
+    AND c.oid NOT IN
+        (SELECT DISTINCT parchildrelid
+        FROM pg_catalog.pg_partition_rule)
+    ;

--- a/data-migration-scripts/6-to-7-seed-scripts/initialize/tables_using_name_and_tsquery/gen_fix_tsquery_to_text.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/initialize/tables_using_name_and_tsquery/gen_fix_tsquery_to_text.sql
@@ -1,0 +1,96 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Columns having an index on a tsquery column can't be altered, so generate a drop statement for them
+WITH distcols AS
+         (
+             SELECT localoid, numsegments
+             FROM gp_distribution_policy
+         ),
+     partitionedKeys AS
+         (
+             SELECT DISTINCT parrelid, unnest(paratts) att_num
+             FROM pg_catalog.pg_partition p
+         )
+SELECT $$DROP INDEX IF EXISTS $$ || pg_catalog.quote_ident(n.nspname) || '.' || pg_catalog.quote_ident(xc.relname) || ';'
+FROM
+    pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n
+ON c.relnamespace = n.oid
+    JOIN pg_index x ON c.oid = x.indrelid
+    JOIN pg_class xc ON x.indexrelid = xc.oid
+WHERE
+    EXISTS (
+    SELECT 1 FROM pg_catalog.pg_attribute a
+    LEFT JOIN distcols
+    ON a.attnum = distcols.numsegments
+        AND a.attrelid = distcols.localoid
+    LEFT JOIN partitionedKeys
+    ON a.attnum = partitionedKeys.att_num
+        AND a.attrelid = partitionedKeys.parrelid
+    WHERE a.attrelid = c.oid
+        AND a.attnum = ANY (x.indkey)
+        AND a.atttypid = 'pg_catalog.tsquery'::pg_catalog.regtype
+        AND NOT a.attisdropped
+-- exclude table entries which has a distribution key using name data type
+        AND distcols.numsegments IS NULL
+-- exclude partition tables entries which has partition columns using name data type
+        AND partitionedKeys.parrelid IS NULL
+-- exclude inherited columns
+        AND a.attinhcount = 0
+    )
+    AND c.relkind = 'r'
+    AND xc.relkind = 'i'
+    AND n.nspname NOT LIKE 'pg_temp_%'
+    AND n.nspname NOT LIKE 'pg_toast_temp_%'
+    AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND c.oid NOT IN
+        (SELECT DISTINCT parchildrelid
+        FROM pg_catalog.pg_partition_rule);
+
+-- generates alter statement to modify tsquery datatype to text datatype
+WITH distcols AS
+         (
+             SELECT localoid, numsegments
+             FROM gp_distribution_policy
+         ),
+     partitionedKeys AS
+         (
+             SELECT DISTINCT parrelid, unnest(paratts) att_num
+             FROM pg_catalog.pg_partition p
+         )
+SELECT 'DO $$ BEGIN ALTER TABLE ' ||
+       pg_catalog.quote_ident(n.nspname) || '.' || pg_catalog.quote_ident(c.relname) ||
+       ' ALTER COLUMN ' || pg_catalog.quote_ident(a.attname) ||
+       ' TYPE VARCHAR(63); EXCEPTION WHEN feature_not_supported THEN PERFORM pg_temp.notsupported(''' ||
+       c.oid::pg_catalog.regclass || '''); END $$;'
+FROM pg_catalog.pg_class c,
+     pg_catalog.pg_namespace n,
+     pg_catalog.pg_attribute a
+         LEFT JOIN distcols
+                   ON a.attnum = distcols.numsegments
+                       AND a.attrelid = distcols.localoid
+         LEFT JOIN partitionedKeys
+                   ON a.attnum = partitionedKeys.att_num
+                       AND a.attrelid = partitionedKeys.parrelid
+WHERE
+  -- exclude table entries which has a distribution key using tsquery data type
+    distcols.numsegments IS NULL
+  -- exclude partition tables entries which has partition columns using tsquery data type
+  AND partitionedKeys.parrelid IS NULL
+  -- exclude inherited columns
+  AND a.attinhcount = 0
+  AND c.relkind = 'r'
+  AND c.oid = a.attrelid
+  AND NOT a.attisdropped
+  AND a.atttypid = 'pg_catalog.tsquery'::pg_catalog.regtype
+    AND c.relnamespace = n.oid
+    AND n.nspname NOT LIKE 'pg_temp_%'
+    AND n.nspname NOT LIKE 'pg_toast_temp_%'
+    AND n.nspname NOT IN ('pg_catalog',
+                        'information_schema')
+    -- exclude child partitions
+    AND c.oid NOT IN
+        (SELECT DISTINCT parchildrelid
+         FROM pg_catalog.pg_partition_rule)
+;

--- a/data-migration-scripts/6-to-7-seed-scripts/initialize/unique_primary_foreign_key_constraint/gen_drop_constraint_1_fk.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/initialize/unique_primary_foreign_key_constraint/gen_drop_constraint_1_fk.sql
@@ -1,0 +1,32 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- generates a script to drop foreign key constraints.
+-- Foreign key constraints have to be dropped before primary/unique constraints to make sure that
+-- we can successfully drop the dependee constraints.
+-- Note that we primary and unique constraints need to be created before
+-- foreign key constraints such that they can be properly referenced referenced.
+-- Thus, we place them in the same subdirectory.
+SELECT
+   'ALTER TABLE ' || pg_catalog.quote_ident(nspname) || '.' || pg_catalog.quote_ident(relname) || ' DROP CONSTRAINT ' || pg_catalog.quote_ident(conname) || ';'
+FROM
+   pg_constraint cc
+   JOIN
+      (
+         SELECT DISTINCT
+            c.oid,
+            n.nspname,
+            c.relname
+         FROM
+            pg_catalog.pg_partition p
+            JOIN
+               pg_catalog.pg_class c
+               ON (p.parrelid = c.oid)
+            JOIN
+               pg_catalog.pg_namespace n
+               ON (n.oid = c.relnamespace)
+      )
+      as sub
+      ON sub.oid = cc.conrelid
+WHERE
+   cc.contype = 'f';

--- a/data-migration-scripts/6-to-7-seed-scripts/initialize/unique_primary_foreign_key_constraint/gen_drop_constraint_2_primary_unique.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/initialize/unique_primary_foreign_key_constraint/gen_drop_constraint_2_primary_unique.sql
@@ -1,0 +1,44 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Generate a script to drop unique/primary key constraints.
+
+-- For upgrades from 5X we need to set gp_enable_drop_key_constraint_child_partition so we can drop unique and primary
+-- key constraints directly from leaf partitions, in addition to dropping them from the root. Normally, dropping
+-- constraints directly from leaves is banned by GPDB - and dropping constraints from the root suffices. However,
+-- dropping such constraints from the root doesn't always drop the constraint from the leaves (if an unnamed constraint
+-- was added to the partition hierarchy with ALTER TABLE ADD CONSTRAINT at the root level).
+
+-- For upgrades from 6X onwards, it is sufficient to drop the constraint from the root level.
+
+SELECT 'SET gp_enable_drop_key_constraint_child_partition=on;';
+SELECT
+   'ALTER TABLE ' || pg_catalog.quote_ident(n.nspname) || '.' || pg_catalog.quote_ident(cc.relname) || ' DROP CONSTRAINT ' || pg_catalog.quote_ident(conname) || ' CASCADE;'
+FROM
+   pg_constraint con
+   JOIN
+      pg_depend dep
+      ON (refclassid, classid, objsubid) =
+      (
+         'pg_constraint'::regclass,
+         'pg_class'::regclass,
+         0
+      )
+      AND refobjid = con.oid
+      AND deptype = 'i'
+      AND contype IN
+      (
+         'u',
+         'p'
+      )
+   JOIN
+      pg_class c
+      ON objid = c.oid
+      AND relkind = 'i'
+   JOIN
+      pg_class cc
+      ON cc.oid = con.conrelid
+   JOIN
+      pg_namespace n
+      ON (n.oid = cc.relnamespace);
+SELECT 'SET gp_enable_drop_key_constraint_child_partition=off;';

--- a/data-migration-scripts/6-to-7-seed-scripts/revert/gphdfs_external_tables/recreate_gphdfs_external_tables.sh
+++ b/data-migration-scripts/6-to-7-seed-scripts/revert/gphdfs_external_tables/recreate_gphdfs_external_tables.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+if [ "$#" -ne 3 ]; then
+    echo "Illegal number of parameters"
+    echo "Usage: $(basename "$0") <GPHOME> <PGPORT> <DBNAME>"
+    exit 1
+fi
+
+GPHOME=$1
+PGPORT=$2
+DBNAME=$3
+
+main() {
+    local psql="$GPHOME"/bin/psql
+    local pg_dump="$GPHOME"/bin/pg_dump
+
+    local tables=()
+
+    # Find all GPHDFS external tables.
+    #
+    # NOTE: psql's -c implies -X; we don't need to worry about .psqlrc
+    # influencing these queries. For 8.3 this is undocumented but still true.
+    while read -r table; do
+        tables+=(-t "$table")
+    done < <($psql -v ON_ERROR_STOP=1 -d "$DBNAME" -p "$PGPORT" -Atc "
+        SELECT d.objid::regclass
+        FROM pg_catalog.pg_depend d
+               JOIN pg_catalog.pg_exttable x ON ( d.objid = x.reloid )
+               JOIN pg_catalog.pg_extprotocol p ON ( p.oid = d.refobjid )
+               JOIN pg_catalog.pg_class c ON ( c.oid = d.objid )
+        WHERE d.refclassid = 'pg_extprotocol'::regclass
+            AND p.ptcname = 'gphdfs';
+    ")
+
+    if (( ! ${#tables[@]} )); then
+        # Don't pg_dump if there are no interesting tables; we'll get useless
+        # SQL files.
+        return
+    fi
+
+    $pg_dump -p "$PGPORT" --schema-only "${tables[@]}" "$DBNAME"
+}
+
+main

--- a/data-migration-scripts/6-to-7-seed-scripts/revert/partitioned_tables_indexes/recreate_partition_indexes_step_1.header
+++ b/data-migration-scripts/6-to-7-seed-scripts/revert/partitioned_tables_indexes/recreate_partition_indexes_step_1.header
@@ -1,0 +1,11 @@
+-- The below CREATE INDEX statement will create the indexes on the root
+-- partitions, which get cascaded to the child partitions.
+-- 
+-- Note:
+-- 1. There may be cases where an index was dropped on child partition in
+-- source cluster explicitly as it was allowed with Greenplum Database 5.x
+-- version, but with Greenplum Database 6.x since a CREATE INDEX will be executed
+-- on the root, indexes will be created on all the child partitions.
+--
+-- 2. The name of the unique indexes on the child partitions created in target cluster
+-- may have a different name in source cluster.

--- a/data-migration-scripts/6-to-7-seed-scripts/revert/partitioned_tables_indexes/recreate_partition_indexes_step_1.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/revert/partitioned_tables_indexes/recreate_partition_indexes_step_1.sql
@@ -1,0 +1,103 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- generates SQL statement to create indexes on root partition tables
+-- that don't correspond to unique or primary key constraints
+
+-- cte to get all the unique and primary key constraints
+WITH root_partitions (relid) AS
+(
+   SELECT DISTINCT
+      parrelid
+   FROM
+      pg_partition
+)
+,
+root_constraints AS
+(
+   SELECT
+      conname,
+      c.relname conrel,
+      n.nspname relschema,
+      cc.relname rel
+   FROM
+      pg_constraint con
+      JOIN
+         pg_depend dep
+         ON (dep.refclassid, dep.classid, dep.objsubid) =
+         (
+            'pg_constraint'::regclass,
+            'pg_class'::regclass,
+            0
+         )
+         AND dep.refobjid = con.oid
+         AND dep.deptype = 'i'
+         AND con.contype IN
+         (
+            'u',
+            'p'
+         )
+      JOIN
+         pg_class c
+         ON dep.objid = c.oid
+         AND c.relkind = 'i'
+      JOIN
+         root_partitions
+         ON con.conrelid = root_partitions.relid
+      JOIN
+         pg_class cc
+         ON cc.oid = con.conrelid
+      JOIN
+         pg_namespace n
+         ON (n.oid = cc.relnamespace)
+)
+,
+indexes AS
+(
+   SELECT
+      n.nspname AS schemaname,
+      c.relname AS tablename,
+      i.relname AS indexname,
+      t.spcname AS tablespace,
+      pg_get_indexdef(i.oid) AS indexdef
+   FROM
+      pg_index x
+      JOIN
+         root_partitions rp
+         on rp.relid = x.indrelid
+      JOIN
+         pg_class c
+         ON c.oid = x.indrelid
+      JOIN
+         pg_class i
+         ON i.oid = x.indexrelid
+      LEFT JOIN
+         pg_namespace n
+         ON n.oid = c.relnamespace
+      LEFT JOIN
+         pg_tablespace t
+         ON t.oid = i.reltablespace
+   WHERE
+      c.relkind = 'r'::"char"
+      AND i.relkind = 'i'::"char"
+)
+SELECT
+$$SET SEARCH_PATH=$$ || schemaname || $$; $$ || indexdef || $$;$$
+FROM
+   indexes
+WHERE
+   (
+      indexname,
+      schemaname,
+      tablename
+   )
+   NOT IN
+   (
+      SELECT
+         conrel,
+         relschema,
+         rel
+      FROM
+         root_constraints
+   )
+;

--- a/data-migration-scripts/6-to-7-seed-scripts/revert/partitioned_tables_indexes/recreate_partition_indexes_step_2.header
+++ b/data-migration-scripts/6-to-7-seed-scripts/revert/partitioned_tables_indexes/recreate_partition_indexes_step_2.header
@@ -1,0 +1,5 @@
+-- The below CREATE INDEX statement will create the indexes on the leaf
+-- partitions only. Indexes on the root partition will be created via a
+-- separate step.
+-- This script recreates only child table specific indexes. Any index
+-- inherited from the root table will be filtered out.

--- a/data-migration-scripts/6-to-7-seed-scripts/revert/partitioned_tables_indexes/recreate_partition_indexes_step_2.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/revert/partitioned_tables_indexes/recreate_partition_indexes_step_2.sql
@@ -1,0 +1,103 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- generates SQL statement to create indexes on child partition tables that do
+-- not correspond to primary or unique constraints.
+
+WITH child_partitions (relid) AS
+(
+   SELECT DISTINCT
+      parchildrelid
+   FROM
+      pg_partition_rule
+)
+,
+part_constraints AS
+(
+   SELECT
+      conname,
+      c.relname conrel,
+      n.nspname relschema,
+      cc.relname rel
+   FROM
+      pg_constraint con
+      JOIN
+         pg_depend dep
+         ON (dep.refclassid, dep.classid, dep.objsubid) =
+         (
+            'pg_constraint'::regclass,
+            'pg_class'::regclass,
+            0
+         )
+         AND dep.refobjid = con.oid
+         AND dep.deptype = 'i'
+         AND con.contype IN
+         (
+            'u',
+            'p'
+         )
+      JOIN
+         pg_class c
+         ON dep.objid = c.oid
+         AND c.relkind = 'i'
+      JOIN
+         child_partitions
+         ON con.conrelid = child_partitions.relid
+      JOIN
+         pg_class cc
+         ON cc.oid = con.conrelid
+      JOIN
+         pg_namespace n
+         ON (n.oid = cc.relnamespace)
+)
+,
+indexes AS
+(
+   SELECT
+      n.nspname AS schemaname,
+      c.relname AS tablename,
+      i.relname AS indexname,
+      t.spcname AS tablespace,
+      pg_get_indexdef(i.oid) AS indexdef
+   FROM
+      pg_index x
+      JOIN
+         child_partitions np
+         on np.relid = x.indrelid
+      JOIN
+         pg_class c
+         ON c.oid = x.indrelid
+      JOIN
+         pg_class i
+         ON i.oid = x.indexrelid
+      LEFT JOIN
+         pg_namespace n
+         ON n.oid = c.relnamespace
+      LEFT JOIN
+         pg_tablespace t
+         ON t.oid = i.reltablespace
+   WHERE
+      c.relkind = 'r'::"char"
+      AND i.relkind = 'i'::"char"
+)
+SELECT
+'DO $$ BEGIN IF NOT EXISTS ( SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE  c.relname = ''' || indexname ||
+''' AND n.nspname = ''' || schemaname || ''' ) THEN ' || indexdef || '; END IF; END $$; '
+FROM
+   indexes
+WHERE
+   (
+      indexname,
+      schemaname,
+      tablename
+   )
+   NOT IN
+   (
+      SELECT
+         conrel,
+         relschema,
+         rel
+      FROM
+         part_constraints
+   )
+;

--- a/data-migration-scripts/6-to-7-seed-scripts/revert/tables_using_name_and_tsquery/gen_change_text_to_name.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/revert/tables_using_name_and_tsquery/gen_change_text_to_name.sql
@@ -1,0 +1,58 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+WITH distcols as
+(
+   SELECT
+      localoid,
+      numsegments
+   from
+      gp_distribution_policy
+),
+partitionedKeys as
+(
+   SELECT
+      DISTINCT parrelid, unnest(paratts) att_num
+   FROM
+      pg_catalog.pg_partition p
+)
+SELECT 'DO $$ BEGIN ALTER TABLE ' || c.oid::pg_catalog.regclass ||
+       ' ALTER COLUMN ' || pg_catalog.quote_ident(a.attname) ||
+       ' TYPE NAME; EXCEPTION WHEN feature_not_supported THEN PERFORM pg_temp.notsupported(''' || c.oid::pg_catalog.regclass || '''); END $$;'
+FROM
+   pg_catalog.pg_class c
+   JOIN
+      pg_catalog.pg_namespace n
+      ON c.relnamespace = n.oid
+      AND c.relkind = 'r'
+      AND n.nspname !~ '^pg_temp_'
+      AND n.nspname !~ '^pg_toast_temp_'
+      AND n.nspname NOT IN
+      (
+         'pg_catalog',
+         'information_schema',
+         'gp_toolkit'
+      )
+   JOIN
+      pg_catalog.pg_attribute a
+      ON c.oid = a.attrelid
+      AND a.attnum > 1
+      AND NOT a.attisdropped
+      AND a.atttypid = 'pg_catalog.name'::pg_catalog.regtype
+   LEFT JOIN distcols
+      ON a.attnum = distcols.numsegments
+      AND a.attrelid = distcols.localoid
+   LEFT JOIN partitionedKeys
+      ON a.attnum = partitionedKeys.att_num
+      AND a.attrelid = partitionedKeys.parrelid
+WHERE
+    -- exclude table entries which has a distribution key using name data type
+    distcols.numsegments is NULL
+    -- exclude partition tables entries which has partition columns using name data type
+    AND partitionedKeys.parrelid is NULL
+    -- exclude child partitions
+    AND c.oid NOT IN
+        (SELECT DISTINCT parchildrelid
+         FROM pg_catalog.pg_partition_rule)
+    -- exclude inherited columns
+    AND a.attinhcount = 0;

--- a/data-migration-scripts/6-to-7-seed-scripts/revert/tables_using_name_and_tsquery/gen_change_text_to_tsquery.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/revert/tables_using_name_and_tsquery/gen_change_text_to_tsquery.sql
@@ -1,0 +1,25 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- generates alter statement to modify text datatype to tsquery datatype
+SELECT $$ALTER TABLE $$ || pg_catalog.quote_ident(n.nspname) || '.' || pg_catalog.quote_ident(c.relname) ||
+       $$ ALTER COLUMN $$ || pg_catalog.quote_ident(a.attname) ||
+       $$ TYPE TSQUERY USING $$ || pg_catalog.quote_ident(a.attname) || $$::tsquery;$$
+FROM pg_catalog.pg_class c,
+     pg_catalog.pg_namespace n,
+     pg_catalog.pg_attribute a
+WHERE c.relkind = 'r'
+    AND c.oid = a.attrelid
+    AND NOT a.attisdropped
+    AND a.atttypid = 'pg_catalog.tsquery'::pg_catalog.regtype
+    AND c.relnamespace = n.oid
+    AND n.nspname NOT LIKE 'pg_temp_%'
+    AND n.nspname NOT LIKE 'pg_toast_temp_%'
+    AND n.nspname NOT IN ('pg_catalog',
+                        'information_schema')
+    AND c.oid NOT IN
+        (SELECT DISTINCT parchildrelid
+         FROM pg_catalog.pg_partition_rule)
+
+    -- exclude inherited columns
+    AND a.attinhcount = 0;

--- a/data-migration-scripts/6-to-7-seed-scripts/revert/tables_using_name_and_tsquery/recreate_indexes_on_deprecated_built_in_types.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/revert/tables_using_name_and_tsquery/recreate_indexes_on_deprecated_built_in_types.sql
@@ -1,0 +1,52 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Combine both name and tsquery scripts into the same subdirectory since both
+-- reply on this single recreate index script.
+
+-- generates create index statement to re-create indexes on deprecated types.
+
+SELECT pg_get_indexdef(xc.oid) || ';'
+||
+CASE WHEN x.indisclustered
+THEN
+    chr(10) ||
+    $$ALTER TABLE $$ ||
+    pg_catalog.quote_ident(n.nspname) || '.' || pg_catalog.quote_ident(c.relname) ||
+    $$ CLUSTER ON $$ || pg_catalog.quote_ident(xc.relname) || ';'
+ELSE
+''
+END
+||
+CASE WHEN d.description IS NOT NULL
+THEN
+    chr(10) ||
+    $$COMMENT ON INDEX $$ ||
+    pg_catalog.quote_ident(n.nspname) || '.' || pg_catalog.quote_ident(xc.relname) ||
+    $$ IS '$$ || d.description || $$';$$
+ELSE
+''
+END
+FROM
+    pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+    JOIN pg_index x ON c.oid = x.indrelid
+    JOIN pg_class xc ON x.indexrelid = xc.oid
+    LEFT JOIN pg_description d ON xc.oid = d.objoid
+WHERE
+    EXISTS (
+            SELECT 1 FROM pg_catalog.pg_attribute
+            WHERE attrelid = c.oid
+              AND attnum = ANY(x.indkey)
+              AND (atttypid = 'pg_catalog.tsquery'::pg_catalog.regtype OR
+                   atttypid = 'pg_catalog.name'::pg_catalog.regtype)
+              AND NOT attisdropped
+        )
+    AND c.relkind = 'r'
+    AND xc.relkind = 'i'
+    AND n.nspname NOT LIKE 'pg_temp_%'
+    AND n.nspname NOT LIKE 'pg_toast_temp_%'
+    AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+    AND c.oid NOT IN
+        (SELECT DISTINCT parchildrelid
+         FROM pg_catalog.pg_partition_rule);

--- a/data-migration-scripts/6-to-7-seed-scripts/revert/tables_using_name_and_tsquery/recreate_views_on_deprecated_built_in_types.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/revert/tables_using_name_and_tsquery/recreate_views_on_deprecated_built_in_types.sql
@@ -1,0 +1,9 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Combine both name and tsquery scripts into the same subdirectory since both
+-- reply on this single recreate views script.
+SELECT
+    $$CREATE VIEW $$ || full_view_name || $$ AS $$ || pg_catalog.pg_get_viewdef(full_view_name::regclass::oid, false) || $$;$$ || E'\n'||
+    $$ALTER TABLE $$ || full_view_name || $$ OWNER TO $$ || view_owner || $$;$$
+FROM __gpupgrade_tmp_generator.__temp_views_list ORDER BY view_order;

--- a/data-migration-scripts/6-to-7-seed-scripts/revert/unique_primary_foreign_key_constraint/recreate_constraints_1_primary_unique.header
+++ b/data-migration-scripts/6-to-7-seed-scripts/revert/unique_primary_foreign_key_constraint/recreate_constraints_1_primary_unique.header
@@ -1,0 +1,7 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- The below ALTER TABLE statement will recreate primary and unique constraints
+-- on non-partitioned tables. Note that we primary and unique constraints need
+-- to be created before foreign key constraints such that they can be properly
+-- referenced referenced. Thus, we place them in the same subdirectory.

--- a/data-migration-scripts/6-to-7-seed-scripts/revert/unique_primary_foreign_key_constraint/recreate_constraints_1_primary_unique.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/revert/unique_primary_foreign_key_constraint/recreate_constraints_1_primary_unique.sql
@@ -1,0 +1,49 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Generate a script to recreate unique/primary key constraints for
+-- non-child partition tables. Exclude all the child partitions as their
+-- constraints get created by their parent tables.
+
+-- cte to get oids of all tables that are not child partition tables
+WITH CTE as (
+    SELECT oid, *
+    FROM pg_class
+    WHERE
+            oid NOT IN (
+            SELECT DISTINCT parchildrelid
+            FROM pg_partition_rule
+        )
+)
+SELECT
+    $$ALTER TABLE $$ || pg_catalog.quote_ident(n.nspname) || $$.$$ ||
+    pg_catalog.quote_ident(cc.relname) ||
+    $$ ADD CONSTRAINT $$ || pg_catalog.quote_ident(conname) || $$ $$ ||
+    pg_catalog.pg_get_constraintdef(con.oid, false)  || $$;$$
+FROM
+    pg_constraint con
+        JOIN
+    pg_depend dep
+    ON (refclassid, classid, objsubid) =
+       (
+        'pg_constraint'::regclass,
+        'pg_class'::regclass,
+        0
+           )
+        AND refobjid = con.oid
+        AND deptype = 'i'
+        AND contype IN
+            (
+             'u',
+             'p'
+                )
+        JOIN
+    CTE c
+    ON objid = c.oid
+        AND relkind = 'i'
+        JOIN
+    CTE cc
+    ON cc.oid = con.conrelid
+        JOIN
+    pg_namespace n
+    ON (n.oid = cc.relnamespace);

--- a/data-migration-scripts/6-to-7-seed-scripts/revert/unique_primary_foreign_key_constraint/recreate_constraints_2_fk.header
+++ b/data-migration-scripts/6-to-7-seed-scripts/revert/unique_primary_foreign_key_constraint/recreate_constraints_2_fk.header
@@ -1,0 +1,4 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- The below ALTER TABLE statement will recreate foreign key constraints.

--- a/data-migration-scripts/6-to-7-seed-scripts/revert/unique_primary_foreign_key_constraint/recreate_constraints_2_fk.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/revert/unique_primary_foreign_key_constraint/recreate_constraints_2_fk.sql
@@ -1,0 +1,30 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- We have to create foreign key constraints after primary/unique constraints to make sure that
+-- we can successfully reference them.
+SELECT
+    $$ALTER TABLE $$ || pg_catalog.quote_ident(nspname) || $$.$$ || pg_catalog.quote_ident(relname) ||
+    $$ ADD CONSTRAINT $$ || pg_catalog.quote_ident(conname) || $$ $$ ||
+    pg_catalog.pg_get_constraintdef(cc.oid, false)  || $$;$$
+FROM
+    pg_constraint cc
+        JOIN
+    (
+        SELECT DISTINCT
+            c.oid,
+            n.nspname,
+            c.relname
+        FROM
+            pg_catalog.pg_partition p
+                JOIN
+            pg_catalog.pg_class c
+            ON (p.parrelid = c.oid)
+                JOIN
+            pg_catalog.pg_namespace n
+            ON (n.oid = c.relnamespace)
+    )
+        as sub
+    ON sub.oid = cc.conrelid
+WHERE
+    cc.contype = 'f';

--- a/data-migration-scripts/6-to-7-seed-scripts/stats/generate_stats/generate_stats.sh
+++ b/data-migration-scripts/6-to-7-seed-scripts/stats/generate_stats/generate_stats.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+cat << 'EOF'
+
+SELECT current_database();
+
+-- Cluster Statistics
+SELECT hostname, COUNT(dbid) AS Primaries FROM pg_catalog.gp_segment_configuration WHERE role='p' GROUP BY hostname;
+SELECT hostname, COUNT(dbid) AS Mirrors FROM pg_catalog.gp_segment_configuration WHERE role='m' GROUP BY hostname;
+
+-- Extensions
+SELECT COUNT(*) AS InstalledExtensions FROM pg_catalog.pg_extension;
+
+-- Database size
+SELECT pg_size_pretty(pg_database_size(current_database())) AS DatabaseSize;
+SELECT COUNT(*) as Databases FROM pg_catalog.pg_database;
+
+-- No. of triggers
+SELECT COUNT(*) AS Triggers FROM pg_catalog.pg_trigger;
+
+-- GUCs
+SELECT COUNT(*) AS NonDefaultParameters FROM pg_catalog.pg_settings WHERE source <> 'default';
+
+-- No. of Tablespaces
+SELECT COUNT(*) AS Tablespaces FROM pg_catalog.pg_tablespace;
+
+-- No. of schemas
+SELECT COUNT(nspname) AS Schemas FROM pg_catalog.pg_namespace;
+
+-- Table Statistics
+SELECT COUNT(*) AS OrdinaryTables FROM pg_catalog.pg_class WHERE RELKIND='r';
+SELECT COUNT(*) AS IndexTables FROM pg_catalog.pg_class WHERE RELKIND='i';
+SELECT COUNT(*) AS Views FROM pg_catalog.pg_class WHERE RELKIND='v';
+SELECT COUNT(*) AS ToastTables FROM pg_catalog.pg_class WHERE RELKIND='t';
+SELECT COUNT(*) AS AOTables FROM pg_catalog.pg_appendonly WHERE columnstore = 'f';
+SELECT COUNT(*) AS AOCOTables FROM pg_catalog.pg_appendonly WHERE columnstore = 't';
+SELECT COUNT(*) AS UserTables FROM pg_catalog.pg_stat_user_tables;
+
+-- No. of Columns in AOCO
+SELECT COUNT(*) AS AOCOColumns FROM information_schema.columns
+ WHERE table_name IN (SELECT relid::regclass::text FROM pg_catalog.pg_appendonly WHERE columnstore = 't');
+
+-- Partition Table Statistics
+SELECT COUNT(DISTINCT parrelid) AS RootPartitions FROM pg_catalog.pg_partition;
+SELECT COUNT(DISTINCT parchildrelid) AS ChildPartitions FROM pg_catalog.pg_partition_rule;
+
+-- No. of views
+SELECT COUNT(*) AS Views FROM pg_catalog.pg_views;
+
+-- No. of indexes
+SELECT COUNT(*) AS Indexes FROM pg_catalog.pg_index;
+
+
+EOF

--- a/data-migration-scripts/6-to-7-seed-scripts/test/create_nonupgradable_objects.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/test/create_nonupgradable_objects.sql
@@ -1,0 +1,347 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Ensure data migration scripts fully qualify objects by creating the
+-- non-upgradable objects in a custom schema.
+DROP SCHEMA IF EXISTS testschema CASCADE;
+CREATE SCHEMA testschema;
+SET search_path to testschema;
+
+DROP TABLE IF EXISTS regular CASCADE;
+CREATE TABLE regular (a int unique);
+
+-- create partitioned table with foreign key constraints
+DROP TABLE IF EXISTS pt_with_index CASCADE;
+CREATE TABLE pt_with_index (a int references regular(a), b int, c int, d int)
+    PARTITION BY RANGE(b)
+        (
+        PARTITION pt1 START(1),
+        PARTITION pt2 START(2) END (3),
+        PARTITION pt3 START(3) END (4)
+        );
+
+CREATE INDEX ptidxc on pt_with_index(c);
+CREATE INDEX ptidxc_bitmap on pt_with_index using bitmap(c);
+
+CREATE INDEX ptidxb_prt_2 on pt_with_index_1_prt_pt2(b);
+CREATE INDEX ptidxb_prt_2_bitmap on pt_with_index_1_prt_pt2 using bitmap(b);
+
+CREATE INDEX ptidxc_prt_2 on pt_with_index_1_prt_pt2(c);
+CREATE INDEX ptidxc_prt_2_bitmap on pt_with_index_1_prt_pt2 using bitmap(c);
+INSERT INTO pt_with_index SELECT i, i%2+1, i, i FROM generate_series(1,10)i;
+
+-- create multi level partitioned table with indexes
+DROP TABLE IF EXISTS sales;
+CREATE TABLE sales (trans_id int, office_id int, region text)
+    DISTRIBUTED BY (trans_id)
+    PARTITION BY RANGE (office_id)
+        SUBPARTITION BY LIST (region)
+            SUBPARTITION TEMPLATE
+            ( SUBPARTITION usa VALUES ('usa'),
+            SUBPARTITION asia VALUES ('asia'),
+            SUBPARTITION europe VALUES ('europe'),
+            DEFAULT SUBPARTITION other_regions)
+        (START (1) END (4) EVERY (1),
+        DEFAULT PARTITION outlying_dates );
+
+CREATE INDEX sales_idx on sales(office_id);
+CREATE INDEX sales_idx_bitmap on sales using bitmap(office_id);
+CREATE INDEX sales_1_prt_2_idx on sales_1_prt_2(office_id, region);
+CREATE INDEX sales_1_prt_3_2_prt_asia_idx on sales_1_prt_3_2_prt_asia(region);
+CREATE INDEX sales_1_prt_outlying_dates_idx on sales_1_prt_outlying_dates(trans_id);
+INSERT INTO sales VALUES (1, 2, 'usa');
+CREATE UNIQUE INDEX sales_unique_idx on sales(trans_id);
+
+-- create tables where the index relation name is not equal primary/unique key constraint name.
+-- we create a TYPE with the default name of the constraint that would have been created to force
+-- skipping the default name
+DROP TABLE IF EXISTS table_with_unique_constraint;
+CREATE TYPE table_with_unique_constraint_author_key AS (dummy int);
+CREATE TYPE table_with_unique_constraint_author_key1 AS (dummy int);
+CREATE TABLE table_with_unique_constraint (author int, title int, CONSTRAINT table_with_unique_constraint_uniq_au_ti UNIQUE (author, title)) DISTRIBUTED BY (author);
+DROP TYPE table_with_unique_constraint_author_key, table_with_unique_constraint_author_key1;
+ALTER TABLE table_with_unique_constraint ADD PRIMARY KEY (author, title);
+INSERT INTO table_with_unique_constraint VALUES(1, 1);
+INSERT INTO table_with_unique_constraint VALUES(2, 2);
+
+DROP TABLE IF EXISTS table_with_primary_constraint;
+CREATE TYPE table_with_primary_constraint_pkey AS (dummy int);
+CREATE TYPE table_with_primary_constraint_pkey1 AS (dummy int);
+CREATE TABLE table_with_primary_constraint (author int, title int, CONSTRAINT table_with_primary_constraint_au_ti PRIMARY KEY (author, title)) DISTRIBUTED BY (author);
+DROP TYPE table_with_primary_constraint_pkey, table_with_primary_constraint_pkey1;
+ALTER TABLE table_with_primary_constraint ADD UNIQUE (author, title);
+INSERT INTO table_with_primary_constraint VALUES(1, 1);
+INSERT INTO table_with_primary_constraint VALUES(2, 2);
+
+-- create partitioned tables where the index relation name is not equal primary/unique key constraint name for the root
+-- Note that the naming of the constraint is key, not the type of constraint
+-- If the constraint is named, every partition will have the same named constraint and they all can be dropped with the same command
+-- If the constraint is not named, greenplum generates a unique name for each partition as well as the coordinator table. We can only drop the coordinator tables constraint and the partition constraints remain in effect
+DROP TABLE IF EXISTS table_with_unique_constraint_p;
+CREATE TYPE unique_constraint_p_author_key AS (dummy int);
+CREATE TYPE unique_constraint_p_author_key1 AS (dummy int);
+CREATE TABLE table_with_unique_constraint_p (author int, title int, CONSTRAINT unique_constraint_p_uniq_au_ti UNIQUE (author, title)) PARTITION BY RANGE(title) (START(1) END(4) EVERY(1));
+DROP TYPE unique_constraint_p_author_key, unique_constraint_p_author_key1;
+ALTER TABLE table_with_unique_constraint_p ADD PRIMARY KEY (author, title);
+INSERT INTO table_with_unique_constraint_p VALUES(1, 1);
+INSERT INTO table_with_unique_constraint_p VALUES(2, 2);
+
+DROP TABLE IF EXISTS table_with_primary_constraint_p;
+CREATE TYPE primary_constraint_p_pkey AS (dummy int);
+CREATE TYPE primary_constraint_p_pkey1 AS (dummy int);
+CREATE TABLE table_with_primary_constraint_p (author int, title int, CONSTRAINT primary_constraint_p_au_ti PRIMARY KEY (author, title)) PARTITION BY RANGE(title) (START(1) END(4) EVERY(1));
+DROP TYPE primary_constraint_p_pkey, primary_constraint_p_pkey1;
+ALTER TABLE table_with_primary_constraint_p ADD UNIQUE (author, title);
+INSERT INTO table_with_primary_constraint_p VALUES(1, 1);
+INSERT INTO table_with_primary_constraint_p VALUES(2, 2);
+
+-- create external gphdfs table
+-- NOTE: We fake the gphdfs protocol here so that it doesn't actually have to be
+-- installed.
+CREATE OR REPLACE FUNCTION noop() RETURNS integer AS 'select 0' LANGUAGE SQL;
+DROP PROTOCOL IF EXISTS gphdfs CASCADE;
+CREATE PROTOCOL gphdfs (writefunc=noop, readfunc=noop);
+
+CREATE EXTERNAL TABLE ext_gphdfs (name text)
+	LOCATION ('gphdfs://example.com/data/filename.txt')
+	FORMAT 'TEXT' (DELIMITER '|');
+CREATE EXTERNAL TABLE "ext gphdfs" (name text) -- whitespace in the name
+	LOCATION ('gphdfs://example.com/data/filename.txt')
+	FORMAT 'TEXT' (DELIMITER '|');
+
+-- create name datatype attributes as the not-first column
+DROP TABLE IF EXISTS table_with_name_as_second_column;
+CREATE TABLE table_with_name_as_second_column (a int, "first last" name);
+INSERT INTO table_with_name_as_second_column VALUES(1, 'George Washington');
+INSERT INTO table_with_name_as_second_column VALUES(1, 'Henry Ford');
+-- create partition table with name datatype attribute as the not-first column as the partition key
+DROP TABLE IF EXISTS partition_table_partitioned_by_name_type;
+CREATE TABLE partition_table_partitioned_by_name_type(a int, b name) PARTITION BY RANGE (b) (START('a') END('z'));
+-- create table with name datatype attribute as the not-first column as the distribution key
+DROP TABLE IF EXISTS table_distributed_by_name_type;
+CREATE TABLE table_distributed_by_name_type(a int, b name) DISTRIBUTED BY (b);
+INSERT INTO table_distributed_by_name_type VALUES (1,'z'),(2,'x');
+-- create table / views with name datatype
+CREATE TABLE t1_with_name(a name, b name) DISTRIBUTED RANDOMLY;
+INSERT INTO t1_with_name SELECT 'aaa', 'bbb';
+CREATE TABLE t2_with_name(a int, b name) DISTRIBUTED RANDOMLY;
+INSERT INTO t2_with_name SELECT 1, 'bbb';
+CREATE VIEW v2_on_t2_with_name AS SELECT * FROM t2_with_name;
+ALTER TABLE v2_on_t2_with_name OWNER TO test_role1;
+-- multilevel partition table with partitioning keys using name datatype
+CREATE TABLE multilevel_part_with_partition_col_name_datatype (trans_id int, country name, amount decimal(9,2), region name)
+DISTRIBUTED BY (trans_id)
+PARTITION BY LIST (country)
+SUBPARTITION BY LIST (region)
+SUBPARTITION TEMPLATE
+( SUBPARTITION south VALUES ('south'),
+    DEFAULT SUBPARTITION other_regions)
+    (PARTITION usa VALUES ('usa'),
+    DEFAULT PARTITION outlying_country );
+-- multilevel partition table with partitioning keys using not using name datatype
+CREATE TABLE multilevel_part_with_partition_col_text_datatype (trans_id int, country text, state name, region text)
+DISTRIBUTED BY (trans_id)
+PARTITION BY LIST (country)
+SUBPARTITION BY LIST (region)
+SUBPARTITION TEMPLATE
+( SUBPARTITION south VALUES ('south'),
+    DEFAULT SUBPARTITION other_regions)
+    (PARTITION usa VALUES ('usa'),
+    DEFAULT PARTITION outlying_country );
+
+-- create tables with tsquery datatype
+DROP TABLE IF EXISTS table_with_tsquery_datatype_columns;
+CREATE TABLE table_with_tsquery_datatype_columns(a tsquery, b tsquery, c tsquery, d int)
+    PARTITION BY RANGE(d) (START(1) END(4) EVERY(1));
+INSERT INTO table_with_tsquery_datatype_columns
+    VALUES  ('b & c'::tsquery, 'b & c'::tsquery, 'b & c'::tsquery, 1),
+            ('e & f'::tsquery, 'e & f'::tsquery, 'e & f'::tsquery, 2),
+            ('x & y'::tsquery, 'x & y'::tsquery, 'x & y'::tsquery, 3);
+
+-- Index tests on tsquery
+--composite index
+DROP TABLE IF EXISTS tsquery_composite;
+CREATE TABLE tsquery_composite(i int, j tsquery, k tsquery);
+CREATE INDEX tsquery_composite_idx ON tsquery_composite(j, k);
+--gist index
+DROP TABLE IF EXISTS tsquery_gist;
+CREATE TABLE tsquery_gist(i int, j tsquery, k tsquery);
+CREATE INDEX tsquery_gist_idx ON tsquery_gist using gist(j) ;
+--clustered index with comment
+DROP TABLE IF EXISTS tsquery_cluster_comment;
+CREATE TABLE tsquery_cluster_comment(i int, j tsquery);
+CREATE INDEX tsquery_cluster_comment_idx ON tsquery_cluster_comment(j);
+ALTER TABLE tsquery_cluster_comment CLUSTER ON tsquery_cluster_comment_idx;
+COMMENT ON INDEX tsquery_cluster_comment_idx IS 'hello world';
+
+-- Index tests on name
+--composite index
+DROP TABLE IF EXISTS name_composite;
+CREATE TABLE name_composite(i int, j name, k name);
+CREATE INDEX name_composite_idx ON name_composite(j, k);
+--clustered index with comment
+DROP TABLE IF EXISTS name_cluster_comment;
+CREATE TABLE name_cluster_comment(i int, j name);
+CREATE INDEX name_cluster_comment_idx ON name_cluster_comment(j);
+ALTER TABLE name_cluster_comment CLUSTER ON name_cluster_comment_idx;
+COMMENT ON INDEX name_cluster_comment_idx IS 'hello world';
+
+-- inherits with tsquery column
+DROP TABLE IF EXISTS tsquery_inherits;
+CREATE TABLE tsquery_inherits (
+    e      tsquery
+) INHERITS (table_with_tsquery_datatype_columns);
+
+-- inherits with name and tsquery columns
+DROP TABLE IF EXISTS table_with_name_column;
+CREATE TABLE table_with_name_tsquery (
+    name       text,
+    population name,
+    altitude   tsquery
+);
+CREATE INDEX table_with_name_tsquery_name_idx on table_with_name_tsquery(population);
+CREATE INDEX table_with_name_tsquery_tsquery_idx on table_with_name_tsquery(altitude);
+
+DROP TABLE IF EXISTS name_inherits;
+CREATE TABLE name_inherits (
+    state      char(2)
+) INHERITS (table_with_name_tsquery);
+
+-- view on a view on a name column with owner different than the underlying table
+DROP VIEW IF EXISTS v3_on_v2_recursive;
+CREATE VIEW v3_on_v2_recursive AS SELECT * FROM v2_on_t2_with_name;
+ALTER TABLE v3_on_v2_recursive OWNER TO test_role2;
+
+-- Third level recursive view on a name column
+DROP VIEW IF EXISTS v4_on_v3_recursive;
+CREATE VIEW v4_on_v3_recursive AS SELECT * FROM v3_on_v2_recursive;
+
+-- view on a table with view that doesn't actually depend on the name column
+-- this one should not be dropped since its dependent columns are not changing
+DROP VIEW IF EXISTS v4_on_t2_no_name;
+CREATE VIEW v4_on_t2_no_name AS SELECT a, 1::INTEGER AS i FROM t2_with_name;
+
+-- view on both name and tsquery from the same table
+DROP VIEW IF EXISTS view_on_name_tsquery;
+CREATE VIEW view_on_name_tsquery AS SELECT * FROM table_with_name_tsquery;
+
+-- view on both name and tsquery from multiple tables
+DROP VIEW IF EXISTS view_on_name_tsquery_mult_tables;
+CREATE VIEW view_on_name_tsquery_mult_tables AS SELECT t1.population, t2.altitude FROM table_with_name_tsquery t1, table_with_name_tsquery t2;
+
+CREATE TABLE sales_name (trans_id int, office_name name, region text)
+    DISTRIBUTED BY (trans_id)
+    PARTITION BY LIST (office_name)
+            ( PARTITION usa VALUES ('usa'),
+            PARTITION asia VALUES ('asia'),
+            PARTITION europe VALUES ('europe'),
+            DEFAULT PARTITION other_regions);
+
+CREATE INDEX sales_name_idx on sales_name(office_name);
+
+CREATE TABLE sales_tsquery (trans_id int, office_tsquery tsquery, region text)
+    DISTRIBUTED BY (trans_id)
+    PARTITION BY LIST (office_tsquery)
+            ( PARTITION usa VALUES ('usa'),
+            PARTITION asia VALUES ('asia'),
+            PARTITION europe VALUES ('europe'),
+            DEFAULT PARTITION other_regions);
+
+CREATE INDEX sales_tsquery_idx on sales_tsquery USING GIST (office_tsquery);
+
+-- Multilevel partitioned table with unique index
+DROP TABLE IF EXISTS ml_partitioned_with_index;
+CREATE TABLE ml_partitioned_with_index (trans_id int, office_id int, region int, dummy int)
+DISTRIBUTED BY (trans_id)
+    PARTITION BY RANGE (office_id)
+        SUBPARTITION BY RANGE (dummy)
+            SUBPARTITION TEMPLATE (
+            START (1) END (16) EVERY (4),
+            DEFAULT SUBPARTITION other_dummy )
+        (START (1) END (4) EVERY (1),
+        DEFAULT PARTITION outlying_dates );
+CREATE UNIQUE INDEX ml_partitioned_with_index_idx ON ml_partitioned_with_index(trans_id);
+
+-- heterogeneous partitioned tables
+-- copied from acceptance tests
+
+-- Heterogeneous partition table with dropped column
+-- The root and only a subset of children have the dropped column reference.
+CREATE TABLE dropped_column (a int CONSTRAINT positive_int CHECK (b > 0), b int DEFAULT 1, c char, d varchar(50)) DISTRIBUTED BY (c)
+    PARTITION BY RANGE (a)
+        (PARTITION part_1 START(1) END(5),
+        PARTITION part_2 START(5));
+ALTER TABLE dropped_column DROP COLUMN d;
+ALTER TABLE dropped_column OWNER TO test_role1;
+
+-- Splitting the subpartition leads to its rewrite, eliminating its dropped column
+-- reference. So, after this, only part_2 and the root partition will have a
+-- dropped column reference.
+ALTER TABLE dropped_column SPLIT PARTITION FOR(1) AT (2) INTO (PARTITION split_part_1, PARTITION split_part_2);
+INSERT INTO dropped_column VALUES(1, 2, 'a');
+
+-- Root partitions do not have dropped column references, but some child partitions do
+CREATE TABLE child_has_dropped_column (a int, b int, c char, d varchar(50))
+    PARTITION BY RANGE (a)
+        (PARTITION part_1 START(1) END(5),
+        PARTITION part_2 START(5));
+
+CREATE TABLE intermediate_table (a int, b int, c char, d varchar(50), to_drop int);
+ALTER TABLE intermediate_table DROP COLUMN to_drop;
+
+ALTER TABLE child_has_dropped_column EXCHANGE PARTITION part_1 WITH TABLE intermediate_table;
+DROP TABLE intermediate_table;
+
+-- heterogeneous multilevel partitioned table
+DROP TABLE IF EXISTS heterogeneous_ml_partition_table;
+CREATE TABLE heterogeneous_ml_partition_table (trans_id int, office_id int, region int, dummy int)
+    DISTRIBUTED BY (trans_id)
+    PARTITION BY RANGE (office_id)
+        SUBPARTITION BY RANGE (dummy)
+            SUBPARTITION TEMPLATE (
+            START (1) END (16) EVERY (4),
+            DEFAULT SUBPARTITION other_dummy )
+        (START (1) END (4) EVERY (1),
+        DEFAULT PARTITION outlying_dates );
+
+ALTER TABLE heterogeneous_ml_partition_table DROP COLUMN region;
+ALTER TABLE heterogeneous_ml_partition_table ALTER PARTITION for (1) SPLIT PARTITION for (1) at (3) into (PARTITION p1, PARTITION p2);
+
+RESET search_path;
+
+-- parent partition with seg entries
+CREATE OR REPLACE FUNCTION insert_dummy_segentry(segrelfqname text)
+    RETURNS void AS
+$func$
+BEGIN /* in func */
+EXECUTE 'INSERT INTO ' || segrelfqname || ' VALUES(null)'; /* in func */
+END /* in func */
+$func$  LANGUAGE plpgsql;
+
+-- test AO parent partition with seg entries
+CREATE TABLE ao_root_partition (A INT, B INT) WITH (APPENDONLY=TRUE) DISTRIBUTED BY(A)
+    PARTITION BY RANGE(A)
+        SUBPARTITION BY RANGE(B)
+            SUBPARTITION TEMPLATE (START(1) END (5) EVERY(1)) (START (1) END (2) EVERY (1));
+
+INSERT INTO ao_root_partition SELECT 1,i FROM GENERATE_SERIES(1,4) AS i;
+-- Create an artificial aoseg entry for the root and interior partition.
+SET allow_system_table_mods TO DML;
+SELECT insert_dummy_segentry(s.interior_segrelfqname) FROM
+    (SELECT segrelid::regclass::text AS interior_segrelfqname FROM pg_appendonly
+     WHERE relid IN ('ao_root_partition'::regclass, 'ao_root_partition_1_prt_1'::regclass)) AS s;
+RESET allow_system_table_mods;
+
+-- test AOCO parent partition with seg entries
+CREATE TABLE aoco_root_partition (A INT, B INT) WITH (APPENDONLY=TRUE, ORIENTATION=COLUMN) DISTRIBUTED BY(A)
+    PARTITION BY RANGE(A)
+        SUBPARTITION BY RANGE(B)
+            SUBPARTITION TEMPLATE (START(1) END (5) EVERY(1)) (START (1) END (2) EVERY (1));
+
+INSERT INTO aoco_root_partition SELECT 1,i FROM GENERATE_SERIES(1,4) AS i;
+-- Create an artificial aocsseg entry for the root and interior partition.
+SET allow_system_table_mods TO DML;
+SELECT insert_dummy_segentry(s.interior_segrelfqname) FROM
+    (SELECT segrelid::regclass::text AS interior_segrelfqname FROM pg_appendonly
+     WHERE relid IN ('aoco_root_partition'::regclass, 'aoco_root_partition_1_prt_1'::regclass)) AS s;
+RESET allow_system_table_mods;

--- a/data-migration-scripts/6-to-7-seed-scripts/test/drop_unfixable_objects.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/test/drop_unfixable_objects.sql
@@ -1,0 +1,14 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+SET search_path to testschema;
+
+DROP TABLE partition_table_partitioned_by_name_type;
+DROP TABLE table_distributed_by_name_type;
+DROP TABLE multilevel_part_with_partition_col_name_datatype;
+
+-- Cannot handle cases where we have to change the type of a partition key column
+DROP TABLE sales_name;
+DROP TABLE sales_tsquery;
+
+RESET search_path;

--- a/data-migration-scripts/6-to-7-seed-scripts/test/setup_nonupgradable_objects.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/test/setup_nonupgradable_objects.sql
@@ -1,0 +1,7 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- CREATE global objects
+CREATE DATABASE testdb;
+CREATE ROLE test_role1;
+CREATE ROLE test_role2;

--- a/data-migration-scripts/6-to-7-seed-scripts/test/teardown_nonupgradable_objects.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/test/teardown_nonupgradable_objects.sql
@@ -1,0 +1,7 @@
+-- Copyright (c) 2017-2022 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- DROP global objects
+DROP DATABASE IF EXISTS testdb;
+DROP ROLE IF EXISTS test_role1;
+DROP ROLE IF EXISTS test_role2;

--- a/test/acceptance/gpupgrade/migration_scripts.bats
+++ b/test/acceptance/gpupgrade/migration_scripts.bats
@@ -20,14 +20,20 @@ setup() {
 
     PSQL="$GPHOME_SOURCE/bin/psql -X --no-align --tuples-only"
 
-    # Setup is creating a nonupgradable gphdfs user. Gphdfs is removed on 6x in
-    # favor of PXF, so this setup sql file will not pass on 6 -> 6 upgrade with
-    # ON_ERROR_STOP enabled.
-    $PSQL -v ON_ERROR_STOP=0 -d postgres -f "$SCRIPTS_DIR"/5-to-6-seed-scripts/test/setup_nonupgradable_objects.sql
+    local seed_dir=6-to-7-seed-scripts
+    if is_GPDB5 "$GPHOME_SOURCE"; then
+        seed_dir=5-to-6-seed-scripts
+    fi
+
+    $PSQL -v ON_ERROR_STOP=1 -d postgres -f "$SCRIPTS_DIR"/"${seed_dir}"/test/setup_nonupgradable_objects.sql
 }
 
 teardown() {
-    $PSQL -v ON_ERROR_STOP=1 -d postgres -f "$SCRIPTS_DIR"/5-to-6-seed-scripts/test/teardown_nonupgradable_objects.sql
+    local seed_dir=6-to-7-seed-scripts
+    if is_GPDB5 "$GPHOME_SOURCE"; then
+        seed_dir=5-to-6-seed-scripts
+    fi
+    $PSQL -v ON_ERROR_STOP=1 -d postgres -f "$SCRIPTS_DIR"/"${seed_dir}"/test/teardown_nonupgradable_objects.sql
 
     # XXX Beware, BATS_TEST_SKIPPED is not a documented export.
     if [ -n "${BATS_TEST_SKIPPED}" ]; then


### PR DESCRIPTION
This is to support 6-6-cluster jobs which is already running, but never had proper 6-to-7 seed scripts. Certain SQL was failing which we were ignoring. This commit allows us to no longer ignore errors and helps us start to support 6-to-7 data migration scripts. As an initial attempt to support 6-to-7 seed scripts copy and paste the 5-to-6-seed-scripts and tweak the necessary scripts. These 6-to-7-seed-scripts are not production ready.

Specifically:
1) Update initialize/tables_using_name_and_tsquery scripts to work on 6X by  changing `unnest(attrnums) attnum` to numsegments when querying gp_distribution_policy.

2) Remove gphdfs_user_roles


Nothing is calling this change yet, but a followup PR will make use of it once the generator & executor are ported over to golang.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:6to7SeedScripts