### PR TITLE
remove data migration test directory from rpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,8 @@ tarball:
 	cp open_source_licenses.txt tarball
 	cp -r data-migration-scripts/ tarball/data-migration-scripts/
 	# remove test files
-	rm -r tarball/data-migration-scripts/5-to-6-seed-scripts/test
+	rm -r tarball/data-migration-scripts/README.md
+	find -path "./tarball/data-migration-scripts/*/test" -type d -exec rm -r {} +
 	# create tarball
 	( cd tarball; tar czf ../$(TARBALL_NAME) . )
 	sha256sum $(TARBALL_NAME) > CHECKSUM


### PR DESCRIPTION
remove following from both the tarball and rpm:
- 6-to-7-seed-scripts/test directory
- data-migration-scripts/README.md

This will also remove any future X-to-Y-seed-scripts/test directories.