### PR TITLE
bump minimum supported GPDB version

### DIFF
--- a/greenplum/allowed_gpdb_versions.go
+++ b/greenplum/allowed_gpdb_versions.go
@@ -11,7 +11,7 @@ import (
 
 // Change these values to bump the minimum supported versions and associated tests.
 const min5xVersion = "5.29.10"
-const min6xVersion = "6.24.0"
+const min6xVersion = "6.25.0"
 const min7xVersion = "7.0.0"
 
 var GetSourceVersion = Version


### PR DESCRIPTION
bump minimum supported GPDB version. This PR is dependent on https://github.com/greenplum-db/gpupgrade/pull/842 going in first.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:bumpVersion