### PR TITLE
ensure log prefix is printed to hub and agent logs

### DIFF
--- a/cli/clistep/step.go
+++ b/cli/clistep/step.go
@@ -94,9 +94,9 @@ func Begin(currentStep idl.Step, verbose bool, nonInteractive bool, confirmation
 
 	stepName := cases.Title(language.English).String(currentStep.String())
 
-	fmt.Println()
-	fmt.Println(stepName + " in progress.")
-	fmt.Println()
+	msg := stepName + " in progress."
+	fmt.Printf("\n%s\n\n", msg)
+	log.Print(msg)
 
 	return NewStep(currentStep, stepName, stepStore, substepStore, step.StdStreams, verbose)
 }

--- a/hub/execute.go
+++ b/hub/execute.go
@@ -6,13 +6,11 @@ package hub
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/greenplum-db/gpupgrade/config/backupdir"
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/utils"
-	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 func (s *Server) Execute(req *idl.ExecuteRequest, stream idl.CliToHub_ExecuteServer) (err error) {
@@ -20,16 +18,6 @@ func (s *Server) Execute(req *idl.ExecuteRequest, stream idl.CliToHub_ExecuteSer
 	if err != nil {
 		return err
 	}
-
-	defer func() {
-		if ferr := st.Finish(); ferr != nil {
-			err = errorlist.Append(err, ferr)
-		}
-
-		if err != nil {
-			log.Printf("%s: %s", idl.Step_execute, err)
-		}
-	}()
 
 	st.AlwaysRun(idl.Substep_ensure_gpupgrade_agents_are_running, func(_ step.OutStreams) error {
 		_, err := RestartAgents(context.Background(), nil, AgentHosts(s.Source), s.AgentPort, utils.GetStateDir())

--- a/hub/finalize.go
+++ b/hub/finalize.go
@@ -5,14 +5,12 @@ package hub
 
 import (
 	"context"
-	"log"
 	"time"
 
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 	"github.com/greenplum-db/gpupgrade/utils"
-	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 func (s *Server) Finalize(req *idl.FinalizeRequest, stream idl.CliToHub_FinalizeServer) (err error) {
@@ -20,16 +18,6 @@ func (s *Server) Finalize(req *idl.FinalizeRequest, stream idl.CliToHub_Finalize
 	if err != nil {
 		return err
 	}
-
-	defer func() {
-		if ferr := st.Finish(); ferr != nil {
-			err = errorlist.Append(err, ferr)
-		}
-
-		if err != nil {
-			log.Printf("%s: %s", idl.Step_finalize, err)
-		}
-	}()
 
 	st.AlwaysRun(idl.Substep_ensure_gpupgrade_agents_are_running, func(_ step.OutStreams) error {
 		_, err := RestartAgents(context.Background(), nil, AgentHosts(s.Source), s.AgentPort, utils.GetStateDir())

--- a/hub/initialize.go
+++ b/hub/initialize.go
@@ -11,7 +11,6 @@ import (
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 	"github.com/greenplum-db/gpupgrade/utils"
-	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 func (s *Server) Initialize(req *idl.InitializeRequest, stream idl.CliToHub_InitializeServer) (err error) {
@@ -19,16 +18,6 @@ func (s *Server) Initialize(req *idl.InitializeRequest, stream idl.CliToHub_Init
 	if err != nil {
 		return err
 	}
-
-	defer func() {
-		if ferr := st.Finish(); ferr != nil {
-			err = errorlist.Append(err, ferr)
-		}
-
-		if err != nil {
-			log.Printf("%s: %s", idl.Step_initialize, err)
-		}
-	}()
 
 	// Since the agents might not be up if gpupgrade is not properly installed, check it early on using ssh.
 	st.Run(idl.Substep_verify_gpupgrade_is_installed_across_all_hosts, func(streams step.OutStreams) error {
@@ -93,16 +82,6 @@ func (s *Server) InitializeCreateCluster(req *idl.InitializeCreateClusterRequest
 	if err != nil {
 		return err
 	}
-
-	defer func() {
-		if ferr := st.Finish(); ferr != nil {
-			err = errorlist.Append(err, ferr)
-		}
-
-		if err != nil {
-			log.Printf("%s: %s", idl.Step_initialize, err)
-		}
-	}()
 
 	st.Run(idl.Substep_generate_target_config, func(_ step.OutStreams) error {
 		return s.GenerateInitsystemConfig(s.Source)

--- a/hub/restore_source_cluster_test.go
+++ b/hub/restore_source_cluster_test.go
@@ -76,7 +76,7 @@ func TestRsyncCoordinatorAndPrimaries(t *testing.T) {
 			}
 		}))
 
-		err := hub.RsyncCoordinator(&testutils.DevNullWithClose{}, cluster.Standby(), cluster.Coordinator())
+		err := hub.RsyncCoordinator(step.DevNullStream, cluster.Standby(), cluster.Coordinator())
 		if err != nil {
 			t.Errorf("unexpected err %#v", err)
 		}
@@ -107,7 +107,7 @@ func TestRsyncCoordinatorAndPrimaries(t *testing.T) {
 			}
 		}))
 
-		err := hub.RsyncCoordinatorTablespaces(&testutils.DevNullWithClose{}, cluster.StandbyHostname(), tablespaces[int32(cluster.Coordinator().DbID)], tablespaces[int32(cluster.Standby().DbID)])
+		err := hub.RsyncCoordinatorTablespaces(step.DevNullStream, cluster.StandbyHostname(), tablespaces[int32(cluster.Coordinator().DbID)], tablespaces[int32(cluster.Standby().DbID)])
 		if err != nil {
 			t.Errorf("unexpected err %#v", err)
 		}
@@ -209,7 +209,7 @@ func TestRsyncCoordinatorAndPrimaries(t *testing.T) {
 		rsync.SetRsyncCommand(exectest.NewCommand(hub.Failure))
 		defer rsync.ResetRsyncCommand()
 
-		err := hub.RsyncCoordinator(&testutils.DevNullWithClose{}, cluster.Standby(), cluster.Coordinator())
+		err := hub.RsyncCoordinator(step.DevNullStream, cluster.Standby(), cluster.Coordinator())
 		if err == nil {
 			t.Error("unexpected nil error")
 		}
@@ -219,14 +219,14 @@ func TestRsyncCoordinatorAndPrimaries(t *testing.T) {
 		rsync.SetRsyncCommand(exectest.NewCommand(hub.Failure))
 		defer rsync.ResetRsyncCommand()
 
-		err := hub.RsyncCoordinatorTablespaces(&testutils.DevNullWithClose{}, cluster.CoordinatorHostname(), tablespaces[int32(greenplum.CoordinatorDbid)], tablespaces[int32(cluster.Standby().DbID)])
+		err := hub.RsyncCoordinatorTablespaces(step.DevNullStream, cluster.CoordinatorHostname(), tablespaces[int32(greenplum.CoordinatorDbid)], tablespaces[int32(cluster.Standby().DbID)])
 		if err == nil {
 			t.Error("unexpected nil error")
 		}
 	})
 
 	t.Run("errors when restoring the mirrors fails in copy mode on GPDB5", func(t *testing.T) {
-		err := hub.Recoverseg(&testutils.DevNullWithClose{}, cluster, false)
+		err := hub.Recoverseg(step.DevNullStream, cluster, false)
 		var exitErr *exec.ExitError
 		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
 			t.Errorf("returned error %#v, want exit code %d", err, 1)

--- a/hub/revert.go
+++ b/hub/revert.go
@@ -5,7 +5,6 @@ package hub
 
 import (
 	"context"
-	"log"
 	"os/exec"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/utils"
-	"github.com/greenplum-db/gpupgrade/utils/errorlist"
 )
 
 func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) (err error) {
@@ -23,16 +21,6 @@ func (s *Server) Revert(_ *idl.RevertRequest, stream idl.CliToHub_RevertServer) 
 	if err != nil {
 		return err
 	}
-
-	defer func() {
-		if ferr := st.Finish(); ferr != nil {
-			err = errorlist.Append(err, ferr)
-		}
-
-		if err != nil {
-			log.Printf("%s: %s", idl.Step_revert, err)
-		}
-	}()
 
 	hasExecuteStarted, err := step.HasStarted(idl.Step_execute)
 	if err != nil {

--- a/step/stream_test.go
+++ b/step/stream_test.go
@@ -4,10 +4,8 @@
 package step
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 	"testing"
 
@@ -32,7 +30,7 @@ func ExampleDevNullStream() {
 }
 
 func TestBufStream(t *testing.T) {
-	t.Run("records stdout and stderr to the stream", func(t *testing.T) {
+	t.Run("records stdout and stderr to the sender", func(t *testing.T) {
 		const (
 			stdout = "this command has progress..."
 			stderr = "there are some warnings..."
@@ -54,7 +52,7 @@ func TestBufStream(t *testing.T) {
 func TestMultiplexedStream(t *testing.T) {
 	logOutput := testlog.SetupTestLogger()
 
-	t.Run("forwards stdout and stderr to the stream", func(t *testing.T) {
+	t.Run("forwards stdout and stderr to the sender", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -75,12 +73,12 @@ func TestMultiplexedStream(t *testing.T) {
 				Type:   idl.Chunk_stderr,
 			}}})
 
-		stream := newMultiplexedStream(mockStream, io.Discard)
+		stream := newLogMessageSender(mockStream)
 		fmt.Fprint(stream.Stdout(), expectedStdout)
 		fmt.Fprint(stream.Stderr(), expectedStderr)
 	})
 
-	t.Run("also writes all data to a local io.Writer", func(t *testing.T) {
+	t.Run("also writes all data to the log", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -89,8 +87,7 @@ func TestMultiplexedStream(t *testing.T) {
 			Send(gomock.Any()).
 			AnyTimes()
 
-		var buf bytes.Buffer
-		stream := newMultiplexedStream(mockStream, &buf)
+		stream := newLogMessageSender(mockStream)
 
 		// Write 10 bytes to each stream.
 		for i := 0; i < 10; i++ {
@@ -104,13 +101,16 @@ func TestMultiplexedStream(t *testing.T) {
 			}
 		}
 
+		logContents := string(logOutput.Bytes())
 		expected := "OEOEOEOEOEOEOEOEOEOE"
-		if buf.String() != expected {
-			t.Errorf("writer got %q, want %q", buf.String(), expected)
+		for _, char := range expected {
+			if strings.HasSuffix(logContents, string(char)) {
+				t.Errorf("log got %q, want %q", logContents, expected)
+			}
 		}
 	})
 
-	t.Run("continues writing to the local io.Writer even if Send fails", func(t *testing.T) {
+	t.Run("continues writing to the log file even if Send fails", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -121,8 +121,7 @@ func TestMultiplexedStream(t *testing.T) {
 			Return(errors.New("error during send")).
 			Times(1) // we expect only one failed attempt to Send
 
-		var buf bytes.Buffer
-		stream := newMultiplexedStream(mockStream, &buf)
+		stream := newLogMessageSender(mockStream)
 
 		// Write 10 bytes to each stream.
 		for i := 0; i < 10; i++ {
@@ -138,45 +137,20 @@ func TestMultiplexedStream(t *testing.T) {
 		}
 
 		// The Writer should not have been affected in any way.
-		if len(buf.Bytes()) != 20 {
-			t.Errorf("got %d want 20", len(buf.Bytes()))
+		logContents := string(logOutput.Bytes())
+		numO := strings.Count(logContents, "O\n")
+		if numO != 20 {
+			t.Errorf("got %d want 20", numO)
 		}
 
-		expected := "halting client stream: error during send"
-		contents := string(logOutput.Bytes())
-		if !strings.Contains(contents, expected) {
-			t.Errorf("log file %q does not contain %q", contents, expected)
-		}
-	})
-
-	t.Run("bubbles up underlying io.Writer failures before streaming", func(t *testing.T) {
-		expected := errors.New("ahhhh")
-
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		mockStream := mock_idl.NewMockCliToHub_ExecuteServer(ctrl)
-		// we expect no calls on the stream
-
-		stream := newMultiplexedStream(mockStream, &failingWriter{expected})
-
-		_, err := stream.Stdout().Write([]byte{'x'})
-		if !errors.Is(err, expected) {
-			t.Errorf("Stdout().Write() returned %#v, want %#v", err, expected)
+		numE := strings.Count(logContents, "E\n")
+		if numE != 20 {
+			t.Errorf("got %d want 20", +numE)
 		}
 
-		_, err = stream.Stderr().Write([]byte{'x'})
-		if !errors.Is(err, expected) {
-			t.Errorf("Stderr().Write() returned %#v, want %#v", err, expected)
+		expected := "halting client sender: error during send"
+		if !strings.Contains(logContents, expected) {
+			t.Errorf("log %q does not contain %q", logContents, expected)
 		}
 	})
-}
-
-// failingWriter is an io.Writer for which all calls to Write() return an error.
-type failingWriter struct {
-	err error
-}
-
-func (f *failingWriter) Write(_ []byte) (int, error) {
-	return 0, f.err
 }

--- a/testutils/stream.go
+++ b/testutils/stream.go
@@ -33,23 +33,3 @@ func (f FailingStreams) Stdout() io.Writer {
 func (f FailingStreams) Stderr() io.Writer {
 	return &FailingWriter{f.Err}
 }
-
-// DevNullWithClose implements step.OutStreamsCloser as a no-op. It also tracks calls to
-// Close().
-type DevNullWithClose struct {
-	Closed   bool
-	CloseErr error
-}
-
-func (DevNullWithClose) Stdout() io.Writer {
-	return io.Discard
-}
-
-func (DevNullWithClose) Stderr() io.Writer {
-	return io.Discard
-}
-
-func (d *DevNullWithClose) Close() error {
-	d.Closed = true
-	return d.CloseErr
-}


### PR DESCRIPTION
Currently, the hub and agent substeps write to both stdout/stderr “and” the log file. Similar functionality should likely be done for the CLI as well. That is, writing to stdout will also write to the log.

The log prefix contains the timestamp which is critical for debugging and support. Previously the log file handle was passed to MultiplexedStream which was not correctly adding the log prefix. Rather simply calling log.Print() does print the prefix.

Thus, refactor multiplexedStream to call log.Print to print out the prefix with timestamp. Doing so removes the need for Close() and its associated functions. When printing to the log trim leading and trailing whitespace to avoid awkward multi-line whitespace in the log file.

https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:hubLogging