### PR TITLE
gpupgrade apply: re-enable ON_ERROR_STOP

### DIFF
--- a/cli/commanders/data_migration_apply.go
+++ b/cli/commanders/data_migration_apply.go
@@ -142,9 +142,7 @@ func ApplyDataMigrationScriptSubDir(gphome string, port int, scriptDirFS fs.FS, 
 			continue
 		}
 
-		// FIXME: Disabled ON_ERROR_STOP due to incompatibilities of deprecated objects on 6->6 upgrade that will cause
-		//  scripts to fail.
-		output, err := applySQLFile(gphome, port, "postgres", filepath.Join(scriptDir, entry.Name()), "-v", "ON_ERROR_STOP=0", "--echo-queries")
+		output, err := applySQLFile(gphome, port, "postgres", filepath.Join(scriptDir, entry.Name()), "-v", "ON_ERROR_STOP=1", "--echo-queries")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Re-enable ON_ERROR_STOP which was disabled due to 6->6 data migration script incompatibilities.  Specifically, f8f6639 now allows DELETE FROM AO/CO auxiliary tables enabling the parent_partitions_with_seg_entries scripts to succeed.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:reEnableOnErrorStop