### PR TITLE
Add post-upgrade test to verify polymorphic partition tables handling

### DIFF
--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/expected/.gitignore
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/expected/.gitignore
@@ -1,2 +1,3 @@
 external_table.out
 exchange_external_partition.out
+partitioned_polymorphic_table.out

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/input/partitioned_polymorphic_table.source
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/input/partitioned_polymorphic_table.source
@@ -1,0 +1,74 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Test to ensure that partitioned polymorphic tables can be
+-- upgraded. We create the tables with 2 heap, 1 AO, 1 AOCO, and 1
+-- external partitions. The root partition of each table will be
+-- either heap or AOCO.
+
+--------------------------------------------------------------------------------
+-- Create and setup upgradeable objects
+--------------------------------------------------------------------------------
+
+CREATE TABLE poly_range_partition_with_heap_root (a int, b int)
+PARTITION BY RANGE(b)
+(
+    PARTITION ext_part START(0) END(2),
+    PARTITION ao_part START(2) END(4) WITH (appendonly=true),
+    PARTITION aoco_part START(4) END(6) WITH (appendonly=true, orientation=column),
+    PARTITION heap_part_1 START(6) END(8) WITH (appendonly=false),
+    PARTITION heap_part_2 START(8) END(10) WITH (appendonly=false)
+);
+CREATE EXTERNAL TABLE external_table (a int, b int) LOCATION ('file://@hostname@/@abs_srcdir@/data/one_level_external_table_data.csv') FORMAT 'TEXT' (DELIMITER '|');
+ALTER TABLE poly_range_partition_with_heap_root EXCHANGE PARTITION ext_part WITH TABLE external_table WITHOUT VALIDATION;
+DROP TABLE external_table;
+INSERT INTO poly_range_partition_with_heap_root SELECT i, i FROM generate_series(2, 9)i;
+SELECT * FROM poly_range_partition_with_heap_root;
+
+CREATE TABLE poly_range_partition_with_aoco_root (a int, b int) WITH (appendonly=true, orientation=column)
+PARTITION BY RANGE(b)
+(
+    PARTITION ext_part START(0) END(2),
+    PARTITION ao_part START(2) END(4) WITH (appendonly=true),
+    PARTITION aoco_part START(4) END(6) WITH (appendonly=true, orientation=column),
+    PARTITION heap_part_1 START(6) END(8) WITH (appendonly=false),
+    PARTITION heap_part_2 START(8) END(10) WITH (appendonly=false)
+);
+CREATE EXTERNAL TABLE external_table (a int, b int) LOCATION ('file://@hostname@/@abs_srcdir@/data/one_level_external_table_data.csv') FORMAT 'TEXT' (DELIMITER '|');
+ALTER TABLE poly_range_partition_with_aoco_root EXCHANGE PARTITION ext_part WITH TABLE external_table WITHOUT VALIDATION;
+DROP TABLE external_table;
+INSERT INTO poly_range_partition_with_aoco_root SELECT i, i FROM generate_series(2, 9)i;
+SELECT * FROM poly_range_partition_with_aoco_root;
+
+CREATE TABLE poly_list_partition_with_heap_root (a int, b int)
+PARTITION BY LIST(b)
+(
+    PARTITION ext_part VALUES (0, 1),
+    PARTITION ao_part VALUES(2, 3) WITH (appendonly=true),
+    PARTITION aoco_part VALUES(4, 5) WITH (appendonly=true, orientation=column),
+    PARTITION heap_part_1 VALUES(6, 7) WITH (appendonly=false),
+    PARTITION heap_part_2 VALUES(8, 9) WITH (appendonly=false)
+);
+CREATE EXTERNAL TABLE external_table (a int, b int) LOCATION ('file://@hostname@/@abs_srcdir@/data/one_level_external_table_data.csv') FORMAT 'TEXT' (DELIMITER '|');
+ALTER TABLE poly_list_partition_with_heap_root EXCHANGE PARTITION ext_part WITH TABLE external_table WITHOUT VALIDATION;
+DROP TABLE external_table;
+INSERT INTO poly_list_partition_with_heap_root SELECT i, i FROM generate_series(2, 9)i;
+SELECT * FROM poly_list_partition_with_heap_root;
+
+CREATE TABLE poly_list_partition_with_aoco_root (a int, b int) WITH (appendonly=true, orientation=column)
+PARTITION BY LIST(b)
+(
+    PARTITION ext_part VALUES (0, 1),
+    PARTITION ao_part VALUES(2, 3) WITH (appendonly=true),
+    PARTITION aoco_part VALUES(4, 5) WITH (appendonly=true, orientation=column),
+    PARTITION heap_part_1 VALUES(6, 7) WITH (appendonly=false),
+    PARTITION heap_part_2 VALUES(8, 9) WITH (appendonly=false)
+);
+CREATE EXTERNAL TABLE external_table (a int, b int) LOCATION ('file://@hostname@/@abs_srcdir@/data/one_level_external_table_data.csv') FORMAT 'TEXT' (DELIMITER '|');
+ALTER TABLE poly_list_partition_with_aoco_root EXCHANGE PARTITION ext_part WITH TABLE external_table WITHOUT VALIDATION;
+DROP TABLE external_table;
+INSERT INTO poly_list_partition_with_aoco_root SELECT i, i FROM generate_series(2, 9)i;
+SELECT * FROM poly_list_partition_with_aoco_root;
+
+-- Show what the storage types of each partition are before upgrade
+SELECT relname, relstorage FROM pg_class WHERE relname SIMILAR TO 'poly_(list|range)_partition_with_(heap|aoco)_root%' ORDER BY relname;

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/output/partitioned_polymorphic_table.source
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/output/partitioned_polymorphic_table.source
@@ -1,0 +1,145 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Test to ensure that partitioned polymorphic tables can be
+-- upgraded. We create the tables with 2 heap, 1 AO, 1 AOCO, and 1
+-- external partitions. The root partition of each table will be
+-- either heap or AOCO.
+
+--------------------------------------------------------------------------------
+-- Create and setup upgradeable objects
+--------------------------------------------------------------------------------
+
+CREATE TABLE poly_range_partition_with_heap_root (a int, b int) PARTITION BY RANGE(b) ( PARTITION ext_part START(0) END(2), PARTITION ao_part START(2) END(4) WITH (appendonly=true), PARTITION aoco_part START(4) END(6) WITH (appendonly=true, orientation=column), PARTITION heap_part_1 START(6) END(8) WITH (appendonly=false), PARTITION heap_part_2 START(8) END(10) WITH (appendonly=false) );
+CREATE
+CREATE EXTERNAL TABLE external_table (a int, b int) LOCATION ('file://@hostname@/@abs_srcdir@/data/one_level_external_table_data.csv') FORMAT 'TEXT' (DELIMITER '|');
+CREATE
+ALTER TABLE poly_range_partition_with_heap_root EXCHANGE PARTITION ext_part WITH TABLE external_table WITHOUT VALIDATION;
+ALTER
+DROP TABLE external_table;
+DROP
+INSERT INTO poly_range_partition_with_heap_root SELECT i, i FROM generate_series(2, 9)i;
+INSERT 8
+SELECT * FROM poly_range_partition_with_heap_root;
+ a | b 
+---+---
+ 8 | 8 
+ 9 | 9 
+ 3 | 3 
+ 4 | 4 
+ 5 | 5 
+ 6 | 6 
+ 7 | 7 
+ 2 | 2 
+ 1 | 1 
+ 3 | 1 
+ 5 | 1 
+(11 rows)
+
+CREATE TABLE poly_range_partition_with_aoco_root (a int, b int) WITH (appendonly=true, orientation=column) PARTITION BY RANGE(b) ( PARTITION ext_part START(0) END(2), PARTITION ao_part START(2) END(4) WITH (appendonly=true), PARTITION aoco_part START(4) END(6) WITH (appendonly=true, orientation=column), PARTITION heap_part_1 START(6) END(8) WITH (appendonly=false), PARTITION heap_part_2 START(8) END(10) WITH (appendonly=false) );
+CREATE
+CREATE EXTERNAL TABLE external_table (a int, b int) LOCATION ('file://@hostname@/@abs_srcdir@/data/one_level_external_table_data.csv') FORMAT 'TEXT' (DELIMITER '|');
+CREATE
+ALTER TABLE poly_range_partition_with_aoco_root EXCHANGE PARTITION ext_part WITH TABLE external_table WITHOUT VALIDATION;
+ALTER
+DROP TABLE external_table;
+DROP
+INSERT INTO poly_range_partition_with_aoco_root SELECT i, i FROM generate_series(2, 9)i;
+INSERT 8
+SELECT * FROM poly_range_partition_with_aoco_root;
+ a | b 
+---+---
+ 8 | 8 
+ 9 | 9 
+ 3 | 3 
+ 4 | 4 
+ 5 | 5 
+ 6 | 6 
+ 7 | 7 
+ 2 | 2 
+ 1 | 1 
+ 3 | 1 
+ 5 | 1 
+(11 rows)
+
+CREATE TABLE poly_list_partition_with_heap_root (a int, b int) PARTITION BY LIST(b) ( PARTITION ext_part VALUES (0, 1), PARTITION ao_part VALUES(2, 3) WITH (appendonly=true), PARTITION aoco_part VALUES(4, 5) WITH (appendonly=true, orientation=column), PARTITION heap_part_1 VALUES(6, 7) WITH (appendonly=false), PARTITION heap_part_2 VALUES(8, 9) WITH (appendonly=false) );
+CREATE
+CREATE EXTERNAL TABLE external_table (a int, b int) LOCATION ('file://@hostname@/@abs_srcdir@/data/one_level_external_table_data.csv') FORMAT 'TEXT' (DELIMITER '|');
+CREATE
+ALTER TABLE poly_list_partition_with_heap_root EXCHANGE PARTITION ext_part WITH TABLE external_table WITHOUT VALIDATION;
+ALTER
+DROP TABLE external_table;
+DROP
+INSERT INTO poly_list_partition_with_heap_root SELECT i, i FROM generate_series(2, 9)i;
+INSERT 8
+SELECT * FROM poly_list_partition_with_heap_root;
+ a | b 
+---+---
+ 8 | 8 
+ 9 | 9 
+ 2 | 2 
+ 1 | 1 
+ 3 | 1 
+ 5 | 1 
+ 3 | 3 
+ 4 | 4 
+ 5 | 5 
+ 6 | 6 
+ 7 | 7 
+(11 rows)
+
+CREATE TABLE poly_list_partition_with_aoco_root (a int, b int) WITH (appendonly=true, orientation=column) PARTITION BY LIST(b) ( PARTITION ext_part VALUES (0, 1), PARTITION ao_part VALUES(2, 3) WITH (appendonly=true), PARTITION aoco_part VALUES(4, 5) WITH (appendonly=true, orientation=column), PARTITION heap_part_1 VALUES(6, 7) WITH (appendonly=false), PARTITION heap_part_2 VALUES(8, 9) WITH (appendonly=false) );
+CREATE
+CREATE EXTERNAL TABLE external_table (a int, b int) LOCATION ('file://@hostname@/@abs_srcdir@/data/one_level_external_table_data.csv') FORMAT 'TEXT' (DELIMITER '|');
+CREATE
+ALTER TABLE poly_list_partition_with_aoco_root EXCHANGE PARTITION ext_part WITH TABLE external_table WITHOUT VALIDATION;
+ALTER
+DROP TABLE external_table;
+DROP
+INSERT INTO poly_list_partition_with_aoco_root SELECT i, i FROM generate_series(2, 9)i;
+INSERT 8
+SELECT * FROM poly_list_partition_with_aoco_root;
+ a | b 
+---+---
+ 8 | 8 
+ 9 | 9 
+ 3 | 3 
+ 4 | 4 
+ 5 | 5 
+ 6 | 6 
+ 7 | 7 
+ 2 | 2 
+ 1 | 1 
+ 3 | 1 
+ 5 | 1 
+(11 rows)
+
+-- Show what the storage types of each partition are before upgrade
+SELECT relname, relstorage FROM pg_class WHERE relname SIMILAR TO 'poly_(list|range)_partition_with_(heap|aoco)_root%' ORDER BY relname;
+ relname                                               | relstorage 
+-------------------------------------------------------+------------
+ poly_list_partition_with_aoco_root                    | c          
+ poly_list_partition_with_aoco_root_1_prt_ao_part      | a          
+ poly_list_partition_with_aoco_root_1_prt_aoco_part    | c          
+ poly_list_partition_with_aoco_root_1_prt_ext_part     | x          
+ poly_list_partition_with_aoco_root_1_prt_heap_part_1  | h          
+ poly_list_partition_with_aoco_root_1_prt_heap_part_2  | h          
+ poly_list_partition_with_heap_root                    | h          
+ poly_list_partition_with_heap_root_1_prt_ao_part      | a          
+ poly_list_partition_with_heap_root_1_prt_aoco_part    | c          
+ poly_list_partition_with_heap_root_1_prt_ext_part     | x          
+ poly_list_partition_with_heap_root_1_prt_heap_part_1  | h          
+ poly_list_partition_with_heap_root_1_prt_heap_part_2  | h          
+ poly_range_partition_with_aoco_root                   | c          
+ poly_range_partition_with_aoco_root_1_prt_ao_part     | a          
+ poly_range_partition_with_aoco_root_1_prt_aoco_part   | c          
+ poly_range_partition_with_aoco_root_1_prt_ext_part    | x          
+ poly_range_partition_with_aoco_root_1_prt_heap_part_1 | h          
+ poly_range_partition_with_aoco_root_1_prt_heap_part_2 | h          
+ poly_range_partition_with_heap_root                   | h          
+ poly_range_partition_with_heap_root_1_prt_ao_part     | a          
+ poly_range_partition_with_heap_root_1_prt_aoco_part   | c          
+ poly_range_partition_with_heap_root_1_prt_ext_part    | x          
+ poly_range_partition_with_heap_root_1_prt_heap_part_1 | h          
+ poly_range_partition_with_heap_root_1_prt_heap_part_2 | h          
+(24 rows)

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/sql/.gitignore
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/sql/.gitignore
@@ -1,2 +1,3 @@
 external_table.sql
 exchange_external_partition.sql
