### PR TITLE
Remove developer stdout debug message

### DIFF
--- a/cli/commanders/initialize.go
+++ b/cli/commanders/initialize.go
@@ -80,7 +80,6 @@ func StartHub() (err error) {
 		return xerrors.Errorf("%q failed with %q: %w", cmd.String(), string(output), err)
 	}
 
-	fmt.Println("Started hub")
 	log.Printf("%s", output)
 	return nil
 }

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -194,6 +194,10 @@ var restartServices = &cobra.Command{
 			return err
 		}
 
+		if !errors.Is(err, step.Skip) {
+			fmt.Println("Restarted hub")
+		}
+
 		client, err := connectToHub()
 		if err != nil {
 			return err


### PR DESCRIPTION
When running initialize, we see this output:
```
Proceeding with upgrade
Starting gpupgrade hub process...                                  [IN PROGRESS]Started hub
Starting gpupgrade hub process...                                  [COMPLETE]
Saving source cluster configuration...                             [COMPLETE]
```

The "Started hub" part doesn't seem like it should be there and messes with the IN PROGRESS to COMPLETE line replacement. With this patch, it'll now look like this:
```
Proceeding with upgrade
Starting gpupgrade hub process...                                  [COMPLETE]
Saving source cluster configuration...                             [COMPLETE]
```