### PR TITLE
log user gpupgrade_config values

### DIFF
--- a/cli/commands/initialize.go
+++ b/cli/commands/initialize.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -167,6 +168,8 @@ func initialize() *cobra.Command {
 				cases.Title(language.English).String(idl.Step_initialize.String()),
 				initializeSubsteps, logdir, configPath,
 				sourcePort, sourceGPHome, targetGPHome, mode, diskFreeRatio, useHbaHostnames, dynamicLibraryPath, ports, hubPort, agentPort)
+
+			log.Print(confirmationText)
 
 			st, err := commanders.NewStep(idl.Step_initialize,
 				&step.BufferedStreams{},


### PR DESCRIPTION
For debugging and troubleshooting its very useful to know what values the user is running gpupgrade with. For simplicity just print the entire initialize confirmation prompt which contains those values. Ideally, we would just print the values rather than the whole prompt.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:printUserConfigValues