### PR TITLE
ci: fix makefile for testing release candidates

### DIFF
--- a/ci/parser/main.go
+++ b/ci/parser/main.go
@@ -90,7 +90,7 @@ func init() {
 			OSVersion:        version.osVersion,
 			OSVersionNumber:  version.osVersionNumber,
 			GPDBVersion:      version.sourceVersion,
-			TestRCIdentifier: version.testRCIdentifier(),
+			TestRCIdentifier: testRCIdentifier(version.sourceVersion),
 		}
 
 		if !gpdbVersions.contains(gpdbVersion) {
@@ -101,7 +101,7 @@ func init() {
 			OSVersion:        version.osVersion,
 			OSVersionNumber:  version.osVersionNumber,
 			GPDBVersion:      version.targetVersion, // need to add all combinations of version
-			TestRCIdentifier: version.testRCIdentifier(),
+			TestRCIdentifier: testRCIdentifier(version.targetVersion),
 		}
 
 		if !gpdbVersions.contains(gpdbVersion) {

--- a/ci/parser/version.go
+++ b/ci/parser/version.go
@@ -16,30 +16,6 @@ type Version struct {
 	SpecialJobs     bool
 }
 
-// testRCIdentifier returns the unique identifier used when naming the test
-// release candidate RPMs. This is used to to prevent bucket filename collisions.
-func (v *Version) testRCIdentifier() string {
-	fmtString := "%s-%s-"
-	identifier := ""
-	switch v.sourceVersion {
-	case "5":
-		identifier = fmt.Sprintf(fmtString, os.Getenv("5X_GIT_USER"), os.Getenv("5X_GIT_BRANCH"))
-	case "6":
-		identifier = fmt.Sprintf(fmtString, os.Getenv("6X_GIT_USER"), os.Getenv("6X_GIT_BRANCH"))
-	case "7":
-		identifier = fmt.Sprintf(fmtString, os.Getenv("7X_GIT_USER"), os.Getenv("7X_GIT_BRANCH"))
-	default:
-		return ""
-	}
-
-	if identifier == fmt.Sprintf(fmtString, "", "") {
-		// If env variables are empty, return empty string rather than the empty fmtString of "--"
-		return ""
-	}
-
-	return identifier
-}
-
 type MajorVersions []string
 
 func (a MajorVersions) contains(needle string) bool {
@@ -69,4 +45,29 @@ func (v GPDBVersions) contains(needle GPDBVersion) bool {
 	}
 
 	return false
+}
+
+// testRCIdentifier returns the unique identifier used when naming the test
+// release candidate RPMs. This is used to prevent bucket filename collisions.
+func testRCIdentifier(version string) string {
+	fmtString := "%s-%s-"
+	identifier := ""
+
+	switch version {
+	case "5":
+		identifier = fmt.Sprintf(fmtString, os.Getenv("5X_GIT_USER"), os.Getenv("5X_GIT_BRANCH"))
+	case "6":
+		identifier = fmt.Sprintf(fmtString, os.Getenv("6X_GIT_USER"), os.Getenv("6X_GIT_BRANCH"))
+	case "7":
+		identifier = fmt.Sprintf(fmtString, os.Getenv("7X_GIT_USER"), os.Getenv("7X_GIT_BRANCH"))
+	default:
+		return ""
+	}
+
+	if identifier == fmt.Sprintf(fmtString, "", "") {
+		// If env variables are empty, return empty string rather than the empty fmtString of "--"
+		return ""
+	}
+
+	return identifier
 }


### PR DESCRIPTION
Often times it is useful to test pg_upgrade or pg_dump changes against the pg_upgrade acceptance tests in the gpupgrade repo before merging to GPDB. To do so, one creates a GPDB RC rpm based off the GPDB branch. Next, create a gpupgrade test branch and push it. Next, generate a gpupgrade test pipeline that uses the GPDB RC RPMs using the appropriate environment variables: `make 5X_GIT_USER=alice 5X_GIT_BRANCH=5X_rc 6X_GIT_USER=bob 6X_GIT_BRANCH=6X_rc set-pipeline`

However, this was failing to generate a correct pipeline since only the sourceVersion was being switched on rather than the appropriate version.

https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixTestRC