### PR TITLE
Add tests for tables names with special characters

### DIFF
--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/expected/special_characters.out
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/expected/special_characters.out
@@ -1,0 +1,128 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Test to ensure that tables with special characters can be upgraded.
+
+--------------------------------------------------------------------------------
+-- Create and setup upgradeable objects
+--------------------------------------------------------------------------------
+
+CREATE TABLE "foo$"(i int);
+CREATE
+CREATE TABLE "$$foo$"(i int);
+CREATE
+CREATE TABLE "my_table_@pple"(i int);
+CREATE
+CREATE TABLE "users!@#$%^&*()_+`-={}|[];':\""<>,.?/"(i int);
+CREATE
+CREATE TABLE "Café_Latté"(i int);
+CREATE
+CREATE TABLE "data_2021-09-25"(i int);
+CREATE
+CREATE TABLE "Sales@2023"(i int);
+CREATE
+CREATE TABLE "table_(parenthesis)"(i int);
+CREATE
+CREATE TABLE "Ελληνικά_τραπέζια"(i int);
+CREATE
+CREATE TABLE "table_with_underscores and spaces"(i int);
+CREATE
+CREATE TABLE "table_with_ö_umlaut"(i int);
+CREATE
+CREATE TABLE "table_with_की_hindi_characters"(i int);
+CREATE
+CREATE TABLE "学生表"(i text);
+CREATE
+
+INSERT INTO "foo$" (i) VALUES (1);
+INSERT 1
+INSERT INTO "$$foo$" (i) VALUES (2);
+INSERT 1
+INSERT INTO "my_table_@pple" (i) VALUES (3);
+INSERT 1
+INSERT INTO "users!@#$%^&*()_+`-={}|[];':\""<>,.?/" (i) VALUES (4);
+INSERT 1
+INSERT INTO "Café_Latté" (i) VALUES (5);
+INSERT 1
+INSERT INTO "data_2021-09-25" (i) VALUES (6);
+INSERT 1
+INSERT INTO "Sales@2023" (i) VALUES (7);
+INSERT 1
+INSERT INTO "table_(parenthesis)" (i) VALUES (8);
+INSERT 1
+INSERT INTO "Ελληνικά_τραπέζια" (i) VALUES (9);
+INSERT 1
+INSERT INTO "table_with_underscores and spaces" (i) VALUES (10);
+INSERT 1
+INSERT INTO "table_with_ö_umlaut" (i) VALUES (11);
+INSERT 1
+INSERT INTO "table_with_की_hindi_characters" (i) VALUES (12);
+INSERT 1
+INSERT INTO "学生表" (i) VALUES ('张三');
+INSERT 1
+
+SELECT * FROM "foo$";
+ i 
+---
+ 1 
+(1 row)
+SELECT * FROM "$$foo$";
+ i 
+---
+ 2 
+(1 row)
+SELECT * FROM "my_table_@pple";
+ i 
+---
+ 3 
+(1 row)
+SELECT * FROM "users!@#$%^&*()_+`-={}|[];':\""<>,.?/";
+ i 
+---
+ 4 
+(1 row)
+SELECT * FROM "Café_Latté";
+ i 
+---
+ 5 
+(1 row)
+SELECT * FROM "data_2021-09-25";
+ i 
+---
+ 6 
+(1 row)
+SELECT * FROM "Sales@2023";
+ i 
+---
+ 7 
+(1 row)
+SELECT * FROM "table_(parenthesis)";
+ i 
+---
+ 8 
+(1 row)
+SELECT * FROM "Ελληνικά_τραπέζια";
+ i 
+---
+ 9 
+(1 row)
+SELECT * FROM "table_with_underscores and spaces";
+ i  
+----
+ 10 
+(1 row)
+SELECT * FROM "table_with_ö_umlaut";
+ i  
+----
+ 11 
+(1 row)
+SELECT * FROM "table_with_की_hindi_characters";
+ i  
+----
+ 12 
+(1 row)
+SELECT * FROM "学生表";
+ i      
+--------
+ 张三 
+(1 row)

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/sql/special_characters.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/sql/special_characters.sql
@@ -1,0 +1,50 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Test to ensure that tables with special characters can be upgraded.
+
+--------------------------------------------------------------------------------
+-- Create and setup upgradeable objects
+--------------------------------------------------------------------------------
+
+CREATE TABLE "foo$"(i int);
+CREATE TABLE "$$foo$"(i int);
+CREATE TABLE "my_table_@pple"(i int);
+CREATE TABLE "users!@#$%^&*()_+`-={}|[];':\""<>,.?/"(i int);
+CREATE TABLE "Café_Latté"(i int);
+CREATE TABLE "data_2021-09-25"(i int);
+CREATE TABLE "Sales@2023"(i int);
+CREATE TABLE "table_(parenthesis)"(i int);
+CREATE TABLE "Ελληνικά_τραπέζια"(i int);
+CREATE TABLE "table_with_underscores and spaces"(i int);
+CREATE TABLE "table_with_ö_umlaut"(i int);
+CREATE TABLE "table_with_की_hindi_characters"(i int);
+CREATE TABLE "学生表"(i text);
+
+INSERT INTO "foo$" (i) VALUES (1);
+INSERT INTO "$$foo$" (i) VALUES (2);
+INSERT INTO "my_table_@pple" (i) VALUES (3);
+INSERT INTO "users!@#$%^&*()_+`-={}|[];':\""<>,.?/" (i) VALUES (4);
+INSERT INTO "Café_Latté" (i) VALUES (5);
+INSERT INTO "data_2021-09-25" (i) VALUES (6);
+INSERT INTO "Sales@2023" (i) VALUES (7);
+INSERT INTO "table_(parenthesis)" (i) VALUES (8);
+INSERT INTO "Ελληνικά_τραπέζια" (i) VALUES (9);
+INSERT INTO "table_with_underscores and spaces" (i) VALUES (10);
+INSERT INTO "table_with_ö_umlaut" (i) VALUES (11);
+INSERT INTO "table_with_की_hindi_characters" (i) VALUES (12);
+INSERT INTO "学生表" (i) VALUES ('张三');
+
+SELECT * FROM "foo$";
+SELECT * FROM "$$foo$";
+SELECT * FROM "my_table_@pple";
+SELECT * FROM "users!@#$%^&*()_+`-={}|[];':\""<>,.?/";
+SELECT * FROM "Café_Latté";
+SELECT * FROM "data_2021-09-25";
+SELECT * FROM "Sales@2023";
+SELECT * FROM "table_(parenthesis)";
+SELECT * FROM "Ελληνικά_τραπέζια";
+SELECT * FROM "table_with_underscores and spaces";
+SELECT * FROM "table_with_ö_umlaut";
+SELECT * FROM "table_with_की_hindi_characters";
+SELECT * FROM "学生表";

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/upgradeable_source_schedule
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/upgradeable_source_schedule
@@ -2,7 +2,7 @@ test: alter_statistic_on_column ao_table_without_base_relfilenode seg_entries ch
 
 # New set of parallel tests because of "FATAL:  sorry, too many clients already" error
 test: gp_fastsequence user_defined_types_encoding distribution_key_and_data partitioned_polymorphic_table partitions_with_different_schemas ao_indexes name_data_type ao_table_multi_segfile aoco_table_multi_segfile
