### PR TITLE
ci: refactor centosVersion to osVersion

### DIFF
--- a/ci/1_resources_anchors_groups.yml
+++ b/ci/1_resources_anchors_groups.yml
@@ -50,7 +50,7 @@ resources:
 # source and target clusters. In order to test this scenario release candidate
 # builds are needed.
 {{range .GPDBVersions}}
-- name: gpdb{{.GPDBVersion}}_centos{{.CentosVersion}}_rpm
+- name: gpdb{{.GPDBVersion}}_{{.OSVersion}}_rpm
   type: gcs
   source:
     {{- if .TestRCIdentifier }}
@@ -61,7 +61,7 @@ resources:
     bucket: pivotal-gpdb-concourse-resources-prod
     {{- end }}
     json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/gpdb{{ majorVersion .GPDBVersion }}/greenplum-db-{{.TestRCIdentifier}}({{escapeVersion .GPDBVersion}}.*)-rhel{{.CentosVersion}}-x86_64.debug.rpm
+    regexp: server/published/gpdb{{ majorVersion .GPDBVersion }}/greenplum-db-{{.TestRCIdentifier}}({{escapeVersion .GPDBVersion}}.*)-rhel{{.OSVersionNumber}}-x86_64.debug.rpm
 {{end}}
 
 - name: oss_rpm
@@ -174,28 +174,28 @@ resources:
 
 {{range .GPDBVersions}}
 # To avoid too many jobs we only run extensions on a single OS version.
-{{- if eq .CentosVersion "7" }}
-- name: postgis_2.x_gpdb{{.GPDBVersion}}_centos{{.CentosVersion}}_gppkg
+{{- if eq .OSVersion "centos7" }}
+- name: postgis_2.x_gpdb{{.GPDBVersion}}_{{.OSVersion}}_gppkg
   type: gcs
   source:
     json_key: ((concourse-gcs-resources-service-account-key))
     bucket: pivotal-gpdb-concourse-resources-prod
-    regexp: postgis/released/gpdb{{.GPDBVersion}}/postgis-2.1.5\+(.*)-gp{{.GPDBVersion}}-rhel{{.CentosVersion}}-x86_64.gppkg
+    regexp: postgis/released/gpdb{{.GPDBVersion}}/postgis-2.1.5\+(.*)-gp{{.GPDBVersion}}-rhel{{.OSVersionNumber}}-x86_64.gppkg
 
-- name: madlib_1.x_gpdb{{.GPDBVersion}}_centos{{.CentosVersion}}_gppkg
+- name: madlib_1.x_gpdb{{.GPDBVersion}}_{{.OSVersion}}_gppkg
   type: s3
   source:
     access_key_id: ((madlib-s3-access_key_id))
     secret_access_key: ((madlib-s3-secret_access_key))
     region_name: us-west-2
     bucket: madlib-artifacts
-    versioned_file: bin_madlib_artifacts_centos{{.CentosVersion}}/madlib-master-gp{{.GPDBVersion}}-rhel{{.CentosVersion}}-x86_64.gppkg
+    versioned_file: bin_madlib_artifacts_{{.OSVersion}}/madlib-master-gp{{.GPDBVersion}}-rhel{{.OSVersionNumber}}-x86_64.gppkg
 
 # NOTE: The same gptext artifact is used for both gpdb5 and gpdb6. Also, the same
 # rhel6 artifact is used for both centos6 and centos7, since the rhel7 artifact
 # does not support gpdb5.
 {{- if ne .GPDBVersion "6" }}
-- name: gptext_3.x_gpdb6_rhel{{.CentosVersion}}_targz
+- name: gptext_3.x_gpdb6_{{.OSVersion}}_targz
   type: gcs
   source:
     json_key: ((concourse-gcs-resources-service-account-key))
@@ -207,38 +207,38 @@ resources:
 # supported for centos6. Thus, we can only test pxf upgrades on centos7.
 # NOTE: The resource name is _rpm even though the artifact is a tar.gz since
 # pxf SNAPSHOT builds are only available as an rpm inside a tar.gz.
