### PR TITLE
    Do not generate revert/finalize ALTERs for tables partitioned on tsquery

### DIFF
--- a/data-migration-scripts/5-to-6-seed-scripts/finalize/partitioned_tables_indexes/recreate_partition_indexes_step_2.sql
+++ b/data-migration-scripts/5-to-6-seed-scripts/finalize/partitioned_tables_indexes/recreate_partition_indexes_step_2.sql
@@ -5,12 +5,23 @@
 -- that don't correspond to unique or primary key constraints
 
 -- cte to get all the unique and primary key constraints
-WITH root_partitions (relid) AS
+WITH root_partitions_using_tsquery AS
+(
+   SELECT DISTINCT p.parrelid oid
+   FROM pg_partition p
+   JOIN pg_class pt ON p.parrelid = pt.oid
+   JOIN pg_attribute a ON a.attrelid = pt.oid
+   WHERE a.atttypid = 'pg_catalog.tsquery'::pg_catalog.regtype
+)
+,
+root_partitions (relid) AS
 (
    SELECT DISTINCT
       parrelid
    FROM
       pg_partition
+   WHERE
+      parrelid NOT IN (SELECT oid FROM root_partitions_using_tsquery)
 )
 ,
 root_constraints AS

--- a/data-migration-scripts/5-to-6-seed-scripts/finalize/tables_using_tsquery_type/gen_change_text_to_tsquery.sql
+++ b/data-migration-scripts/5-to-6-seed-scripts/finalize/tables_using_tsquery_type/gen_change_text_to_tsquery.sql
@@ -2,12 +2,20 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- generates alter statement to modify text datatype to tsquery datatype
+WITH partitionedKeys AS
+(
+   SELECT DISTINCT parrelid, unnest(paratts) att_num
+   FROM pg_catalog.pg_partition p
+)
 SELECT $$ALTER TABLE $$ || pg_catalog.quote_ident(n.nspname) || '.' || pg_catalog.quote_ident(c.relname) ||
        $$ ALTER COLUMN $$ || pg_catalog.quote_ident(a.attname) ||
        $$ TYPE TSQUERY USING $$ || pg_catalog.quote_ident(a.attname) || $$::tsquery;$$
 FROM pg_catalog.pg_class c,
      pg_catalog.pg_namespace n,
      pg_catalog.pg_attribute a
+     LEFT JOIN partitionedKeys
+     ON a.attnum = partitionedKeys.att_num
+         AND a.attrelid = partitionedKeys.parrelid
 WHERE c.relkind = 'r'
     AND c.oid = a.attrelid
     AND NOT a.attisdropped
@@ -17,9 +25,11 @@ WHERE c.relkind = 'r'
     AND n.nspname NOT LIKE 'pg_toast_temp_%'
     AND n.nspname NOT IN ('pg_catalog',
                         'information_schema')
+    -- exclude child partitions
     AND c.oid NOT IN
         (SELECT DISTINCT parchildrelid
          FROM pg_catalog.pg_partition_rule)
-
+    -- exclude tables partitioned on a tsquery data type
+    AND partitionedKeys.parrelid IS NULL
     -- exclude inherited columns
     AND a.attinhcount = 0;

--- a/data-migration-scripts/5-to-6-seed-scripts/revert/partitioned_tables_indexes/recreate_partition_indexes_step_1.sql
+++ b/data-migration-scripts/5-to-6-seed-scripts/revert/partitioned_tables_indexes/recreate_partition_indexes_step_1.sql
@@ -5,12 +5,23 @@
 -- that don't correspond to unique or primary key constraints
 
 -- cte to get all the unique and primary key constraints
-WITH root_partitions (relid) AS
+WITH root_partitions_using_tsquery AS
+(
+   SELECT DISTINCT p.parrelid oid
+   FROM pg_partition p
+   JOIN pg_class pt ON p.parrelid = pt.oid
+   JOIN pg_attribute a ON a.attrelid = pt.oid
+   WHERE a.atttypid = 'pg_catalog.tsquery'::pg_catalog.regtype
+)
+,
+root_partitions (relid) AS
 (
    SELECT DISTINCT
       parrelid
    FROM
       pg_partition
+   WHERE
+      parrelid NOT IN (SELECT oid FROM root_partitions_using_tsquery)
 )
 ,
 root_constraints AS

