### PR TITLE
refactor data migration archive directory name

### DIFF
--- a/cli/commanders/data_migration_generate.go
+++ b/cli/commanders/data_migration_generate.go
@@ -199,7 +199,7 @@ Select: `)
 
 		switch input {
 		case "a":
-			archiveDir := filepath.Join(outputDir, "archive", currentDirModTime.Format("2006-01-02T15:04"))
+			archiveDir := filepath.Join(outputDir, "archive", currentDirModTime.Format("20060102T1504"))
 			exist, err := upgrade.PathExist(archiveDir)
 			if err != nil {
 				return err


### PR DESCRIPTION
For ease in typing and navigating don't use ":" colons in the directory name. Keep it simple.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:refactorDataMigrationArchiveDirName