-- name: pxf_6_gpdb{{.GPDBVersion}}_centos{{.CentosVersion}}_rpm
+- name: pxf_6_gpdb{{.GPDBVersion}}_{{.OSVersion}}_rpm
   type: gcs
   source:
     json_key: ((ud/pxf/secrets/pxf-storage-service-account-key))
     bucket: data-gpdb-ud-pxf-build
-    versioned_file: prod/snapshots/pxf6/pxf-gp{{.GPDBVersion}}.el{{.CentosVersion}}.tar.gz
+    versioned_file: prod/snapshots/pxf6/pxf-gp{{.GPDBVersion}}.el{{.OSVersionNumber}}.tar.gz
 
-- name: plr_gpdb{{.GPDBVersion}}_rhel{{.CentosVersion}}_gppkg
+- name: plr_gpdb{{.GPDBVersion}}_{{.OSVersion}}_gppkg
   type: gcs
   source:
     json_key: ((concourse-gcs-resources-service-account-key))
     bucket: pivotal-gpdb-concourse-resources-prod
-    regexp: plr/released/gpdb{{.GPDBVersion}}/plr-(.*)-gp{{.GPDBVersion}}-rhel{{.CentosVersion}}-x86_64.gppkg
+    regexp: plr/released/gpdb{{.GPDBVersion}}/plr-(.*)-gp{{.GPDBVersion}}-rhel{{.OSVersionNumber}}-x86_64.gppkg
 
 # NOTE: plcontainer is only supported for centos7. And plcontainer 1.x is only for GPDB 5X.
 {{- if eq .GPDBVersion "5" }}
-- name: plcontainer_1.x_gpdb{{.GPDBVersion}}_rhel{{.CentosVersion}}_gppkg
+- name: plcontainer_1.x_gpdb{{.GPDBVersion}}_{{.OSVersion}}_gppkg
   type: gcs
   source:
     json_key: ((concourse-gcs-resources-service-account-key))
     bucket: pivotal-gpdb-concourse-resources-prod
-    regexp: plcontainer/released/gpdb{{.GPDBVersion}}/plcontainer-1.(.*)-rhel{{.CentosVersion}}-x86_64.gppkg
+    regexp: plcontainer/released/gpdb{{.GPDBVersion}}/plcontainer-1.(.*)-rhel{{.OSVersionNumber}}-x86_64.gppkg
 {{- end }}
 
 # NOTE: plcontainer is only supported for centos7. And plcontainer 2.x is only for GPDB 6X.
 {{- if eq .GPDBVersion "6" }}
-- name: plcontainer_2.x_gpdb{{.GPDBVersion}}_rhel{{.CentosVersion}}_gppkg
+- name: plcontainer_2.x_gpdb{{.GPDBVersion}}_{{.OSVersion}}_gppkg
   type: gcs
   source:
     json_key: ((concourse-gcs-resources-service-account-key))
     bucket: pivotal-gpdb-concourse-resources-prod
-    regexp: plcontainer/released/gpdb{{.GPDBVersion}}/plcontainer-2.(.*)-gp{{.GPDBVersion}}-rhel{{.CentosVersion}}_x86_64.gppkg
+    regexp: plcontainer/released/gpdb{{.GPDBVersion}}/plcontainer-2.(.*)-gp{{.GPDBVersion}}-rhel{{.OSVersionNumber}}_x86_64.gppkg
 {{- end }}
 
 {{- end}}

--- a/ci/3_gpupgrade_jobs.yml
+++ b/ci/3_gpupgrade_jobs.yml
@@ -33,10 +33,10 @@
           resource: gpdb{{.Source}}_src
         - get: bats
         - get: rpm_gpdb_source
-          resource: gpdb{{.Source}}_centos{{.CentosVersion}}_rpm
+          resource: gpdb{{.Source}}_{{.OSVersion}}_rpm
           trigger: true
         - get: rpm_gpdb_target
-          resource: gpdb{{.Target}}_centos{{.CentosVersion}}_rpm
+          resource: gpdb{{.Target}}_{{.OSVersion}}_rpm
           trigger: true
     - task: cluster-tests
       config:
