### PR TITLE
Test COPY TO/COPY FROM/ANALYZE on AOCO tables with a dropped column post upgrade

### DIFF
--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/expected/aoco_dropped_col_and_encoding.out
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/expected/aoco_dropped_col_and_encoding.out
@@ -1,0 +1,22 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Test to ensure that AOCO tables with a dropped column that had a non-default ENCODING can be COPY'd after upgrade.
+
+CREATE TABLE aoco_dropped_col_and_encoding( a int, b int ENCODING (compresstype=zlib,compresslevel=1), c int ) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (a);
+CREATE
+
+INSERT INTO aoco_dropped_col_and_encoding VALUES (1, 2, 3), (4, 5, 6), (7, 8, 9);
+INSERT 3
+
+ALTER TABLE aoco_dropped_col_and_encoding DROP COLUMN b;
+ALTER
+
+CREATE TABLE aoco_dropped_col_and_encoding_partitioned ( a int, b int ENCODING (compresstype=zlib,compresslevel=1), c int ) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (a) PARTITION BY RANGE (c) ( PARTITION p1 START(1) END(4) );
+CREATE
+
+INSERT INTO aoco_dropped_col_and_encoding_partitioned VALUES (1,1,1), (2, 2, 2), (3, 3, 3);
+INSERT 3
+
+ALTER TABLE aoco_dropped_col_and_encoding_partitioned DROP COLUMN b;
+ALTER

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/sql/aoco_dropped_col_and_encoding.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/sql/aoco_dropped_col_and_encoding.sql
@@ -1,0 +1,28 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Test to ensure that AOCO tables with a dropped column that had a non-default ENCODING can be COPY'd after upgrade.
+
+CREATE TABLE aoco_dropped_col_and_encoding(
+    a int,
+    b int ENCODING (compresstype=zlib,compresslevel=1),
+    c int
+) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (a);
+
+INSERT INTO aoco_dropped_col_and_encoding VALUES (1, 2, 3), (4, 5, 6), (7, 8, 9);
+
+ALTER TABLE aoco_dropped_col_and_encoding DROP COLUMN b;
+
+CREATE TABLE aoco_dropped_col_and_encoding_partitioned (
+    a int,
+    b int ENCODING (compresstype=zlib,compresslevel=1),
+    c int
+) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (a)
+PARTITION BY RANGE (c)
+(
+    PARTITION p1 START(1) END(4)
+);
+
+INSERT INTO aoco_dropped_col_and_encoding_partitioned VALUES (1,1,1), (2, 2, 2), (3, 3, 3);
+
+ALTER TABLE aoco_dropped_col_and_encoding_partitioned DROP COLUMN b;

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/upgradeable_source_schedule
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/upgradeable_source_schedule
@@ -2,6 +2,7 @@ test: alter_statistic_on_column ao_table_multi_segfile ao_table_without_base_rel
 
 # New set of parallel tests because of "FATAL:  sorry, too many clients already" error
 test: distribution_key_and_data partitioned_polymorphic_table partitions_with_different_schemas ao_indexes name_data_type
