### PR TITLE
ci: skip pg_upgrade checks during execute

### DIFF
--- a/ci/main/scripts/upgrade-cluster.bash
+++ b/ci/main/scripts/upgrade-cluster.bash
@@ -33,7 +33,7 @@ time ssh -n cdw "
               --temp-port-range 6020-6040 \
               --disk-free-ratio 0
 
-    gpupgrade execute --non-interactive
+    gpupgrade execute --non-interactive --skip-pg-upgrade-checks
     gpupgrade finalize --non-interactive
 "
 

--- a/ci/main/scripts/upgrade-extensions.bash
+++ b/ci/main/scripts/upgrade-extensions.bash
@@ -106,7 +106,7 @@ time ssh -n cdw "
               --temp-port-range 6020-6040 \
               --dynamic-library-path ${GPHOME_TARGET}/madlib/Current/ports/greenplum/6/lib:/usr/local/greenplum-db-text/lib/gpdb6:/usr/local/pxf-gp6/gpextable
 
-    gpupgrade execute --non-interactive
+    gpupgrade execute --non-interactive --skip-pg-upgrade-checks
     gpupgrade finalize --non-interactive
 "
 


### PR DESCRIPTION
Save time by skipping the same checks that were just immediately run during initialize.

Need to wait for the `6X_STABLE_centos7` pipeline to go green to pickup the latest 6X RPM.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:skipChecks