### PR TITLE
Refactor revert

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,15 @@ Optional steps (ie: commands):
   - To restore the cluster to the state before the upgrade.
   - Can be run after initialize or execute, but *not* finalize.
   - Substeps include deleting the target cluster, archiving the gpupgrade log 
-  directory, and restoring the source cluster.
+    directory, and restoring the source cluster.
+  - Reverting in copy mode consists of simply removing the target cluster.
+    However, due to a GPDB 5X bug gprecoverseg is needed.
+  - Reverting in link mode consists of restoring the pg_control file on the
+    primaries, and rsyncing the source cluster mirrors to the primaries.
+  - When the source cluster has no mirrors/standby:
+    - reverting during initialize is allowed in both copy and link mode
+    - reverting during execute is allowed in copy mode
+    - reverting during execute is *not* allowed in link mode
 
 ```
   start <---- run migration

--- a/cli/commands/confirmation_text.go
+++ b/cli/commands/confirmation_text.go
@@ -101,8 +101,10 @@ has completed.
 var revertWarningText = color.RedString(`
 WARNING
 _______
-The source cluster does not have standby and/or mirrors.
-After "gpupgrade execute" has been run, there will be no way to
+The source cluster does not have standby and/or mirrors and 
+is being upgraded in link mode.
+
+Once "gpupgrade execute" has started, there will be no way to
 return the cluster to its original state using "gpupgrade revert".
 
 If you do not already have a backup, we strongly recommend that

--- a/cli/commands/execute.go
+++ b/cli/commands/execute.go
@@ -43,7 +43,7 @@ func execute() *cobra.Command {
 			}
 
 			revertWarning := ""
-			if !conf.Source.HasAllMirrorsAndStandby() {
+			if !conf.Source.HasAllMirrorsAndStandby() && conf.LinkMode {
 				revertWarning = revertWarningText
 			}
 

--- a/cli/commands/initialize.go
+++ b/cli/commands/initialize.go
@@ -274,7 +274,7 @@ func initialize() *cobra.Command {
 			})
 
 			revertWarning := ""
-			if !response.GetHasAllMirrorsAndStandby() {
+			if !response.GetHasAllMirrorsAndStandby() && linkMode {
 				revertWarning = revertWarningText
 			}
 

--- a/hub/revert.go
+++ b/hub/revert.go
@@ -72,14 +72,7 @@ func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) 
 		return RestoreCoordinatorAndPrimariesPgControl(streams, s.agentConns, s.Source)
 	})
 
-	// if the target cluster has been started at any point, we must restore the source
-	// cluster as its files could have been modified.
-	targetStarted, err := step.HasRun(idl.Step_execute, idl.Substep_start_target_cluster)
-	if err != nil {
-		return err
-	}
-
-	st.RunConditionally(idl.Substep_restore_source_cluster, s.LinkMode && targetStarted, func(stream step.OutStreams) error {
+	st.RunConditionally(idl.Substep_restore_source_cluster, s.LinkMode, func(stream step.OutStreams) error {
 		if err := RsyncCoordinatorAndPrimaries(stream, s.agentConns, s.Source); err != nil {
 			return err
 		}

--- a/hub/revert.go
+++ b/hub/revert.go
@@ -92,12 +92,7 @@ func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) 
 		return err
 	}
 
-	sourceClusterIsRunning, err := s.Source.IsCoordinatorRunning(step.DevNullStream)
-	if err != nil {
-		return err
-	}
-
-	st.RunConditionally(idl.Substep_start_source_cluster, !sourceClusterIsRunning, func(streams step.OutStreams) error {
+	st.Run(idl.Substep_start_source_cluster, func(streams step.OutStreams) error {
 		err = s.Source.Start(streams)
 		var exitErr *exec.ExitError
 		if xerrors.As(err, &exitErr) {

--- a/hub/revert.go
+++ b/hub/revert.go
@@ -61,12 +61,7 @@ Cannot revert and restore the source cluster. Please contact support.`)
 			return DeleteTargetTablespaces(streams, s.agentConns, s.Config.Intermediate, s.Intermediate.CatalogVersion, s.Source.Tablespaces)
 		})
 
-	// For any of the link-mode cases described in the "Reverting to old
-	// cluster" section of https://www.postgresql.org/docs/9.4/pgupgrade.html,
-	// it is correct to restore the pg_control file. Even in the case where
-	// we're going to perform a full rsync restoration, we rely on this
-	// substep to clean up the pg_control.old file, since the rsync will not
-	// remove it.
+	// See "Reverting to old cluster" from https://www.postgresql.org/docs/9.4/pgupgrade.html
 	st.RunConditionally(idl.Substep_restore_pgcontrol, s.LinkMode, func(streams step.OutStreams) error {
 		return RestoreCoordinatorAndPrimariesPgControl(streams, s.agentConns, s.Source)
 	})


### PR DESCRIPTION
- Fixes the bug where source cluster is not brought back correct after a link mode execute failure.
- Simplifies the logic around bug fix running gprecoverseg to restore 5X source cluster mirrors after execute failure in copy mode.

pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:refactor-revert