### PR TITLE
pass terraform state to destroy jobs

### DIFF
--- a/ci/functional/pipeline/5_teardown_cluster.yml
+++ b/ci/functional/pipeline/5_teardown_cluster.yml
@@ -5,13 +5,35 @@
           - get: dummy_resource
             passed: [ validate ]
             trigger: true
+          - get: gpupgrade_src
           - get: saved_cluster_env_files
           - get: ccp_src
-          - get: terraform
-            passed: [ generate-cluster ]
           - get: terraform.d
             params:
               unpack: true
+      - task: copy_terraform_files
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
+              tag: latest
+          inputs:
+            - name: gpupgrade_src
+            - name: saved_cluster_env_files
+          outputs:
+            - name: terraform
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -eux -o pipefail
+
+                source gpupgrade_src/ci/main/scripts/environment.bash
+
+                cp -R cluster_env_files/terraform/* terraform
     ensure:
       do:
         - <<: *ccp_destroy
@@ -24,12 +46,35 @@
   - name: manually-destroy-cluster
     plan:
       - in_parallel:
+          - get: gpupgrade_src
+          - get: saved_cluster_env_files
           - get: ccp_src
-          - get: terraform
-            passed: [ generate-cluster ]
           - get: terraform.d
             params:
               unpack: true
+      - task: copy_terraform_files
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
+              tag: latest
+          inputs:
+            - name: gpupgrade_src
+            - name: saved_cluster_env_files
+          outputs:
+            - name: terraform
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -eux -o pipefail
+
+                source gpupgrade_src/ci/main/scripts/environment.bash
+
+                cp -R cluster_env_files/terraform/* terraform
     ensure:
       do:
         - <<: *ccp_destroy


### PR DESCRIPTION
Previously, we were using a passed constraint on the terraform resource such as:
```
- get: terraform
  passed: [ generate-cluster ]
```

However, for long running jobs 3+ days it appears Concourse would expire or roll off the specific terraform resource associated with the generate-cluster job. This would cause the destroy jobs to hang while "waiting for a suitable set of input versions":
`terraform - no satisfiable builds from passed jobs found for set of inputs`

Thus, pass the saved_cluster_env_files from GCP to the ccp_destroy task to avoid this issue.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixManualDestroyClusterJob