### PR TITLE
Use gpfdist's full path in external table tests

### DIFF
--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/input/external_table.source
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/input/external_table.source
@@ -10,7 +10,7 @@
 !\retcode > @abs_srcdir@/data/external_table_with_serial_column_type.csv;
 !\retcode > @abs_srcdir@/data/external_table_with_user_type_and_default_value.csv;
 !\retcode > @abs_srcdir@/data/external_table_with_dropped_column.csv;
-!&\retcode gpfdist -d @abs_srcdir@/data -p 8081 -l /tmp/gpfdist_external_table.log;
+!&\retcode @bindir@/gpfdist -d @abs_srcdir@/data -p 8081 -l /tmp/gpfdist_external_table.log;
 
 -- Scenario 1: simple external table
 CREATE READABLE EXTERNAL TABLE readable_external_table (a int, b int)

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/output/external_table.source
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/output/external_table.source
@@ -13,7 +13,7 @@
 (exited with code 0)
 !\retcode > @abs_srcdir@/data/external_table_with_dropped_column.csv;
 (exited with code 0)
-!&\retcode gpfdist -d @abs_srcdir@/data -p 8081 -l /tmp/gpfdist_external_table.log; 
+!&\retcode @bindir@/gpfdist -d @abs_srcdir@/data -p 8081 -l /tmp/gpfdist_external_table.log; 
 -- Scenario 1: simple external table
 CREATE READABLE EXTERNAL TABLE readable_external_table (a int, b int) LOCATION ('file://@hostname@/@abs_srcdir@/data/external_table.csv') FORMAT 'TEXT' (DELIMITER '|');
 CREATE

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/input/external_table.source
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/input/external_table.source
@@ -4,7 +4,7 @@
 --------------------------------------------------------------------------------
 -- Validate that the upgradeable objects are functional post-upgrade
 --------------------------------------------------------------------------------
-!&\retcode gpfdist -d @abs_srcdir@/../source_cluster_regress/data -p 8081 -l /tmp/gpfdist_external_table.log;
+!&\retcode @bindir@/gpfdist -d @abs_srcdir@/../source_cluster_regress/data -p 8081 -l /tmp/gpfdist_external_table.log;
 
 SELECT * FROM readable_external_table;
 

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/output/external_table.source
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/output/external_table.source
@@ -4,7 +4,7 @@
 --------------------------------------------------------------------------------
 -- Validate that the upgradeable objects are functional post-upgrade
 --------------------------------------------------------------------------------
-!&\retcode gpfdist -d @abs_srcdir@/../source_cluster_regress/data -p 8081 -l /tmp/gpfdist_external_table.log; 
+!&\retcode @bindir@/gpfdist -d @abs_srcdir@/../source_cluster_regress/data -p 8081 -l /tmp/gpfdist_external_table.log; 
 SELECT * FROM readable_external_table;
  a | b 
 ---+---


### PR DESCRIPTION
If there is no cluster sourced when tests are run, it will result a command not found error. By using gpfdist's full path we can avoid this issue.

pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:gpfdist-full-path