### PR TITLE
Use cdw instead of mdw in CI scripts and yaml templates

### DIFF
--- a/ci/5_multi_host_gpupgrade_jobs.yml
+++ b/ci/5_multi_host_gpupgrade_jobs.yml
@@ -24,7 +24,7 @@
       params:
         <<: *ccp_default_params
         vars:
-          standby_master: true
+          standby_coordinator: true
           instance_type: n1-standard-2
           number_of_nodes: 4
           PLATFORM: {{.OSVersion}}

--- a/ci/6_upgrade_and_functional_jobs.yml
+++ b/ci/6_upgrade_and_functional_jobs.yml
@@ -72,7 +72,7 @@
           {{- if .PrimariesOnly}}
           mirrors: false
           {{- else if not .NoStandby}}
-          standby_master: true
+          standby_coordinator: true
           {{- end}}
           instance_type: n1-standard-2
           number_of_nodes: 4
@@ -249,7 +249,7 @@
               source gpupgrade_src/test/acceptance/helpers/finalize_checks.bash
 
               echo 'Doing failover tests of mirrors and standby...'
-              validate_mirrors_and_standby /usr/local/greenplum-db-target mdw 5432
+              validate_mirrors_and_standby /usr/local/greenplum-db-target cdw 5432
     {{- end -}}
     {{- end }}
   ensure:

