### PR TITLE
initialize: always run data migration substeps

### DIFF
--- a/cli/commands/finalize.go
+++ b/cli/commands/finalize.go
@@ -68,7 +68,11 @@ func finalize() *cobra.Command {
 				return stopHubAndAgents()
 			})
 
-			st.RunConditionally(idl.Substep_execute_finalize_data_migration_scripts, !nonInteractive, func(streams step.OutStreams) error {
+			st.AlwaysRun(idl.Substep_execute_finalize_data_migration_scripts, func(streams step.OutStreams) error {
+				if nonInteractive {
+					return nil
+				}
+
 				fmt.Println()
 				fmt.Println()
 

--- a/cli/commands/initialize.go
+++ b/cli/commands/initialize.go
@@ -218,7 +218,11 @@ func initialize() *cobra.Command {
 				return nil
 			}
 
-			st.RunConditionally(idl.Substep_generate_data_migration_scripts, !nonInteractive, func(streams step.OutStreams) error {
+			st.AlwaysRun(idl.Substep_generate_data_migration_scripts, func(streams step.OutStreams) error {
+				if nonInteractive {
+					return nil
+				}
+
 				fmt.Println()
 				fmt.Println()
 
@@ -226,7 +230,11 @@ func initialize() *cobra.Command {
 					filepath.Clean(dataMigrationSeedDir), generatedScriptsOutputDir, utils.System.DirFS(generatedScriptsOutputDir))
 			})
 
-			st.RunConditionally(idl.Substep_execute_stats_data_migration_scripts, !nonInteractive, func(streams step.OutStreams) error {
+			st.AlwaysRun(idl.Substep_execute_stats_data_migration_scripts, func(streams step.OutStreams) error {
+				if nonInteractive {
+					return nil
+				}
+
 				fmt.Println()
 				fmt.Println()
 
@@ -235,7 +243,11 @@ func initialize() *cobra.Command {
 					logdir, utils.System.DirFS(currentDir), currentDir, idl.Step_stats)
 			})
 
-			st.RunConditionally(idl.Substep_execute_initialize_data_migration_scripts, !nonInteractive, func(streams step.OutStreams) error {
+			st.AlwaysRun(idl.Substep_execute_initialize_data_migration_scripts, func(streams step.OutStreams) error {
+				if nonInteractive {
+					return nil
+				}
+
 				fmt.Println()
 				fmt.Println()
 

--- a/cli/commands/revert.go
+++ b/cli/commands/revert.go
@@ -68,7 +68,11 @@ func revert() *cobra.Command {
 				return stopHubAndAgents()
 			})
 
-			st.RunConditionally(idl.Substep_execute_revert_data_migration_scripts, !nonInteractive, func(streams step.OutStreams) error {
+			st.AlwaysRun(idl.Substep_execute_revert_data_migration_scripts, func(streams step.OutStreams) error {
+				if nonInteractive {
+					return nil
+				}
+
 				fmt.Println()
 				fmt.Println()
 


### PR DESCRIPTION
If user runs through initialize and chooses to skip applying the data migration scripts to uncover all pg_upgrade --check errors, and then decides to re-run initialize and apply the scripts they will be skipped unless we always run them.

The only downside to using AlwaysRun with the conditional nonInteractive inside vs. outside the substep is that when non-interactive the substep shows up on the user interface as running even though it is skipped. Putting the conditional outside the substep is super clunky. What we really want is AlwaysRunConditionally, but that doesn't really make sense semantically.  For now this is okay since the non-interactive is only used for testing purposes.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:alwaysRunDataMigrationSubsteps