### PR TITLE
remove extra PGOPTIONS when loading dump

### DIFF
--- a/ci/functional/pipeline/3_load_schema_data_migration_scripts.yml
+++ b/ci/functional/pipeline/3_load_schema_data_migration_scripts.yml
@@ -48,7 +48,6 @@
                     set -eux -o pipefail
 
                     source /usr/local/greenplum-db-source/greenplum_path.sh
-                    export PGOPTIONS='--client-min-messages=warning'
                     # This is failing due to a number of errors. Disabling ON_ERROR_STOP until this is fixed.
                     unxz --threads $(nproc) /tmp/dump.sql.xz
                     PGOPTIONS='--client-min-messages=warning' psql -v ON_ERROR_STOP=0 --quiet --dbname postgres -f /tmp/dump.sql

--- a/ci/main/scripts/load-dump.bash
+++ b/ci/main/scripts/load-dump.bash
@@ -14,7 +14,6 @@ time ssh -n gpadmin@cdw "
     set -eux -o pipefail
 
     source /usr/local/greenplum-db-source/greenplum_path.sh
-    export PGOPTIONS='--client-min-messages=warning'
     # This is failing due to a number of errors. Disabling ON_ERROR_STOP until this is fixed.
     unxz --threads $(nproc) /tmp/dump.sql.xz
     PGOPTIONS='--client-min-messages=warning' psql -v ON_ERROR_STOP=0 --quiet --dbname postgres -f /tmp/dump.sql


### PR DESCRIPTION
The following psql line to load the dump is already using: `PGOPTIONS='--client-min-messages=warning' psql`

No need to export it twice.