### PR TITLE
Re-enable on error stop

### DIFF
--- a/cli/commanders/data_migration_apply.go
+++ b/cli/commanders/data_migration_apply.go
@@ -142,9 +142,7 @@ func ApplyDataMigrationScriptSubDir(gphome string, port int, scriptDirFS fs.FS, 
 			continue
 		}
 
-		// FIXME: Disabled ON_ERROR_STOP due to incompatibilities of deprecated objects on 6->6 upgrade that will cause
-		//  scripts to fail.
-		output, err := applySQLFile(gphome, port, "postgres", filepath.Join(scriptDir, entry.Name()), "-v", "ON_ERROR_STOP=0", "--echo-queries")
+		output, err := applySQLFile(gphome, port, "postgres", filepath.Join(scriptDir, entry.Name()), "-v", "ON_ERROR_STOP=1", "--echo-queries")
 		if err != nil {
 			return nil, err
 		}

--- a/data-migration-scripts/5-to-6-seed-scripts/initialize/unique_primary_foreign_key_constraint/gen_drop_constraint_2_primary_unique.sql
+++ b/data-migration-scripts/5-to-6-seed-scripts/initialize/unique_primary_foreign_key_constraint/gen_drop_constraint_2_primary_unique.sql
@@ -40,5 +40,7 @@ FROM
       ON cc.oid = con.conrelid
    JOIN
       pg_namespace n
-      ON (n.oid = cc.relnamespace);
+      ON (n.oid = cc.relnamespace)
+ORDER BY
+    con.oid DESC, cc.oid DESC;
 SELECT 'SET gp_enable_drop_key_constraint_child_partition=off;';


### PR DESCRIPTION
1) fix unique and primary key constraints initialize data migration script 

The data migration scripts create alter statements to drop the constraints from both the root and child partitions in that order.

Since dropping unique constraints cascade to the child partitions when the alter child partition statement is executed it fails since the constraint was already removed when the root partition alter statement was run. However, the error message is misleading saying "ERROR: can't drop a constraint from "table_with_unique_constraint_p_1_prt_1"; it is part of a partitioned table." Rather than something like constraint does not exist.

This problem only occurs for unique constraints which cascade since primary key constraints do not cascade to their child partitions.

Thus, as a workaround reverse the order in which we drop constraints from the child partitions up to the root partitions.

2) Re-enable ON_ERROR_STOP which was disabled due to 6->6 data migration script incompatibilities. Specifically, f8f6639 now allows DELETE FROM AO/CO auxiliary tables enabling the parent_partitions_with_seg_entries scripts to succeed.


Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:reEnableOnErrorStop