### PR TITLE
gpupgrade generate & apply fixups

### DIFF
--- a/cli/commanders/data_migration.go
+++ b/cli/commanders/data_migration.go
@@ -52,7 +52,7 @@ func ResetPsqlFileCommand() {
 	psqlFileCommand = exec.Command
 }
 
-func executeSQLFile(gphome string, port int, database string, path string, args ...string) ([]byte, error) {
+func applySQLFile(gphome string, port int, database string, path string, args ...string) ([]byte, error) {
 	args = append(args,
 		"--no-psqlrc", "--quiet",
 		"-d", database,

--- a/cli/commanders/data_migration_apply.go
+++ b/cli/commanders/data_migration_apply.go
@@ -46,7 +46,12 @@ func ExecuteDataMigrationScripts(nonInteractive bool, gphome string, port int, c
 		return err
 	}
 
-	outputPath := filepath.Join(currentScriptDir, phase.String()+".log")
+	logDir, err := utils.GetLogDir()
+	if err != nil {
+		return err
+	}
+
+	outputPath := filepath.Join(logDir, "apply_"+phase.String()+".log")
 	file, err := utils.System.OpenFile(outputPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
@@ -79,18 +84,12 @@ func ExecuteDataMigrationScripts(nonInteractive bool, gphome string, port int, c
 	}
 
 	if phase == idl.Step_stats {
-		fmt.Print(color.YellowString("To receive an upgrade time estimate send the stats output:\n%s\n\n", utils.Bold.Sprint(filepath.Join(currentScriptDir, phase.String()+".log"))))
-	}
-
-	logDir, err := utils.GetLogDir()
-	if err != nil {
-		return err
+		fmt.Print(color.YellowString("To receive an upgrade time estimate send the stats output:\n%s\n\n", utils.Bold.Sprint(filepath.Join(logDir, "apply_"+phase.String()+".log"))))
 	}
 
 	fmt.Printf(`Logs:
 %s
-%s
-`, utils.Bold.Sprint(logDir), utils.Bold.Sprint(currentScriptDir))
+`, utils.Bold.Sprint(logDir))
 
 	return nil
 }

--- a/cli/commanders/data_migration_apply_test.go
+++ b/cli/commanders/data_migration_apply_test.go
@@ -357,16 +357,16 @@ func TestExecuteDataMigrationScriptsPrompt(t *testing.T) {
 
 		expected := "\nScripts to apply:\n"
 		expected += "  0: parent_partitions_with_seg_entries\n"
-		expected += "     Fixes non-empty segment relfiles for AO and AOCO parent partitions\n\n  "
+		expected += "     - Fixes non-empty segment relfiles for AO and AOCO parent partitions\n\n  "
 		expected += "1: unique_primary_foreign_key_constraint\n"
-		expected += "     Drops constraints\n\n"
-		expected += "\nWhich \"initialize\" data migration SQL scripts to apply? \n"
+		expected += "     - Drops constraints\n\n"
+		expected += "Which \"initialize\" data migration SQL scripts to apply? \n"
 		expected += "  [a]ll\n"
 		expected += "  [s]ome\n"
 		expected += "  [n]one\n"
 		expected += "  [q]uit\n"
 		expected += "\nSelect: \n"
-		expected += "Select scripts to apply separated by commas. Or [q]uit?\n\n"
+		expected += "Select scripts to apply separated by commas such as 1, 3. Or [q]uit?\n\n"
 		expected += "  0: parent_partitions_with_seg_entries\n"
 		expected += "  1: unique_primary_foreign_key_constraint\n\n"
 		expected += "Select: "
@@ -426,15 +426,15 @@ func TestExecuteDataMigrationScriptsPrompt(t *testing.T) {
 
 		expected := "\nScripts to apply:\n"
 		expected += "  0: parent_partitions_with_seg_entries\n"
-		expected += "     Fixes non-empty segment relfiles for AO and AOCO parent partitions\n\n  "
+		expected += "     - Fixes non-empty segment relfiles for AO and AOCO parent partitions\n\n  "
 		expected += "1: unique_primary_foreign_key_constraint\n"
-		expected += "     Drops constraints\n\n"
-		expected += "\nWhich \"initialize\" data migration SQL scripts to apply? \n"
+		expected += "     - Drops constraints\n\n"
+		expected += "Which \"initialize\" data migration SQL scripts to apply? \n"
 		expected += "  [a]ll\n"
 		expected += "  [s]ome\n"
 		expected += "  [n]one\n"
 		expected += "  [q]uit\n"
-		expected += "\nSelect: \n"
+		expected += "\nSelect: "
 		expected += "Which \"initialize\" data migration SQL scripts to apply? \n"
 		expected += "  [a]ll\n"
 		expected += "  [s]ome\n"
@@ -525,10 +525,10 @@ func TestSelectDataMigrationScriptsPrompt(t *testing.T) {
 			t.Errorf("unexpected stderr %#v", string(stderr))
 		}
 
-		expected := "\nSelect scripts to apply separated by commas. Or [q]uit?\n\n\n"
+		expected := "\nSelect scripts to apply separated by commas such as 1, 3. Or [q]uit?\n\n\n"
 		expected += "Select: \n"
-		expected += "Invalid selection. Found \"0.5\" expected a number or numbers separated by commas.\n\n"
-		expected += "Select scripts to apply separated by commas. Or [q]uit?\n\n\n"
+		expected += "Invalid selection. Found \"0.5\" expected a number or numbers separated by commas such as 1, 3.\n\n"
+		expected += "Select scripts to apply separated by commas such as 1, 3. Or [q]uit?\n\n\n"
 		expected += "Select: \n"
 		expected += "Quiting..."
 
@@ -574,7 +574,7 @@ func TestSelectDataMigrationScriptsPrompt(t *testing.T) {
 			t.Errorf("unexpected stderr %#v", string(stderr))
 		}
 
-		expected := "\nSelect scripts to apply separated by commas. Or [q]uit?\n\n"
+		expected := "\nSelect scripts to apply separated by commas such as 1, 3. Or [q]uit?\n\n"
 		expected += "  0: parent_partitions_with_seg_entries\n"
 		expected += "  1: unique_primary_foreign_key_constraint\n\n"
 		expected += "Select: \n"
@@ -582,7 +582,7 @@ func TestSelectDataMigrationScriptsPrompt(t *testing.T) {
 		expected += "  0: parent_partitions_with_seg_entries\n\n"
 		expected += "[c]ontinue, [e]dit selection, or [q]uit.\n"
 		expected += "Select: \n"
-		expected += "Select scripts to apply separated by commas. Or [q]uit?\n\n"
+		expected += "Select scripts to apply separated by commas such as 1, 3. Or [q]uit?\n\n"
 		expected += "  0: parent_partitions_with_seg_entries\n"
 		expected += "  1: unique_primary_foreign_key_constraint\n\n"
 		expected += "Select: \nSelected:\n\n"
@@ -618,7 +618,7 @@ func TestSelectDataMigrationScriptsPrompt(t *testing.T) {
 			t.Errorf("unexpected stderr %#v", string(stderr))
 		}
 
-		expected := "\nSelect scripts to apply separated by commas. Or [q]uit?\n\n"
+		expected := "\nSelect scripts to apply separated by commas such as 1, 3. Or [q]uit?\n\n"
 		expected += "  0: parent_partitions_with_seg_entries\n"
 		expected += "  1: unique_primary_foreign_key_constraint\n\n"
 		expected += "Select: \n"
@@ -626,7 +626,7 @@ func TestSelectDataMigrationScriptsPrompt(t *testing.T) {
 		expected += "  0: parent_partitions_with_seg_entries\n\n"
 		expected += "[c]ontinue, [e]dit selection, or [q]uit.\n"
 		expected += "Select: \n"
-		expected += "Select scripts to apply separated by commas. Or [q]uit?\n\n"
+		expected += "Select scripts to apply separated by commas such as 1, 3. Or [q]uit?\n\n"
 		expected += "  0: parent_partitions_with_seg_entries\n"
 		expected += "  1: unique_primary_foreign_key_constraint\n\n"
 		expected += "Select: \nSelected:\n\n"
@@ -662,7 +662,7 @@ func TestSelectDataMigrationScriptsPrompt(t *testing.T) {
 			t.Errorf("unexpected stderr %#v", string(stderr))
 		}
 
-		expected := "\nSelect scripts to apply separated by commas. Or [q]uit?\n\n"
+		expected := "\nSelect scripts to apply separated by commas such as 1, 3. Or [q]uit?\n\n"
 		expected += "  0: parent_partitions_with_seg_entries\n"
 		expected += "  1: unique_primary_foreign_key_constraint\n\n"
 		expected += "Select: \n"
@@ -670,7 +670,7 @@ func TestSelectDataMigrationScriptsPrompt(t *testing.T) {
 		expected += "  0: parent_partitions_with_seg_entries\n\n"
 		expected += "[c]ontinue, [e]dit selection, or [q]uit.\n"
 		expected += "Select: \n"
-		expected += "Select scripts to apply separated by commas. Or [q]uit?\n\n"
+		expected += "Select scripts to apply separated by commas such as 1, 3. Or [q]uit?\n\n"
 		expected += "  0: parent_partitions_with_seg_entries\n"
 		expected += "  1: unique_primary_foreign_key_constraint\n\n"
 		expected += "Select: \n"
@@ -708,12 +708,12 @@ func TestParseSelection(t *testing.T) {
 		{
 			name:     "errors when input is empty",
 			input:    "",
-			expected: fmt.Errorf("Expected a number or numbers separated by commas."),
+			expected: fmt.Errorf("Expected a number or numbers separated by commas such as 1, 3."),
 		},
 		{
 			name:     "errors when input is whitespace",
 			input:    "  \t   \n",
-			expected: fmt.Errorf("Expected a number or numbers separated by commas."),
+			expected: fmt.Errorf("Expected a number or numbers separated by commas such as 1, 3."),
 		},
 		{
 			name:     "cancels when input is 'q'",
@@ -723,17 +723,17 @@ func TestParseSelection(t *testing.T) {
 		{
 			name:     "errors when selection is not a number",
 			input:    "A",
-			expected: fmt.Errorf("Invalid selection. Found %q expected a number or numbers separated by commas.", "a"),
+			expected: fmt.Errorf("Invalid selection. Found %q expected a number or numbers separated by commas such as 1, 3.", "a"),
 		},
 		{
 			name:     "errors when selection is not a positive number",
 			input:    "-1",
-			expected: fmt.Errorf("Invalid selection. Found %q expected a number or numbers separated by commas.", "-1"),
+			expected: fmt.Errorf("Invalid selection. Found %q expected a number or numbers separated by commas such as 1, 3.", "-1"),
 		},
 		{
 			name:     "errors when selection is not a whole number",
 			input:    "0.5",
-			expected: fmt.Errorf("Invalid selection. Found %q expected a number or numbers separated by commas.", "0.5"),
+			expected: fmt.Errorf("Invalid selection. Found %q expected a number or numbers separated by commas such as 1, 3.", "0.5"),
 		},
 	}
 

--- a/cli/commanders/data_migration_generate.go
+++ b/cli/commanders/data_migration_generate.go
@@ -119,14 +119,17 @@ func GenerateDataMigrationScripts(nonInteractive bool, gphome string, port int, 
 		fmt.Println()
 	}
 
-	fmt.Printf("Generated data migration scripts are in %q\n", filepath.Join(outputDir, "current"))
-
 	logDir, err := utils.GetLogDir()
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Logs located in %q\n", logDir)
+	fmt.Printf(`Generated scripts:
+%s
+
+Logs:
+%s
+`, utils.Bold.Sprint(filepath.Join(outputDir, "current")), utils.Bold.Sprint(logDir))
 
 	return nil
 }
@@ -163,13 +166,14 @@ func ArchiveDataMigrationScriptsPrompt(nonInteractive bool, reader *bufio.Reader
 
 Archive and re-generate the data migration scripts if potentially 
 new problematic objects have been added since the scripts were 
-first generated. 
+first generated. If unsure its safe to archive and re-generate 
+the scripts.
 
 The generator takes a "snapshot" of the current source cluster
 to generate the scripts. If new "problematic" objects are added 
 after the generator was run, then the previously generated 
 scripts are outdated. The generator will need to be re-run 
-to detect the newly added objects.`, currentDirModTime.Format(time.RFC1123Z), currentDir)
+to detect the newly added objects.`, currentDirModTime.Format(time.RFC1123Z), utils.Bold.Sprint(currentDir))
 
 		input := "a"
 		if !nonInteractive {
@@ -197,11 +201,11 @@ Select: `)
 			}
 
 			if exist {
-				log.Printf("Skip archiving data migration scripts as it already exists in %q\n", archiveDir)
+				log.Printf("Skip archiving data migration scripts as it already exists in %s\n", utils.Bold.Sprint(archiveDir))
 				return step.Skip
 			}
 
-			fmt.Printf("\nArchiving previously generated scripts under\n%q\n", archiveDir)
+			fmt.Printf("\nArchiving previously generated scripts under\n%s\n", utils.Bold.Sprint(archiveDir))
 			err = utils.System.MkdirAll(filepath.Dir(archiveDir), 0700)
 			if err != nil {
 				return fmt.Errorf("make directory: %w", err)
@@ -214,7 +218,7 @@ Select: `)
 
 			return nil
 		case "c":
-			fmt.Printf("\nContinuing with previously generated data migration scripts in\n%s\n", currentDir)
+			fmt.Printf("\nContinuing with previously generated data migration scripts in\n%s\n", utils.Bold.Sprint(currentDir))
 			return step.Skip
 		case "q":
 			fmt.Print("\nQuiting...")

--- a/cli/commanders/data_migration_generate.go
+++ b/cli/commanders/data_migration_generate.go
@@ -95,7 +95,7 @@ func GenerateDataMigrationScripts(nonInteractive bool, gphome string, port int, 
 
 		log.Println(string(output))
 
-		output, err = executeSQLFile(gphome, port, database.Datname, filepath.Join(seedDir, "create_find_view_dep_function.sql"))
+		output, err = applySQLFile(gphome, port, database.Datname, filepath.Join(seedDir, "create_find_view_dep_function.sql"))
 		if err != nil {
 			return err
 		}
@@ -263,7 +263,7 @@ func GenerateMigrationScript(phase idl.Step, seedDir string, seedDirFS fs.FS, ou
 		for _, script := range scripts {
 			var scriptOutput []byte
 			if strings.HasSuffix(script.Name(), ".sql") {
-				scriptOutput, err = executeSQLFile(gphome, port, database.Datname, filepath.Join(seedDir, phase.String(), scriptDir.Name(), script.Name()),
+				scriptOutput, err = applySQLFile(gphome, port, database.Datname, filepath.Join(seedDir, phase.String(), scriptDir.Name(), script.Name()),
 					"-v", "ON_ERROR_STOP=1", "--no-align", "--tuples-only")
 				if err != nil {
 					return err

--- a/cli/commanders/data_migration_script.go
+++ b/cli/commanders/data_migration_script.go
@@ -73,7 +73,7 @@ func (scripts Scripts) Description() string {
 
 	var output string
 	for _, script := range scripts {
-		output += fmt.Sprintf("  %d: %s\n     %s\n\n", script.Num, script.Name, scriptDescription[script.Name])
+		output += fmt.Sprintf("  %d: %s\n     - %s\n\n", script.Num, script.Name, scriptDescription[script.Name])
 	}
 	return output
 }

--- a/cli/commands/data_migration.go
+++ b/cli/commands/data_migration.go
@@ -68,7 +68,7 @@ func dataMigrationApply() *cobra.Command {
 			}
 
 			currentDir := filepath.Join(filepath.Clean(inputDir), "current")
-			err = commanders.ExecuteDataMigrationScripts(nonInteractive, filepath.Clean(gphome), port, utils.System.DirFS(currentDir), currentDir, parsedPhase)
+			err = commanders.ApplyDataMigrationScripts(nonInteractive, filepath.Clean(gphome), port, utils.System.DirFS(currentDir), currentDir, parsedPhase)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/finalize.go
+++ b/cli/commands/finalize.go
@@ -73,7 +73,7 @@ func finalize() *cobra.Command {
 				fmt.Println()
 
 				currentDir := filepath.Join(response.GetLogArchiveDirectory(), "data-migration-scripts", "current")
-				return commanders.ExecuteDataMigrationScripts(nonInteractive, response.GetTargetCluster().GPHome, int(response.GetTargetCluster().GetPort()),
+				return commanders.ApplyDataMigrationScripts(nonInteractive, response.GetTargetCluster().GPHome, int(response.GetTargetCluster().GetPort()),
 					utils.System.DirFS(currentDir), currentDir, idl.Step_finalize)
 			})
 

--- a/cli/commands/initialize.go
+++ b/cli/commands/initialize.go
@@ -207,7 +207,7 @@ func initialize() *cobra.Command {
 				fmt.Println()
 
 				currentDir := filepath.Join(generatedScriptsOutputDir, "current")
-				return commanders.ExecuteDataMigrationScripts(nonInteractive, sourceGPHome, sourcePort,
+				return commanders.ApplyDataMigrationScripts(nonInteractive, sourceGPHome, sourcePort,
 					utils.System.DirFS(currentDir), currentDir, idl.Step_stats)
 			})
 
@@ -216,7 +216,7 @@ func initialize() *cobra.Command {
 				fmt.Println()
 
 				currentDir := filepath.Join(filepath.Clean(generatedScriptsOutputDir), "current")
-				return commanders.ExecuteDataMigrationScripts(nonInteractive, sourceGPHome, sourcePort,
+				return commanders.ApplyDataMigrationScripts(nonInteractive, sourceGPHome, sourcePort,
 					utils.System.DirFS(currentDir), currentDir, idl.Step_initialize)
 			})
 

--- a/cli/commands/initialize.go
+++ b/cli/commands/initialize.go
@@ -281,16 +281,11 @@ Initialize completed successfully.
 %s
 NEXT ACTIONS
 ------------
-If you have not already, execute the "%s" and “%s” data migration scripts with
-"gpupgrade initialize" or "gpupgrade apply --gphome %s --port %d --input-dir %s --phase %s" (and --phase %s)
-
 To proceed with the upgrade, run "gpupgrade execute"
 followed by "gpupgrade finalize".
 
 To return the cluster to its original state, run "gpupgrade revert".`,
-				revertWarning,
-				idl.Step_stats, idl.Step_initialize,
-				sourceGPHome, sourcePort, generatedScriptsOutputDir, idl.Step_stats, idl.Step_initialize))
+				revertWarning))
 		},
 	}
 