@@ -44,7 +44,7 @@
         image_resource:
           type: registry-image
           source:
-            repository: gcr.io/data-gpdb-public-images/gpdb{{.Target}}-centos{{.CentosVersion}}-test-golang
+            repository: gcr.io/data-gpdb-public-images/gpdb{{.Target}}-{{.OSVersion}}-test-golang
             tag: latest
         inputs:
           - name: gpupgrade_src

--- a/ci/4_pg_upgrade_jobs.yml
+++ b/ci/4_pg_upgrade_jobs.yml
@@ -13,10 +13,10 @@
           resource: gpdb{{.Target}}_src
         - get: bats
         - get: rpm_gpdb_source
-          resource: gpdb{{.Source}}_centos{{.CentosVersion}}_rpm
+          resource: gpdb{{.Source}}_{{.OSVersion}}_rpm
           trigger: true
         - get: rpm_gpdb_target
-          resource: gpdb{{.Target}}_centos{{.CentosVersion}}_rpm
+          resource: gpdb{{.Target}}_{{.OSVersion}}_rpm
           trigger: true
     - task: pg-upgrade-tests
       config:
@@ -26,7 +26,7 @@
           source:
             # NOTE: Since we build isolation2 the build image OS needs to match
             # the GPDB target version we are testing.
-            repository: gcr.io/data-gpdb-public-images/gpdb{{.Target}}-centos{{.CentosVersion}}-test
+            repository: gcr.io/data-gpdb-public-images/gpdb{{.Target}}-{{.OSVersion}}-test
             tag: latest
         inputs:
           - name: enterprise_rpm

--- a/ci/5_multi_host_gpupgrade_jobs.yml
+++ b/ci/5_multi_host_gpupgrade_jobs.yml
@@ -12,11 +12,11 @@
         - get: gpupgrade_src
           passed: [ build ]
         - get: rpm_gpdb_source
-          resource: gpdb{{.Source}}_centos{{.CentosVersion}}_rpm
+          resource: gpdb{{.Source}}_{{.OSVersion}}_rpm
           trigger: true
         {{- if ne .Source .Target }}
         - get: rpm_gpdb_target
-          resource: gpdb{{.Target}}_centos{{.CentosVersion}}_rpm
+          resource: gpdb{{.Target}}_{{.OSVersion}}_rpm
           trigger: true
         {{- end }}
         - get: ccp_src
@@ -31,7 +31,7 @@
           standby_master: true
           instance_type: n1-standard-2
           number_of_nodes: 4
-          PLATFORM: centos{{.CentosVersion}}
+          PLATFORM: {{.OSVersion}}
           # Decrease the reap time from the default of 8 hours now that there are
           # both centos6 and centos7 jobs in order to not overload concourse.
           ccp_reap_minutes: 180
@@ -39,7 +39,7 @@
       file: ccp_src/ci/tasks/gen_cluster.yml
       params:
         <<: *ccp_gen_cluster_default_params
-        PLATFORM: centos{{.CentosVersion}}
+        PLATFORM: {{.OSVersion}}
         GPDB_RPM: true
       input_mapping:
         gpdb_rpm: rpm_gpdb_source

--- a/ci/6_upgrade_and_functional_jobs.yml
+++ b/ci/6_upgrade_and_functional_jobs.yml
@@ -12,11 +12,11 @@
         - get: gpupgrade_src
           passed: [ build ]
         - get: rpm_gpdb_source
-          resource: gpdb{{.Source}}_centos{{.CentosVersion}}_rpm
+          resource: gpdb{{.Source}}_{{.OSVersion}}_rpm
           trigger: true
         {{- if ne .Source .Target }}
         - get: rpm_gpdb_target
-          resource: gpdb{{.Target}}_centos{{.CentosVersion}}_rpm
+          resource: gpdb{{.Target}}_{{.OSVersion}}_rpm
           trigger: true
         {{- end }}
         - get: ccp_src
@@ -39,28 +39,28 @@
         {{- end }}
         {{- if .ExtensionsJob }}
         - get: gptext_targz # NOTE: The same gptext artifact is used for both the source and target clusters.
