### PR TITLE
fix timestamps in log prefix

### DIFF
--- a/utils/logger/log.go
+++ b/utils/logger/log.go
@@ -21,10 +21,10 @@ func Initialize(process string) {
 		os.Exit(1)
 	}
 
-	// If more robust logging is needed consider using the logrus package.
+	// If more robust logging is needed consider using logutils, zap, zerolog, etc.
 	log.SetOutput(f)
 	log.SetPrefix(prefix())
-	log.SetFlags(0)
+	log.SetFlags(log.Ldate | log.Ltime | log.Lmsgprefix)
 }
 
 func OpenFile(process string) (*os.File, error) {
@@ -40,25 +40,15 @@ func OpenFile(process string) (*os.File, error) {
 		os.Exit(1)
 	}
 
-	path := filepath.Join(logDir, fmt.Sprintf("%s_%s.log", process, timestamp(false)))
+	path := filepath.Join(logDir, fmt.Sprintf("%s_%s.log", process, time.Now().Format("20060102")))
 	return os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 }
 
-// prefix has the form PROGRAMNAME:USERNAME:HOSTNAME:PID-[LOGLEVEL]:-
+// prefix has the form PROGRAMNAME:USERNAME:HOSTNAME:PID [LOGLEVEL]:
 func prefix() string {
 	currentUser, _ := user.Current()
 	host, _ := os.Hostname()
 
-	return fmt.Sprintf("%s gpupgrade:%s:%s:%06d-[INFO]:-",
-		timestamp(true),
+	return fmt.Sprintf("gpupgrade:%s:%s:%06d [INFO]: ",
 		currentUser.Username, host, os.Getpid())
-}
-
-func timestamp(includeTime bool) string {
-	layout := "20060102"
-	if includeTime {
-		layout += ":15:04:05"
-	}
-
-	return time.Now().Format(layout)
 }


### PR DESCRIPTION
The timestamp in the log prefix was not being updated. The logger from the go standard library sets the static prefix during initialization, and does not call it before each log message. Thus, the timestamp is fixed. Use the built in standard log timestamp.

Update log prefix to:
`2023/06/07 14:44:11 gpupgrade:gpadmin:sdw-1:161174 [INFO]: State directory /home/gpadmin/.gpupgrade already present. Skipping.`

from:
`20230607:14:44:11 gpupgrade:gpadmin:sdw-1:161174-[INFO]:-State directory /home/gpadmin/.gpupgrade already present. Skipping.`

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixLogging