### PR TITLE
pg_upgrade acceptance tests: update check constraint test

### DIFF
--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/expected/check_constraints.out
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/expected/check_constraints.out
@@ -6,10 +6,20 @@
 --------------------------------------------------------------------------------
 -- Create and setup upgradeable objects
 --------------------------------------------------------------------------------
-create table users_with_check_constraints ( id int, name text check (id>=1 and id<2) );
+CREATE TABLE heap_table_with_check_constraint ( id INT, name text CHECK (id>=1 AND id<2) );
 CREATE
 
-insert into users_with_check_constraints values (1, 'Joe');
+INSERT INTO heap_table_with_check_constraint VALUES (1, 'Joe');
 INSERT 1
-insert into users_with_check_constraints values (2, 'Jane');
-ERROR:  new row for relation "users_with_check_constraints" violates check constraint "users_with_check_constraints_id_check"
+-- this insert should fail
+INSERT INTO heap_table_with_check_constraint VALUES (2, 'Jane');
+ERROR:  new row for relation "heap_table_with_check_constraint" violates check constraint "heap_table_with_check_constraint_id_check"
+
+CREATE TABLE partition_table_with_check_constraint ( a INT CONSTRAINT a_check CHECK (a+b>c), b INT, c INT) DISTRIBUTED BY (a) PARTITION BY RANGE(b) (PARTITION part START(0) END(4242));
+CREATE
+
+INSERT INTO partition_table_with_check_constraint SELECT i, i, i FROM generate_series(1, 10) i;
+INSERT 10
+-- this insert should fail
+INSERT INTO partition_table_with_check_constraint VALUES (1, 1, 3);
+ERROR:  new row for relation "partition_table_with_check_constraint_1_prt_part" violates check constraint "a_check"

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/sql/check_constraints.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/sql/check_constraints.sql
@@ -6,10 +6,22 @@
 --------------------------------------------------------------------------------
 -- Create and setup upgradeable objects
 --------------------------------------------------------------------------------
-create table users_with_check_constraints (
-    id int, 
-    name text check (id>=1 and id<2)
+CREATE TABLE heap_table_with_check_constraint (
+    id INT,
+    name text CHECK (id>=1 AND id<2)
 );
 
-insert into users_with_check_constraints values (1, 'Joe');
-insert into users_with_check_constraints values (2, 'Jane');
+INSERT INTO heap_table_with_check_constraint VALUES (1, 'Joe');
+-- this insert should fail
+INSERT INTO heap_table_with_check_constraint VALUES (2, 'Jane');
+
+CREATE TABLE partition_table_with_check_constraint (
+    a INT CONSTRAINT a_check CHECK (a+b>c),
+    b INT,
+    c INT) DISTRIBUTED BY (a)
+    PARTITION BY RANGE(b)
+        (PARTITION part START(0) END(4242));
+
+INSERT INTO partition_table_with_check_constraint SELECT i, i, i FROM generate_series(1, 10) i;
+-- this insert should fail
+INSERT INTO partition_table_with_check_constraint VALUES (1, 1, 3);

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/check_constraints.out
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/check_constraints.out
@@ -5,12 +5,32 @@
 -- Validate that the upgradeable objects are functional post-upgrade
 --------------------------------------------------------------------------------
 
-select * from users_with_check_constraints;
+SELECT * FROM heap_table_with_check_constraint;
  id | name 
 ----+------
  1  | Joe  
 (1 row)
-
-insert into users_with_check_constraints values (2, 'Jane');
-ERROR:  new row for relation "users_with_check_constraints" violates check constraint "users_with_check_constraints_id_check"
+-- this insert should fail
+INSERT INTO heap_table_with_check_constraint VALUES (2, 'Jane');
+ERROR:  new row for relation "heap_table_with_check_constraint" violates check constraint "heap_table_with_check_constraint_id_check"
 DETAIL:  Failing row contains (2, Jane).
+
+SELECT * FROM partition_table_with_check_constraint;
+ a  | b  | c  
+----+----+----
+ 1  | 1  | 1  
+ 2  | 2  | 2  
+ 3  | 3  | 3  
+ 4  | 4  | 4  
+ 5  | 5  | 5  
+ 6  | 6  | 6  
+ 7  | 7  | 7  
+ 8  | 8  | 8  
+ 9  | 9  | 9  
+ 10 | 10 | 10 
+(10 rows)
+-- this insert should fail
+INSERT INTO partition_table_with_check_constraint VALUES (1, 1, 3);
+ERROR:  new row for relation "partition_table_with_check_constraint_1_prt_part" violates check constraint "a_check"
+DETAIL:  Failing row contains (1, 1, 3).
+

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/check_constraints.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/check_constraints.sql
@@ -5,6 +5,11 @@
 -- Validate that the upgradeable objects are functional post-upgrade
 --------------------------------------------------------------------------------
 
-select * from users_with_check_constraints;
+SELECT * FROM heap_table_with_check_constraint;
+-- this insert should fail
+INSERT INTO heap_table_with_check_constraint VALUES (2, 'Jane');
 
-insert into users_with_check_constraints values (2, 'Jane');
+SELECT * FROM partition_table_with_check_constraint;
+-- this insert should fail
+INSERT INTO partition_table_with_check_constraint VALUES (1, 1, 3);
+


### PR DESCRIPTION
These tests are associated with GPDB 6X PR: https://github.com/greenplum-db/gpdb/pull/14679 which fixes a regression to properly dump check constraints.

Update pg_upgrade upgradeable acceptance test with a partition table for check constraints.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:updateCheckConstraintTest