### PR TITLE
Consolidate substep text in help text and confirmation prompts

### DIFF
--- a/cli/commanders/step.go
+++ b/cli/commanders/step.go
@@ -45,7 +45,7 @@ type Step struct {
 	err         error
 }
 
-func NewStep(currentStep idl.Step, streams *step.BufferedStreams, verbose bool, interactive bool, confirmationText string) (*Step, error) {
+func NewStep(currentStep idl.Step, streams *step.BufferedStreams, verbose bool, nonInteractive bool, confirmationText string) (*Step, error) {
 	stepStore, err := NewStepStore()
 	if err != nil {
 		context := fmt.Sprintf("Note: If commands were issued in order, ensure gpupgrade can write to %s", utils.GetStateDir())
@@ -58,7 +58,7 @@ func NewStep(currentStep idl.Step, streams *step.BufferedStreams, verbose bool, 
 		return nil, err
 	}
 
-	if !interactive {
+	if !nonInteractive {
 		fmt.Println(confirmationText)
 
 		err := Prompt(bufio.NewReader(os.Stdin), currentStep)

--- a/cli/commanders/substeps.go
+++ b/cli/commanders/substeps.go
@@ -4,8 +4,21 @@
 package commanders
 
 import (
+	"fmt"
+
 	"github.com/greenplum-db/gpupgrade/idl"
 )
+
+type Substeps []idl.Substep
+
+func (s Substeps) String() string {
+	var output string
+	for _, substep := range s {
+		output += fmt.Sprintf(" - %s\n", SubstepDescriptions[substep].HelpText)
+	}
+
+	return output
+}
 
 type substepText struct {
 	OutputText string

--- a/cli/commands/confirmation_text.go
+++ b/cli/commands/confirmation_text.go
@@ -8,11 +8,8 @@ import "github.com/fatih/color"
 const initializeConfirmationText = `
 You are about to initialize a major-version upgrade of Greenplum.
 
-gpupgrade initialize will perform a series of steps, including:
- - Check disk space
- - Create the target cluster
- - Run pg_upgrade consistency checks
-
+%s will carry out the following steps:
+%s
 gpupgrade log files can be found on all hosts in %s
 
 gpupgrade initialize will use these values from %s
@@ -43,10 +40,8 @@ const executeConfirmationText = `
 You are about to run the "execute" command for a major-version upgrade of Greenplum.
 This should be done only during a downtime window.
 %s
-gpupgrade execute will perform a series of steps, including:
-- Upgrade master
-- Upgrade primary segments
-
+%s will carry out the following steps:
+%s
 gpupgrade log files can be found on all hosts in %s
 
 You will still have the opportunity to revert the cluster to its original state
@@ -60,13 +55,8 @@ const finalizeConfirmationText = `
 You are about to finalize a major-version upgrade of Greenplum.
 This should be done only during a downtime window.
 
-gpupgrade finalize will perform a series of steps, including:
- - Update target master catalog
- - Update data directories
- - Update target master configuration files
- - Upgrade standby master
- - Upgrade mirror segments
-
+%s will carry out the following steps:
+%s
 gpupgrade log files can be found on all hosts in %s
 
 WARNING: You will not be able to revert the cluster to its original state after this step.
@@ -79,14 +69,8 @@ const revertConfirmationText = `
 You are about to revert this upgrade.
 This should be done only during a downtime window.
 
-gpupgrade revert will perform a series of steps, including:
- - Delete target cluster data directories
- - Delete state directories on the segments
- - Delete master state directory
- - Archive log directories
- - Restore source cluster
- - Start source cluster
-
+%s will carry out the following steps:
+%s
 gpupgrade log files can be found on all hosts in %s
 
 WARNING: You cannot revert if you do not have mirrors & standby configured, and execute has started.

--- a/cli/commands/execute.go
+++ b/cli/commands/execute.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/greenplum-db/gpupgrade/cli/commanders"
 	"github.com/greenplum-db/gpupgrade/hub"
@@ -52,7 +54,9 @@ func execute() *cobra.Command {
 				return err
 			}
 
-			confirmationText := fmt.Sprintf(executeConfirmationText, revertWarning, logdir)
+			confirmationText := fmt.Sprintf(executeConfirmationText, revertWarning,
+				cases.Title(language.English).String(idl.Step_execute.String()),
+				executeSubsteps, logdir)
 
 			st, err := commanders.NewStep(idl.Step_execute,
 				&step.BufferedStreams{},

--- a/cli/commands/finalize.go
+++ b/cli/commands/finalize.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/greenplum-db/gpupgrade/cli/commanders"
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -33,7 +35,9 @@ func finalize() *cobra.Command {
 				return err
 			}
 
-			confirmationText := fmt.Sprintf(finalizeConfirmationText, logdir)
+			confirmationText := fmt.Sprintf(finalizeConfirmationText,
+				cases.Title(language.English).String(idl.Step_finalize.String()),
+				finalizeSubsteps, logdir)
 
 			st, err := commanders.NewStep(idl.Step_finalize,
 				&step.BufferedStreams{},

--- a/cli/commands/initialize.go
+++ b/cli/commands/initialize.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"golang.org/x/xerrors"
 
 	"github.com/greenplum-db/gpupgrade/cli/commanders"
@@ -59,7 +61,7 @@ func initialize() *cobra.Command {
 
 			// If no required flags are set then return help.
 			if !cmd.Flag("file").Changed && !isAnyDevModeFlagSet {
-				fmt.Println(Help["initialize"])
+				fmt.Println(InitializeHelp)
 				cmd.SilenceErrors = true // silence UserCanceled error message below
 				return step.UserCanceled // exit early and don't call RunE
 			}
@@ -164,7 +166,9 @@ func initialize() *cobra.Command {
 				return err
 			}
 
-			confirmationText := fmt.Sprintf(initializeConfirmationText, logdir, configPath,
+			confirmationText := fmt.Sprintf(initializeConfirmationText,
+				cases.Title(language.English).String(idl.Step_initialize.String()),
+				initializeSubsteps, logdir, configPath,
 				sourcePort, sourceGPHome, targetGPHome, mode, diskFreeRatio, useHbaHostnames, dynamicLibraryPath, ports, hubPort, agentPort)
 
 			st, err := commanders.NewStep(idl.Step_initialize,

--- a/cli/commands/revert.go
+++ b/cli/commands/revert.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/greenplum-db/gpupgrade/cli/commanders"
 	"github.com/greenplum-db/gpupgrade/idl"
@@ -33,7 +35,9 @@ func revert() *cobra.Command {
 				return err
 			}
 
-			confirmationText := fmt.Sprintf(revertConfirmationText, logdir)
+			confirmationText := fmt.Sprintf(revertConfirmationText,
+				cases.Title(language.English).String(idl.Step_revert.String()),
+				revertSubsteps, logdir)
 
 			st, err := commanders.NewStep(idl.Step_revert,
 				&step.BufferedStreams{},

--- a/cmd/gpupgrade/main.go
+++ b/cmd/gpupgrade/main.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/greenplum-db/gpupgrade/cli/commands"
+	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/greenplum-db/gpupgrade/utils/daemon"
 	"github.com/greenplum-db/gpupgrade/utils/logger"
@@ -31,8 +32,9 @@ func main() {
 	err := root.Execute()
 	if err != nil && err != daemon.ErrSuccessfullyDaemonized {
 		if strings.HasPrefix(err.Error(), "unknown flag") {
-			cmd := os.Args[1]
-			fmt.Println(commands.Help[cmd])
+			cmd := strings.TrimSpace(os.Args[1])
+			step := idl.Step(idl.Step_value[cmd])
+			fmt.Println(commands.Help[step])
 		}
 
 		// We use gplog.Debug instead of Error so the error is not displayed


### PR DESCRIPTION
Help text and confirmation prompt both show the substeps for the
command gpupgrade intends to run. They should be the same.

pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:consolidate-substep-text