### PR TITLE
Refactor CI Jobs

### DIFF
--- a/ci/functional/README.md
+++ b/ci/functional/README.md
@@ -8,6 +8,7 @@
   - [CCP Cluster Settings](#ccp-cluster-settings)
   - [Flying the Pipeline](#flying-the-pipeline)
   - [Fixing Failures](#fixing-failures)
+  - [Saving Logs](#saving-logs)
   - [Tearing Down the Cluster](#tearing-down-the-cluster)
 - [Purpose](#purpose)
 - [Design and Implementation](#design-and-implementation)
@@ -40,6 +41,16 @@ Run `make functional-pipeline` to fly the pipeline
 #### Fixing Failures
 - Fix the change in the pipeline yaml and re-fly the pipeline.
 - Log into the box and fix the issue and re-trigger the job.
+
+#### Saving Logs
+- SSH to the cluster
+- `gcloud auth login`
+  - Click the browser link and follow the directions.
+  - Copy the verification code (bottom box) into the gcloud CLI prompt.
+- Upload the files from the CCP cluster to GCS
+  - `gsutil cp logs.tar.gz gs://gpupgrade-intermediates/functional-testing/logs/`
+- Download the files from GCS to your local machine
+  - `gsutil cp gs://gpupgrade-intermediates/functional-testing/logs/logs.tar.gz .` 
 
 #### Tearing Down the Cluster
 - The end of the pipeline will run the `teardown-cluster` job to destroy the cluster.

--- a/ci/functional/pipeline/2_generate_cluster.yml
+++ b/ci/functional/pipeline/2_generate_cluster.yml
@@ -1,6 +1,5 @@
 jobs:
-{{range .UpgradeJobs}}
-  {{- if .FunctionalTest}}
+{{range .FunctionalJobs}}
   - name: generate-cluster
     plan:
       - in_parallel:
@@ -131,5 +130,4 @@ jobs:
       do:
         - <<: *ccp_destroy
         - <<: *slack_alert
-  {{- end }}
 {{end -}}

--- a/ci/functional/pipeline/3_load_schema_data_migration_scripts.yml
+++ b/ci/functional/pipeline/3_load_schema_data_migration_scripts.yml
@@ -1,5 +1,4 @@
-{{range .UpgradeJobs}}
-  {{- if .FunctionalTest}}
+{{range .FunctionalJobs}}
   - name: load-schema
     plan:
       - in_parallel:
@@ -57,11 +56,9 @@
     on_failure:
       do:
         - <<: *slack_alert
-  {{- end }}
 {{end -}}
 
-{{range .UpgradeJobs}}
-  {{- if .FunctionalTest}}
+{{range .FunctionalJobs}}
   - name: data-migration-scripts
     plan:
       - in_parallel:
@@ -104,5 +101,4 @@
     on_failure:
       do:
         - <<: *slack_alert
-  {{- end }}
 {{end -}}

--- a/ci/functional/pipeline/4_initialize_upgrade_cluster_validate.yml
+++ b/ci/functional/pipeline/4_initialize_upgrade_cluster_validate.yml
@@ -1,5 +1,4 @@
-{{range .UpgradeJobs}}
-  {{- if .FunctionalTest}}
+{{range .FunctionalJobs}}
   - name: initialize
     plan:
       - in_parallel:
@@ -60,11 +59,9 @@
     on_failure:
       do:
         - <<: *slack_alert
-  {{- end }}
 {{end -}}
 
-{{range .UpgradeJobs}}
-  {{- if .FunctionalTest}}
+{{range .FunctionalJobs}}
   - name: upgrade
     plan:
       - in_parallel:
@@ -112,11 +109,9 @@
     on_failure:
       do:
         - <<: *slack_alert
-  {{- end }}
 {{end -}}
 
-{{range .UpgradeJobs}}
-  {{- if .FunctionalTest}}
+{{range .FunctionalJobs}}
   - name: validate
     plan:
       - in_parallel:
@@ -185,5 +180,4 @@
     on_failure:
       do:
         - <<: *slack_alert
-  {{- end }}
 {{end -}}

--- a/ci/functional/pipeline/5_teardown_cluster.yml
+++ b/ci/functional/pipeline/5_teardown_cluster.yml
@@ -1,5 +1,4 @@
-{{range .UpgradeJobs}}
-  {{- if .FunctionalTest}}
+{{range .FunctionalJobs}}
   - name: teardown-cluster
     plan:
       - in_parallel:
@@ -19,11 +18,9 @@
     on_failure:
       do:
         - <<: *slack_alert
-  {{- end }}
 {{end -}}
 
-{{range .UpgradeJobs}}
-  {{- if .FunctionalTest}}
+{{range .FunctionalJobs}}
   - name: manually-destroy-cluster
     plan:
       - in_parallel:
@@ -39,5 +36,4 @@
     on_failure:
       do:
         - <<: *slack_alert
-  {{- end }}
 {{end -}}

--- a/ci/parser/jobs.go
+++ b/ci/parser/jobs.go
@@ -8,20 +8,13 @@ import (
 	"strings"
 )
 
-// gpupgrade cluster jobs
-
-type AcceptanceJob struct {
+type Job struct {
 	Source, Target string
 	OSVersion      string
+	Mode           Mode
+	PrimariesOnly  bool
+	NoStandby      bool
 }
-
-type AcceptanceJobs []AcceptanceJob
-
-func (c *AcceptanceJob) Name() string {
-	return fmt.Sprintf("%s-to-%s-%s-acceptance-tests", c.Source, c.Target, c.OSVersion)
-}
-
-// Mode
 
 type Mode string
 
@@ -30,17 +23,23 @@ const (
 	link Mode = "link"
 )
 
+type AcceptanceJob struct {
+	Job
+}
+
+type AcceptanceJobs []AcceptanceJob
+
+func (c *AcceptanceJob) Name() string {
+	return fmt.Sprintf("%s-to-%s-%s-acceptance-tests", c.Source, c.Target, c.OSVersion)
+}
+
 // upgrade jobs
 
 type UpgradeJob struct {
-	Source, Target string
-	PrimariesOnly  bool
-	NoStandby      bool
-	Mode           Mode
+	Job
 	RetailDemo     bool
 	TestExtensions bool
 	FunctionalTest bool
-	OSVersion      string
 }
 
 func (j *UpgradeJob) Name() string {
@@ -73,11 +72,8 @@ func (j *UpgradeJob) SerialGroup() string {
 
 type UpgradeJobs []UpgradeJob
 
-// pgupgrade jobs
-
 type PgUpgradeJob struct {
-	Source, Target string
-	OSVersion      string
+	Job
 }
 
 func (p *PgUpgradeJob) Name() string {
@@ -86,11 +82,8 @@ func (p *PgUpgradeJob) Name() string {
 
 type PgUpgradeJobs []PgUpgradeJob
 
-// multihost-gpupgrade jobs
-
 type MultihostAcceptanceJob struct {
-	Source, Target string
-	OSVersion      string
+	Job
 }
 
 func (j *MultihostAcceptanceJob) Name() string {

--- a/ci/parser/jobs.go
+++ b/ci/parser/jobs.go
@@ -39,7 +39,6 @@ type UpgradeJob struct {
 	Job
 	RetailDemo     bool
 	TestExtensions bool
-	FunctionalTest bool
 }
 
 func (j *UpgradeJob) Name() string {
@@ -58,8 +57,6 @@ func (j *UpgradeJob) Suffix() string {
 		suffix = "-retail-demo"
 	case j.TestExtensions:
 		suffix = "-extension"
-	case j.FunctionalTest:
-		suffix = "-functional-test"
 	}
 
 	return suffix
@@ -91,3 +88,31 @@ func (j *MultihostAcceptanceJob) Name() string {
 }
 
 type MultihostAcceptanceJobs []MultihostAcceptanceJob
+
+type FunctionalJob struct {
+	Job
+}
+
+func (j *FunctionalJob) Name() string {
+	return fmt.Sprintf("%s-to-%s-%s-functional-test-%s-mode%s", j.Source, j.Target, j.OSVersion, j.Mode, j.Suffix())
+}
+
+func (j *FunctionalJob) Suffix() string {
+	var suffix string
+
+	switch {
+	case j.PrimariesOnly:
+		suffix = "-primaries-only"
+	case j.NoStandby:
+		suffix = "-no-standby"
+	}
+
+	return suffix
+}
+
+// SerialGroup is used to prevent Concourse from becoming overloaded.
+func (j *FunctionalJob) SerialGroup() string {
+	return strings.TrimPrefix(j.Suffix(), "-")
+}
+
+type FunctionalJobs []FunctionalJob

--- a/ci/parser/main.go
+++ b/ci/parser/main.go
@@ -69,6 +69,7 @@ type Data struct {
 	MultihostAcceptanceJobs MultihostAcceptanceJobs
 	UpgradeJobs             UpgradeJobs
 	PgupgradeJobs           PgUpgradeJobs
+	FunctionalJobs          FunctionalJobs
 }
 
 var data Data
@@ -80,6 +81,7 @@ func init() {
 	var multihostAcceptanceJobs MultihostAcceptanceJobs
 	var upgradeJobs UpgradeJobs
 	var pgupgradeJobs PgUpgradeJobs
+	var functionalJobs FunctionalJobs
 
 	for _, version := range versions {
 		if !majorVersions.contains(version.sourceVersion) {
@@ -146,7 +148,6 @@ func init() {
 		UpgradeJob{Job: Job{NoStandby: true}},
 		UpgradeJob{RetailDemo: true},
 		UpgradeJob{TestExtensions: true},
-		UpgradeJob{FunctionalTest: true},
 	}
 
 	// SpecialJobs cases for 5->6. (These are special-cased to avoid exploding the
@@ -166,6 +167,27 @@ func init() {
 		}
 	}
 
+	specialFunctionalJobs := FunctionalJobs{
+		FunctionalJob{Job{Mode: link}},
+	}
+
+	// SpecialJobs cases for 5->6. (These are special-cased to avoid exploding the
+	// test matrix too much.)
+	for _, job := range specialFunctionalJobs {
+		for _, version := range versions {
+			if !version.SpecialJobs {
+				continue
+			}
+
+			job.Source = version.sourceVersion
+			job.Target = version.targetVersion
+			job.OSVersion = version.osVersion
+			job.Mode = link
+
+			functionalJobs = append(functionalJobs, job)
+		}
+	}
+
 	data = Data{
 		JobType:                 os.Getenv("JOB_TYPE"),
 		MajorVersions:           majorVersions,
@@ -174,6 +196,7 @@ func init() {
 		MultihostAcceptanceJobs: multihostAcceptanceJobs,
 		UpgradeJobs:             upgradeJobs,
 		PgupgradeJobs:           pgupgradeJobs,
+		FunctionalJobs:          functionalJobs,
 	}
 }
 

--- a/ci/parser/main.go
+++ b/ci/parser/main.go
@@ -112,41 +112,41 @@ func init() {
 		// major versions (ie: SpecialJobs), and only one for same major
 		// versions (ie: 6-to-6 or 7-to-7).
 		if version.SpecialJobs || (version.sourceVersion == version.targetVersion) {
-			acceptanceJobs = append(acceptanceJobs, AcceptanceJob{
+			acceptanceJobs = append(acceptanceJobs, AcceptanceJob{Job{
 				Source:    version.sourceVersion,
 				Target:    version.targetVersion,
 				OSVersion: version.osVersion,
-			})
+			}})
 
-			multihostAcceptanceJobs = append(multihostAcceptanceJobs, MultihostAcceptanceJob{
+			multihostAcceptanceJobs = append(multihostAcceptanceJobs, MultihostAcceptanceJob{Job{
 				Source:    version.sourceVersion,
 				Target:    version.targetVersion,
 				OSVersion: version.osVersion,
-			})
+			}})
 		}
 
-		upgradeJobs = append(upgradeJobs, UpgradeJob{
+		upgradeJobs = append(upgradeJobs, UpgradeJob{Job: Job{
 			Source:    version.sourceVersion,
 			Target:    version.targetVersion,
 			OSVersion: version.osVersion,
 			Mode:      copy,
-		})
+		}})
 
 		if version.SpecialJobs {
-			pgupgradeJobs = append(pgupgradeJobs, PgUpgradeJob{
+			pgupgradeJobs = append(pgupgradeJobs, PgUpgradeJob{Job{
 				Source:    version.sourceVersion,
 				Target:    version.targetVersion,
 				OSVersion: version.osVersion,
-			})
+			}})
 		}
 	}
 
 	specialUpgradeJobs := UpgradeJobs{
-		{PrimariesOnly: true},
-		{NoStandby: true},
-		{RetailDemo: true},
-		{TestExtensions: true},
-		{FunctionalTest: true},
+		UpgradeJob{Job: Job{PrimariesOnly: true}},
+		UpgradeJob{Job: Job{NoStandby: true}},
+		UpgradeJob{RetailDemo: true},
+		UpgradeJob{TestExtensions: true},
+		UpgradeJob{FunctionalTest: true},
 	}
 
 	// SpecialJobs cases for 5->6. (These are special-cased to avoid exploding the


### PR DESCRIPTION
This fixes the state checker which is complaining about an extra "fucntional" e2e job from recent work on functional pipeline.

1. add base type Jobs struct

Add a base type Jobs struct that other CI job types can embed and inherit. This will be useful for adding functional jobs for the functional testing pipeline to keep the type types separate and the two pipelines untangled.

2. Remove FunctionalTest from UpgradeJob in favor of using FunctionalJob

Main Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:refactorCIJobs?group=all
Functional Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:refactorCIJobs-functional

