### PR TITLE
fix open_source_license spelling in verify-rpm

### DIFF
--- a/ci/main/scripts/verify-rpm.bash
+++ b/ci/main/scripts/verify-rpm.bash
@@ -35,7 +35,7 @@ verify_license_files() {
   local license_file="/usr/local/bin/greenplum/gpupgrade/open_source_licenses.txt"
   [ -s "$license_file" ]
 
-  [[ $(head -1 "$license_file") =~ open_source_licenses.txt ]]
+  [[ $(head -1 "$license_file") =~ open_source_license.txt ]]
   [[ $(head -3 "$license_file" | tail -1) == *"VMware Greenplum Upgrade ${VERSION}"* ]]
   [[ $(tail -1 "$license_file") =~ "GREENPLUMUPGRADE" ]]
 }


### PR DESCRIPTION
For the last several releases the top of the OSM file has been open_source_license.txt. Rather than running into minor errors in the pipeline upon tagging and release simply update our test in verify-rpm.bash.

Perhaps we should rename "all" refernces including the filename itself. But for now keep it simple.