### PR TITLE
Do path lookup for sed in update_conf_files unit test

### DIFF
--- a/hub/update_conf_files_test.go
+++ b/hub/update_conf_files_test.go
@@ -6,6 +6,7 @@ package hub_test
 import (
 	"errors"
 	"fmt"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -526,8 +527,13 @@ primary_slot_name = 'internal_wal_replication_slot'
 			t.Fatalf("got error count %d, want %d", len(errs), len(opts))
 		}
 
+		sedPath, err := exec.LookPath("sed")
+		if err != nil {
+			t.Fatalf("expected sed: %v", err)
+		}
+
 		for _, err := range errs {
-			expected := `update . using "/usr/bin/sed -E -i.bak s@@@ " failed with "sed:`
+			expected := fmt.Sprintf(`update . using "%s -E -i.bak s@@@ " failed with "sed:`, sedPath)
 			if !strings.HasPrefix(err.Error(), expected) {
 				t.Errorf("expected error to contain %q got %q", expected, err.Error())
 			}


### PR DESCRIPTION
The update_conf_files unit test assumes that the sed tool is located in /usr/bin/sed. However, this assumption isn't guaranteed since developers could have their sed somewhere else
(e.g. /usr/local/bin/sed from MacOS brew or compiling from scratch on linux). It's safer to do a path lookup for sed and use that for the expected output string to avoid developer environment assumptions.