### PR TITLE
pass logDir to finalize & revert data migration scripts

### DIFF
--- a/cli/commanders/data_migration_apply.go
+++ b/cli/commanders/data_migration_apply.go
@@ -25,7 +25,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
-func ApplyDataMigrationScripts(nonInteractive bool, gphome string, port int, currentScriptDirFS fs.FS, currentScriptDir string, phase idl.Step) error {
+func ApplyDataMigrationScripts(nonInteractive bool, gphome string, port int, logDir string, currentScriptDirFS fs.FS, currentScriptDir string, phase idl.Step) error {
 	_, err := currentScriptDirFS.Open(phase.String())
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -44,11 +44,6 @@ func ApplyDataMigrationScripts(nonInteractive bool, gphome string, port int, cur
 			return nil
 		}
 
-		return err
-	}
-
-	logDir, err := utils.GetLogDir()
-	if err != nil {
 		return err
 	}
 

--- a/cli/commands/finalize.go
+++ b/cli/commands/finalize.go
@@ -74,7 +74,7 @@ func finalize() *cobra.Command {
 
 				currentDir := filepath.Join(response.GetLogArchiveDirectory(), "data-migration-scripts", "current")
 				return commanders.ApplyDataMigrationScripts(nonInteractive, response.GetTargetCluster().GPHome, int(response.GetTargetCluster().GetPort()),
-					utils.System.DirFS(currentDir), currentDir, idl.Step_finalize)
+					response.GetLogArchiveDirectory(), utils.System.DirFS(currentDir), currentDir, idl.Step_finalize)
 			})
 
 			st.RunCLISubstep(idl.Substep_delete_master_statedir, func(streams step.OutStreams) error {

--- a/cli/commands/initialize.go
+++ b/cli/commands/initialize.go
@@ -209,7 +209,7 @@ func initialize() *cobra.Command {
 
 				currentDir := filepath.Join(generatedScriptsOutputDir, "current")
 				return commanders.ApplyDataMigrationScripts(nonInteractive, sourceGPHome, sourcePort,
-					utils.System.DirFS(currentDir), currentDir, idl.Step_stats)
+					logdir, utils.System.DirFS(currentDir), currentDir, idl.Step_stats)
 			})
 
 			st.RunCLISubstepConditionally(idl.Substep_execute_initialize_data_migration_scripts, !nonInteractive, func(streams step.OutStreams) error {
@@ -218,7 +218,7 @@ func initialize() *cobra.Command {
 
 				currentDir := filepath.Join(filepath.Clean(generatedScriptsOutputDir), "current")
 				return commanders.ApplyDataMigrationScripts(nonInteractive, sourceGPHome, sourcePort,
-					utils.System.DirFS(currentDir), currentDir, idl.Step_initialize)
+					logdir, utils.System.DirFS(currentDir), currentDir, idl.Step_initialize)
 			})
 
 			st.RunInternalSubstep(func() error {

--- a/cli/commands/revert.go
+++ b/cli/commands/revert.go
@@ -74,7 +74,7 @@ func revert() *cobra.Command {
 
 				currentDir := filepath.Join(response.GetLogArchiveDirectory(), "data-migration-scripts", "current")
 				return commanders.ApplyDataMigrationScripts(nonInteractive, response.GetSource().GPHome, int(response.GetSource().GetPort()),
-					utils.System.DirFS(currentDir), currentDir, idl.Step_revert)
+					response.GetLogArchiveDirectory(), utils.System.DirFS(currentDir), currentDir, idl.Step_revert)
 			})
 
 			st.RunCLISubstep(idl.Substep_delete_master_statedir, func(streams step.OutStreams) error {


### PR DESCRIPTION
**Note:** Let me know if there is a better interface for `ApplyDataMigrationScripts(nonInteractive bool, gphome string, port int, logDir string, currentScriptDirFS fs.FS, currentScriptDir string, phase idl.Step)` in terms of passing in logDir and deriving currentScriptDir from logDir.

Previously, applying the finalize and revert data migration scripts would fail trying to open
/home/gpadmin/gpAdminLogs/gpupgrade/apply_revert.log

This is because the gpupgrade log directory has already been archived. And internally the apply data migration script code is calling utils.GetLogDir() rather than the archived directory. Thus, pass either the logDir during initialize, or the logArchiveDirectory during finalize & revert.

By passing in the log directory this removes the need for input-dir and output-dir as those can be derived from the log directory.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:passLogDir