### PR TITLE
Fix Concourse CI lint job

### DIFF
--- a/ci/main/pipeline/2_build_lint.yml
+++ b/ci/main/pipeline/2_build_lint.yml
@@ -40,6 +40,8 @@ jobs:
           type: registry-image
           source:
             repository: golangci/golangci-lint
+            # Pin the image to v1.52 because v1.53 has issues with current prod Concourse
+            tag: v1.52
         inputs:
           - name: gpupgrade_src
         run:


### PR DESCRIPTION
The golangci/golangci-lint image was recently updated from v1.52 to v1.53 which caused our Concourse CI lint job to start failing. It seems like this new image does not play well with our prod Concourse workers since the new image seems to work on our developer Concourse instances that are on newer versions of Concourse. To work around the issue for now, pin the image to v1.52.

The image is already pinned on our gpupgrade prod pipeline which is now green.  This PR is to save the change.