-test: aoco_dropped_col_and_encoding
+test: aoco_dropped_col_and_encoding special_characters
 
 test: clog_preservation
 test: vacuum_freeze_tables

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/special_characters.out
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/special_characters.out
@@ -1,0 +1,180 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Test to ensure that tables with special characters can be upgraded.
+
+--------------------------------------------------------------------------------
+-- Create and setup upgradeable objects
+--------------------------------------------------------------------------------
+
+SELECT * FROM "foo$";
+ i 
+---
+ 1 
+(1 row)
+SELECT * FROM "$$foo$";
+ i 
+---
+ 2 
+(1 row)
+SELECT * FROM "my_table_@pple";
+ i 
+---
+ 3 
+(1 row)
+SELECT * FROM "users!@#$%^&*()_+`-={}|[];':\""<>,.?/";
+ i 
+---
+ 4 
+(1 row)
+SELECT * FROM "Café_Latté";
+ i 
+---
+ 5 
+(1 row)
+SELECT * FROM "data_2021-09-25";
+ i 
+---
+ 6 
+(1 row)
+SELECT * FROM "Sales@2023";
+ i 
+---
+ 7 
+(1 row)
+SELECT * FROM "table_(parenthesis)";
+ i 
+---
+ 8 
+(1 row)
+SELECT * FROM "Ελληνικά_τραπέζια";
+ i 
+---
+ 9 
+(1 row)
+SELECT * FROM "table_with_underscores and spaces";
+ i  
+----
+ 10 
+(1 row)
+SELECT * FROM "table_with_ö_umlaut";
+ i  
+----
+ 11 
+(1 row)
+SELECT * FROM "table_with_की_hindi_characters";
+ i  
+----
+ 12 
+(1 row)
+SELECT * FROM "学生表";
+ i      
+--------
+ 张三 
+(1 row)
+
+INSERT INTO "foo$" (i) VALUES (1);
+INSERT 1
+INSERT INTO "$$foo$" (i) VALUES (2);
+INSERT 1
+INSERT INTO "my_table_@pple" (i) VALUES (3);
+INSERT 1
+INSERT INTO "users!@#$%^&*()_+`-={}|[];':\""<>,.?/" (i) VALUES (4);
+INSERT 1
+INSERT INTO "Café_Latté" (i) VALUES (5);
+INSERT 1
+INSERT INTO "data_2021-09-25" (i) VALUES (6);
+INSERT 1
+INSERT INTO "Sales@2023" (i) VALUES (7);
+INSERT 1
+INSERT INTO "table_(parenthesis)" (i) VALUES (8);
+INSERT 1
+INSERT INTO "Ελληνικά_τραπέζια" (i) VALUES (9);
+INSERT 1
+INSERT INTO "table_with_underscores and spaces" (i) VALUES (10);
+INSERT 1
+INSERT INTO "table_with_ö_umlaut" (i) VALUES (11);
+INSERT 1
+INSERT INTO "table_with_की_hindi_characters" (i) VALUES (12);
+INSERT 1
+INSERT INTO "学生表" (i) VALUES ('张三');
+INSERT 1
+
+SELECT * FROM "foo$";
+ i 
+---
+ 1 
+ 1 
+(2 row)
+SELECT * FROM "$$foo$";
+ i 
+---
+ 2 
+ 2 
+(2 row)
+SELECT * FROM "my_table_@pple";
+ i 
+---
+ 3 
+ 3 
+(2 row)
+SELECT * FROM "users!@#$%^&*()_+`-={}|[];':\""<>,.?/";
+ i 
+---
+ 4 
+ 4 
+(2 row)
+SELECT * FROM "Café_Latté";
+ i 
+---
+ 5 
+ 5 
+(2 row)
+SELECT * FROM "data_2021-09-25";
+ i 
+---
+ 6 
+ 6 
+(2 row)
+SELECT * FROM "Sales@2023";
+ i 
+---
+ 7 
+ 7 
+(2 row)
+SELECT * FROM "table_(parenthesis)";
+ i 
+---
+ 8 
+ 8 
+(2 row)
+SELECT * FROM "Ελληνικά_τραπέζια";
+ i 
+---
+ 9 
+ 9 
+(2 row)
+SELECT * FROM "table_with_underscores and spaces";
+ i  
+----
+ 10 
+ 10 
+(2 row)
+SELECT * FROM "table_with_ö_umlaut";
+ i  
+----
+ 11 
+ 11 
+(2 row)
+SELECT * FROM "table_with_की_hindi_characters";
+ i  
+----
+ 12 
+ 12 
+(2 row)
+SELECT * FROM "学生表";
+ i      
+--------
+ 张三 
+ 张三 
+(2 row)

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/special_characters.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/special_characters.sql
@@ -1,0 +1,50 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Test to ensure that tables with special characters can be upgraded.
+
+--------------------------------------------------------------------------------
+-- Create and setup upgradeable objects
+--------------------------------------------------------------------------------
+
+SELECT * FROM "foo$";
+SELECT * FROM "$$foo$";
+SELECT * FROM "my_table_@pple";
+SELECT * FROM "users!@#$%^&*()_+`-={}|[];':\"<>,.?/";
+SELECT * FROM "Café_Latté";
+SELECT * FROM "data_2021-09-25";
+SELECT * FROM "Sales@2023";
+SELECT * FROM "table_(parenthesis)";
+SELECT * FROM "Ελληνικά_τραπέζια";
+SELECT * FROM "table_with_underscores and spaces";
+SELECT * FROM "table_with_ö_umlaut";
+SELECT * FROM "table_with_की_hindi_characters";
+SELECT * FROM "学生表";
+
+INSERT INTO "foo$" (i) VALUES (1);
+INSERT INTO "$$foo$" (i) VALUES (2);
+INSERT INTO "my_table_@pple" (i) VALUES (3);
+INSERT INTO "users!@#$%^&*()_+`-={}|[];':\""<>,.?/" (i) VALUES (4);
+INSERT INTO "Café_Latté" (i) VALUES (5);
+INSERT INTO "data_2021-09-25" (i) VALUES (6);
+INSERT INTO "Sales@2023" (i) VALUES (7);
+INSERT INTO "table_(parenthesis)" (i) VALUES (8);
+INSERT INTO "Ελληνικά_τραπέζια" (i) VALUES (9);
+INSERT INTO "table_with_underscores and spaces" (i) VALUES (10);
+INSERT INTO "table_with_ö_umlaut" (i) VALUES (11);
+INSERT INTO "table_with_की_hindi_characters" (i) VALUES (12);
+INSERT INTO "学生表" (i) VALUES ('张三');
+
+SELECT * FROM "foo$";
+SELECT * FROM "$$foo$";
+SELECT * FROM "my_table_@pple";
+SELECT * FROM "users!@#$%^&*()_+`-={}|[];':\""<>,.?/";
+SELECT * FROM "Café_Latté";
+SELECT * FROM "data_2021-09-25";
+SELECT * FROM "Sales@2023";
+SELECT * FROM "table_(parenthesis)";
+SELECT * FROM "Ελληνικά_τραπέζια";
+SELECT * FROM "table_with_underscores and spaces";
+SELECT * FROM "table_with_ö_umlaut";
+SELECT * FROM "table_with_की_hindi_characters";
+SELECT * FROM "学生表";

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/upgradeable_target_schedule
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/upgradeable_target_schedule
@@ -2,7 +2,7 @@ test: alter_statistic_on_column seg_entries ao_table_without_base_relfilenode ch
 
 # New set of parallel tests because of "FATAL:  sorry, too many clients already" error
 test: distribution_key_and_data partitioned_polymorphic_table partitions_with_different_schemas name_data_type ao_table_multi_segfile aoco_table_multi_segfile
-test: aoco_dropped_col_and_encoding
+test: aoco_dropped_col_and_encoding special_characters
 
 test: clog_preservation
 test: vacuum_freeze_tables


### PR DESCRIPTION
Recently it was found that tables ending with $ would fail upgrade
because we were using blank dollar syntax tags $$ to escape special
characters in table names.

pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:special-char-tests.

7x PR that fixes this issue: https://github.com/greenplum-db/gpdb/pull/15408