--- a/data-migration-scripts/5-to-6-seed-scripts/revert/tables_using_tsquery_type/gen_change_text_to_tsquery.sql
+++ b/data-migration-scripts/5-to-6-seed-scripts/revert/tables_using_tsquery_type/gen_change_text_to_tsquery.sql
@@ -2,12 +2,20 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- generates alter statement to modify text datatype to tsquery datatype
+WITH partitionedKeys AS
+(
+   SELECT DISTINCT parrelid, unnest(paratts) att_num
+   FROM pg_catalog.pg_partition p
+)
 SELECT $$ALTER TABLE $$ || pg_catalog.quote_ident(n.nspname) || '.' || pg_catalog.quote_ident(c.relname) ||
        $$ ALTER COLUMN $$ || pg_catalog.quote_ident(a.attname) ||
        $$ TYPE TSQUERY USING $$ || pg_catalog.quote_ident(a.attname) || $$::tsquery;$$
 FROM pg_catalog.pg_class c,
      pg_catalog.pg_namespace n,
      pg_catalog.pg_attribute a
+     LEFT JOIN partitionedKeys
+     ON a.attnum = partitionedKeys.att_num
+         AND a.attrelid = partitionedKeys.parrelid
 WHERE c.relkind = 'r'
     AND c.oid = a.attrelid
     AND NOT a.attisdropped
@@ -17,9 +25,11 @@ WHERE c.relkind = 'r'
     AND n.nspname NOT LIKE 'pg_toast_temp_%'
     AND n.nspname NOT IN ('pg_catalog',
                         'information_schema')
+    -- exclude child partitions
     AND c.oid NOT IN
         (SELECT DISTINCT parchildrelid
          FROM pg_catalog.pg_partition_rule)
-
+    -- exclude tables partitioned on a tsquery data type
+    AND partitionedKeys.parrelid IS NULL
     -- exclude inherited columns
     AND a.attinhcount = 0;

--- a/data-migration-scripts/5-to-6-seed-scripts/test/setup_nonupgradable_objects.sql
+++ b/data-migration-scripts/5-to-6-seed-scripts/test/setup_nonupgradable_objects.sql
@@ -5,4 +5,3 @@
 CREATE DATABASE testdb;
 CREATE ROLE gphdfs_user CREATEEXTTABLE(protocol='gphdfs', type='writable') CREATEEXTTABLE(protocol='gphdfs', type='readable');
 CREATE ROLE test_role1;
-CREATE ROLE test_role2;

--- a/data-migration-scripts/5-to-6-seed-scripts/test/teardown_nonupgradable_objects.sql
+++ b/data-migration-scripts/5-to-6-seed-scripts/test/teardown_nonupgradable_objects.sql
@@ -5,4 +5,3 @@
 DROP DATABASE IF EXISTS testdb;
 DROP ROLE IF EXISTS gphdfs_user;
 DROP ROLE IF EXISTS test_role1;
-DROP ROLE IF EXISTS test_role2;


### PR DESCRIPTION
Altering a column type when the column is a partition key is not
allowed. For this reason, intialize migration scripts for deprecated
tsquery type does not generate an ALTER statement for tables partitioned
on a tsquery column. Tables that are partitioned on a tsquery column
should also not generate an ALTER statement for revert and finalize
migration scripts.

When recreating indexes on partition tables during revert and finalize,
dropped child partition indexes are also brought back. This is a known
behavior that has not been addressed. Tsquery partition indexes
recreation is not immune to this behavior.

Commit where tsquery ALTER statements were disabled in intialize for tables
partitioned on a tsquery column:
1c455b85e44ce5ff2426ece00ee97fbd77c6e1d1

pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:tsquery-partition-reverts