### PR TITLE
set gp_vmem_protect_limit on functional pipeline

### DIFF
--- a/ci/functional/pipeline/3_load_schema_data_migration_scripts.yml
+++ b/ci/functional/pipeline/3_load_schema_data_migration_scripts.yml
@@ -97,7 +97,9 @@
                     TOTAL_MEM=\$(grep MemTotal /proc/meminfo | awk '{print \$2}')
                     MAX_STATEMENT_MEM=\$((\${TOTAL_MEM}/2))
                     STATEMENT_MEM=\$((\${MAX_STATEMENT_MEM}/16))
+                    GP_VMEM_PROTECT_LIMIT=\$((\${MAX_STATEMENT_MEM}/1000))
 
+                    gpconfig -c gp_vmem_protect_limit -v \${GP_VMEM_PROTECT_LIMIT}
                     gpconfig -c max_statement_mem -v \${MAX_STATEMENT_MEM}kB
                     gpconfig -c statement_mem -v \${STATEMENT_MEM}kB
                     gpconfig -c max_locks_per_transaction -v 512


### PR DESCRIPTION
Set gp_vmem_protect_limit specified in MB to same value as max_statement_mem. On an n2-standard-16 instnace with 64GB of memory has a value of 32901 MB or 32 GB. This prevents the following errors encountered during the pg_upgrade checks:

Canceling query because of high VMEM usage. Used: 1919MB, available 819MB, red zone: 7372MB (runaway_cleaner.c:202)