### PR TITLE
bump minimum supported GPDB versions

### DIFF
--- a/greenplum/allowed_gpdb_versions.go
+++ b/greenplum/allowed_gpdb_versions.go
@@ -10,9 +10,9 @@ import (
 )
 
 // Change these values to bump the minimum supported versions and associated tests.
-var min5xVersion = "5.29.7"
-var min6xVersion = "6.21.1"
-var min7xVersion = "7.0.0"
+const min5xVersion = "5.29.10"
+const min6xVersion = "6.24.0"
+const min7xVersion = "7.0.0"
 
 var GetSourceVersion = Version
 var GetTargetVersion = Version


### PR DESCRIPTION
Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:bumpMinVersions