-          resource: gptext_3.x_gpdb6_rhel{{.CentosVersion}}_targz
+          resource: gptext_3.x_gpdb6_{{.OSVersion}}_targz
         - get: postgis_gppkg_source
-          resource: postgis_2.x_gpdb{{.Source}}_centos{{.CentosVersion}}_gppkg
+          resource: postgis_2.x_gpdb{{.Source}}_{{.OSVersion}}_gppkg
         - get: postgis_gppkg_target
-          resource: postgis_2.x_gpdb{{.Target}}_centos{{.CentosVersion}}_gppkg
+          resource: postgis_2.x_gpdb{{.Target}}_{{.OSVersion}}_gppkg
         - get: madlib_gppkg_source
-          resource: madlib_1.x_gpdb{{.Source}}_centos{{.CentosVersion}}_gppkg
+          resource: madlib_1.x_gpdb{{.Source}}_{{.OSVersion}}_gppkg
         - get: madlib_gppkg_target
-          resource: madlib_1.x_gpdb{{.Target}}_centos{{.CentosVersion}}_gppkg
+          resource: madlib_1.x_gpdb{{.Target}}_{{.OSVersion}}_gppkg
         - get: plr_gppkg_source
-          resource: plr_gpdb{{.Source}}_rhel{{.CentosVersion}}_gppkg
+          resource: plr_gpdb{{.Source}}_{{.OSVersion}}_gppkg
         - get: plr_gppkg_target
-          resource: plr_gpdb{{.Target}}_rhel{{.CentosVersion}}_gppkg
-        {{- if ne .CentosVersion "6" }}
+          resource: plr_gpdb{{.Target}}_{{.OSVersion}}_gppkg
+        {{- if ne .OSVersion "centos6" }}
         - get: pxf_rpm_source
-          resource: pxf_6_gpdb{{.Source}}_centos{{.CentosVersion}}_rpm
+          resource: pxf_6_gpdb{{.Source}}_{{.OSVersion}}_rpm
         - get: pxf_rpm_target
-          resource: pxf_6_gpdb{{.Target}}_centos{{.CentosVersion}}_rpm
+          resource: pxf_6_gpdb{{.Target}}_{{.OSVersion}}_rpm
         - get: plcontainer_gppkg_source
-          resource: plcontainer_1.x_gpdb5_rhel{{.CentosVersion}}_gppkg
+          resource: plcontainer_1.x_gpdb5_{{.OSVersion}}_gppkg
         - get: plcontainer_gppkg_target
-          resource: plcontainer_2.x_gpdb6_rhel{{.CentosVersion}}_gppkg
+          resource: plcontainer_2.x_gpdb6_{{.OSVersion}}_gppkg
         {{- end }}
         {{- end }}
     - put: terraform
@@ -74,7 +74,7 @@
           {{- end}}
           instance_type: n1-standard-2
           number_of_nodes: 4
-          PLATFORM: centos{{.CentosVersion}}
+          PLATFORM: {{.OSVersion}}
           # Decrease the reap time from the default of 8 hours now that there are
           # both centos6 and centos7 jobs in order to not overload concourse.
           ccp_reap_minutes: 180
@@ -82,7 +82,7 @@
       file: ccp_src/ci/tasks/gen_cluster.yml
       params:
         <<: *ccp_gen_cluster_default_params
-        PLATFORM: centos{{.CentosVersion}}
+        PLATFORM: {{.OSVersion}}
         GPDB_RPM: true
       input_mapping:
         gpdb_rpm: rpm_gpdb_source
@@ -135,7 +135,7 @@
             tag: latest
         params:
           GOOGLE_CREDENTIALS: ((upgrade/cm-gcs-service-account-key))
-          OS_VERSION: centos{{.CentosVersion}}
+          OS_VERSION: {{.OSVersion}}
         inputs:
           - name: ccp_src
           - name: cluster_env_files
@@ -145,7 +145,7 @@
           - name: madlib_gppkg_source
           - name: plr_gppkg_source
           - name: sqldump