--- a/cli/commands/revert.go
+++ b/cli/commands/revert.go
@@ -73,7 +73,7 @@ func revert() *cobra.Command {
 				fmt.Println()
 
 				currentDir := filepath.Join(response.GetLogArchiveDirectory(), "data-migration-scripts", "current")
-				return commanders.ExecuteDataMigrationScripts(nonInteractive, response.GetSource().GPHome, int(response.GetSource().GetPort()),
+				return commanders.ApplyDataMigrationScripts(nonInteractive, response.GetSource().GPHome, int(response.GetSource().GetPort()),
 					utils.System.DirFS(currentDir), currentDir, idl.Step_revert)
 			})
 

--- a/testutils/test_utils.go
+++ b/testutils/test_utils.go
@@ -138,7 +138,7 @@ func MustGetPort(t *testing.T) int {
 func GetTempDir(t *testing.T, prefix string) string {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", prefix+"-")
+	dir, err := os.MkdirTemp("", prefix)
 	if err != nil {
 		t.Fatalf("creating temporary directory: %+v", err)
 	}

--- a/utils/sys_utils.go
+++ b/utils/sys_utils.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/google/renameio"
 
 	"github.com/greenplum-db/gpupgrade/utils/errorlist"
@@ -21,6 +22,7 @@ import (
 
 var (
 	System = InitializeSystemFunctions()
+	Bold   = color.New(color.Bold)
 )
 
 /*


### PR DESCRIPTION
See individual commits.

- tweak output based on user feedback
- colorize text to send stats output
- bold directory paths
- gpupgrade apply append output to file rather than truncating
- output gpupgrade apply logs to gpupgrade log directory
- rename functions to match their command name

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:dataMigrationFixups