### PR TITLE
Add non-upgradable test for tables distributed on duplicate columns

### DIFF
--- a/test/acceptance/pg_upgrade/5-to-6/non_upgradeable_tests/expected/distribution_on_duplicated_columns.out
+++ b/test/acceptance/pg_upgrade/5-to-6/non_upgradeable_tests/expected/distribution_on_duplicated_columns.out
@@ -1,0 +1,37 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- There is a bug in the GPDB5 parser that allows distribution on duplicated
+-- columns. This has been patched in GPDB6+ so users need to fix any affected
+-- table's distribution before upgrading. A check has been put in GPDB6 to
+-- ensure upgrade will not continue if there are tables distributed on
+-- duplicate columns.
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+CREATE TABLE distributed_on_duplicated_columns1 (a int, b int) DISTRIBUTED BY (a, a, b);
+CREATE
+CREATE TABLE distributed_on_duplicated_columns2 (a int, b int, c int) DISTRIBUTED BY (a, a, b, b, a, b, c);
+CREATE
+
+--------------------------------------------------------------------------------
+-- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+--------------------------------------------------------------------------------
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --non-interactive;
+-- start_ignore
+-- end_ignore
+(exited with code 1)
+! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/duplicate_column_distribution.txt;
+Database: isolation2test
+  public.distributed_on_duplicated_columns1: 1
+  public.distributed_on_duplicated_columns2: 1, 2
+
+
+--------------------------------------------------------------------------------
+-- Workaround to unblock upgrade
+--------------------------------------------------------------------------------
+ALTER TABLE distributed_on_duplicated_columns1 SET WITH (REORGANIZE=TRUE) DISTRIBUTED BY (a, b);
+ALTER
+ALTER TABLE distributed_on_duplicated_columns2 SET WITH (REORGANIZE=TRUE) DISTRIBUTED BY (a, b, c);
+ALTER

--- a/test/acceptance/pg_upgrade/5-to-6/non_upgradeable_tests/non_upgradeable_schedule
+++ b/test/acceptance/pg_upgrade/5-to-6/non_upgradeable_tests/non_upgradeable_schedule
@@ -12,3 +12,4 @@ test: views_referencing_deprecated_tables
 test: views_with_lag_lead_functions
 test: views_referencing_deprecated_columns
 test: parent_partitions_with_seg_entries
+test: distribution_on_duplicated_columns

--- a/test/acceptance/pg_upgrade/5-to-6/non_upgradeable_tests/sql/distribution_on_duplicated_columns.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/non_upgradeable_tests/sql/distribution_on_duplicated_columns.sql
@@ -1,0 +1,26 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- There is a bug in the GPDB5 parser that allows distribution on duplicated
+-- columns. This has been patched in GPDB6+ so users need to fix any affected
+-- table's distribution before upgrading. A check has been put in GPDB6 to
+-- ensure upgrade will not continue if there are tables distributed on
+-- duplicate columns.
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+CREATE TABLE distributed_on_duplicated_columns1 (a int, b int) DISTRIBUTED BY (a, a, b);
+CREATE TABLE distributed_on_duplicated_columns2 (a int, b int, c int) DISTRIBUTED BY (a, a, b, b, a, b, c);
+
+--------------------------------------------------------------------------------
+-- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+--------------------------------------------------------------------------------
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --non-interactive;
+! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/duplicate_column_distribution.txt;
+
+--------------------------------------------------------------------------------
+-- Workaround to unblock upgrade
+--------------------------------------------------------------------------------
+ALTER TABLE distributed_on_duplicated_columns1 SET WITH (REORGANIZE=TRUE) DISTRIBUTED BY (a, b);
+ALTER TABLE distributed_on_duplicated_columns2 SET WITH (REORGANIZE=TRUE) DISTRIBUTED BY (a, b, c);


### PR DESCRIPTION
Because of a GPDB5 bug in it's parser, it is possible to create tables distributed on duplicate columns. Ensure pg_upgrade does not proceed with upgrade and generates a txt file with the problem tables. Since this is patched on GPDB6 allowing pg_upgrade to continue would result in pg_restore failure during `gpupgrade execute`.