### PR TITLE
test: check distribution key and data distribution is preserved

### DIFF
--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/expected/distribution_key_and_data.out
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/expected/distribution_key_and_data.out
@@ -1,0 +1,149 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Test to verify distribution keys and data distribution are preserved after
+-- upgrade. Since there is a new hasing method in GPDB6 (consistent jump hash),
+-- we are expecting all hash operators to be turned into legacy hash operators.
+
+--------------------------------------------------------------------------------
+-- Create and setup upgradeable objects
+--------------------------------------------------------------------------------
+
+-- single column distributed tables
+CREATE TABLE single_col_dist_heap (a int2) DISTRIBUTED BY (a);
+CREATE
+INSERT INTO single_col_dist_heap SELECT generate_series(1, 10);
+INSERT 10
+CREATE TABLE single_col_dist_ao (a int4) WITH (appendonly=true) DISTRIBUTED BY (a);
+CREATE
+INSERT INTO single_col_dist_ao SELECT generate_series(1, 10);
+INSERT 10
+CREATE TABLE single_col_dist_aoco (a int8) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (a);
+CREATE
+INSERT INTO single_col_dist_aoco SELECT generate_series(1, 10);
+INSERT 10
+
+-- check distribution policy
+SELECT c.relname, dp.attrnum AS dist_key_column, a.attname, op.opcname AS hashop FROM (SELECT localoid, unnest(attrnums) AS attrnum FROM gp_distribution_policy) dp JOIN pg_class c ON c.oid = dp.localoid JOIN pg_attribute a ON a.attrelid = dp.localoid AND a.attnum = dp.attrnum JOIN pg_opclass op ON op.opcintype = a.atttypid JOIN pg_am am ON op.opcmethod = am.oid AND am.amname = 'hash' WHERE c.relname LIKE 'single_col%' ORDER BY 1, 2, 3;
+ relname              | dist_key_column | attname | hashop   
+----------------------+-----------------+---------+----------
+ single_col_dist_ao   | 1               | a       | int4_ops 
+ single_col_dist_aoco | 1               | a       | int8_ops 
+ single_col_dist_heap | 1               | a       | int2_ops 
+(3 rows)
+
+-- check data distribution
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_heap') order by 1, 2;
+ gp_segment_id | a  
+---------------+----
+ 0             | 1  
+ 0             | 2  
+ 1             | 3  
+ 1             | 4  
+ 1             | 5  
+ 1             | 6  
+ 1             | 7  
+ 2             | 8  
+ 2             | 9  
+ 2             | 10 
+(10 rows)
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_ao') order by 1, 2;
+ gp_segment_id | a  
+---------------+----
+ 0             | 1  
+ 0             | 2  
+ 1             | 3  
+ 1             | 4  
+ 1             | 5  
+ 1             | 6  
+ 1             | 7  
+ 2             | 8  
+ 2             | 9  
+ 2             | 10 
+(10 rows)
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_aoco') order by 1, 2;
+ gp_segment_id | a  
+---------------+----
+ 0             | 1  
+ 0             | 2  
+ 1             | 3  
+ 1             | 4  
+ 1             | 5  
+ 1             | 6  
+ 1             | 7  
+ 2             | 8  
+ 2             | 9  
+ 2             | 10 
+(10 rows)
+
+
+
+-- multi column distributed tables
+CREATE TABLE multi_col_dist_heap (a int2, b int2) DISTRIBUTED BY (a, b);
+CREATE
+INSERT INTO multi_col_dist_heap SELECT a, 1 AS b FROM generate_series(1,10) a;
+INSERT 10
+CREATE TABLE multi_col_dist_ao (a int4, b int4) WITH (appendonly=true) DISTRIBUTED BY (a, b);
+CREATE
+INSERT INTO multi_col_dist_ao SELECT a, 1 AS b FROM generate_series(1,10) a;
+INSERT 10
+CREATE TABLE multi_col_dist_aoco (a int8, b int8) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (a, b);
+CREATE
+INSERT INTO multi_col_dist_aoco SELECT a, 1 AS b FROM generate_series(1,10) a;
+INSERT 10
+
+-- check distribution policy
+SELECT c.relname, dp.attrnum AS dist_key_column, a.attname, op.opcname AS hashop FROM (SELECT localoid, unnest(attrnums) AS attrnum FROM gp_distribution_policy) dp JOIN pg_class c ON c.oid = dp.localoid JOIN pg_attribute a ON a.attrelid = dp.localoid AND a.attnum = dp.attrnum JOIN pg_opclass op ON op.opcintype = a.atttypid JOIN pg_am am ON op.opcmethod = am.oid AND am.amname = 'hash' WHERE c.relname LIKE 'multi_col%' ORDER BY 1, 2, 3;
+ relname             | dist_key_column | attname | hashop   
+---------------------+-----------------+---------+----------
+ multi_col_dist_ao   | 1               | a       | int4_ops 
+ multi_col_dist_ao   | 2               | b       | int4_ops 
+ multi_col_dist_aoco | 1               | a       | int8_ops 
+ multi_col_dist_aoco | 2               | b       | int8_ops 
+ multi_col_dist_heap | 1               | a       | int2_ops 
+ multi_col_dist_heap | 2               | b       | int2_ops 
+(6 rows)
+
+-- check data distribution
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_heap') order by 1, 2, 3;
+ gp_segment_id | a  | b 
+---------------+----+---
+ 0             | 7  | 1 
+ 0             | 10 | 1 
+ 1             | 1  | 1 
+ 1             | 4  | 1 
+ 1             | 5  | 1 
+ 1             | 8  | 1 
+ 1             | 9  | 1 
+ 2             | 2  | 1 
+ 2             | 3  | 1 
+ 2             | 6  | 1 
+(10 rows)
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_ao') order by 1, 2, 3;
+ gp_segment_id | a  | b 
+---------------+----+---
+ 0             | 7  | 1 
+ 0             | 10 | 1 
+ 1             | 1  | 1 
+ 1             | 4  | 1 
+ 1             | 5  | 1 
+ 1             | 8  | 1 
+ 1             | 9  | 1 
+ 2             | 2  | 1 
+ 2             | 3  | 1 
+ 2             | 6  | 1 
+(10 rows)
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_aoco') order by 1, 2, 3;
+ gp_segment_id | a  | b 
+---------------+----+---
+ 0             | 7  | 1 
+ 0             | 10 | 1 
+ 1             | 1  | 1 
+ 1             | 4  | 1 
+ 1             | 5  | 1 
+ 1             | 8  | 1 
+ 1             | 9  | 1 
+ 2             | 2  | 1 
+ 2             | 3  | 1 
+ 2             | 6  | 1 
+(10 rows)

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/sql/distribution_key_and_data.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/sql/distribution_key_and_data.sql
@@ -1,0 +1,64 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Test to verify distribution keys and data distribution are preserved after
+-- upgrade. Since there is a new hasing method in GPDB6 (consistent jump hash),
+-- we are expecting all hash operators to be turned into legacy hash operators.
+
+--------------------------------------------------------------------------------
+-- Create and setup upgradeable objects
+--------------------------------------------------------------------------------
+
+-- single column distributed tables
+CREATE TABLE single_col_dist_heap (a int2) DISTRIBUTED BY (a);
+INSERT INTO single_col_dist_heap SELECT generate_series(1, 10);
+CREATE TABLE single_col_dist_ao (a int4) WITH (appendonly=true) DISTRIBUTED BY (a);
+INSERT INTO single_col_dist_ao SELECT generate_series(1, 10);
+CREATE TABLE single_col_dist_aoco (a int8) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (a);
+INSERT INTO single_col_dist_aoco SELECT generate_series(1, 10);
+
+-- check distribution policy
+SELECT c.relname,
+dp.attrnum AS dist_key_column,
+a.attname,
+op.opcname AS hashop
+FROM (SELECT localoid, unnest(attrnums) AS attrnum FROM gp_distribution_policy) dp
+JOIN pg_class c ON c.oid = dp.localoid
+JOIN pg_attribute a ON a.attrelid = dp.localoid AND a.attnum = dp.attrnum
+JOIN pg_opclass op ON op.opcintype = a.atttypid
+JOIN pg_am am ON op.opcmethod = am.oid AND am.amname = 'hash'
+WHERE c.relname LIKE 'single_col%'
+ORDER BY 1, 2, 3;
+
+-- check data distribution
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_heap') order by 1, 2;
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_ao') order by 1, 2;
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_aoco') order by 1, 2;
+
+
+
+-- multi column distributed tables
+CREATE TABLE multi_col_dist_heap (a int2, b int2) DISTRIBUTED BY (a, b);
+INSERT INTO multi_col_dist_heap SELECT a, 1 AS b FROM generate_series(1,10) a;
+CREATE TABLE multi_col_dist_ao (a int4, b int4) WITH (appendonly=true) DISTRIBUTED BY (a, b);
+INSERT INTO multi_col_dist_ao SELECT a, 1 AS b FROM generate_series(1,10) a;
+CREATE TABLE multi_col_dist_aoco (a int8, b int8) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (a, b);
+INSERT INTO multi_col_dist_aoco SELECT a, 1 AS b FROM generate_series(1,10) a;
+
+-- check distribution policy
+SELECT c.relname,
+dp.attrnum AS dist_key_column,
+a.attname,
+op.opcname AS hashop
+FROM (SELECT localoid, unnest(attrnums) AS attrnum FROM gp_distribution_policy) dp
+JOIN pg_class c ON c.oid = dp.localoid
+JOIN pg_attribute a ON a.attrelid = dp.localoid AND a.attnum = dp.attrnum
+JOIN pg_opclass op ON op.opcintype = a.atttypid
+JOIN pg_am am ON op.opcmethod = am.oid AND am.amname = 'hash'
+WHERE c.relname LIKE 'multi_col%'
+ORDER BY 1, 2, 3;
+
+-- check data distribution
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_heap') order by 1, 2, 3;
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_ao') order by 1, 2, 3;
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_aoco') order by 1, 2, 3;

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/upgradeable_source_schedule
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/upgradeable_source_schedule
@@ -1,3 +1,5 @@
 test: alter_statistic_on_column ao_table_multi_segfile ao_table_without_base_relfilenode seg_entries aoco_table_multi_segfile check_constraints external_table indexes partitioned_ao_aoco_table partitioned_heap_table partitions_using_keywords pl_functions resource_group_queue sequences user_defined_aggregates user_defined_types views_referencing_deprecated_columns views_with_lag_lead_functions exchange_external_partition gp_fastsequence user_defined_types_encoding
