### PR TITLE
Move some unit tests into their respective test packages

### DIFF
--- a/ci/scripts/filters/double_precision_test.go
+++ b/ci/scripts/filters/double_precision_test.go
@@ -1,9 +1,13 @@
 // Copyright (c) 2017-2023 VMware, Inc. or its affiliates
 // SPDX-License-Identifier: Apache-2.0
 
-package filters
+package filters_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/greenplum-db/gpupgrade/ci/scripts/filters"
+)
 
 func TestReplacePrecision(t *testing.T) {
 	cases := []struct {
@@ -69,7 +73,7 @@ func TestReplacePrecision(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := ReplacePrecision(c.line)
+			got := filters.ReplacePrecision(c.line)
 			if got != c.want {
 				t.Errorf("got %v, want %v", got, c.want)
 			}

--- a/ci/scripts/filters/partition_tables_test.go
+++ b/ci/scripts/filters/partition_tables_test.go
@@ -1,10 +1,12 @@
 // Copyright (c) 2017-2023 VMware, Inc. or its affiliates
 // SPDX-License-Identifier: Apache-2.0
 
-package filters
+package filters_test
 
 import (
 	"testing"
+
+	"github.com/greenplum-db/gpupgrade/ci/scripts/filters"
 )
 
 func Test_FormatWithClause(t *testing.T) {
@@ -27,7 +29,7 @@ func Test_FormatWithClause(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := FormatWithClause(tt.input)
+			got := filters.FormatWithClause(tt.input)
 
 			if got != tt.result {
 				t.Errorf("got %v, want %v", got, tt.result)

--- a/ci/scripts/filters/replacement_test.go
+++ b/ci/scripts/filters/replacement_test.go
@@ -1,10 +1,12 @@
 // Copyright (c) 2017-2023 VMware, Inc. or its affiliates
 // SPDX-License-Identifier: Apache-2.0
 
-package filters
+package filters_test
 
 import (
 	"testing"
+
+	"github.com/greenplum-db/gpupgrade/ci/scripts/filters"
 )
 
 func TestReplacements5X_RemoveOperatorRecheck(t *testing.T) {
@@ -37,7 +39,7 @@ func TestReplacements5X_RemoveOperatorRecheck(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := Replacements5X(c.line)
+			got := filters.Replacements5X(c.line)
 			if got != c.expected {
 				t.Errorf("got %v want %v", got, c.expected)
 				t.Logf("actual:   %s", got)
@@ -77,7 +79,7 @@ func TestReplacements5X_CastingParenthesis(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := Replacements5X(c.line)
+			got := filters.Replacements5X(c.line)
 			if got != c.expected {
 				t.Errorf("got %v want %v", got, c.expected)
 				t.Logf("actual:   %s", got)
@@ -111,7 +113,7 @@ func TestReplacements6X(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := Replacements6X(tt.line)
+			actual := filters.Replacements6X(tt.line)
 			if actual != tt.expected {
 				t.Errorf("got %v, expected %v", actual, tt.expected)
 			}

--- a/ci/scripts/filters/trigger_test.go
+++ b/ci/scripts/filters/trigger_test.go
@@ -1,10 +1,12 @@
 // Copyright (c) 2017-2023 VMware, Inc. or its affiliates
 // SPDX-License-Identifier: Apache-2.0
 
-package filters
+package filters_test
 
 import (
 	"testing"
+
+	"github.com/greenplum-db/gpupgrade/ci/scripts/filters"
 )
 
 func TestFormatTriggerDdl(t *testing.T) {
@@ -31,7 +33,7 @@ func TestFormatTriggerDdl(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, err := FormatTriggerDdl(tt.tokens)
+			actual, err := filters.FormatTriggerDdl(tt.tokens)
 
 			if err == nil && tt.expectedErr {
 				t.Errorf("expect an error")
@@ -66,7 +68,7 @@ func TestIsTriggerDdl(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if actual := IsTriggerDdl(tt.buf, tt.line); actual != tt.expected {
+			if actual := filters.IsTriggerDdl(tt.buf, tt.line); actual != tt.expected {
 				t.Errorf("got %t, want %t", actual, tt.expected)
 			}
 		})

--- a/ci/scripts/filters/view_and_rule_test.go
+++ b/ci/scripts/filters/view_and_rule_test.go
@@ -1,10 +1,12 @@
 // Copyright (c) 2017-2023 VMware, Inc. or its affiliates
 // SPDX-License-Identifier: Apache-2.0
 
-package filters
+package filters_test
 
 import (
 	"testing"
+
+	"github.com/greenplum-db/gpupgrade/ci/scripts/filters"
 )
 
 func TestFormatViewOrRuleDdl(t *testing.T) {
@@ -35,7 +37,7 @@ func TestFormatViewOrRuleDdl(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := FormatViewOrRuleDdl(tt.tokens)
+			got, err := filters.FormatViewOrRuleDdl(tt.tokens)
 
 			if err == nil && tt.wantErr {
 				t.Errorf("expect an error")
@@ -76,7 +78,7 @@ func TestIsViewOrRuleDdl(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if actual := IsViewOrRuleDdl(tt.buf, tt.line); actual != tt.expected {
+			if actual := filters.IsViewOrRuleDdl(tt.buf, tt.line); actual != tt.expected {
 				t.Errorf("got %t, want %t", actual, tt.expected)
 			}
 		})


### PR DESCRIPTION
General golang testing best practices is to have public functions be tested in respective test packages instead of the actual package. There's a handful of gpupgrade unit tests that do not do this. This patch takes care of the trivial ones. The remaining ones can be dealt with later as they require some minor discussion and thought.