### PR TITLE
Add functional testing pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 gpupgrade-*.tar.gz
 CHECKSUM
 /ci/main/generated/
+/ci/functional/generated/

--- a/README.md
+++ b/README.md
@@ -250,6 +250,13 @@ functional tests. These cannot be run locally.
 make pipeline
 ```
 
+#### Functional tests
+Creates a Concourse pipeline for testing metadata and _any_ other SQL dump file.
+See [ci/functional/README.md](https://github.com/greenplum-db/gpupgrade/blob/main/ci/functional/README.md) 
+for specifics. These cannot be run locally.
+```
+make functional-pipeline
+```
 
 ## Concourse Pipeline
 

--- a/ci/functional/README.md
+++ b/ci/functional/README.md
@@ -1,0 +1,79 @@
+# Functional Testing Pipeline
+
+<!-- TOC -->
+- [How to Use](#how-to-use)
+  - [Create a gpupgrade branch](#create-a-gpupgrade-branch)
+  - [Generating a Dump](#generating-a-dump)
+  - [Using a Dump](#using-a-dump)
+  - [CCP Cluster Settings](#ccp-cluster-settings)
+  - [Flying the Pipeline](#flying-the-pipeline)
+  - [Fixing Failures](#fixing-failures)
+  - [Tearing Down the Cluster](#tearing-down-the-cluster)
+- [Purpose](#purpose)
+- [Design and Implementation](#design-and-implementation)
+<!-- /TOC -->
+
+---
+
+# How to Use
+
+#### Create a gpupgrade branch
+- Create a gpupgrade branch without any private information.
+
+#### Generating a Dump
+- On a production cluster use `gpbackup --metadata-only --dbname <db>` for all databases to generate a schema only metadata dump.
+- XZ the dump with `xz --threads $(nproc) customer_5X_metadata_05_2023.sql` to create a `customer_5X_metadata_05_2023.sql.xz` file.
+- Place the xz'd dump in the `user-schemas` bucket under the `data-gpdb-server` GCP project.
+
+#### Using a Dump
+- Place _any_ xz'd SQL file in `gpupgrade-intermediates/dump/5X` bucket under the `data-gpdb-cm` GCP project.
+- If multiple `.sql.xz` files are present in the bucket update the `schema_dump` resource to either use a more precise 
+  regex or switch to using a `versioned_file` resource.
+
+#### CCP Cluster Settings
+The defaults should be fine. One can change the `instance_type`, `disk_type`, `disk_size`, and `ccp_reap_minutes` in the 
+generate-cluster job.
+
+#### Flying the Pipeline
+Run `make functional-pipeline` to fly the pipeline
+
+#### Fixing Failures
+- Fix the change in the pipeline yaml and re-fly the pipeline.
+- Log into the box and fix the issue and re-trigger the job.
+
+#### Tearing Down the Cluster
+- The end of the pipeline will run the `teardown-cluster` job to destroy the cluster.
+- If the pipeline does not finish run `manually-destroy-cluster` to clean up the cluster.
+- Note: If either of these jobs fail to run, CCP does eventually clean up the cluster based on `ccp_reap_minutes` and the 
+  `instance creation_timestamp`. See comment in the `generate-cluster` job.
+
+# Purpose
+
+The functional pipeline easily tests user-schemas and any other SQL dump file. It spins up a performant CCP cluster, 
+loads the SQL dump, and performs the upgrade.
+
+The pipeline is designed to easily fix and re-run failed jobs without needing to reload the SQL dump saving many hours.
+For example, if initialize fails on a pg_upgrade check, one can fix the issue and re-run the job without needing to 
+reload the data.
+
+# Design and Implementation
+
+There are some design considerations since each step in the upgrade process is its own job.
+
+We tar up and save the `cluster_env_files` that are produced from the generated CCP cluster. This `saved_cluster_env_files` 
+resource is passed to each job since it has the information needed to connect to the cluster.
+
+We do not place a passed constraint on `gpupgrade_src` or `saved_cluster_env_files` to easily push new changes to these 
+resources. Without a passed constraint the job can be re-triggered and not fail with `fatal: reference is not a tree: error.`
+This occurs when the commit history has been overwritten by a force-push and the job cannot find the correct SHA.
+
+Since we don't place a passed constraint on `gpupgrade_src` or `saved_cluster_env_files` we use a `dummy_resource` to 
+automatically trigger subsequent jobs during the upgrade workflow. 
+
+The `saved_cluster_env_files` and `dummy_resource` include the branch name to avoid collisions when multiple pipelines are 
+run.
+
+To clean up the generated cluster we have a job at the end of the pipeline to teardown the cluster from the passed
+terraform resource. Additionally, we have a job to manually destroy the cluster if the pipeline does not complete and
+the cluster needs to be removed. If either of these jobs fail to run, CCP does eventually clean up the cluster based on
+`ccp_reap_minutes` and the instance `creation_timestamp`. See comment in the `generate-cluster` job.

--- a/ci/functional/generate.go
+++ b/ci/functional/generate.go
@@ -1,0 +1,7 @@
+// Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package functional
+
+// Generate the pipeline from template.yml using parse_template
+//go:generate go run ../../ci/parser generated/template.yml generated/pipeline.yml

--- a/ci/functional/pipeline/1_resources_anchors_groups.yml
+++ b/ci/functional/pipeline/1_resources_anchors_groups.yml
@@ -1,0 +1,181 @@
+---
+# Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+resource_types:
+  - name: gcs
+    type: registry-image
+    source:
+      repository: frodenas/gcs-resource
+
+  - name: slack-notification
+    type: registry-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: latest
+
+  - name: terraform
+    type: registry-image
+    source:
+      repository: ljfranklin/terraform-resource
+      tag: 0.11.14
+
+resources:
+  - name: gpupgrade_src
+    type: git
+    source:
+      uri: ((gpupgrade-git-remote))
+      branch: ((gpupgrade-git-branch))
+      fetch_tags: true
+
+  - name: schema_dump
+    type: gcs
+    source:
+      json_key: ((upgrade/cm-gcs-service-account-key))
+      bucket: gpupgrade-intermediates
+      regexp: dump/5X/(.*).sql.xz
+    # versioned_file: dump/5X/dump.sql.xz # Use versioned_file when specifying the full name otherwise Concourse won't pick it up.
+
+{{range .GPDBVersions}}
+  {{- if not (eq .OSVersion "centos6") }}
+  - name: gpdb{{.GPDBVersion}}_{{.OSVersion}}_rpm
+    type: gcs
+    source:
+      bucket: pivotal-gpdb-concourse-resources-prod
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: server/published/gpdb{{ majorVersion .GPDBVersion }}/greenplum-db-{{.TestRCIdentifier}}({{escapeVersion .GPDBVersion}}.*)-rhel{{.OSVersionNumber}}-x86_64.debug.rpm
+  {{- end }}
+{{end}}
+
+  - name: saved_cluster_env_files
+    type: gcs
+    source:
+      json_key: ((upgrade/cm-gcs-service-account-key))
+      bucket: gpupgrade-intermediates
+      regexp: functional-testing/cluster_env_files(.*).tar.gz
+
+  # Since we don't place a passed constraint on `gpupgrade_src` or `saved_cluster_env_files`
+  # use a `dummy_resource` to automatically trigger subsequent jobs during the
+  # upgrade workflow.
+  - name: dummy_resource
+    type: gcs
+    source:
+      json_key: ((upgrade/cm-gcs-service-account-key))
+      bucket: gpupgrade-intermediates
+      regexp: functional-testing/dummy_resource(.*).txt
+
+  - name: gpupgrade_rpm
+    type: gcs
+    source:
+      bucket: gpupgrade-artifacts-prod
+      json_key: ((upgrade/cm-gcs-service-account-key))
+      regexp: release-candidates/enterprise/gpupgrade-(.*).rpm
+
+  - name: slack-alert
+    type: slack-notification
+    source:
+      url: ((upgrade/{{.JobType}}/cm-slack-webhook-url))
+
+  - name: ccp_src
+    type: git
+    source:
+      branch: main
+      private_key: ((gp-concourse-cluster-provisioner-git-key))
+      uri: git@github.com:pivotal/gp-concourse-cluster-provisioner.git
+
+  - name: terraform
+    type: terraform
+    source:
+      env:
+        AWS_ACCESS_KEY_ID: ((tf-machine-access-key-id))
+        AWS_SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
+        GOOGLE_CREDENTIALS: ((upgrade/{{.JobType}}/google-service-account-key))
+      vars:
+        project_id: ((upgrade/{{.JobType}}/google-project-id))
+      storage:
+        access_key_id: ((tf-machine-access-key-id))
+        secret_access_key: ((tf-machine-secret-access-key))
+        region_name: us-west-2
+        # This is not parameterized, on purpose. All tfstates will go to this spot,
+        # and different teams will place there clusters' tfstate files under different paths
+        bucket: gpdb5-pipeline-dynamic-terraform
+        bucket_path: clusters-google/
+
+  - name: terraform.d
+    source:
+      access_key_id: ((aws-bucket-access-key-id))
+      secret_access_key: ((aws-bucket-secret-access-key))
+      region_name: us-west-2
+      bucket: ccp-terraform-provider-plugins
+      versioned_file: plugin-cache.tgz
+    type: s3
+
+anchors:
+  - &ccp_default_params
+    action: create
+    delete_on_failure: true
+    generate_random_name: true
+    plugin_dir: ../../terraform.d/plugin-cache/linux_amd64
+    terraform_source: ccp_src/google/
+
+  - &ccp_gen_cluster_default_params
+    AWS_ACCESS_KEY_ID: ((tf-machine-access-key-id))
+    AWS_SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
+    AWS_DEFAULT_REGION: us-west-2
+    BUCKET_PATH: clusters-google/
+    BUCKET_NAME: gpdb5-pipeline-dynamic-terraform
+    CLOUD_PROVIDER: google
+
+  - &ccp_destroy
+    put: terraform
+    params:
+      action: destroy
+      plugin_dir: ../../terraform.d/plugin-cache/linux_amd64
+      env_name_file: terraform/name
+      terraform_source: ccp_src/google/
+      vars:
+        aws_instance-node-instance_type: t2.micro #t2.micro is ignored in destroy, but aws_instance-node-instance_type is required.
+        aws_ebs_volume_type: standard
+    get_params:
+      action: destroy
+
+  - &set_failed
+    task: on_failure_set_failed
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: gcr.io/data-gpdb-public-images/ccp
+      inputs:
+        - name: ccp_src
+        - name: terraform
+      run:
+        path: ccp_src/google/ccp_failed_test.sh
+      params:
+        GOOGLE_CREDENTIALS: ((upgrade/{{.JobType}}/google-service-account-key))
+        GOOGLE_PROJECT_ID: ((upgrade/{{.JobType}}/google-project-id))
+        GOOGLE_ZONE: us-central1-a
+        AWS_ACCESS_KEY_ID: ((tf-machine-access-key-id))
+        AWS_SECRET_ACCESS_KEY: ((tf-machine-secret-access-key))
+        AWS_DEFAULT_REGION: us-west-2
+        BUCKET_PATH: clusters-google/
+        BUCKET_NAME: gpdb5-pipeline-dynamic-terraform
+
+  - &slack_alert
+    put: slack-alert
+    params:
+      text: |
+        Hey team, <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|gpupgrade/$BUILD_JOB_NAME> failed.
+
+groups:
+  - name: all
+    jobs:
+      - generate-cluster
+      - load-schema
+      - initialize
+      - data-migration-scripts
+      - upgrade
+      - validate
+      - teardown-cluster
+      - manually-destroy-cluster

--- a/ci/functional/pipeline/2_generate_cluster.yml
+++ b/ci/functional/pipeline/2_generate_cluster.yml
@@ -1,0 +1,135 @@
+jobs:
+{{range .UpgradeJobs}}
+  {{- if .FunctionalTest}}
+  - name: generate-cluster
+    plan:
+      - in_parallel:
+          - get: gpupgrade_src
+          - get: enterprise_rpm
+            resource: gpupgrade_rpm
+          - get: rpm_gpdb_source
+            resource: gpdb{{.Source}}_{{.OSVersion}}_rpm
+          {{- if ne .Source .Target }}
+          - get: rpm_gpdb_target
+            resource: gpdb{{.Target}}_{{.OSVersion}}_rpm
+          {{- end }}
+          - get: ccp_src
+          - get: terraform.d
+            params:
+              unpack: true
+      - put: terraform
+        params:
+          <<: *ccp_default_params
+          vars:
+            {{- if .PrimariesOnly}}
+            mirrors: false
+            {{- else if not .NoStandby}}
+            standby_coordinator: true
+            {{- end}}
+            # Increase the instance type, disk_size from the defaults.
+            instance_type: n1-standard-16
+            disk_type: pd-ssd
+            disk_size: 200
+            number_of_nodes: 4
+            PLATFORM: {{.OSVersion}}
+            # Increase reap time to 7 days to prevent the cluster from being
+            # removed during very long-running tests. See code snippet where
+            # creation_timestamp will be used plus reap_mins to destroy cluster.
+            # https://github.com/pivotal/gp-concourse-cluster-provisioner/blob/6fd2935bcfbe529854b83ecccad3cdba3c56ae66/utilities/ClusterReaper/ccp-reaper.rb#L150-L152
+            ccp_reap_minutes: 10080
+      - task: gen_source_cluster
+        file: ccp_src/ci/tasks/gen_cluster.yml
+        params:
+          <<: *ccp_gen_cluster_default_params
+          PLATFORM: {{.OSVersion}}
+          GPDB_RPM: true
+        input_mapping:
+          gpdb_rpm: rpm_gpdb_source
+      - task: gpinitsystem_source_cluster
+        file: ccp_src/ci/tasks/gpinitsystem.yml
+      - task: prepare_installation
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: registry.access.redhat.com/ubi8/ubi
+              tag: latest
+          inputs:
+            - name: gpupgrade_src
+            - name: cluster_env_files
+            - name: enterprise_rpm
+            {{- if ne .Source .Target }}
+            - name: rpm_gpdb_target
+            {{- end }}
+          run:
+            path: gpupgrade_src/ci/main/scripts/prepare-installation.bash
+            args:
+              - greenplum-db-{{majorVersion .Source}}
+              - greenplum-db-{{majorVersion .Target}}
+      - task: save_cluster_env_files
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
+              tag: latest
+          inputs:
+            - name: gpupgrade_src
+            - name: ccp_src
+            - name: cluster_env_files
+          outputs:
+            - name: tared_cluster_env_files
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -eux -o pipefail
+
+                # Make cluster_env_files.tar.gz filename unique with git branch
+                # name to avoid collisions when multiple pipelines are run.
+                # Since branch may be detached from HEAD use this method to
+                # easily find the actual branch name.
+                BRANCH=$(cat gpupgrade_src/.git/config |  grep branch | sed -e 's@.*"\(.*\)".*@\1@')
+                tar -czvf cluster_env_files_${BRANCH}.tar.gz cluster_env_files/
+                mv cluster_env_files*.tar.gz tared_cluster_env_files/
+      - put: saved_cluster_env_files
+        params:
+          file: tared_cluster_env_files/*.tar.gz
+      - task: create_dummy_resource
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
+              tag: latest
+          inputs:
+            - name: gpupgrade_src
+          outputs:
+            - name: dummy_resource_file
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -eux -o pipefail
+
+                # Make the dummy resource filename unique with git branch
+                # name to avoid collisions when multiple pipelines are run.
+                # Since branch may be detached from HEAD use this method to
+                # easily find the actual branch name.
+                BRANCH=$(cat gpupgrade_src/.git/config |  grep branch | sed -e 's@.*"\(.*\)".*@\1@')
+                touch dummy_resource_file/dummy_resource_${BRANCH}.txt
+      - put: dummy_resource
+        params:
+          file: dummy_resource_file/dummy_resource*.txt
+    # Purposely leave the CCP cluster up and running...
+    on_failure:
+      do:
+        - <<: *ccp_destroy
+        - <<: *slack_alert
+  {{- end }}
+{{end -}}

--- a/ci/functional/pipeline/3_load_schema_data_migration_scripts.yml
+++ b/ci/functional/pipeline/3_load_schema_data_migration_scripts.yml
@@ -1,0 +1,108 @@
+{{range .UpgradeJobs}}
+  {{- if .FunctionalTest}}
+  - name: load-schema
+    plan:
+      - in_parallel:
+          - get: dummy_resource
+            passed: [ generate-cluster ]
+            trigger: true
+          - get: gpupgrade_src
+          - get: saved_cluster_env_files
+          - get: schema_dump
+      - task: load_schema
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
+              tag: latest
+          inputs:
+            - name: gpupgrade_src
+            - name: saved_cluster_env_files
+            - name: schema_dump
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -eux -o pipefail
+
+                source gpupgrade_src/ci/main/scripts/environment.bash
+
+                echo "Dropping unsupported objects and Adding necessary objects..."
+                ssh -n cdw "
+                    set -eux -o pipefail
+
+                    source /usr/local/greenplum-db-source/greenplum_path.sh
+
+                    psql -v ON_ERROR_STOP=1 -d postgres <<SQL_EOF
+                        DROP VIEW IF EXISTS problematic_view_or_table;
+                        -- CREATE ROLE necessary_user_role;
+                SQL_EOF
+                "
+
+                scp schema_dump/*.sql.xz gpadmin@cdw:/tmp/dump.sql.xz
+
+                echo "Loading the SQL dump into the source cluster..."
+                time ssh -n gpadmin@cdw "
+                    set -eux -o pipefail
+
+                    source /usr/local/greenplum-db-source/greenplum_path.sh
+                    export PGOPTIONS='--client-min-messages=warning'
+                    # This is failing due to a number of errors. Disabling ON_ERROR_STOP until this is fixed.
+                    unxz --threads $(nproc) /tmp/dump.sql.xz
+                    PGOPTIONS='--client-min-messages=warning' psql -v ON_ERROR_STOP=0 --quiet --dbname postgres -f /tmp/dump.sql
+                "
+    on_failure:
+      do:
+        - <<: *slack_alert
+  {{- end }}
+{{end -}}
+
+{{range .UpgradeJobs}}
+  {{- if .FunctionalTest}}
+  - name: data-migration-scripts
+    plan:
+      - in_parallel:
+          - get: dummy_resource
+            passed: [ load-schema ]
+            trigger: true
+          - get: gpupgrade_src
+          - get: saved_cluster_env_files
+      - task: generate_and_apply_data_migration_scripts
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
+              tag: latest
+          inputs:
+            - name: gpupgrade_src
+            - name: saved_cluster_env_files
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -eux -o pipefail
+
+                source gpupgrade_src/ci/main/scripts/environment.bash
+
+                echo "Running the data migration scripts on the source cluster..."
+                time ssh -n cdw "
+                    set -eux -o pipefail
+
+                    gpupgrade generate --non-interactive --gphome "$GPHOME_SOURCE" --port "$PGPORT" --output-dir /home/gpadmin/gpupgrade
+                    gpupgrade apply    --non-interactive --gphome "$GPHOME_SOURCE" --port "$PGPORT" --input-dir /home/gpadmin/gpupgrade --phase stats
+                    gpupgrade apply    --non-interactive --gphome "$GPHOME_SOURCE" --port "$PGPORT" --input-dir /home/gpadmin/gpupgrade --phase initialize
+
+                    echo 'Outputting stats...'
+                    cat /home/gpadmin/gpAdminLogs/gpupgrade/apply_stats.log
+                "
+    on_failure:
+      do:
+        - <<: *slack_alert
+  {{- end }}
+{{end -}}

--- a/ci/functional/pipeline/4_initialize_upgrade_cluster_validate.yml
+++ b/ci/functional/pipeline/4_initialize_upgrade_cluster_validate.yml
@@ -1,0 +1,189 @@
+{{range .UpgradeJobs}}
+  {{- if .FunctionalTest}}
+  - name: initialize
+    plan:
+      - in_parallel:
+          - get: dummy_resource
+            passed: [ data-migration-scripts ]
+            trigger: true
+          - get: gpupgrade_src
+          - get: saved_cluster_env_files
+      - task: run_initialize
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
+              tag: latest
+          inputs:
+            - name: gpupgrade_src
+            - name: saved_cluster_env_files
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -eux -o pipefail
+
+                source gpupgrade_src/ci/main/scripts/environment.bash
+                source gpupgrade_src/ci/main/scripts/ci-helpers.bash
+
+                MODE=${MODE:-"copy"}
+
+                echo "Dropping unsupported objects and Adding necessary objects..."
+                ssh -n cdw "
+                    set -eux -o pipefail
+
+                    source /usr/local/greenplum-db-source/greenplum_path.sh
+
+                    psql -v ON_ERROR_STOP=1 -d postgres <<SQL_EOF
+                        DROP VIEW IF EXISTS problematic_view_or_table;
+                        -- CREATE ROLE necessary_user_role;
+                SQL_EOF
+                "
+
+                echo "Running gpupgrade initialize..."
+                time ssh -n cdw "
+                    set -eux -o pipefail
+
+                    gpupgrade initialize \
+                              --non-interactive \
+                              --verbose \
+                              --target-gphome $GPHOME_TARGET \
+                              --source-gphome $GPHOME_SOURCE \
+                              --source-master-port $PGPORT \
+                              --mode $MODE \
+                              --temp-port-range 6020-6040 \
+                              --disk-free-ratio 0
+                "
+    on_failure:
+      do:
+        - <<: *slack_alert
+  {{- end }}
+{{end -}}
+
+{{range .UpgradeJobs}}
+  {{- if .FunctionalTest}}
+  - name: upgrade
+    plan:
+      - in_parallel:
+          - get: dummy_resource
+            passed: [ initialize ]
+            trigger: true
+          - get: gpupgrade_src
+          - get: saved_cluster_env_files
+      - task: upgrade_cluster
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
+              tag: latest
+          inputs:
+            - name: gpupgrade_src
+            - name: saved_cluster_env_files
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -eux -o pipefail
+
+                source gpupgrade_src/ci/main/scripts/environment.bash
+                source gpupgrade_src/ci/main/scripts/ci-helpers.bash
+
+                MODE=${MODE:-"copy"}
+
+                echo "Performing gpupgrade execute and finalize..."
+                time ssh -n cdw "
+                    set -eux -o pipefail
+
+                    gpupgrade execute  --non-interactive --verbose
+                    gpupgrade finalize --non-interactive --verbose
+
+                    gpupgrade apply --non-interactive --gphome "$GPHOME_SOURCE" --port "$PGPORT" --input-dir /home/gpadmin/gpupgrade --phase finalize
+                "
+                echo "Upgrade successful..."
+        params:
+          FILTER_DIFF: 0
+          MODE: {{ .Mode }}
+    on_failure:
+      do:
+        - <<: *slack_alert
+  {{- end }}
+{{end -}}
+
+{{range .UpgradeJobs}}
+  {{- if .FunctionalTest}}
+  - name: validate
+    plan:
+      - in_parallel:
+          - get: dummy_resource
+            passed: [ upgrade ]
+            trigger: true
+          - get: gpupgrade_src
+          - get: saved_cluster_env_files
+      - task: run_gpcheckcat
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
+              tag: latest
+          inputs:
+            - name: gpupgrade_src
+            - name: saved_cluster_env_files
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -eux -o pipefail
+
+                source gpupgrade_src/ci/main/scripts/environment.bash
+
+                echo "Running gpcheckcat..."
+                time ssh -n cdw "
+                    set -eux -o pipefail
+
+                    source /usr/local/greenplum-db-target/greenplum_path.sh
+                    export MASTER_DATA_DIRECTORY=$MASTER_DATA_DIRECTORY
+                    export PGPORT=$PGPORT
+
+                    gpcheckcat -A
+                "
+      {{- if not .NoStandby -}}
+      {{- if not .PrimariesOnly }}
+      - task: validate_mirrors_and_standby
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
+              tag: latest
+          inputs:
+            - name: gpupgrade_src
+            - name: saved_cluster_env_files
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -eux -o pipefail
+
+                source gpupgrade_src/ci/main/scripts/environment.bash
+
+                echo 'Doing failover tests of mirrors and standby...'
+                source gpupgrade_src/test/acceptance/helpers/finalize_checks.bash
+                validate_mirrors_and_standby /usr/local/greenplum-db-target cdw 5432
+      {{- end -}}
+      {{- end }}
+    on_failure:
+      do:
+        - <<: *slack_alert
+  {{- end }}
+{{end -}}

--- a/ci/functional/pipeline/5_teardown_cluster.yml
+++ b/ci/functional/pipeline/5_teardown_cluster.yml
@@ -1,0 +1,43 @@
+{{range .UpgradeJobs}}
+  {{- if .FunctionalTest}}
+  - name: teardown-cluster
+    plan:
+      - in_parallel:
+          - get: dummy_resource
+            passed: [ validate ]
+            trigger: true
+          - get: saved_cluster_env_files
+          - get: ccp_src
+          - get: terraform
+            passed: [ generate-cluster ]
+          - get: terraform.d
+            params:
+              unpack: true
+    ensure:
+      do:
+        - <<: *ccp_destroy
+    on_failure:
+      do:
+        - <<: *slack_alert
+  {{- end }}
+{{end -}}
+
+{{range .UpgradeJobs}}
+  {{- if .FunctionalTest}}
+  - name: manually-destroy-cluster
+    plan:
+      - in_parallel:
+          - get: ccp_src
+          - get: terraform
+            passed: [ generate-cluster ]
+          - get: terraform.d
+            params:
+              unpack: true
+    ensure:
+      do:
+        - <<: *ccp_destroy
+    on_failure:
+      do:
+        - <<: *slack_alert
+  {{- end }}
+{{end -}}

--- a/ci/main/scripts/environment.bash
+++ b/ci/main/scripts/environment.bash
@@ -6,3 +6,9 @@ export GPHOME_SOURCE=/usr/local/greenplum-db-source
 export GPHOME_TARGET=/usr/local/greenplum-db-target
 export MASTER_DATA_DIRECTORY=/data/gpdata/coordinator/gpseg-1
 export PGPORT=5432
+
+echo "For functional testing pipeline enabling ssh to the ccp cluster..."
+if [ -d saved_cluster_env_files ]; then
+    tar -xzvf saved_cluster_env_files/cluster_env_files*.tar.gz
+    cp -R cluster_env_files/.ssh /root/.ssh
+fi

--- a/ci/parser/jobs.go
+++ b/ci/parser/jobs.go
@@ -39,6 +39,7 @@ type UpgradeJob struct {
 	Mode           Mode
 	RetailDemo     bool
 	TestExtensions bool
+	FunctionalTest bool
 	OSVersion      string
 }
 
@@ -58,6 +59,8 @@ func (j *UpgradeJob) Suffix() string {
 		suffix = "-retail-demo"
 	case j.TestExtensions:
 		suffix = "-extension"
+	case j.FunctionalTest:
+		suffix = "-functional-test"
 	}
 
 	return suffix

--- a/ci/parser/main.go
+++ b/ci/parser/main.go
@@ -146,6 +146,7 @@ func init() {
 		{NoStandby: true},
 		{RetailDemo: true},
 		{TestExtensions: true},
+		{FunctionalTest: true},
 	}
 
 	// SpecialJobs cases for 5->6. (These are special-cased to avoid exploding the


### PR DESCRIPTION
See ci/functional/README.md for full details.

The functional pipeline easily tests user-schemas and any other SQL dump file. It spins up a performant CCP cluster, loads the SQL dump, and performs the upgrade.

The pipeline is designed to easily fix and re-run failed jobs without needing to reload the SQL dump saving many hours.  For example, if initialize fails on a pg_upgrade check, one can fix the issue and re-run the job without needing to reload the data.

Pipeline:
1) Main pipeline
`PIPELINE_NAME=functionalPipeline2-main make pipeline`
https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/functionalPipeline2-main

2) Functional Pipeline
`PIPELINE_NAME=functionalPipeline2-functional make functional-pipeline`
https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/functionalPipeline2-functional