### PR TITLE
Makefile: fix make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,8 @@ rpm:
 	rm -r rpm
 
 install:
-	go install $(BUILD_FLAGS) github.com/greenplum-db/gpupgrade/cmd/gpupgrade
+	@test $${GOPATH?Error GOPATH not set}
+	cp gpupgrade $(GOPATH)/bin/
 
 # To lint, you must install golangci-lint via one of the supported methods
 # listed at

--- a/ci/main/scripts/acceptance-tests.bash
+++ b/ci/main/scripts/acceptance-tests.bash
@@ -17,9 +17,11 @@ function run_migration_scripts_and_tests() {
         set -eux -o pipefail
 
         export TERM=linux
-        export PATH=$PATH:$HOME/go/bin
+        export GOPATH=$HOME/go
+        export PATH=$PATH:$GOPATH/bin
         export GOFLAGS="-mod=readonly" # do not update dependencies during build
 
+        mkdir -p $GOPATH/bin
         cd gpupgrade_src
         make && make install
 


### PR DESCRIPTION
Make install was not correctly building with the version flags. Thus, our acceptance tests and using gpupgrade locally during development did not have the version information set.

Refactor make install to simply copy the built binary to $GOPATH/bin.

_Note_: I am not exactly sure if there are other side effects or things to be aware of to "not" using `go install` over `cp`.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:refactorMakeInstall