+# New set of parallel tests because of "FATAL:  sorry, too many clients already" error
+test: distribution_key_and_data
 test: clog_preservation
 test: vacuum_freeze_tables

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/distribution_key_and_data.out
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/distribution_key_and_data.out
@@ -1,0 +1,352 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Validate that the upgradeable objects are functional post-upgrade
+--------------------------------------------------------------------------------
+
+-- check data distribution
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_heap') ORDER BY 1, 2;
+ gp_segment_id | a  
+---------------+----
+ 0             | 1  
+ 0             | 2  
+ 1             | 3  
+ 1             | 4  
+ 1             | 5  
+ 1             | 6  
+ 1             | 7  
+ 2             | 8  
+ 2             | 9  
+ 2             | 10 
+(10 rows)
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_ao') ORDER BY 1, 2;
+ gp_segment_id | a  
+---------------+----
+ 0             | 1  
+ 0             | 2  
+ 1             | 3  
+ 1             | 4  
+ 1             | 5  
+ 1             | 6  
+ 1             | 7  
+ 2             | 8  
+ 2             | 9  
+ 2             | 10 
+(10 rows)
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_aoco') ORDER BY 1, 2;
+ gp_segment_id | a  
+---------------+----
+ 0             | 1  
+ 0             | 2  
+ 1             | 3  
+ 1             | 4  
+ 1             | 5  
+ 1             | 6  
+ 1             | 7  
+ 2             | 8  
+ 2             | 9  
+ 2             | 10 
+(10 rows)
+
+-- check distribution policy
+SELECT c.relname, dp.distkey, opc.opcname FROM gp_distribution_policy dp JOIN pg_class c ON dp.localoid = c.oid JOIN pg_opclass opc ON dp.distclass[0] = opc.oid WHERE c.relname LIKE 'single_col%' ORDER BY c.relname;
+ relname              | distkey | opcname          
+----------------------+---------+------------------
+ single_col_dist_ao   | 1       | cdbhash_int4_ops 
+ single_col_dist_aoco | 1       | cdbhash_int8_ops 
+ single_col_dist_heap | 1       | cdbhash_int2_ops 
+(3 rows)
+
+-- insert same rows int tables
+INSERT INTO single_col_dist_heap SELECT generate_series(1, 10);
+INSERT 10
+INSERT INTO single_col_dist_ao SELECT generate_series(1, 10);
+INSERT 10
+INSERT INTO single_col_dist_aoco SELECT generate_series(1, 10);
+INSERT 10
+
+-- check data was placed into expected segments
+SELECT count(*) from single_col_dist_heap;
+ count 
+-------
+ 20    
+(1 row)
+SELECT count(*) from single_col_dist_ao;
+ count 
+-------
+ 20    
+(1 row)
+SELECT count(*) from single_col_dist_aoco;
+ count 
+-------
+ 20    
+(1 row)
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_heap') GROUP BY 1, 2 ORDER BY 1, 2;
+ gp_segment_id | a  
+---------------+----
+ 0             | 1  
+ 0             | 2  
+ 1             | 3  
+ 1             | 4  
+ 1             | 5  
+ 1             | 6  
+ 1             | 7  
+ 2             | 8  
+ 2             | 9  
+ 2             | 10 
+(10 rows)
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_ao') GROUP BY 1, 2 ORDER BY 1, 2;
+ gp_segment_id | a  
+---------------+----
+ 0             | 1  
+ 0             | 2  
+ 1             | 3  
+ 1             | 4  
+ 1             | 5  
+ 1             | 6  
+ 1             | 7  
+ 2             | 8  
+ 2             | 9  
+ 2             | 10 
+(10 rows)
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_aoco') GROUP BY 1, 2 ORDER BY 1, 2;
+ gp_segment_id | a  
+---------------+----
+ 0             | 1  
+ 0             | 2  
+ 1             | 3  
+ 1             | 4  
+ 1             | 5  
+ 1             | 6  
+ 1             | 7  
+ 2             | 8  
+ 2             | 9  
+ 2             | 10 
+(10 rows)
+
+-- reorganize with the same distribution columns
+ALTER TABLE single_col_dist_heap SET WITH (reorganize=true) DISTRIBUTED BY (a);
+ALTER
+ALTER TABLE single_col_dist_ao SET WITH (reorganize=true) DISTRIBUTED BY (a);
+ALTER
+ALTER TABLE single_col_dist_aoco SET WITH (reorganize=true) DISTRIBUTED BY (a);
+ALTER
+
+-- check data distribution
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_heap') GROUP BY 1, 2 ORDER BY 1, 2;
+ gp_segment_id | a  
+---------------+----
+ 0             | 1  
+ 0             | 2  
+ 1             | 3  
+ 1             | 4  
+ 1             | 5  
+ 1             | 6  
+ 1             | 7  
+ 2             | 8  
+ 2             | 9  
+ 2             | 10 
+(10 rows)
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_ao') GROUP BY 1, 2 ORDER BY 1, 2;
+ gp_segment_id | a  
+---------------+----
+ 0             | 1  
+ 0             | 2  
+ 1             | 3  
+ 1             | 4  
+ 1             | 5  
+ 1             | 6  
+ 1             | 7  
+ 2             | 8  
+ 2             | 9  
+ 2             | 10 
+(10 rows)
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_aoco') GROUP BY 1, 2 ORDER BY 1, 2;
+ gp_segment_id | a  
+---------------+----
+ 0             | 1  
+ 0             | 2  
+ 1             | 3  
+ 1             | 4  
+ 1             | 5  
+ 1             | 6  
+ 1             | 7  
+ 2             | 8  
+ 2             | 9  
+ 2             | 10 
+(10 rows)
+
+
+
+-- check data distribution
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_heap') ORDER BY 1, 2, 3;
+ gp_segment_id | a  | b 
+---------------+----+---
+ 0             | 7  | 1 
+ 0             | 10 | 1 
+ 1             | 1  | 1 
+ 1             | 4  | 1 
+ 1             | 5  | 1 
+ 1             | 8  | 1 
+ 1             | 9  | 1 
+ 2             | 2  | 1 
+ 2             | 3  | 1 
+ 2             | 6  | 1 
+(10 rows)
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_ao') ORDER BY 1, 2, 3;
+ gp_segment_id | a  | b 
+---------------+----+---
+ 0             | 7  | 1 
+ 0             | 10 | 1 
+ 1             | 1  | 1 
+ 1             | 4  | 1 
+ 1             | 5  | 1 
+ 1             | 8  | 1 
+ 1             | 9  | 1 
+ 2             | 2  | 1 
+ 2             | 3  | 1 
+ 2             | 6  | 1 
+(10 rows)
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_aoco') ORDER BY 1, 2, 3;
+ gp_segment_id | a  | b 
+---------------+----+---
+ 0             | 7  | 1 
+ 0             | 10 | 1 
+ 1             | 1  | 1 
+ 1             | 4  | 1 
+ 1             | 5  | 1 
+ 1             | 8  | 1 
+ 1             | 9  | 1 
+ 2             | 2  | 1 
+ 2             | 3  | 1 
+ 2             | 6  | 1 
+(10 rows)
+
+-- check distribution policy
+SELECT c.relname, dp.distkey, opc0.opcname, opc1.opcname FROM gp_distribution_policy dp JOIN pg_class c ON dp.localoid = c.oid JOIN pg_opclass opc0 ON dp.distclass[0] = opc0.oid JOIN pg_opclass opc1 ON dp.distclass[1] = opc1.oid WHERE c.relname LIKE 'multi_col%' ORDER BY c.relname;
+ relname             | distkey | opcname          | opcname          
+---------------------+---------+------------------+------------------
+ multi_col_dist_ao   | 1 2     | cdbhash_int4_ops | cdbhash_int4_ops 
+ multi_col_dist_aoco | 1 2     | cdbhash_int8_ops | cdbhash_int8_ops 
+ multi_col_dist_heap | 1 2     | cdbhash_int2_ops | cdbhash_int2_ops 
+(3 rows)
+
+-- insert same rows int tables
+INSERT INTO multi_col_dist_heap SELECT a, 1 AS b FROM generate_series(1,10) a;
+INSERT 10
+INSERT INTO multi_col_dist_ao SELECT a, 1 AS b FROM generate_series(1,10) a;
+INSERT 10
+INSERT INTO multi_col_dist_aoco SELECT a, 1 AS b FROM generate_series(1,10) a;
+INSERT 10
+
+-- check data was placed into expected segments
+SELECT count(*) from multi_col_dist_heap;
+ count 
+-------
+ 20    
+(1 row)
+SELECT count(*) from multi_col_dist_ao;
+ count 
+-------
+ 20    
+(1 row)
+SELECT count(*) from multi_col_dist_aoco;
+ count 
+-------
+ 20    
+(1 row)
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_heap') GROUP BY 1, 2, 3 ORDER BY 1, 2, 3;
+ gp_segment_id | a  | b 
+---------------+----+---
+ 0             | 7  | 1 
+ 0             | 10 | 1 
+ 1             | 1  | 1 
+ 1             | 4  | 1 
+ 1             | 5  | 1 
+ 1             | 8  | 1 
+ 1             | 9  | 1 
+ 2             | 2  | 1 
+ 2             | 3  | 1 
+ 2             | 6  | 1 
+(10 rows)
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_ao') GROUP BY 1, 2, 3 ORDER BY 1, 2, 3;
+ gp_segment_id | a  | b 
+---------------+----+---
+ 0             | 7  | 1 
+ 0             | 10 | 1 
+ 1             | 1  | 1 
+ 1             | 4  | 1 
+ 1             | 5  | 1 
+ 1             | 8  | 1 
+ 1             | 9  | 1 
+ 2             | 2  | 1 
+ 2             | 3  | 1 
+ 2             | 6  | 1 
+(10 rows)
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_aoco') GROUP BY 1, 2, 3 ORDER BY 1, 2, 3;
+ gp_segment_id | a  | b 
+---------------+----+---
+ 0             | 7  | 1 
+ 0             | 10 | 1 
+ 1             | 1  | 1 
+ 1             | 4  | 1 
+ 1             | 5  | 1 
+ 1             | 8  | 1 
+ 1             | 9  | 1 
+ 2             | 2  | 1 
+ 2             | 3  | 1 
+ 2             | 6  | 1 
+(10 rows)
+
+-- reorganize with the same distribution columns
+ALTER TABLE multi_col_dist_heap SET WITH (reorganize=true) DISTRIBUTED BY (a, b);
+ALTER
+ALTER TABLE multi_col_dist_ao SET WITH (reorganize=true) DISTRIBUTED BY (a, b);
+ALTER
+ALTER TABLE multi_col_dist_aoco SET WITH (reorganize=true) DISTRIBUTED BY (a, b);
+ALTER
+
+-- check data distribution
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_heap') GROUP BY 1, 2, 3 ORDER BY 1, 2, 3;
+ gp_segment_id | a  | b 
+---------------+----+---
+ 0             | 7  | 1 
+ 0             | 10 | 1 
+ 1             | 1  | 1 
+ 1             | 4  | 1 
+ 1             | 5  | 1 
+ 1             | 8  | 1 
+ 1             | 9  | 1 
+ 2             | 2  | 1 
+ 2             | 3  | 1 
+ 2             | 6  | 1 
+(10 rows)
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_ao') GROUP BY 1, 2, 3 ORDER BY 1, 2, 3;
+ gp_segment_id | a  | b 
+---------------+----+---
+ 0             | 7  | 1 
+ 0             | 10 | 1 
+ 1             | 1  | 1 
+ 1             | 4  | 1 
+ 1             | 5  | 1 
+ 1             | 8  | 1 
+ 1             | 9  | 1 
+ 2             | 2  | 1 
+ 2             | 3  | 1 
+ 2             | 6  | 1 
+(10 rows)
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_aoco') GROUP BY 1, 2, 3 ORDER BY 1, 2, 3;
+ gp_segment_id | a  | b 
+---------------+----+---
+ 0             | 7  | 1 
+ 0             | 10 | 1 
+ 1             | 1  | 1 
+ 1             | 4  | 1 
+ 1             | 5  | 1 
+ 1             | 8  | 1 
+ 1             | 9  | 1 
+ 2             | 2  | 1 
+ 2             | 3  | 1 
+ 2             | 6  | 1 
+(10 rows)

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/distribution_key_and_data.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/distribution_key_and_data.sql
@@ -1,0 +1,81 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Validate that the upgradeable objects are functional post-upgrade
+--------------------------------------------------------------------------------
+
+-- check data distribution
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_heap') ORDER BY 1, 2;
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_ao') ORDER BY 1, 2;
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_aoco') ORDER BY 1, 2;
+
+-- check distribution policy
+SELECT c.relname, dp.distkey, opc.opcname
+FROM gp_distribution_policy dp
+JOIN pg_class c ON dp.localoid = c.oid
+JOIN pg_opclass opc ON dp.distclass[0] = opc.oid
+WHERE c.relname LIKE 'single_col%'
+ORDER BY c.relname;
+
+-- insert same rows int tables
+INSERT INTO single_col_dist_heap SELECT generate_series(1, 10);
+INSERT INTO single_col_dist_ao SELECT generate_series(1, 10);
+INSERT INTO single_col_dist_aoco SELECT generate_series(1, 10);
+
+-- check data was placed into expected segments
+SELECT count(*) from single_col_dist_heap;
+SELECT count(*) from single_col_dist_ao;
+SELECT count(*) from single_col_dist_aoco;
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_heap') GROUP BY 1, 2 ORDER BY 1, 2;
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_ao') GROUP BY 1, 2 ORDER BY 1, 2;
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_aoco') GROUP BY 1, 2 ORDER BY 1, 2;
+
+-- reorganize with the same distribution columns
+ALTER TABLE single_col_dist_heap SET WITH (reorganize=true) DISTRIBUTED BY (a);
+ALTER TABLE single_col_dist_ao SET WITH (reorganize=true) DISTRIBUTED BY (a);
+ALTER TABLE single_col_dist_aoco SET WITH (reorganize=true) DISTRIBUTED BY (a);
+
+-- check data distribution
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_heap') GROUP BY 1, 2 ORDER BY 1, 2;
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_ao') GROUP BY 1, 2 ORDER BY 1, 2;
+SELECT gp_segment_id, * FROM gp_dist_random('single_col_dist_aoco') GROUP BY 1, 2 ORDER BY 1, 2;
+
+
+
+-- check data distribution
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_heap') ORDER BY 1, 2, 3;
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_ao') ORDER BY 1, 2, 3;
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_aoco') ORDER BY 1, 2, 3;
+
+-- check distribution policy
+SELECT c.relname, dp.distkey, opc0.opcname, opc1.opcname
+FROM gp_distribution_policy dp
+JOIN pg_class c ON dp.localoid = c.oid
+JOIN pg_opclass opc0 ON dp.distclass[0] = opc0.oid
+JOIN pg_opclass opc1 ON dp.distclass[1] = opc1.oid
+WHERE c.relname LIKE 'multi_col%'
+ORDER BY c.relname;
+
+-- insert same rows int tables
+INSERT INTO multi_col_dist_heap SELECT a, 1 AS b FROM generate_series(1,10) a;
+INSERT INTO multi_col_dist_ao SELECT a, 1 AS b FROM generate_series(1,10) a;
+INSERT INTO multi_col_dist_aoco SELECT a, 1 AS b FROM generate_series(1,10) a;
+
+-- check data was placed into expected segments
+SELECT count(*) from multi_col_dist_heap;
+SELECT count(*) from multi_col_dist_ao;
+SELECT count(*) from multi_col_dist_aoco;
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_heap') GROUP BY 1, 2, 3 ORDER BY 1, 2, 3;
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_ao') GROUP BY 1, 2, 3 ORDER BY 1, 2, 3;
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_aoco') GROUP BY 1, 2, 3 ORDER BY 1, 2, 3;
+
+-- reorganize with the same distribution columns
+ALTER TABLE multi_col_dist_heap SET WITH (reorganize=true) DISTRIBUTED BY (a, b);
+ALTER TABLE multi_col_dist_ao SET WITH (reorganize=true) DISTRIBUTED BY (a, b);
+ALTER TABLE multi_col_dist_aoco SET WITH (reorganize=true) DISTRIBUTED BY (a, b);
+
+-- check data distribution
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_heap') GROUP BY 1, 2, 3 ORDER BY 1, 2, 3;
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_ao') GROUP BY 1, 2, 3 ORDER BY 1, 2, 3;
+SELECT gp_segment_id, * FROM gp_dist_random('multi_col_dist_aoco') GROUP BY 1, 2, 3 ORDER BY 1, 2, 3;

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/upgradeable_target_schedule
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/upgradeable_target_schedule
@@ -1,4 +1,6 @@
 test: alter_statistic_on_column ao_table_multi_segfile seg_entries aoco_table_multi_segfile ao_table_without_base_relfilenode check_constraints external_table indexes partitioned_ao_aoco_table partitioned_heap_table partitions_using_keywords pl_functions resource_group_queue user_defined_aggregates sequences user_defined_types views_referencing_deprecated_columns views_with_lag_lead_functions exchange_external_partition user_defined_types_encoding
+# New set of parallel tests because of "FATAL:  sorry, too many clients already" error
+test: distribution_key_and_data
 test: clog_preservation
 test: vacuum_freeze_tables
 


### PR DESCRIPTION
Test to verify distribution keys and data distribution are preserved after upgrade. Since there is a new hasing method in GPDB6 (consistent jump hash), we are expecting all hash operators to be turned into legacy hash operators.

pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:test-distribution-key-data