### PR TITLE
Rebrand from VMware Tanzu Greenplum to VMware Greenplum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ tarball:
 	rm -r tarball
 
 enterprise-rpm: RELEASE=Enterprise
-enterprise-rpm: NAME=VMware Tanzu Greenplum Upgrade
+enterprise-rpm: NAME=VMware Greenplum Upgrade
 enterprise-rpm: LICENSE=VMware Software EULA
 enterprise-rpm: enterprise-tarball rpm
 

--- a/ci/scripts/verify-rpm.bash
+++ b/ci/scripts/verify-rpm.bash
@@ -28,7 +28,7 @@ verify_rpm_info() {
   fi
 
   [[ $info == *"License     : VMware Software EULA"* ]]
-  [[ $info == *"Summary     : VMware Tanzu Greenplum Upgrade"* ]]
+  [[ $info == *"Summary     : VMware Greenplum Upgrade"* ]]
 }
 
 verify_license_files() {
@@ -36,7 +36,7 @@ verify_license_files() {
   [ -s "$license_file" ]
 
   [[ $(head -1 "$license_file") =~ open_source_licenses.txt ]]
-  [[ $(head -3 "$license_file" | tail -1) == *"VMware Tanzu Greenplum Upgrade ${VERSION}"* ]]
+  [[ $(head -3 "$license_file" | tail -1) == *"VMware Greenplum Upgrade ${VERSION}"* ]]
   [[ $(tail -1 "$license_file") =~ "GREENPLUMUPGRADE" ]]
 }
 


### PR DESCRIPTION
VMware Tanzu Greenplum was recently rebranded to simply VMware Greenplum. Update where necessary.