### PR TITLE
finalize: always run archive log dir and delete state dir

### DIFF
--- a/hub/finalize.go
+++ b/hub/finalize.go
@@ -87,7 +87,7 @@ func (s *Server) Finalize(req *idl.FinalizeRequest, stream idl.CliToHub_Finalize
 	})
 
 	var logArchiveDir string
-	st.Run(idl.Substep_archive_log_directories, func(_ step.OutStreams) error {
+	st.AlwaysRun(idl.Substep_archive_log_directories, func(_ step.OutStreams) error {
 		logDir, err := utils.GetLogDir()
 		if err != nil {
 			return err
@@ -101,7 +101,7 @@ func (s *Server) Finalize(req *idl.FinalizeRequest, stream idl.CliToHub_Finalize
 		return DeleteBackupDirectories(streams, s.agentConns, s.BackupDirs)
 	})
 
-	st.Run(idl.Substep_delete_segment_statedirs, func(_ step.OutStreams) error {
+	st.AlwaysRun(idl.Substep_delete_segment_statedirs, func(_ step.OutStreams) error {
 		return DeleteStateDirectories(s.agentConns, s.Source.CoordinatorHostname())
 	})
 


### PR DESCRIPTION
If a substep after these fails and finalize needs to be re-run we want to always archive the log directory and always delete the state directory. (It would probably be good to eventually get an acceptance test written to cover these. Ideally, there were talks of getting a unit or integration level [testing framework](https://github.com/greenplum-db/gpupgrade/compare/dev/idempotence-tests) to test idempotentence and alwaysRun functionality. But that requires a decent amount of time and focus.)

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:finalizeAlwaysRun