+test: aoco_dropped_col_and_encoding
 
 test: clog_preservation
 test: vacuum_freeze_tables

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/aoco_dropped_col_and_encoding.out
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/aoco_dropped_col_and_encoding.out
@@ -1,0 +1,28 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Test to ensure that AOCO tables with a dropped column that has a non-default ENCODING can be COPY'd/ANALYZE'd after upgrade.
+
+COPY aoco_dropped_col_and_encoding (a,c) TO '/dev/null';
+COPY 3
+
+COPY (SELECT a,c FROM aoco_dropped_col_and_encoding) TO '/dev/null';
+COPY 3
+
+COPY aoco_dropped_col_and_encoding_partitioned (a,c) TO '/dev/null';
+COPY 3
+
+COPY (SELECT a,c FROM aoco_dropped_col_and_encoding_partitioned) TO '/dev/null';
+COPY 3
+
+COPY aoco_dropped_col_and_encoding (a, c) FROM PROGRAM 'for i in `seq 1 3`; do echo $i,$i; done' DELIMITER ',';
+COPY 3
+
+COPY aoco_dropped_col_and_encoding_partitioned (a, c) FROM PROGRAM 'for i in `seq 1 3`; do echo $i,$i; done' DELIMITER ',';
+COPY 3
+
+ANALYZE aoco_dropped_col_and_encoding;
+ANALYZE
+
+ANALYZE aoco_dropped_col_and_encoding_partitioned;
+ANALYZE

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/aoco_dropped_col_and_encoding.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/aoco_dropped_col_and_encoding.sql
@@ -1,0 +1,20 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Test to ensure that AOCO tables with a dropped column that has a non-default ENCODING can be COPY'd/ANALYZE'd after upgrade.
+
+COPY aoco_dropped_col_and_encoding (a,c) TO '/dev/null';
+
+COPY (SELECT a,c FROM aoco_dropped_col_and_encoding) TO '/dev/null';
+
+COPY aoco_dropped_col_and_encoding_partitioned (a,c) TO '/dev/null';
+
+COPY (SELECT a,c FROM aoco_dropped_col_and_encoding_partitioned) TO '/dev/null';
+
+COPY aoco_dropped_col_and_encoding (a, c) FROM PROGRAM 'for i in `seq 1 3`; do echo $i,$i; done' DELIMITER ',';
+
+COPY aoco_dropped_col_and_encoding_partitioned (a, c) FROM PROGRAM 'for i in `seq 1 3`; do echo $i,$i; done' DELIMITER ',';
+
+ANALYZE aoco_dropped_col_and_encoding;
+
+ANALYZE aoco_dropped_col_and_encoding_partitioned;

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/upgradeable_target_schedule
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/upgradeable_target_schedule
@@ -2,6 +2,7 @@ test: alter_statistic_on_column ao_table_multi_segfile seg_entries aoco_table_mu
 
 # New set of parallel tests because of "FATAL:  sorry, too many clients already" error
 test: distribution_key_and_data partitioned_polymorphic_table partitions_with_different_schemas name_data_type
+test: aoco_dropped_col_and_encoding
 
 test: clog_preservation
 test: vacuum_freeze_tables

--- a/test/acceptance/pg_upgrade/6-to-7/upgradeable_tests/source_cluster_regress/expected/aoco_dropped_col_and_encoding.out
+++ b/test/acceptance/pg_upgrade/6-to-7/upgradeable_tests/source_cluster_regress/expected/aoco_dropped_col_and_encoding.out
@@ -1,0 +1,22 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Test to ensure that AOCO tables with a dropped column that has a non-default ENCODING can be COPY'd after upgrade.
+
+CREATE TABLE aoco_dropped_col_and_encoding( a int, b int ENCODING (compresstype=zlib,compresslevel=1), c int ) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (a);
+CREATE
+
+INSERT INTO aoco_dropped_col_and_encoding VALUES (1, 2, 3), (4, 5, 6), (7, 8, 9);
+INSERT 3
+
+ALTER TABLE aoco_dropped_col_and_encoding DROP COLUMN b;
+ALTER
+
+CREATE TABLE aoco_dropped_col_and_encoding_partitioned ( a int, b int ENCODING (compresstype=zlib,compresslevel=1), c int ) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (a) PARTITION BY RANGE (c) ( PARTITION p1 START(1) END(4) );
+CREATE
+
+INSERT INTO aoco_dropped_col_and_encoding_partitioned VALUES (1,1,1), (2, 2, 2), (3, 3, 3);
+INSERT 3
+
+ALTER TABLE aoco_dropped_col_and_encoding_partitioned DROP COLUMN b;
+ALTER

--- a/test/acceptance/pg_upgrade/6-to-7/upgradeable_tests/source_cluster_regress/sql/aoco_dropped_col_and_encoding.sql
+++ b/test/acceptance/pg_upgrade/6-to-7/upgradeable_tests/source_cluster_regress/sql/aoco_dropped_col_and_encoding.sql
@@ -1,0 +1,28 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Test to ensure that AOCO tables with a dropped column that had a non-default ENCODING can be COPY'd after upgrade.
+
+CREATE TABLE aoco_dropped_col_and_encoding(
+    a int,
+    b int ENCODING (compresstype=zlib,compresslevel=1),
+    c int
+) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (a);
+
+INSERT INTO aoco_dropped_col_and_encoding VALUES (1, 2, 3), (4, 5, 6), (7, 8, 9);
+
+ALTER TABLE aoco_dropped_col_and_encoding DROP COLUMN b;
+
+CREATE TABLE aoco_dropped_col_and_encoding_partitioned (
+    a int,
+    b int ENCODING (compresstype=zlib,compresslevel=1),
+    c int
+) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (a)
+PARTITION BY RANGE (c)
+(
+    PARTITION p1 START(1) END(4)
+);
+
+INSERT INTO aoco_dropped_col_and_encoding_partitioned VALUES (1,1,1), (2, 2, 2), (3, 3, 3);
+
+ALTER TABLE aoco_dropped_col_and_encoding_partitioned DROP COLUMN b;

