### PR TITLE
CI: run gpcheckcat after e2e tests

### DIFF
--- a/ci/main/pipeline/6_upgrade_and_functional_jobs.yml
+++ b/ci/main/pipeline/6_upgrade_and_functional_jobs.yml
@@ -222,6 +222,38 @@
         DIFF_FILE: retail_demo.diff
         {{- end }}
     {{- end }}
+    - task: run_gpcheckcat
+      config:
+        platform: linux
+        image_resource:
+          type: registry-image
+          source:
+            repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test-golang
+            tag: latest
+        inputs:
+          - name: gpupgrade_src
+          - name: ccp_src
+          - name: cluster_env_files
+        run:
+          path: bash
+          args:
+            - -c
+            - |
+              set -eux -o pipefail
+
+              source gpupgrade_src/ci/main/scripts/environment.bash
+              ./ccp_src/scripts/setup_ssh_to_cluster.sh
+
+              echo "Running gpcheckcat..."
+              time ssh -n cdw "
+                  set -eux -o pipefail
+
+                  source /usr/local/greenplum-db-target/greenplum_path.sh
+                  export MASTER_DATA_DIRECTORY=$MASTER_DATA_DIRECTORY
+                  export PGPORT=$PGPORT
+
+                  gpcheckcat -A
+              "
     {{- if not .NoStandby -}}
     {{- if not .PrimariesOnly }}
     - task: validate_mirrors_and_standby


### PR DESCRIPTION
For extra validation post-upgrade for end-to-end tests run gpcheckcat. This is in addition to validating the standby and mirrors post-upgrade by failing over and failing back.

Note, we do not run gpcheckcat or validate mirrors after the pg_upgrade acceptance tests or multi-host gpupgrade acceptance tests. This would require leaving the cluster intact after running the tests which is cumbersome during dev iteration and upon failures.

https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:runGPCheckcat