### PR TITLE
Add acceptance test for list partitioned tables with custom type

### DIFF
--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/expected/partitioned_heap_table.out
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/expected/partitioned_heap_table.out
@@ -144,3 +144,31 @@ CREATE TABLE p_alter_owner (id INTEGER, name TEXT) DISTRIBUTED BY (id) PARTITION
 CREATE
 ALTER TABLE p_alter_owner OWNER TO testrole;
 ALTER
+
+--
+-- list partitioned by custom type where equality operator is in different schema
+-- Note: On 5X, inserts into the table won't work due to a bug where it assumes
+--       the equality operator is in pg_catalog. This is fixed in 6X so we'll at
+--       least test the table creation here.
+--
+
+CREATE TYPE equal_operator_not_in_search_path_type AS (a int, b int);
+CREATE
+CREATE FUNCTION equal_operator_not_in_search_path_func (equal_operator_not_in_search_path_type, equal_operator_not_in_search_path_type) RETURNS boolean AS 'SELECT $1.a = $2.a;' LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT;
+CREATE
+
+CREATE SCHEMA equal_operator_not_in_search_path_schema;
+CREATE
+CREATE OPERATOR equal_operator_not_in_search_path_schema.= ( LEFTARG = equal_operator_not_in_search_path_type, RIGHTARG = equal_operator_not_in_search_path_type, PROCEDURE = equal_operator_not_in_search_path_func );
+CREATE
+
+CREATE OPERATOR CLASS equal_operator_not_in_search_path_opclass DEFAULT FOR TYPE equal_operator_not_in_search_path_type USING btree AS OPERATOR 3 equal_operator_not_in_search_path_schema.=;
+CREATE
+
+SET search_path TO equal_operator_not_in_search_path_schema,"$user",public;
+SET
+CREATE TABLE public.equal_operator_not_in_search_path_table (a int, b equal_operator_not_in_search_path_type) DISTRIBUTED BY (a) PARTITION BY LIST(b) ( PARTITION part1 VALUES('(1,1)') );
+CREATE
+
+CREATE TABLE public.equal_operator_not_in_search_path_table_multi_key (a int, b equal_operator_not_in_search_path_type, c int) DISTRIBUTED BY (a) PARTITION BY LIST(b, c) ( PARTITION part1 VALUES(('(1,1)', 1)) );
+CREATE

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/partitioned_heap_table.out
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/partitioned_heap_table.out
@@ -109,3 +109,19 @@ SELECT c.relname, pg_catalog.pg_get_userbyid(c.relowner) as owner FROM pg_class 
  p_alter_owner_1_prt_1 | testrole 
  p_alter_owner_1_prt_2 | testrole 
 (3 rows)
+
+INSERT INTO equal_operator_not_in_search_path_table VALUES (1, '(1,1)');
+INSERT 1
+SELECT * FROM equal_operator_not_in_search_path_table;
+ a | b     
+---+-------
+ 1 | (1,1) 
+(1 row)
+
+INSERT INTO equal_operator_not_in_search_path_table_multi_key VALUES (1, '(1,1)', 1);
+INSERT 1
+SELECT * FROM equal_operator_not_in_search_path_table_multi_key;
+ a | b     | c 
+---+-------+---
+ 1 | (1,1) | 1 
+(1 row)

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/partitioned_heap_table.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/partitioned_heap_table.sql
@@ -30,3 +30,9 @@ SELECT c, d FROM dropped_and_added_column WHERE a=10;
 SELECT c.relname, pg_catalog.pg_get_userbyid(c.relowner) as owner
 FROM pg_class c
 WHERE relname like 'p_alter_owner%';
+
+INSERT INTO equal_operator_not_in_search_path_table VALUES (1, '(1,1)');
+SELECT * FROM equal_operator_not_in_search_path_table;
+
+INSERT INTO equal_operator_not_in_search_path_table_multi_key VALUES (1, '(1,1)', 1);
+SELECT * FROM equal_operator_not_in_search_path_table_multi_key;


### PR DESCRIPTION
A partition table can be list partitioned by a custom type but this previously had issues when running through upgrade because the CREATE TABLE assumes the custom type's equality operator is in the pg_catalog schema or in search_path. Since the SQL dump from pg_dump explicitly sets the search_path to blank, only pg_catalog was searched which would result in the pg_restore section of upgrade to fail. This has been fixed in a recent GPDB commit and we should be able to support this scenario now.

GPDB commit reference:
https://github.com/greenplum-db/gpdb/commit/d18208cf0bb82e2ba78121547f44f9615196744e