### PR TITLE
Fix some AOCO test queries in the pg_upgrade acceptance tests

### DIFF
--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/aoco_table_multi_segfile.out
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/aoco_table_multi_segfile.out
@@ -4,7 +4,7 @@
 --------------------------------------------------------------------------------
 -- Validate that the upgradeable objects are functional post-upgrade
 --------------------------------------------------------------------------------
-SELECT * FROM ao_users;
+SELECT * FROM aoco_users;
  id | name 
 ----+------
  1  | Jane 

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/partitioned_ao_aoco_table.out
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/partitioned_ao_aoco_table.out
@@ -13,7 +13,7 @@ SELECT * FROM p_ao_table_with_multiple_segfiles;
  1  | Jane    
  1  | Jane    
 (5 rows)
-SELECT * FROM p_ao_table_with_multiple_segfiles;
+SELECT * FROM p_aoco_table_with_multiple_segfiles;
  id | name    
 ----+---------
  2  | Jane    

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/aoco_table_multi_segfile.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/aoco_table_multi_segfile.sql
@@ -4,4 +4,4 @@
 --------------------------------------------------------------------------------
 -- Validate that the upgradeable objects are functional post-upgrade
 --------------------------------------------------------------------------------
-SELECT * FROM ao_users;
+SELECT * FROM aoco_users;

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/partitioned_ao_aoco_table.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/partitioned_ao_aoco_table.sql
@@ -5,4 +5,4 @@
 -- Validate that the upgradeable objects are functional post-upgrade
 --------------------------------------------------------------------------------
 SELECT * FROM p_ao_table_with_multiple_segfiles;
-SELECT * FROM p_ao_table_with_multiple_segfiles;
+SELECT * FROM p_aoco_table_with_multiple_segfiles;


### PR DESCRIPTION
The original queries were querying the wrong table (the append-only row-oriented one). Fix the queries to query against the correct table (the append-only column-oriented one).