### PR TITLE
pass --old-tablespaces-file only for 6X

### DIFF
--- a/upgrade/run.go
+++ b/upgrade/run.go
@@ -62,12 +62,12 @@ func Run(stdout, stderr io.Writer, opts *idl.PgOptions) error {
 		args = append(args, "--old-options", opts.GetOldOptions())
 	}
 
-	if opts.Action != idl.PgOptions_check {
-		args = append(args, "--old-tablespaces-file", utils.GetTablespaceMappingFile())
-	}
-
 	// Below 7X, specify the dbid's for upgrading tablespaces.
 	if semver.MustParse(opts.TargetVersion).Major < 7 {
+		if opts.Action != idl.PgOptions_check {
+			args = append(args, "--old-tablespaces-file", utils.GetTablespaceMappingFile())
+		}
+
 		args = append(args, "--old-gp-dbid", opts.GetOldDBID())
 		args = append(args, "--new-gp-dbid", opts.GetNewDBID())
 	}

--- a/upgrade/run_test.go
+++ b/upgrade/run_test.go
@@ -484,7 +484,7 @@ func TestRun(t *testing.T) {
 			},
 		},
 		{
-			name:        "sets --old-tablespaces-file when upgrading and not calling --check",
+			name:        "sets --old-tablespaces-file when upgrading and not calling --check when target version is 6x",
 			expectedCmd: "pg_upgrade",
 			expectedArgs: []string{"--retain", "--progress",
 				"--old-bindir", "",
@@ -505,7 +505,7 @@ func TestRun(t *testing.T) {
 			},
 		},
 		{
-			name:        "sets --old-gp-dbid and --new-gp-dbid when target version is less than 7X",
+			name:        "sets --old-tablespaces-file, --old-gp-dbid, and --new-gp-dbid when target version is 6X",
 			expectedCmd: "pg_upgrade",
 			expectedArgs: []string{"--retain", "--progress",
 				"--old-bindir", "",
@@ -528,7 +528,7 @@ func TestRun(t *testing.T) {
 			},
 		},
 		{
-			name:        "does not set --old-gp-dbid and --new-gp-dbid when target version 7X or higher",
+			name:        "does not set --old-tablespaces-file, --old-gp-dbid, and --new-gp-dbid when target version is 7X or higher",
 			expectedCmd: "pg_upgrade",
 			expectedArgs: []string{"--retain", "--progress",
 				"--old-bindir", "",
@@ -537,8 +537,7 @@ func TestRun(t *testing.T) {
 				"--new-datadir", "",
 				"--old-port", "",
 				"--new-port", "",
-				"--mode", "unknown_mode",
-				"--old-tablespaces-file", utils.GetTablespaceMappingFile()},
+				"--mode", "unknown_mode"},
 			opts: idl.PgOptions{
 				Role:          greenplum.PrimaryRole,
 				ContentID:     3,


### PR DESCRIPTION
Only pass --old-tablespaces-file to pg_upgrade when in check mode and target version is less than 7X. The pg_upgrade parameter --old-tablespaces-file is not supported or needed in 7X or higher.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:pgUpgradeRun