-          {{- if ne .CentosVersion "6" }}
+          {{- if ne .OSVersion "centos6" }}
           - name: pxf_rpm_source
           - name: plcontainer_gppkg_source
           {{- end }}
@@ -178,7 +178,7 @@
             repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
             tag: latest
         params:
-          OS_VERSION: centos{{.CentosVersion}}
+          OS_VERSION: {{.OSVersion}}
         inputs:
           - name: ccp_src
           - name: cluster_env_files
@@ -186,7 +186,7 @@
           - name: postgis_gppkg_target
           - name: madlib_gppkg_target
           - name: plr_gppkg_target
-          {{- if ne .CentosVersion "6" }}
+          {{- if ne .OSVersion "centos6" }}
           - name: pxf_rpm_target
           - name: plcontainer_gppkg_target
           {{- end }}

--- a/ci/parser/jobs.go
+++ b/ci/parser/jobs.go
@@ -9,7 +9,7 @@ import "fmt"
 
 type ClusterJob struct {
 	Source, Target string
-	CentosVersion  string
+	OSVersion      string
 }
 
 type ClusterJobs []ClusterJob
@@ -27,11 +27,11 @@ type UpgradeJob struct {
 	LinkMode       bool
 	RetailDemo     bool
 	ExtensionsJob  bool
-	CentosVersion  string
+	OSVersion      string
 }
 
 func (j *UpgradeJob) Name() string {
-	return fmt.Sprintf("%s-centos-%s", j.BaseName(), j.CentosVersion)
+	return fmt.Sprintf("%s-%s", j.BaseName(), j.OSVersion)
 }
 
 // BaseName returns the pipeline job name without the operating system.
@@ -62,11 +62,11 @@ type UpgradeJobs []UpgradeJob
 
 type PgUpgradeJob struct {
 	Source, Target string
-	CentosVersion  string
+	OSVersion      string
 }
 
 func (p *PgUpgradeJob) Name() string {
-	return fmt.Sprintf("%s-centos-%s", p.BaseName(), p.CentosVersion)
+	return fmt.Sprintf("%s-%s", p.BaseName(), p.OSVersion)
 }
 
 // BaseName returns the pipeline job name without the operating system.
@@ -82,11 +82,11 @@ type PgUpgradeJobs []PgUpgradeJob
 
 type MultihostGpupgradeJob struct {
 	Source, Target string
-	CentosVersion  string
+	OSVersion      string
 }
 
 func (j *MultihostGpupgradeJob) Name() string {
-	return fmt.Sprintf("%s-centos-%s", j.BaseName(), j.CentosVersion)
+	return fmt.Sprintf("%s-%s", j.BaseName(), j.OSVersion)
 }
 
 // BaseName returns the pipeline job name without the operating system.