+partitioned_polymorphic_table.sql

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/upgradeable_source_schedule
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/upgradeable_source_schedule
@@ -1,5 +1,7 @@
 test: alter_statistic_on_column ao_table_multi_segfile ao_table_without_base_relfilenode seg_entries aoco_table_multi_segfile check_constraints external_table indexes partitioned_ao_aoco_table partitioned_heap_table partitions_using_keywords pl_functions resource_group_queue sequences user_defined_aggregates user_defined_types views_referencing_deprecated_columns views_with_lag_lead_functions exchange_external_partition gp_fastsequence user_defined_types_encoding
+
 # New set of parallel tests because of "FATAL:  sorry, too many clients already" error
-test: distribution_key_and_data
+test: distribution_key_and_data partitioned_polymorphic_table
+
 test: clog_preservation
 test: vacuum_freeze_tables

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/partitioned_polymorphic_table.out
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/partitioned_polymorphic_table.out
@@ -1,0 +1,203 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Validate that the partitioned polymorphic tables work as expected
+-- after upgrade.
+--------------------------------------------------------------------------------
+
+-- Show what the storage types of each partition are after upgrade
+SELECT relname, relstorage FROM pg_class WHERE relname SIMILAR TO 'poly_(list|range)_partition_with_(heap|aoco)_root%' ORDER BY relname;
+ relname                                               | relstorage 
+-------------------------------------------------------+------------
+ poly_list_partition_with_aoco_root                    | c          
+ poly_list_partition_with_aoco_root_1_prt_ao_part      | a          
+ poly_list_partition_with_aoco_root_1_prt_aoco_part    | c          
+ poly_list_partition_with_aoco_root_1_prt_ext_part     | x          
+ poly_list_partition_with_aoco_root_1_prt_heap_part_1  | h          
+ poly_list_partition_with_aoco_root_1_prt_heap_part_2  | h          
+ poly_list_partition_with_heap_root                    | h          
+ poly_list_partition_with_heap_root_1_prt_ao_part      | a          
+ poly_list_partition_with_heap_root_1_prt_aoco_part    | c          
+ poly_list_partition_with_heap_root_1_prt_ext_part     | x          
+ poly_list_partition_with_heap_root_1_prt_heap_part_1  | h          
+ poly_list_partition_with_heap_root_1_prt_heap_part_2  | h          
+ poly_range_partition_with_aoco_root                   | c          
+ poly_range_partition_with_aoco_root_1_prt_ao_part     | a          
+ poly_range_partition_with_aoco_root_1_prt_aoco_part   | c          
+ poly_range_partition_with_aoco_root_1_prt_ext_part    | x          
+ poly_range_partition_with_aoco_root_1_prt_heap_part_1 | h          
+ poly_range_partition_with_aoco_root_1_prt_heap_part_2 | h          
+ poly_range_partition_with_heap_root                   | h          
+ poly_range_partition_with_heap_root_1_prt_ao_part     | a          
+ poly_range_partition_with_heap_root_1_prt_aoco_part   | c          
+ poly_range_partition_with_heap_root_1_prt_ext_part    | x          
+ poly_range_partition_with_heap_root_1_prt_heap_part_1 | h          
+ poly_range_partition_with_heap_root_1_prt_heap_part_2 | h          
+(24 rows)
+
+-- Run some simple DELETEs, UPDATEs, and INSERTs to see if things
+-- still work after upgrade
+SELECT * FROM poly_range_partition_with_heap_root;
+ a | b 
+---+---
+ 8 | 8 
+ 9 | 9 
+ 3 | 3 
+ 4 | 4 
+ 5 | 5 
+ 6 | 6 
+ 7 | 7 
+ 2 | 2 
+ 1 | 1 
+ 3 | 1 
+ 5 | 1 
+(11 rows)
+DELETE FROM poly_range_partition_with_heap_root WHERE b%2 = 0 AND b > 1;
+DELETE 4
+UPDATE poly_range_partition_with_heap_root SET b = b - 1 WHERE b > 1;
+UPDATE 4
+INSERT INTO poly_range_partition_with_heap_root SELECT 100 + i, i FROM generate_series(2, 9)i;
+INSERT 8
+SELECT * FROM poly_range_partition_with_heap_root;
+ a   | b 
+-----+---
+ 102 | 2 
+ 9   | 8 
+ 3   | 2 
+ 5   | 4 
+ 7   | 6 
+ 107 | 7 
+ 108 | 8 
+ 109 | 9 
+ 103 | 3 
+ 104 | 4 
+ 105 | 5 
+ 106 | 6 
+ 1   | 1 
+ 3   | 1 
+ 5   | 1 
+(15 rows)
+
+SELECT * FROM poly_range_partition_with_aoco_root;
+ a | b 
+---+---
+ 8 | 8 
+ 9 | 9 
+ 3 | 3 
+ 4 | 4 
+ 5 | 5 
+ 6 | 6 
+ 7 | 7 
+ 2 | 2 
+ 1 | 1 
+ 3 | 1 
+ 5 | 1 
+(11 rows)
+DELETE FROM poly_range_partition_with_aoco_root WHERE b%2 = 0 AND b > 1;
+DELETE 4
+UPDATE poly_range_partition_with_aoco_root SET b = b - 1 WHERE b > 1;
+UPDATE 4
+INSERT INTO poly_range_partition_with_aoco_root SELECT 100 + i, i FROM generate_series(2, 9)i;
+INSERT 8
+SELECT * FROM poly_range_partition_with_aoco_root;
+ a   | b 
+-----+---
+ 102 | 2 
+ 9   | 8 
+ 3   | 2 
+ 5   | 4 
+ 7   | 6 
+ 107 | 7 
+ 108 | 8 
+ 109 | 9 
+ 103 | 3 
+ 104 | 4 
+ 105 | 5 
+ 106 | 6 
+ 1   | 1 
+ 3   | 1 
+ 5   | 1 
+(15 rows)
+
+SELECT * FROM poly_list_partition_with_heap_root;
+ a | b 
+---+---
+ 8 | 8 
+ 9 | 9 
+ 2 | 2 
+ 1 | 1 
+ 3 | 1 
+ 5 | 1 
+ 3 | 3 
+ 4 | 4 
+ 5 | 5 
+ 6 | 6 
+ 7 | 7 
+(11 rows)
+DELETE FROM poly_list_partition_with_heap_root WHERE b%2 = 0 AND b > 1;
+DELETE 4
+UPDATE poly_list_partition_with_heap_root SET b = b - 1 WHERE b > 1;
+UPDATE 4
+INSERT INTO poly_list_partition_with_heap_root SELECT 100 + i, i FROM generate_series(2, 9)i;
+INSERT 8
+SELECT * FROM poly_list_partition_with_heap_root;
+ a   | b 
+-----+---
+ 102 | 2 
+ 9   | 8 
+ 3   | 2 
+ 5   | 4 
+ 7   | 6 
+ 107 | 7 
+ 108 | 8 
+ 109 | 9 
+ 103 | 3 
+ 104 | 4 
+ 105 | 5 
+ 106 | 6 
+ 1   | 1 
+ 3   | 1 
+ 5   | 1 
+(15 rows)
+
+SELECT * FROM poly_list_partition_with_aoco_root;
+ a | b 
+---+---
+ 8 | 8 
+ 9 | 9 
+ 2 | 2 
+ 1 | 1 
+ 3 | 1 
+ 5 | 1 
+ 3 | 3 
+ 4 | 4 
+ 5 | 5 
+ 6 | 6 
+ 7 | 7 
+(11 rows)
+DELETE FROM poly_list_partition_with_aoco_root WHERE b%2 = 0 AND b > 1;
+DELETE 4
+UPDATE poly_list_partition_with_aoco_root SET b = b - 1 WHERE b > 1;
+UPDATE 4
+INSERT INTO poly_list_partition_with_aoco_root SELECT 100 + i, i FROM generate_series(2, 9)i;
+INSERT 8
+SELECT * FROM poly_list_partition_with_aoco_root;
+ a   | b 
+-----+---
+ 102 | 2 
+ 9   | 8 
+ 3   | 2 
+ 5   | 4 
+ 7   | 6 
+ 107 | 7 
+ 108 | 8 
+ 109 | 9 
+ 103 | 3 
+ 104 | 4 
+ 105 | 5 
+ 106 | 6 
+ 1   | 1 
+ 3   | 1 
+ 5   | 1 
+(15 rows)

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/partitioned_polymorphic_table.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/partitioned_polymorphic_table.sql
@@ -1,0 +1,36 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Validate that the partitioned polymorphic tables work as expected
+-- after upgrade.
+--------------------------------------------------------------------------------
+
+-- Show what the storage types of each partition are after upgrade
+SELECT relname, relstorage FROM pg_class WHERE relname SIMILAR TO 'poly_(list|range)_partition_with_(heap|aoco)_root%' ORDER BY relname;
+
+-- Run some simple DELETEs, UPDATEs, and INSERTs to see if things
+-- still work after upgrade
+SELECT * FROM poly_range_partition_with_heap_root;
+DELETE FROM poly_range_partition_with_heap_root WHERE b%2 = 0 AND b > 1;
+UPDATE poly_range_partition_with_heap_root SET b = b - 1 WHERE b > 1;
+INSERT INTO poly_range_partition_with_heap_root SELECT 100 + i, i FROM generate_series(2, 9)i;
+SELECT * FROM poly_range_partition_with_heap_root;
+
+SELECT * FROM poly_range_partition_with_aoco_root;
+DELETE FROM poly_range_partition_with_aoco_root WHERE b%2 = 0 AND b > 1;
+UPDATE poly_range_partition_with_aoco_root SET b = b - 1 WHERE b > 1;
+INSERT INTO poly_range_partition_with_aoco_root SELECT 100 + i, i FROM generate_series(2, 9)i;
+SELECT * FROM poly_range_partition_with_aoco_root;
+
+SELECT * FROM poly_list_partition_with_heap_root;
+DELETE FROM poly_list_partition_with_heap_root WHERE b%2 = 0 AND b > 1;
+UPDATE poly_list_partition_with_heap_root SET b = b - 1 WHERE b > 1;
+INSERT INTO poly_list_partition_with_heap_root SELECT 100 + i, i FROM generate_series(2, 9)i;
+SELECT * FROM poly_list_partition_with_heap_root;
+
+SELECT * FROM poly_list_partition_with_aoco_root;
+DELETE FROM poly_list_partition_with_aoco_root WHERE b%2 = 0 AND b > 1;
+UPDATE poly_list_partition_with_aoco_root SET b = b - 1 WHERE b > 1;
+INSERT INTO poly_list_partition_with_aoco_root SELECT 100 + i, i FROM generate_series(2, 9)i;
+SELECT * FROM poly_list_partition_with_aoco_root;

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/upgradeable_target_schedule
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/upgradeable_target_schedule
@@ -1,6 +1,8 @@
 test: alter_statistic_on_column ao_table_multi_segfile seg_entries aoco_table_multi_segfile ao_table_without_base_relfilenode check_constraints external_table indexes partitioned_ao_aoco_table partitioned_heap_table partitions_using_keywords pl_functions resource_group_queue user_defined_aggregates sequences user_defined_types views_referencing_deprecated_columns views_with_lag_lead_functions exchange_external_partition user_defined_types_encoding
+
 # New set of parallel tests because of "FATAL:  sorry, too many clients already" error
-test: distribution_key_and_data
+test: distribution_key_and_data partitioned_polymorphic_table
+
 test: clog_preservation
 test: vacuum_freeze_tables
 


### PR DESCRIPTION
Polymorphic partition tables are a thing in GPDB and we need to verify that there are no issues upgrading them. The added test sanity checks a couple mixed storage partition tables and checks that they are still operational after upgrading.