### PR TITLE
Fix spelling of quitting

### DIFF
--- a/cli/commanders/data_migration_apply.go
+++ b/cli/commanders/data_migration_apply.go
@@ -228,7 +228,7 @@ Select: `, phase)
 			fmt.Printf("\nProceeding with 'none' of the %s data migration scripts.\n", phase)
 			return nil, step.Skip
 		case "q":
-			fmt.Print("\nQuiting...\n")
+			fmt.Print("\nQuitting...\n")
 			return nil, step.UserCanceled
 		default:
 			continue
@@ -258,7 +258,7 @@ func SelectDataMigrationScriptsPrompt(reader *bufio.Reader, currentScriptDir str
 		if err != nil {
 			if errors.Is(err, step.UserCanceled) {
 				fmt.Println()
-				fmt.Print("Quiting...")
+				fmt.Print("Quitting...")
 				return nil, err
 			}
 
@@ -288,7 +288,7 @@ func SelectDataMigrationScriptsPrompt(reader *bufio.Reader, currentScriptDir str
 		case "e":
 			continue
 		case "q":
-			fmt.Print("\nQuiting...")
+			fmt.Print("\nQuitting...")
 			return nil, step.UserCanceled
 		default:
 			continue

--- a/cli/commanders/data_migration_apply_test.go
+++ b/cli/commanders/data_migration_apply_test.go
@@ -449,7 +449,7 @@ func TestApplyDataMigrationScriptsPrompt(t *testing.T) {
 		expected += "  [a]ll scripts.  Usually run 'during' the upgrade within the downtime window.\n"
 		expected += "  [q]uit\n"
 		expected += "\nSelect: \n"
-		expected += "Quiting...\n"
+		expected += "Quitting...\n"
 
 		actual := string(stdout)
 		if actual != expected {
@@ -493,7 +493,7 @@ func TestApplyDataMigrationScriptsPrompt(t *testing.T) {
 		expected += "  [a]ll scripts.  Usually run 'during' the upgrade within the downtime window.\n"
 		expected += "  [q]uit\n"
 		expected += "\nSelect: \n"
-		expected += "Quiting...\n"
+		expected += "Quitting...\n"
 
 		actual := string(stdout)
 		if actual != expected {
@@ -541,7 +541,7 @@ func TestApplyDataMigrationScriptsPrompt(t *testing.T) {
 		expected += "  [n]one\n"
 		expected += "  [q]uit\n"
 		expected += "\nSelect: \n"
-		expected += "Quiting...\n"
+		expected += "Quitting...\n"
 
 		actual := string(stdout)
 		if actual != expected {
@@ -630,7 +630,7 @@ func TestSelectDataMigrationScriptsPrompt(t *testing.T) {
 		expected += "Invalid selection. Found \"0.5\" expected a number or numbers separated by commas such as 1, 3.\n\n"
 		expected += "Select scripts to apply separated by commas such as 1, 3. Or [q]uit?\n\n\n"
 		expected += "Select: \n"
-		expected += "Quiting..."
+		expected += "Quitting..."
 
 		actual := string(stdout)
 		if actual != expected {
@@ -733,7 +733,7 @@ func TestSelectDataMigrationScriptsPrompt(t *testing.T) {
 		expected += "  1: unique_primary_foreign_key_constraint\n\n"
 		expected += "[c]ontinue, [e]dit selection, or [q]uit.\n"
 		expected += "Select: \n"
-		expected += "Quiting..."
+		expected += "Quitting..."
 
 		actual := string(stdout)
 		if actual != expected {
@@ -774,7 +774,7 @@ func TestSelectDataMigrationScriptsPrompt(t *testing.T) {
 		expected += "  0: parent_partitions_with_seg_entries\n"
 		expected += "  1: unique_primary_foreign_key_constraint\n\n"
 		expected += "Select: \n"
-		expected += "Quiting..."
+		expected += "Quitting..."
 
 		actual := string(stdout)
 		if actual != expected {

--- a/cli/commanders/data_migration_generate.go
+++ b/cli/commanders/data_migration_generate.go
@@ -209,7 +209,7 @@ Select: `)
 			fmt.Printf("\nContinuing with previously generated data migration scripts in\n%s\n", utils.Bold.Sprint(currentDir))
 			return step.Skip
 		case "q":
-			fmt.Print("\nQuiting...")
+			fmt.Print("\nQuitting...")
 			return step.UserCanceled
 		default:
 			continue


### PR DESCRIPTION
Online dictionaries show that it should be quitting, not quiting. Do a quick search and replace to fix the trivial spelling mistake.