--- a/ci/parser/main.go
+++ b/ci/parser/main.go
@@ -28,31 +28,36 @@ import (
 
 var versions = []Version{
 	{
-		sourceVersion: "5",
-		targetVersion: "6",
-		centosVersion: "6",
+		sourceVersion:   "5",
+		targetVersion:   "6",
+		osVersion:       "centos6",
+		osVersionNumber: "6",
 	},
 	{
-		sourceVersion: "5",
-		targetVersion: "6",
-		centosVersion: "7",
-		SpecialJobs:   true, // To avoid exploding the test matrix set specialJobs for 5->6 for only a single OS.
+		sourceVersion:   "5",
+		targetVersion:   "6",
+		osVersion:       "centos7",
+		osVersionNumber: "7",
+		SpecialJobs:     true, // To avoid exploding the test matrix set specialJobs for 5->6 for only a single OS.
 	},
 	{
-		sourceVersion: "6",
-		targetVersion: "6",
-		centosVersion: "7", // To avoid exploding the test matrix have 6->6 for only a single OS.
+		sourceVersion:   "6",
+		targetVersion:   "6",
+		osVersion:       "centos7", // To avoid exploding the test matrix have 6->6 for only a single OS.
+		osVersionNumber: "7",
 	},
 	//{
-	//	sourceVersion: "6",
-	//	targetVersion: "7",
-	//	centosVersion: "8",
-	//	SpecialJobs:   true,
+	//	sourceVersion:   "6",
+	//	targetVersion:   "7",
+	//	osVersion:       "rocky8",
+	//	osVersionNumber: "8",
+	//	SpecialJobs:     true,
 	//},
 	//{
-	//	sourceVersion: "7",
-	//	targetVersion: "7",
-	//	centosVersion: "8",
+	//	sourceVersion:   "7",
+	//	targetVersion:   "7",
+	//	osVersion:       "rocky8",
+	//	osVersionNumber: "8",
 	//},
 }
 
@@ -82,7 +87,8 @@ func init() {
 		}
 
 		gpdbVersion := GPDBVersion{
-			CentosVersion:    version.centosVersion,
+			OSVersion:        version.osVersion,
+			OSVersionNumber:  version.osVersionNumber,
 			GPDBVersion:      version.sourceVersion,
 			TestRCIdentifier: version.testRCIdentifier(),
 		}
@@ -92,7 +98,8 @@ func init() {
 		}
 
 		gpdbVersion = GPDBVersion{
-			CentosVersion:    version.centosVersion,
+			OSVersion:        version.osVersion,
+			OSVersionNumber:  version.osVersionNumber,
 			GPDBVersion:      version.targetVersion, // need to add all combinations of version
 			TestRCIdentifier: version.testRCIdentifier(),
 		}
@@ -102,28 +109,28 @@ func init() {
 		}
 
 		multihostClusterJobs = append(multihostClusterJobs, MultihostGpupgradeJob{
-			Source:        version.sourceVersion,
-			Target:        version.targetVersion,
-			CentosVersion: version.centosVersion,
+			Source:    version.sourceVersion,
+			Target:    version.targetVersion,
+			OSVersion: version.osVersion,
 		})
 
 		upgradeJobs = append(upgradeJobs, UpgradeJob{
-			Source:        version.sourceVersion,
-			Target:        version.targetVersion,
-			CentosVersion: version.centosVersion,
+			Source:    version.sourceVersion,
+			Target:    version.targetVersion,
+			OSVersion: version.osVersion,
 		})
 
 		if version.SpecialJobs {
 			clusterJobs = append(clusterJobs, ClusterJob{
-				Source:        version.sourceVersion,
-				Target:        version.targetVersion,
-				CentosVersion: version.centosVersion,
+				Source:    version.sourceVersion,
+				Target:    version.targetVersion,
+				OSVersion: version.osVersion,
 			})
 
 			pgupgradeJobs = append(pgupgradeJobs, PgUpgradeJob{
-				Source:        version.sourceVersion,
-				Target:        version.targetVersion,
-				CentosVersion: version.centosVersion,
+				Source:    version.sourceVersion,
+				Target:    version.targetVersion,
+				OSVersion: version.osVersion,
 			})
 		}
 	}
@@ -146,7 +153,7 @@ func init() {
 
 			job.Source = version.sourceVersion
 			job.Target = version.targetVersion
-			job.CentosVersion = version.centosVersion
+			job.OSVersion = version.osVersion
 
 			upgradeJobs = append(upgradeJobs, job)
 		}

--- a/ci/parser/version.go
+++ b/ci/parser/version.go
@@ -9,10 +9,11 @@ import (
 )
 
 type Version struct {
-	sourceVersion string
-	targetVersion string
-	centosVersion string
-	SpecialJobs   bool
+	sourceVersion   string
+	targetVersion   string
+	osVersion       string
+	osVersionNumber string
+	SpecialJobs     bool
 }
 
 // testRCIdentifier returns the unique identifier used when naming the test
@@ -52,7 +53,8 @@ func (a MajorVersions) contains(needle string) bool {
 }
 
 type GPDBVersion struct {
-	CentosVersion    string
+	OSVersion        string
+	OSVersionNumber  string
 	GPDBVersion      string
 	TestRCIdentifier string
 }


### PR DESCRIPTION
Since rhel8 will be used instead of centos8, refactor centosVersion to be more generic for any operating system.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:refactorPipeline