--- a/ci/scripts/acceptance-multihost-tests.bash
+++ b/ci/scripts/acceptance-multihost-tests.bash
@@ -5,13 +5,13 @@
 set -eux -o pipefail
 
 function run_migration_scripts_and_tests() {
-    time ssh mdw '
+    time ssh cdw '
         set -eux -o pipefail
 
         export GPHOME_SOURCE=/usr/local/greenplum-db-source
         export GPHOME_TARGET=/usr/local/greenplum-db-target
         source "${GPHOME_SOURCE}"/greenplum_path.sh
-        export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1
+        export MASTER_DATA_DIRECTORY=/data/gpdata/coordinator/gpseg-1
         export PGPORT=5432
 
         echo "Running data migration scripts to ensure a clean cluster..."
@@ -26,12 +26,12 @@ main() {
     echo "Enabling ssh to cluster..."
     ./ccp_src/scripts/setup_ssh_to_cluster.sh
 
-    echo "Installing gpupgrade_src on mdw..."
-    scp -rpq gpupgrade_src gpadmin@mdw:/home/gpadmin
+    echo "Installing gpupgrade_src on cdw..."
+    scp -rpq gpupgrade_src gpadmin@cdw:/home/gpadmin
 
     echo "Installing BATS..."
-    rsync --archive bats centos@mdw:
-    ssh centos@mdw sudo ./bats/install.sh /usr/local
+    rsync --archive bats centos@cdw:
+    ssh centos@cdw sudo ./bats/install.sh /usr/local
 
     echo "Running data migration scripts and tests..."
     run_migration_scripts_and_tests

--- a/ci/scripts/load-extensions.bash
+++ b/ci/scripts/load-extensions.bash
@@ -8,18 +8,18 @@ source gpupgrade_src/ci/scripts/ci-helpers.bash
 
 export GPHOME_SOURCE=/usr/local/greenplum-db-source
 export GPHOME_TARGET=/usr/local/greenplum-db-target
-export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1
+export MASTER_DATA_DIRECTORY=/data/gpdata/coordinator/gpseg-1
 export PGPORT=5432
 
 ./ccp_src/scripts/setup_ssh_to_cluster.sh
 
 echo "Copying extensions to the source cluster..."
-scp gptext_targz_source/greenplum-text*.tar.gz gpadmin@mdw:/tmp/gptext_source.tar.gz
-scp postgis_gppkg_source/postgis*.gppkg gpadmin@mdw:/tmp/postgis_source.gppkg
-scp sqldump/*.sql gpadmin@mdw:/tmp/postgis_dump.sql
-scp madlib_gppkg_source/madlib*.gppkg gpadmin@mdw:/tmp/madlib_source.gppkg
-scp plr_gppkg_source/plr*.gppkg gpadmin@mdw:/tmp/plr_source.gppkg
-scp plcontainer_gppkg_source/*.gppkg gpadmin@mdw:/tmp/plcontainer_source.gppkg
+scp gptext_targz_source/greenplum-text*.tar.gz gpadmin@cdw:/tmp/gptext_source.tar.gz
+scp postgis_gppkg_source/postgis*.gppkg gpadmin@cdw:/tmp/postgis_source.gppkg
+scp sqldump/*.sql gpadmin@cdw:/tmp/postgis_dump.sql
+scp madlib_gppkg_source/madlib*.gppkg gpadmin@cdw:/tmp/madlib_source.gppkg
+scp plr_gppkg_source/plr*.gppkg gpadmin@cdw:/tmp/plr_source.gppkg
+scp plcontainer_gppkg_source/*.gppkg gpadmin@cdw:/tmp/plcontainer_source.gppkg
 
 echo "Installing extensions and sample data on source cluster..."
 
@@ -53,7 +53,7 @@ for host in "${hosts[@]}"; do
 done
 
 echo "Installing GPDB extensions and sample data on source cluster..."
-time ssh -n mdw "
+time ssh -n cdw "
     set -eux -o pipefail
     source /usr/local/greenplum-db-source/greenplum_path.sh
     export MASTER_DATA_DIRECTORY=$MASTER_DATA_DIRECTORY
@@ -62,7 +62,7 @@ time ssh -n mdw "
     tar -xzvf /tmp/gptext_source.tar.gz -C /tmp/
     chmod +x /tmp/greenplum-text*.bin
     sed -i -r 's/GPTEXT_HOSTS\=\(localhost\)/GPTEXT_HOSTS\=\"ALLSEGHOSTS\"/' /tmp/gptext_install_config
-    sed -i -r 's/ZOO_HOSTS.*/ZOO_HOSTS\=\(mdw mdw mdw\)/' /tmp/gptext_install_config
+    sed -i -r 's/ZOO_HOSTS.*/ZOO_HOSTS\=\(cdw cdw cdw\)/' /tmp/gptext_install_config
 
     /tmp/greenplum-text*.bin -c /tmp/gptext_install_config -d /usr/local/greenplum-db-text
     source /usr/local/greenplum-db-text/greenplum-text_path.sh
@@ -175,7 +175,7 @@ SQL_EOF
 "
 
 echo "Installing postgres native extensions and sample data on source cluster..."
-time ssh -n mdw "
+time ssh -n cdw "
     set -eux -o pipefail
 
     source /usr/local/greenplum-db-source/greenplum_path.sh
@@ -245,7 +245,7 @@ SQL_EOF
 "
 
 echo "Running the data migration scripts on the source cluster..."
-ssh -n mdw "
+ssh -n cdw "
     set -eux -o pipefail
 
     source /usr/local/greenplum-db-source/greenplum_path.sh

--- a/ci/scripts/upgrade-cluster.bash
+++ b/ci/scripts/upgrade-cluster.bash
@@ -12,7 +12,7 @@ DIFF_FILE=${DIFF_FILE:-"icw.diff"}
 
 export GPHOME_SOURCE=/usr/local/greenplum-db-source
 export GPHOME_TARGET=/usr/local/greenplum-db-target
-export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1
+export MASTER_DATA_DIRECTORY=/data/gpdata/coordinator/gpseg-1
 export PGPORT=5432
 
 ./ccp_src/scripts/setup_ssh_to_cluster.sh
@@ -26,7 +26,7 @@ echo "Dumping the source cluster for comparing after upgrade..."
 dump_sql $PGPORT /tmp/source.sql
 
 echo "Performing gpupgrade..."
-time ssh -n mdw "
+time ssh -n cdw "
     set -eux -o pipefail
 
     gpupgrade initialize \

--- a/ci/scripts/upgrade-extensions.bash
+++ b/ci/scripts/upgrade-extensions.bash
@@ -12,16 +12,16 @@ DIFF_FILE=${DIFF_FILE:-"icw.diff"}
 
 export GPHOME_SOURCE=/usr/local/greenplum-db-source
 export GPHOME_TARGET=/usr/local/greenplum-db-target
-export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1
+export MASTER_DATA_DIRECTORY=/data/gpdata/coordinator/gpseg-1
 export PGPORT=5432
 
 ./ccp_src/scripts/setup_ssh_to_cluster.sh
 
 echo "Copying extensions to the target cluster..."
-scp postgis_gppkg_target/postgis*.gppkg gpadmin@mdw:/tmp/postgis_target.gppkg
-scp madlib_gppkg_target/madlib*.gppkg gpadmin@mdw:/tmp/madlib_target.gppkg
-scp plr_gppkg_target/plr*.gppkg gpadmin@mdw:/tmp/plr_target.gppkg
-scp plcontainer_gppkg_target/*.gppkg gpadmin@mdw:/tmp/plcontainer_target.gppkg
+scp postgis_gppkg_target/postgis*.gppkg gpadmin@cdw:/tmp/postgis_target.gppkg
+scp madlib_gppkg_target/madlib*.gppkg gpadmin@cdw:/tmp/madlib_target.gppkg
+scp plr_gppkg_target/plr*.gppkg gpadmin@cdw:/tmp/plr_target.gppkg
+scp plcontainer_gppkg_target/*.gppkg gpadmin@cdw:/tmp/plcontainer_target.gppkg
 
 # PXF SNAPSHOT builds are only available as an RPM inside a tar.gz
 tar -xf pxf_rpm_target/pxf*.tar.gz --directory pxf_rpm_target --strip-components=1 --wildcards '*.rpm'
@@ -38,7 +38,7 @@ for host in "${hosts[@]}"; do
     "
 done
 
-ssh -n mdw "
+ssh -n cdw "
     set -eux -o pipefail
     export GPHOME=${GPHOME_SOURCE}
     export PXF_BASE=/home/gpadmin/pxf
@@ -55,7 +55,7 @@ echo "Dumping the source cluster for comparing after upgrade..."
 dump_sql $PGPORT /tmp/source.sql
 
 echo "Performing gpupgrade..."
-time ssh -n mdw "
+time ssh -n cdw "
     set -ex -o pipefail
 
     echo 'Running initialize to create target cluster....'
@@ -133,7 +133,7 @@ if ! compare_dumps /tmp/source.sql /tmp/target.sql; then
 fi
 
 echo "Applying post-upgrade extension fixups after comparing dumps..."
-ssh -n mdw "
+ssh -n cdw "
     set -eux -o pipefail
 
     source /usr/local/greenplum-db-target/greenplum_path.sh

--- a/test/acceptance/helpers/finalize_checks.bash
+++ b/test/acceptance/helpers/finalize_checks.bash
@@ -249,7 +249,7 @@ validate_mirrors_and_standby() {
     wait_can_start_transactions $standby_host "${standby_port}"  #TODO: is this necessary?
 
     # sanity check both the demo cluster and CI cluster cases
-    if [[ $coordinator_data_dir != *datadirs/qddir/demoDataDir* && $coordinator_data_dir != */data/gpdata/master/gpseg-1* ]]; then
+    if [[ $coordinator_data_dir != *datadirs/qddir/demoDataDir* && $coordinator_data_dir != */data/gpdata/coordinator/gpseg-1* ]]; then
         echo "cowardly refusing to delete $coordinator_data_dir which does not look like a demo or CI coordinator data dir"
         exit 1
     fi
@@ -291,7 +291,7 @@ validate_mirrors_and_standby() {
     # 4d: rebalance standby
 
     # sanity check both the demo cluster and CI cluster cases
-    if [[ $standby_data_dir != *datadirs/standby* && $standby_data_dir != */data/gpdata/master/gpseg-1* ]]; then
+    if [[ $standby_data_dir != *datadirs/standby* && $standby_data_dir != */data/gpdata/coordinator/gpseg-1* ]]; then
         echo "cowardly refusing to delete $standby_data_dir which does not look like a demo or CI standby data dir"
         exit 1
     fi


### PR DESCRIPTION
Our CI uses a custom tool called CCP to provision GPDB test clusters on the cloud for our automated tests. There was a recent change that changed the hostnames mdw and smdw (master and standby master) to cdw and scdw (coordinator and standby coordinator) as part of the inclusive terminology changes. The master data directory was also changed to use coordinator instead of master. Technically we could pin our CCP to the v2.6.0 tag but updating the hostnames here as well is better so that we keep ourselves aligned with the latest CCP code. The CI scripts and yaml templates have been updated accordingly.

Green developer pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fix_ci_mdw_to_cdw