### PR TITLE
database stats remove duplicate view count

### DIFF
--- a/data-migration-scripts/5-to-6-seed-scripts/stats/cluster_and_database_stats/generate_database_stats.sh
+++ b/data-migration-scripts/5-to-6-seed-scripts/stats/cluster_and_database_stats/generate_database_stats.sh
@@ -44,9 +44,6 @@ SELECT COUNT(*) AS AOCOColumns FROM information_schema.columns
 SELECT COUNT(DISTINCT parrelid) AS RootPartitions FROM pg_catalog.pg_partition;
 SELECT COUNT(DISTINCT parchildrelid) AS ChildPartitions FROM pg_catalog.pg_partition_rule;
 
--- No. of Views
-SELECT COUNT(*) AS Views FROM pg_catalog.pg_views;
-
 -- No. of Indexes
 SELECT COUNT(*) AS Indexes FROM pg_catalog.pg_index;
 

--- a/data-migration-scripts/6-to-7-seed-scripts/stats/cluster_and_database_stats/generate_database_stats.sh
+++ b/data-migration-scripts/6-to-7-seed-scripts/stats/cluster_and_database_stats/generate_database_stats.sh
@@ -44,9 +44,6 @@ SELECT COUNT(*) AS AOCOColumns FROM information_schema.columns
 SELECT COUNT(DISTINCT parrelid) AS RootPartitions FROM pg_catalog.pg_partition;
 SELECT COUNT(DISTINCT parchildrelid) AS ChildPartitions FROM pg_catalog.pg_partition_rule;
 
--- No. of Views
-SELECT COUNT(*) AS Views FROM pg_catalog.pg_views;
-
 -- No. of Indexes
 SELECT COUNT(*) AS Indexes FROM pg_catalog.pg_index;
 


### PR DESCRIPTION
There were two queries for views returning the same result. That is, the current query `pg_class WHERE RELKIND='v'` also returns the number of views. No need to duplicate the value.