--- a/test/acceptance/pg_upgrade/6-to-7/upgradeable_tests/source_cluster_regress/upgradeable_source_schedule
+++ b/test/acceptance/pg_upgrade/6-to-7/upgradeable_tests/source_cluster_regress/upgradeable_source_schedule
@@ -1,2 +1,2 @@
-test: user_defined_aggregates user_defined_types
+test: user_defined_aggregates user_defined_types aoco_dropped_col_and_encoding
 test: vacuum_freeze_tables

--- a/test/acceptance/pg_upgrade/6-to-7/upgradeable_tests/target_cluster_regress/expected/aoco_dropped_col_and_encoding.out
+++ b/test/acceptance/pg_upgrade/6-to-7/upgradeable_tests/target_cluster_regress/expected/aoco_dropped_col_and_encoding.out
@@ -1,0 +1,28 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Test to ensure that AOCO tables with a dropped column that has a non-default ENCODING can be COPY'd/ANALYZE'd after upgrade.
+
+COPY aoco_dropped_col_and_encoding (a,c) TO '/dev/null';
+COPY 3
+
+COPY (SELECT a,c FROM aoco_dropped_col_and_encoding) TO '/dev/null';
+COPY 3
+
+COPY aoco_dropped_col_and_encoding_partitioned (a,c) TO '/dev/null';
+COPY 3
+
+COPY (SELECT a,c FROM aoco_dropped_col_and_encoding_partitioned) TO '/dev/null';
+COPY 3
+
+COPY aoco_dropped_col_and_encoding (a, c) FROM PROGRAM 'for i in `seq 1 3`; do echo $i,$i; done' DELIMITER ',';
+COPY 3
+
+COPY aoco_dropped_col_and_encoding_partitioned (a, c) FROM PROGRAM 'for i in `seq 1 3`; do echo $i,$i; done' DELIMITER ',';
+COPY 3
+
+ANALYZE aoco_dropped_col_and_encoding;
+ANALYZE
+
+ANALYZE aoco_dropped_col_and_encoding_partitioned;
+ANALYZE

--- a/test/acceptance/pg_upgrade/6-to-7/upgradeable_tests/target_cluster_regress/sql/aoco_dropped_col_and_encoding.sql
+++ b/test/acceptance/pg_upgrade/6-to-7/upgradeable_tests/target_cluster_regress/sql/aoco_dropped_col_and_encoding.sql
@@ -1,0 +1,20 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Test to ensure that AOCO tables with a dropped column that has a non-default ENCODING can be COPY'd/ANALYZE'd after upgrade.
+
+COPY aoco_dropped_col_and_encoding (a,c) TO '/dev/null';
+
+COPY (SELECT a,c FROM aoco_dropped_col_and_encoding) TO '/dev/null';
+
+COPY aoco_dropped_col_and_encoding_partitioned (a,c) TO '/dev/null';
+
+COPY (SELECT a,c FROM aoco_dropped_col_and_encoding_partitioned) TO '/dev/null';
+
+COPY aoco_dropped_col_and_encoding (a, c) FROM PROGRAM 'for i in `seq 1 3`; do echo $i,$i; done' DELIMITER ',';
+
+COPY aoco_dropped_col_and_encoding_partitioned (a, c) FROM PROGRAM 'for i in `seq 1 3`; do echo $i,$i; done' DELIMITER ',';
+
+ANALYZE aoco_dropped_col_and_encoding;
+
+ANALYZE aoco_dropped_col_and_encoding_partitioned;

--- a/test/acceptance/pg_upgrade/6-to-7/upgradeable_tests/target_cluster_regress/upgradeable_target_schedule
+++ b/test/acceptance/pg_upgrade/6-to-7/upgradeable_tests/target_cluster_regress/upgradeable_target_schedule
@@ -1,2 +1,2 @@
-test: user_defined_aggregates user_defined_types
+test: user_defined_aggregates user_defined_types aoco_dropped_col_and_encoding
 test: vacuum_freeze_tables


### PR DESCRIPTION
Tests the fixes for `COPY TO`/`COPY FROM`/`ANALYZE` on AOCO tables with a dropped column having a non-default encoding post-upgrade introduced in the following PRs:
https://github.com/greenplum-db/gpdb/pull/14885
https://github.com/greenplum-db/gpdb/pull/15003
https://github.com/greenplum-db/gpdb/pull/15005

Authored-by: Brent Doil <bdoil@vmware.com>