### PR TITLE
Topological sort dependant views using deprecated tsquery

### DIFF
--- a/data-migration-scripts/5-to-6-seed-scripts/create_find_view_dep_function.sql
+++ b/data-migration-scripts/5-to-6-seed-scripts/create_find_view_dep_function.sql
@@ -40,7 +40,7 @@ FROM (
         AND d.classid = 'pg_rewrite'::regclass
         AND d.refclassid = 'pg_class'::regclass
         AND d.deptype = 'n'
-        AND (a.atttypid = 'pg_catalog.tsquery'::pg_catalog.regtype OR a.atttypid = 'pg_catalog.name'::pg_catalog.regtype)
+        AND a.atttypid = 'pg_catalog.tsquery'::pg_catalog.regtype
         AND c.relkind = 'r'
         AND NOT a.attisdropped
         AND nv.nspname NOT LIKE 'pg_temp_%'

--- a/data-migration-scripts/5-to-6-seed-scripts/finalize/tables_using_tsquery_type/recreate_views_on_deprecated_built_in_types.sql
+++ b/data-migration-scripts/5-to-6-seed-scripts/finalize/tables_using_tsquery_type/recreate_views_on_deprecated_built_in_types.sql
@@ -4,4 +4,4 @@
 SELECT
     $$CREATE VIEW $$ || full_view_name || $$ AS $$ || pg_catalog.pg_get_viewdef(full_view_name::regclass::oid, false) || $$;$$ || E'\n'||
     $$ALTER VIEW $$ || full_view_name || $$ OWNER TO $$ || view_owner || $$;$$
-FROM __gpupgrade_tmp_generator.__temp_views_list ORDER BY view_order;
+FROM __gpupgrade_tmp_generator.__temp_views_list ORDER BY view_order DESC;

--- a/data-migration-scripts/5-to-6-seed-scripts/initialize/tables_using_tsquery_type/gen_drop_depr_built_in_type_dependent_views.sql
+++ b/data-migration-scripts/5-to-6-seed-scripts/initialize/tables_using_tsquery_type/gen_drop_depr_built_in_type_dependent_views.sql
@@ -1,5 +1,5 @@
 -- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
 -- SPDX-License-Identifier: Apache-2.0
 
-SELECT 'DROP VIEW '|| full_view_name || ';'
-FROM  __gpupgrade_tmp_generator.__temp_views_list ORDER BY view_order DESC;
+SELECT 'DROP VIEW IF EXISTS '|| full_view_name || ';'
+FROM  __gpupgrade_tmp_generator.__temp_views_list ORDER BY view_order;

--- a/data-migration-scripts/5-to-6-seed-scripts/revert/tables_using_tsquery_type/recreate_views_on_deprecated_built_in_types.sql
+++ b/data-migration-scripts/5-to-6-seed-scripts/revert/tables_using_tsquery_type/recreate_views_on_deprecated_built_in_types.sql
@@ -4,4 +4,4 @@
 SELECT
     $$CREATE VIEW $$ || full_view_name || $$ AS $$ || pg_catalog.pg_get_viewdef(full_view_name::regclass::oid, false) || $$;$$ || E'\n'||
     $$ALTER TABLE $$ || full_view_name || $$ OWNER TO $$ || view_owner || $$;$$
-FROM __gpupgrade_tmp_generator.__temp_views_list ORDER BY view_order;
+FROM __gpupgrade_tmp_generator.__temp_views_list ORDER BY view_order DESC;

--- a/data-migration-scripts/5-to-6-seed-scripts/test/create_nonupgradable_objects.sql
+++ b/data-migration-scripts/5-to-6-seed-scripts/test/create_nonupgradable_objects.sql
@@ -147,13 +147,38 @@ CREATE TABLE table_with_tsquery (
 );
 CREATE INDEX table_with_tsquery_tsquery_idx on table_with_tsquery(altitude);
 
--- view on tsquery from the same table
+CREATE TABLE table2_with_tsquery (
+    b   tsquery
+);
+
+-- View dependency tests on depricated tsquery
+-- view on tsquery from a table
 DROP VIEW IF EXISTS view_on_tsquery;
 CREATE VIEW view_on_tsquery AS SELECT * FROM table_with_tsquery;
 
 -- view on tsquery from multiple tables
 DROP VIEW IF EXISTS view_on_tsquery_mult_tables;
-CREATE VIEW view_on_tsquery_mult_tables AS SELECT t1.name, t2.altitude FROM table_with_tsquery t1, table_with_tsquery t2;
+CREATE VIEW view_on_tsquery_mult_tables AS SELECT t1.name, t2.b FROM table_with_tsquery t1, table2_with_tsquery t2;
+
+-- view on tsquery from a table and a view
+DROP VIEW IF EXISTS view_on_tsquery_table_view;
+CREATE VIEW view_on_tsquery_table_view AS SELECT t1.name, v1.altitude FROM table_with_tsquery t1, view_on_tsquery v1;
+
+-- view on tsquery from multiple views
+DROP VIEW IF EXISTS view_on_tsquery_mult_views;
+CREATE VIEW view_on_tsquery_mult_views AS SELECT v1.name, v2.altitude FROM view_on_tsquery v1, view_on_tsquery_table_view v2;
+
+-- view on tsquery from a table and multiple views
+DROP VIEW IF EXISTS view_on_tsquery_table_mult_views;
+CREATE VIEW view_on_tsquery_table_mult_views AS SELECT t2.b, v1.name, v2.altitude FROM table2_with_tsquery t2, view_on_tsquery v1, view_on_tsquery_table_view v2;
+
+-- view on tsquery from a table to make sure that the creation order of the views does not affect drop order
+DROP VIEW IF EXISTS view_on_tsquery_creation_order;
+CREATE VIEW view_on_tsquery_creation_order AS SELECT * FROM table_with_tsquery;
+
+-- view on tsquery from multiple tables and multiple views
+DROP VIEW IF EXISTS view_on_tsquery_mult_tables_mult_views;
+CREATE VIEW view_on_tsquery_mult_tables_mult_views AS SELECT t1.name, t2.b, v1.altitude FROM table_with_tsquery t1, table2_with_tsquery t2, view_on_tsquery v1, view_on_tsquery_mult_tables v2;
 
 CREATE TABLE sales_tsquery (trans_id int, office_tsquery tsquery, region text)
     DISTRIBUTED BY (trans_id)


### PR DESCRIPTION
To drop views using deprecated types in the correct order, they
 must be sorted based on their dependencies. The previous sort
 implementation was coded under the assumption that a view could only
 depend on 1 other relation. This resulted in a few unaccounted edge
 cases like the ones listed below.
    
  1. A view depending on 1 view and 1 table
  2. A view depending on 2+ tables
  3. A view depending on 2+ views
    
 Trying to fix these edge cases for the old custom sorting algorithm
 uncovered more issues and the code logic quickly became unreadable and
 very difficult to follow. Redoing the sorting using a standard
 topological sort is the right thing to do as it would guarantee the
 correct view order and would be much easier to maintain moving forward.
 
 pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:topological-sort-depricated-views
