### PR TITLE
alwaysRun certain substeps

### DIFF
--- a/hub/execute.go
+++ b/hub/execute.go
@@ -45,11 +45,11 @@ func (s *Server) Execute(req *idl.ExecuteRequest, stream idl.CliToHub_ExecuteSer
 		return nil
 	})
 
-	st.Run(idl.Substep_check_active_connections_on_source_cluster, func(streams step.OutStreams) error {
+	st.AlwaysRun(idl.Substep_check_active_connections_on_source_cluster, func(streams step.OutStreams) error {
 		return s.Source.CheckActiveConnections(streams)
 	})
 
-	st.Run(idl.Substep_shutdown_source_cluster, func(streams step.OutStreams) error {
+	st.AlwaysRun(idl.Substep_shutdown_source_cluster, func(streams step.OutStreams) error {
 		return s.Source.Stop(streams)
 	})
 
@@ -116,7 +116,7 @@ the master.`
 		return UpgradePrimaries(s.agentConns, s.BackupDirs.AgentHostsToBackupDir, req.PgUpgradeVerbose, s.Source, s.Intermediate, idl.PgOptions_upgrade, s.Mode)
 	})
 
-	st.Run(idl.Substep_start_target_cluster, func(streams step.OutStreams) error {
+	st.AlwaysRun(idl.Substep_start_target_cluster, func(streams step.OutStreams) error {
 		return s.Intermediate.Start(streams)
 	})
 

--- a/hub/finalize.go
+++ b/hub/finalize.go
@@ -46,7 +46,7 @@ func (s *Server) Finalize(req *idl.FinalizeRequest, stream idl.CliToHub_Finalize
 		return nil
 	})
 
-	st.Run(idl.Substep_check_active_connections_on_target_cluster, func(streams step.OutStreams) error {
+	st.AlwaysRun(idl.Substep_check_active_connections_on_target_cluster, func(streams step.OutStreams) error {
 		return s.Intermediate.CheckActiveConnections(streams)
 	})
 
@@ -66,7 +66,7 @@ func (s *Server) Finalize(req *idl.FinalizeRequest, stream idl.CliToHub_Finalize
 		return s.Intermediate.WaitForClusterToBeReady()
 	})
 
-	st.Run(idl.Substep_shutdown_target_cluster, func(streams step.OutStreams) error {
+	st.AlwaysRun(idl.Substep_shutdown_target_cluster, func(streams step.OutStreams) error {
 		return s.Intermediate.Stop(streams)
 	})
 
@@ -94,11 +94,11 @@ func (s *Server) Finalize(req *idl.FinalizeRequest, stream idl.CliToHub_Finalize
 		)
 	})
 
-	st.Run(idl.Substep_start_target_cluster, func(streams step.OutStreams) error {
+	st.AlwaysRun(idl.Substep_start_target_cluster, func(streams step.OutStreams) error {
 		return s.Target.Start(streams)
 	})
 
-	st.Run(idl.Substep_wait_for_cluster_to_be_ready_after_updating_catalog, func(streams step.OutStreams) error {
+	st.AlwaysRun(idl.Substep_wait_for_cluster_to_be_ready_after_updating_catalog, func(streams step.OutStreams) error {
 		return s.Target.WaitForClusterToBeReady()
 	})
 

--- a/hub/initialize.go
+++ b/hub/initialize.go
@@ -35,7 +35,7 @@ func (s *Server) Initialize(req *idl.InitializeRequest, stream idl.CliToHub_Init
 		return upgrade.EnsureGpupgradeVersionsMatch(AgentHosts(s.Source))
 	})
 
-	st.Run(idl.Substep_start_agents, func(_ step.OutStreams) error {
+	st.AlwaysRun(idl.Substep_start_agents, func(_ step.OutStreams) error {
 		_, err := RestartAgents(context.Background(), nil, AgentHosts(s.Source), s.AgentPort, utils.GetStateDir())
 		if err != nil {
 			return err
@@ -49,7 +49,7 @@ func (s *Server) Initialize(req *idl.InitializeRequest, stream idl.CliToHub_Init
 		return nil
 	})
 
-	st.Run(idl.Substep_check_environment, func(streams step.OutStreams) error {
+	st.AlwaysRun(idl.Substep_check_environment, func(streams step.OutStreams) error {
 		return CheckEnvironment(append(AgentHosts(s.Source), s.Source.CoordinatorHostname()), s.Source.GPHome, s.Intermediate.GPHome)
 	})
 
@@ -135,7 +135,7 @@ func (s *Server) InitializeCreateCluster(req *idl.InitializeCreateClusterRequest
 		return AppendDynamicLibraryPath(s.Intermediate, req.GetDynamicLibraryPath())
 	})
 
-	st.Run(idl.Substep_shutdown_target_cluster, func(stream step.OutStreams) error {
+	st.AlwaysRun(idl.Substep_shutdown_target_cluster, func(stream step.OutStreams) error {
 		return s.Intermediate.Stop(stream)
 	})
 


### PR DESCRIPTION
When recently debugging a live customer issue when upgrading the coordinator failed resulted in needing to always run certain substeps rather than skipping them. The source cluster was started for inspection and then gpupgrade execute was re-run. However, stopping the source cluster substep was skipped since it was previously run causing pg_upgrade to fail since it expects the cluster to be stopped. Thus, always run some substeps which are needed if a failure occurs downstream.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:alwaysRun