### PR TITLE
Add post-upgrade test coverage for SPLIT DEFAULT PARTITION

### DIFF
--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/partitioned_heap_table.out
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/partitioned_heap_table.out
@@ -39,6 +39,31 @@ SELECT * FROM p_split_partition_test;
  4 | 4 
  5 | 5 
 (5 rows)
+INSERT INTO p_split_partition_test SELECT i, i FROM generate_series(6,10)i;
+INSERT 5
+ALTER TABLE p_split_partition_test SPLIT DEFAULT PARTITION START(6) END(10) INTO (PARTITION second_split, PARTITION extra);
+ALTER
+SELECT * FROM p_split_partition_test;
+ a  | b  
+----+----
+ 1  | 1  
+ 10 | 10 
+ 2  | 2  
+ 3  | 3  
+ 4  | 4  
+ 5  | 5  
+ 6  | 6  
+ 7  | 7  
+ 8  | 8  
+ 9  | 9  
+(10 rows)
+SELECT parname, parisdefault FROM pg_partition_rule pr JOIN pg_partition p ON pr.paroid = p.oid WHERE p.parrelid = 'p_split_partition_test'::regclass AND pr.parname != '';
+ parname      | parisdefault 
+--------------+--------------
+ extra        | t            
+ second_split | f            
+ splitted     | f            
+(3 rows)
 
 SELECT id, age FROM p_subpart_heap_1_prt_partition_id_2_prt_subpartition_age_first;
  id | age 

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/partitioned_heap_table.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/partitioned_heap_table.sql
@@ -12,6 +12,10 @@ SELECT * FROM p_add_partition_test;
 SELECT * FROM p_add_list_partition_test;
 
 SELECT * FROM p_split_partition_test;
+INSERT INTO p_split_partition_test SELECT i, i FROM generate_series(6,10)i;
+ALTER TABLE p_split_partition_test SPLIT DEFAULT PARTITION START(6) END(10) INTO (PARTITION second_split, PARTITION extra);
+SELECT * FROM p_split_partition_test;
+SELECT parname, parisdefault FROM pg_partition_rule pr JOIN pg_partition p ON pr.paroid = p.oid WHERE p.parrelid = 'p_split_partition_test'::regclass AND pr.parname != '';
 
 SELECT id, age FROM p_subpart_heap_1_prt_partition_id_2_prt_subpartition_age_first;
 SELECT id, age FROM p_subpart_heap_1_prt_partition_id_2_prt_subpartition_age_second;


### PR DESCRIPTION
We need post-upgrade test coverage to verify that default partitions can still be inserted into and split into newer partitions.