### PR TITLE
force copy when make installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ rpm:
 
 install:
 	@test $${GOPATH?Error GOPATH not set}
-	cp gpupgrade $(GOPATH)/bin/
+	cp -f gpupgrade $(GOPATH)/bin/
 
 # To lint, you must install golangci-lint via one of the supported methods
 # listed at


### PR DESCRIPTION
Sometimes when running make install the following error will show up:
```
cp: cannot create regular file '/home/gpadmin/go/bin/gpupgrade': Text file busy
make: *** [Makefile:141: install] Error 1
```

Where cp -f will remove the existing destination file if it cannot be opened and try again.

https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixMakeInstall