### PR TITLE
bump golang version to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/greenplum-db/gpupgrade
 
-go 1.17
+go 1.19
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0


### PR DESCRIPTION
Note: With this PR one will have to update your local version of golang to 1.19.1+ in order to build gpupgrade locally.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:bumpGolangVersion