### PR TITLE
Refactor hub and agent

### DIFF
--- a/agent/archive_log_directory_test.go
+++ b/agent/archive_log_directory_test.go
@@ -21,12 +21,12 @@ import (
 
 func TestArchiveLogDirectories(t *testing.T) {
 	testlog.SetupTestLogger()
-	server := agent.NewServer(agent.Config{})
+	agentServer := agent.New()
 
 	t.Run("bubbles up errors", func(t *testing.T) {
 		// empty target directory string to force an error
 		newDir := ""
-		_, err := server.ArchiveLogDirectory(context.Background(), &idl.ArchiveLogDirectoryRequest{NewDir: newDir})
+		_, err := agentServer.ArchiveLogDirectory(context.Background(), &idl.ArchiveLogDirectoryRequest{NewDir: newDir})
 		if err == nil {
 			t.Errorf("expected error")
 		}
@@ -51,7 +51,7 @@ func TestArchiveLogDirectories(t *testing.T) {
 		defer os.RemoveAll(homeDir)
 
 		newLogDir := oldLogDir + "xxxxxx"
-		_, err = server.ArchiveLogDirectory(context.Background(), &idl.ArchiveLogDirectoryRequest{NewDir: newLogDir})
+		_, err = agentServer.ArchiveLogDirectory(context.Background(), &idl.ArchiveLogDirectoryRequest{NewDir: newLogDir})
 		if err != nil {
 			t.Errorf("unexpected error %#v", err)
 		}

--- a/agent/create_recovery_conf_test.go
+++ b/agent/create_recovery_conf_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestCreateRecoveryConf(t *testing.T) {
 	testlog.SetupTestLogger()
-	server := agent.NewServer(agent.Config{})
+	agentServer := agent.New()
 
 	t.Run("creates recovery.conf", func(t *testing.T) {
 		mirrorDataDir := testutils.GetTempDir(t, "")
@@ -31,7 +31,7 @@ func TestCreateRecoveryConf(t *testing.T) {
 			PrimaryPort:   int32(123),
 		}}
 
-		_, err := server.CreateRecoveryConf(context.Background(), &idl.CreateRecoveryConfRequest{Connections: connReqs})
+		_, err := agentServer.CreateRecoveryConf(context.Background(), &idl.CreateRecoveryConfRequest{Connections: connReqs})
 		if err != nil {
 			t.Errorf("unexpected error %#v", err)
 		}
@@ -61,7 +61,7 @@ primary_slot_name = 'internal_wal_replication_slot'`
 				PrimaryPort:   int32(456),
 			}}
 
-		_, err := server.CreateRecoveryConf(context.Background(), &idl.CreateRecoveryConfRequest{Connections: connReqs})
+		_, err := agentServer.CreateRecoveryConf(context.Background(), &idl.CreateRecoveryConfRequest{Connections: connReqs})
 		if err == nil {
 			t.Error("expected error, returned nil")
 		}

--- a/agent/delete_directories.go
+++ b/agent/delete_directories.go
@@ -10,6 +10,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/upgrade"
+	"github.com/greenplum-db/gpupgrade/utils"
 )
 
 var DeleteDirectoriesFunc = upgrade.DeleteDirectories
@@ -19,7 +20,7 @@ func (s *Server) DeleteStateDirectory(ctx context.Context, in *idl.DeleteStateDi
 
 	// pass an empty []string to avoid check for any pre-existing files,
 	// this call might come in before any stateDir files are created
-	err := DeleteDirectoriesFunc([]string{s.conf.StateDir}, []string{}, step.DevNullStream)
+	err := DeleteDirectoriesFunc([]string{utils.GetStateDir()}, []string{}, step.DevNullStream)
 	return &idl.DeleteStateDirectoryReply{}, err
 }
 

--- a/agent/rename_directories_test.go
+++ b/agent/rename_directories_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestRenameDirectories(t *testing.T) {
 	testlog.SetupTestLogger()
-	server := agent.NewServer(agent.Config{})
+	agentServer := agent.New()
 
 	t.Run("bubbles up errors", func(t *testing.T) {
 		expected := errors.New("permission denied")
@@ -23,7 +23,7 @@ func TestRenameDirectories(t *testing.T) {
 			return expected
 		}
 
-		_, err := server.RenameDirectories(context.Background(), &idl.RenameDirectoriesRequest{Dirs: []*idl.RenameDirectories{{}}})
+		_, err := agentServer.RenameDirectories(context.Background(), &idl.RenameDirectoriesRequest{Dirs: []*idl.RenameDirectories{{}}})
 
 		if !errors.Is(err, expected) {
 			t.Errorf("returned error %#v, want %#v", err, expected)

--- a/agent/rename_tablespaces_test.go
+++ b/agent/rename_tablespaces_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestRenameTablespaces(t *testing.T) {
 	testlog.SetupTestLogger()
-	server := agent.NewServer(agent.Config{})
+	agentServer := agent.New()
 
 	t.Run("succeeds", func(t *testing.T) {
 		_, _, tsLocation := testutils.MustMakeTablespaceDir(t, 16386)
@@ -32,7 +32,7 @@ func TestRenameTablespaces(t *testing.T) {
 			Destination: dst,
 		}}
 
-		_, err := server.RenameTablespaces(context.Background(), &idl.RenameTablespacesRequest{RenamePairs: pairs})
+		_, err := agentServer.RenameTablespaces(context.Background(), &idl.RenameTablespacesRequest{RenamePairs: pairs})
 		if err != nil {
 			t.Errorf("unexpected error %#v", err)
 		}
@@ -56,7 +56,7 @@ func TestRenameTablespaces(t *testing.T) {
 				Destination: "/also/does/not/exist/1",
 			}}
 
-		_, err := server.RenameTablespaces(context.Background(), &idl.RenameTablespacesRequest{RenamePairs: pairs})
+		_, err := agentServer.RenameTablespaces(context.Background(), &idl.RenameTablespacesRequest{RenamePairs: pairs})
 		if err == nil {
 			t.Error("expected error, returned nil")
 		}

--- a/agent/restore_pg_control_test.go
+++ b/agent/restore_pg_control_test.go
@@ -22,11 +22,11 @@ import (
 
 func TestServer_RestorePrimariesPgControl(t *testing.T) {
 	testlog.SetupTestLogger()
-	server := agent.NewServer(agent.Config{})
+	agentServer := agent.New()
 
 	t.Run("bubbles up errors when no pg_control files exist", func(t *testing.T) {
 		dirs := []string{"/tmp/test1", "/tmp/test2"}
-		_, err := server.RestorePrimariesPgControl(context.Background(), &idl.RestorePgControlRequest{Datadirs: dirs})
+		_, err := agentServer.RestorePrimariesPgControl(context.Background(), &idl.RestorePgControlRequest{Datadirs: dirs})
 
 		var errs errorlist.Errors
 		if !xerrors.As(err, &errs) {
@@ -60,7 +60,7 @@ func TestServer_RestorePrimariesPgControl(t *testing.T) {
 		src := filepath.Join(sourceDir, "global", "pg_control")
 		testutils.MustWriteToFile(t, src, "")
 
-		_, err = server.RestorePrimariesPgControl(context.Background(), &idl.RestorePgControlRequest{Datadirs: []string{sourceDir}})
+		_, err = agentServer.RestorePrimariesPgControl(context.Background(), &idl.RestorePgControlRequest{Datadirs: []string{sourceDir}})
 		if err != nil {
 			t.Errorf("unexpected error %#v", err)
 		}

--- a/agent/rsync_test.go
+++ b/agent/rsync_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestRsync(t *testing.T) {
 	testlog.SetupTestLogger()
-	server := agent.NewServer(agent.Config{})
+	agentServer := agent.New()
 
 	source := testutils.GetTempDir(t, "")
 	defer testutils.MustRemoveAll(t, source)
@@ -90,7 +90,7 @@ func TestRsync(t *testing.T) {
 			}},
 		}
 
-		_, err := server.RsyncDataDirectories(context.Background(), request)
+		_, err := agentServer.RsyncDataDirectories(context.Background(), request)
 		if err != nil {
 			t.Errorf("unexpected err %#v", err)
 		}
@@ -107,7 +107,7 @@ func TestRsync(t *testing.T) {
 			{Sources: []string{source}, Destination: destination},
 		}}
 
-		_, err := server.RsyncDataDirectories(context.Background(), request)
+		_, err := agentServer.RsyncDataDirectories(context.Background(), request)
 		if err == nil {
 			t.Errorf("expected an error")
 		}
@@ -143,7 +143,7 @@ func TestRsync(t *testing.T) {
 			{Sources: []string{dir}, Destination: destination},
 		}}
 
-		_, err = server.RsyncDataDirectories(context.Background(), request)
+		_, err = agentServer.RsyncDataDirectories(context.Background(), request)
 		if err == nil {
 			t.Errorf("expected an error")
 		}
@@ -170,7 +170,7 @@ func TestRsync(t *testing.T) {
 			{Sources: []string{source}, Destination: destination},
 		}}
 
-		_, err := server.RsyncDataDirectories(context.Background(), request)
+		_, err := agentServer.RsyncDataDirectories(context.Background(), request)
 		if err == nil {
 			t.Error("expected error, returned nil")
 		}
@@ -195,7 +195,7 @@ func TestRsync(t *testing.T) {
 
 func TestRsyncTablespaceDirectories(t *testing.T) {
 	testlog.SetupTestLogger()
-	server := agent.NewServer(agent.Config{})
+	agentServer := agent.New()
 
 	sourceTsLocationDir := "/filespace/demoDataDir0/16386"
 	utils.System.DirFS = func(dir string) fs.FS {
@@ -255,7 +255,7 @@ func TestRsyncTablespaceDirectories(t *testing.T) {
 			}},
 		}
 
-		_, err := server.RsyncTablespaceDirectories(context.Background(), request)
+		_, err := agentServer.RsyncTablespaceDirectories(context.Background(), request)
 		if err != nil {
 			t.Errorf("unexpected err %#v", err)
 		}
@@ -283,7 +283,7 @@ func TestRsyncTablespaceDirectories(t *testing.T) {
 			{Sources: []string{invalidTablespaceDir}, Destination: destination},
 		}}
 
-		_, err := server.RsyncTablespaceDirectories(context.Background(), request)
+		_, err := agentServer.RsyncTablespaceDirectories(context.Background(), request)
 		expected := fmt.Sprintf("invalid tablespace directory %q", filepath.Join(invalidTablespaceDir, "12094"))
 		if err.Error() != expected {
 			t.Errorf("got error %#v want %#v", err, expected)

--- a/agent/upgrade_primaries_test.go
+++ b/agent/upgrade_primaries_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestUpgradePrimaries(t *testing.T) {
 	testlog.SetupTestLogger()
-	server := agent.NewServer(agent.Config{})
+	agentServer := agent.New()
 
 	t.Run("succeeds", func(t *testing.T) {
 		rsync.SetRsyncCommand(exectest.NewCommand(agent.Success))
@@ -45,7 +45,7 @@ func TestUpgradePrimaries(t *testing.T) {
 			TargetVersion: "6.0.0",
 		}}
 
-		_, err := server.UpgradePrimaries(context.Background(), &idl.UpgradePrimariesRequest{Opts: opts})
+		_, err := agentServer.UpgradePrimaries(context.Background(), &idl.UpgradePrimariesRequest{Opts: opts})
 		if err != nil {
 			t.Fatalf("unexpected error %+v", err)
 		}
@@ -85,7 +85,7 @@ func TestUpgradePrimaries(t *testing.T) {
 			},
 		}
 
-		_, err := server.UpgradePrimaries(context.Background(), &idl.UpgradePrimariesRequest{Opts: opts})
+		_, err := agentServer.UpgradePrimaries(context.Background(), &idl.UpgradePrimariesRequest{Opts: opts})
 		if err != nil {
 			t.Fatalf("unexpected error %+v", err)
 		}
@@ -127,7 +127,7 @@ func TestUpgradePrimaries(t *testing.T) {
 			TargetVersion: "6.0.0",
 		}}
 
-		_, err := server.UpgradePrimaries(context.Background(), &idl.UpgradePrimariesRequest{Opts: opts})
+		_, err := agentServer.UpgradePrimaries(context.Background(), &idl.UpgradePrimariesRequest{Opts: opts})
 		if err != nil {
 			t.Fatalf("unexpected error %+v", err)
 		}
@@ -158,7 +158,7 @@ func TestUpgradePrimaries(t *testing.T) {
 			},
 		}
 
-		_, err := server.UpgradePrimaries(context.Background(), &idl.UpgradePrimariesRequest{Opts: opts})
+		_, err := agentServer.UpgradePrimaries(context.Background(), &idl.UpgradePrimariesRequest{Opts: opts})
 		var exitErr *exec.ExitError
 		if !errors.As(err, &exitErr) {
 			t.Fatalf("got error %T, want type %T", err, exitErr)
@@ -190,7 +190,7 @@ func TestUpgradePrimaries(t *testing.T) {
 			},
 		}
 
-		_, err := server.UpgradePrimaries(context.Background(), &idl.UpgradePrimariesRequest{Opts: opts})
+		_, err := agentServer.UpgradePrimaries(context.Background(), &idl.UpgradePrimariesRequest{Opts: opts})
 		var linkErr *os.LinkError
 		if !errors.As(err, &linkErr) {
 			t.Errorf("got error %T, want type %T", err, linkErr)
@@ -213,7 +213,7 @@ func TestUpgradePrimaries(t *testing.T) {
 			{Role: greenplum.PrimaryRole, Action: idl.PgOptions_upgrade, TargetVersion: "6.0.0", ContentID: 2, OldDBID: "2"},
 		}
 
-		_, err := server.UpgradePrimaries(context.Background(), &idl.UpgradePrimariesRequest{Opts: opts})
+		_, err := agentServer.UpgradePrimaries(context.Background(), &idl.UpgradePrimariesRequest{Opts: opts})
 		var errs errorlist.Errors
 		if !xerrors.As(err, &errs) {
 			t.Errorf("error %T does not contain type %T", err, errs)

--- a/cli/commands/agent.go
+++ b/cli/commands/agent.go
@@ -14,38 +14,29 @@ import (
 )
 
 func Agent() *cobra.Command {
-	var port int
-	var statedir string
+	var agentPort int
+	var stateDir string
 	var shouldDaemonize bool
 
 	var cmd = &cobra.Command{
 		Use:    "agent",
-		Short:  "Start the Command Listener (blocks)",
-		Long:   `Start the Command Listener (blocks)`,
+		Short:  "start the agent",
+		Long:   "start the agent",
 		Hidden: true,
-		Args:   cobra.MaximumNArgs(0), //no positional args allowed
+		Args:   cobra.MaximumNArgs(0), // no positional args allowed
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logger.Initialize("agent")
 			defer logger.WritePanics()
 
-			conf := agent.Config{
-				Port:     port,
-				StateDir: statedir,
-			}
-
-			agentServer := agent.NewServer(conf)
-			if shouldDaemonize {
-				agentServer.MakeDaemon()
-			}
+			agentServer := agent.New()
 
 			// blocking call
-			agentServer.Start()
-
-			return nil
+			return agentServer.Start(agentPort, stateDir, shouldDaemonize)
 		},
 	}
-	cmd.Flags().IntVar(&port, "port", upgrade.DefaultAgentPort, "the port to listen for commands on")
-	cmd.Flags().StringVar(&statedir, "state-directory", utils.GetStateDir(), "Agent state directory")
+
+	cmd.Flags().IntVar(&agentPort, "port", upgrade.DefaultAgentPort, "the port to listen for commands on")
+	cmd.Flags().StringVar(&stateDir, "state-directory", utils.GetStateDir(), "Agent state directory")
 
 	daemon.MakeDaemonizable(cmd, &shouldDaemonize)
 

--- a/cli/commands/commands_test.go
+++ b/cli/commands/commands_test.go
@@ -26,8 +26,8 @@ func TestGetHubPort(t *testing.T) {
 
 		// save the expected port value to the conf file
 		expected := 12345
-		server := hub.New(&config.Config{HubPort: expected}, nil, stateDir)
-		err := server.Config.Write()
+		hubServer := hub.New(&config.Config{HubPort: expected})
+		err := hubServer.Config.Write()
 		if err != nil {
 			t.Errorf("got unexpected error %#v", err)
 		}

--- a/hub/initialize.go
+++ b/hub/initialize.go
@@ -36,7 +36,7 @@ func (s *Server) Initialize(req *idl.InitializeRequest, stream idl.CliToHub_Init
 	})
 
 	st.Run(idl.Substep_start_agents, func(_ step.OutStreams) error {
-		_, err := RestartAgents(context.Background(), nil, AgentHosts(s.Source), s.AgentPort, s.StateDir)
+		_, err := RestartAgents(context.Background(), nil, AgentHosts(s.Source), s.AgentPort, utils.GetStateDir())
 		if err != nil {
 			return err
 		}

--- a/hub/server_test.go
+++ b/hub/server_test.go
@@ -65,7 +65,7 @@ func TestHubStart(t *testing.T) {
 			if !errors.Is(err, hub.ErrHubStopped) {
 				t.Errorf("got error %#v want %#v", err, hub.ErrHubStopped)
 			}
-		case <-time.After(timeout): // use timeout to prevent test from hanging
+		case <-time.After(timeout):
 			t.Error("timeout exceeded")
 		}
 	})
@@ -88,7 +88,7 @@ func TestHubStart(t *testing.T) {
 			if err != nil && !strings.Contains(err.Error(), expected) {
 				t.Errorf("got error %#v want %#v", err, expected)
 			}
-		case <-time.After(timeout): // use timeout to prevent test from hanging
+		case <-time.After(timeout):
 			t.Error("timeout exceeded")
 		}
 	})

--- a/test/acceptance/gpupgrade/initialize.bats
+++ b/test/acceptance/gpupgrade/initialize.bats
@@ -261,7 +261,7 @@ wait_for_port_change() {
         --non-interactive \
         --verbose 3>&-
     [ "$status" -ne 0 ] || fail "expected start_agent substep to fail with port already in use: $output"
-    [[ $output = *'"start_agents": exit status 2'* ]] || fail "expected start_agent substep to fail with port already in use: $output"
+    [[ $output = *'"start_agents": exit status 1'* ]] || fail "expected start_agent substep to fail with port already in use: $output"
 
     release_held_port
     run gpupgrade revert --non-interactive --verbose

--- a/testutils/mock_agent/mock_agent_server.go
+++ b/testutils/mock_agent/mock_agent_server.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"sync"
 
-	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/idl"
 
 	"google.golang.org/grpc"
@@ -34,7 +33,7 @@ type MockAgentServer struct {
 //
 // XXX Why is the Dialer type that we need for this agent defined in the hub
 // package?
-func NewMockAgentServer() (*MockAgentServer, hub.Dialer, int) {
+func NewMockAgentServer() (*MockAgentServer, func(ctx context.Context, target string, opts ...grpc.DialOption) (*grpc.ClientConn, error), int) {
 	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
1) Refactor agent
- Pass port, stateDir, and daemonize to Start() which are only used once there. This allows us to remove the entire Config struct and simplify the code.
- Refactor to have Start() return an error rather than panicing. This also matches the similar pattern of Hub.Start().
- Rename variables for clarity.

2) Refactor hub
- Pass the port and daemonize to Start() which are only used once there. This allows us to no longer store these variables on the struct and simplify the code.
- Since gRPCDialer is only used once, inject it rather than store it in the struct.
- Rename variables for clarity.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:refactorHubAndAgent