### PR TITLE
ci: parameterize cluster tests with centos version

### DIFF
--- a/ci/3_gpupgrade_jobs.yml
+++ b/ci/3_gpupgrade_jobs.yml
@@ -33,10 +33,10 @@
           resource: gpdb{{.Source}}_src
         - get: bats
         - get: rpm_gpdb_source
-          resource: gpdb{{.Source}}_centos7_rpm
+          resource: gpdb{{.Source}}_centos{{.CentosVersion}}_rpm
           trigger: true
         - get: rpm_gpdb_target
-          resource: gpdb{{.Target}}_centos7_rpm
+          resource: gpdb{{.Target}}_centos{{.CentosVersion}}_rpm
           trigger: true
     - task: cluster-tests
       config:
@@ -44,7 +44,7 @@
         image_resource:
           type: registry-image
           source:
-            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb{{.Target}}-centos{{.CentosVersion}}-test-golang
             tag: latest
         inputs:
           - name: gpupgrade_src

--- a/ci/parser/jobs.go
+++ b/ci/parser/jobs.go
@@ -9,19 +9,10 @@ import "fmt"
 
 type ClusterJob struct {
 	Source, Target string
+	CentosVersion  string
 }
 
 type ClusterJobs []ClusterJob
-
-func (g ClusterJobs) contains(needle ClusterJob) bool {
-	for _, job := range g {
-		if needle == job {
-			return true
-		}
-	}
-
-	return false
-}
 
 func (j *ClusterJob) Name() string {
 	return fmt.Sprintf("%s-to-%s-cluster-tests", j.Source, j.Target)

--- a/ci/parser/main.go
+++ b/ci/parser/main.go
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
-	This command is used to parse a template file using the text/template package.
-	Given a list of source versions and target versions, it will render these
-	versions into the places specified by the template.
+This command is used to parse a template file using the text/template package.
+Given a list of source versions and target versions, it will render these
+versions into the places specified by the template.
 
-	Usage:
-	parse_template template.yml output.yml
+Usage:
+parse_template template.yml output.yml
 
-	Note: This will overwrite the contents of output.yml (if the file already
-	exists) with the parsed output.
+Note: This will overwrite the contents of output.yml (if the file already
+exists) with the parsed output.
 */
 package main
 
@@ -46,19 +46,13 @@ var versions = []Version{
 	//{
 	//	sourceVersion: "6",
 	//	targetVersion: "7",
-	//	centosVersion: "7",
-	//	SpecialJobs:   true, // Delete this SpecialJobs field once the below 6->7 for centos8 is added.
-	//},
-	//{ // uncomment this block when we support centos8
-	//	sourceVersion: "6",
-	//	targetVersion: "7",
 	//	centosVersion: "8",
 	//	SpecialJobs:   true,
 	//},
 	//{
 	//	sourceVersion: "7",
 	//	targetVersion: "7",
-	//	centosVersion: "7", // Update to centos8 once when we support it.
+	//	centosVersion: "8",
 	//},
 }
 

--- a/ci/parser/main.go
+++ b/ci/parser/main.go
@@ -107,15 +107,6 @@ func init() {
 			CentosVersion: version.centosVersion,
 		})
 
-		clusterJob := ClusterJob{
-			Source: version.sourceVersion,
-			Target: version.targetVersion,
-		}
-
-		if !clusterJobs.contains(clusterJob) {
-			clusterJobs = append(clusterJobs, clusterJob)
-		}
-
 		upgradeJobs = append(upgradeJobs, UpgradeJob{
 			Source:        version.sourceVersion,
 			Target:        version.targetVersion,
@@ -123,6 +114,12 @@ func init() {
 		})
 
 		if version.SpecialJobs {
+			clusterJobs = append(clusterJobs, ClusterJob{
+				Source:        version.sourceVersion,
+				Target:        version.targetVersion,
+				CentosVersion: version.centosVersion,
+			})
+
 			pgupgradeJobs = append(pgupgradeJobs, PgUpgradeJob{
 				Source:        version.sourceVersion,
 				Target:        version.targetVersion,


### PR DESCRIPTION
Parameterize cluster tests with centos version to help with pg_upgrade acceptance testing. Kept running into an annoying thing when working on 6->7 pg_upgrade acceptance testing, and this was relatively simple to fix and is needed anyway.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:inital6to7pipeline