### PR TITLE
Fix revert after early initialize exit

### DIFF
--- a/cli/commanders/initialize_test.go
+++ b/cli/commanders/initialize_test.go
@@ -222,7 +222,9 @@ func TestCreateStateDir(t *testing.T) {
 }
 
 func TestCreateInitialClusterConfigs(t *testing.T) {
-	const port = -1
+	const hubPort = -1
+	const sourcePort = 8888
+	const sourceGPHome = "/mock/gphome"
 
 	home, err := os.MkdirTemp("", t.Name())
 	if err != nil {
@@ -254,7 +256,7 @@ func TestCreateInitialClusterConfigs(t *testing.T) {
 	t.Run("test idempotence", func(t *testing.T) {
 
 		{ // creates initial cluster config files if none exist or fails"
-			err = CreateConfigFile(port)
+			err = CreateConfigFile(hubPort, sourcePort, sourceGPHome)
 			if err != nil {
 				t.Fatalf("unexpected error %#v", err)
 			}
@@ -265,7 +267,7 @@ func TestCreateInitialClusterConfigs(t *testing.T) {
 		}
 
 		{ // creating cluster config files is idempotent
-			err = CreateConfigFile(port)
+			err = CreateConfigFile(hubPort, sourcePort, sourceGPHome)
 			if err != nil {
 				t.Fatalf("unexpected error %#v", err)
 			}
@@ -281,7 +283,7 @@ func TestCreateInitialClusterConfigs(t *testing.T) {
 		}
 
 		{ // creating cluster config files succeeds on multiple runs
-			err = CreateConfigFile(port)
+			err = CreateConfigFile(hubPort, sourcePort, sourceGPHome)
 			if err != nil {
 				t.Fatalf("unexpected error %#v", err)
 			}

--- a/cli/commands/commands_test.go
+++ b/cli/commands/commands_test.go
@@ -26,7 +26,7 @@ func TestGetHubPort(t *testing.T) {
 		// save the expected port value to the conf file
 		expected := 12345
 		server := hub.New(&hub.Config{Port: expected}, nil, stateDir)
-		err := server.SaveConfig()
+		err := server.Config.SaveConfig()
 		if err != nil {
 			t.Errorf("got unexpected error %#v", err)
 		}

--- a/cli/commands/initialize.go
+++ b/cli/commands/initialize.go
@@ -190,6 +190,14 @@ func initialize() *cobra.Command {
 				return nil
 			})
 
+			st.RunCLISubstep(idl.Substep_saving_source_cluster_config, func(streams step.OutStreams) error {
+				return commanders.CreateConfigFile(hubPort, sourcePort, sourceGPHome)
+			})
+
+			st.RunCLISubstep(idl.Substep_start_hub, func(streams step.OutStreams) error {
+				return commanders.StartHub()
+			})
+
 			generatedScriptsOutputDir, err := utils.GetDefaultGeneratedDataMigrationScriptsDir()
 			if err != nil {
 				return nil
@@ -228,14 +236,6 @@ func initialize() *cobra.Command {
 
 				fmt.Println()
 				return commanders.Prompt(bufio.NewReader(os.Stdin), idl.Step_initialize)
-			})
-
-			st.RunInternalSubstep(func() error {
-				return commanders.CreateConfigFile(hubPort)
-			})
-
-			st.RunCLISubstep(idl.Substep_start_hub, func(streams step.OutStreams) error {
-				return commanders.StartHub()
 			})
 
 			var client idl.CliToHubClient

--- a/hub/execute.go
+++ b/hub/execute.go
@@ -57,7 +57,7 @@ func (s *Server) Execute(req *idl.ExecuteRequest, stream idl.CliToHub_ExecuteSer
 				return err
 			}
 
-			err = s.SaveConfig()
+			err = s.Config.SaveConfig()
 			if err != nil {
 				return fmt.Errorf("save backup directories: %w", err)
 			}

--- a/hub/initialize.go
+++ b/hub/initialize.go
@@ -32,7 +32,7 @@ func (s *Server) Initialize(req *idl.InitializeRequest, stream idl.CliToHub_Init
 	}()
 
 	st.Run(idl.Substep_saving_source_cluster_config, func(stream step.OutStreams) error {
-		return FillConfiguration(s.Config, req, s.SaveConfig)
+		return FillConfiguration(s.Config, req, s.Config.SaveConfig)
 	})
 
 	// Since the agents might not be up if gpupgrade is not properly installed, check it early on using ssh.
@@ -76,7 +76,7 @@ func (s *Server) Initialize(req *idl.InitializeRequest, stream idl.CliToHub_Init
 			return err
 		}
 
-		err = s.SaveConfig()
+		err = s.Config.SaveConfig()
 		if err != nil {
 			return fmt.Errorf("save backup directories: %w", err)
 		}
@@ -155,7 +155,7 @@ func (s *Server) InitializeCreateCluster(req *idl.InitializeCreateClusterRequest
 		}
 
 		s.Intermediate.CatalogVersion = catalogVersion
-		return s.SaveConfig()
+		return s.Config.SaveConfig()
 	})
 
 	st.RunConditionally(idl.Substep_setting_dynamic_library_path_on_target_cluster, req.GetDynamicLibraryPath() != upgrade.DefaultDynamicLibraryPath, func(stream step.OutStreams) error {

--- a/hub/server.go
+++ b/hub/server.go
@@ -387,9 +387,9 @@ func (c *Config) Save(w io.Writer) error {
 }
 
 // SaveConfig persists the hub's configuration to disk.
-func (s *Server) SaveConfig() (err error) {
+func (c *Config) SaveConfig() (err error) {
 	var buffer bytes.Buffer
-	if err = s.Config.Save(&buffer); err != nil {
+	if err = c.Save(&buffer); err != nil {
 		return xerrors.Errorf("save config: %w", err)
 	}
 
@@ -407,7 +407,7 @@ func (s *Server) GetLogArchiveDir() (string, error) {
 	}
 
 	s.LogArchiveDir = filepath.Join(filepath.Dir(logDir), upgrade.GetArchiveDirectoryName(s.UpgradeID, time.Now()))
-	err = s.SaveConfig()
+	err = s.Config.SaveConfig()
 	if err != nil {
 		return "", fmt.Errorf("saving archive directory: %w", err)
 	}

--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -341,7 +341,7 @@ func TestHubSaveConfig(t *testing.T) {
 		defer resetEnv()
 
 		// Write the hub's configuration.
-		if err := h.SaveConfig(); err != nil {
+		if err := h.Config.SaveConfig(); err != nil {
 			t.Errorf("SaveConfig returned error %+v", err)
 		}
 

--- a/integration/hub_test.go
+++ b/integration/hub_test.go
@@ -115,7 +115,9 @@ func TestHub(t *testing.T) {
 			t.Errorf("unexpected error got %+v", err)
 		}
 
-		err = commanders.CreateConfigFile(upgrade.DefaultHubPort)
+		mockSourcePort := 8888
+		mockSourceDataDir := "/mock/data/gpseg-1"
+		err = commanders.CreateConfigFile(upgrade.DefaultHubPort, mockSourcePort, mockSourceDataDir)
 		if err != nil {
 			t.Errorf("unexpected error got %+v", err)
 		}


### PR DESCRIPTION
With the migration scripts being generated and applied at the beginning of the initialize command now, starting up the hub and creating the config file is done much later. Both are required for revert to succeed but we allow users to quit early during the migration scripts part of Initialize. If the user quits Initialize during that early phase, running revert will fail. To fix the issue, we create and prepopulate the config file and start the hub prior to the migration script logic in Initialize. New step logic has been introduced as well to allow us to skip over unnecessary revert substeps.

Dev pipeline:
https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:revert_after_migration_scripts