### PR TITLE
Refactor CLI step framework Streaming

### DIFF
--- a/cli/clistep/step.go
+++ b/cli/clistep/step.go
@@ -77,6 +77,8 @@ func Begin(currentStep idl.Step, verbose bool, nonInteractive bool, confirmation
 		return nil, err
 	}
 
+	log.Print(confirmationText)
+
 	if !nonInteractive {
 		fmt.Println(confirmationText)
 
@@ -99,9 +101,9 @@ func Begin(currentStep idl.Step, verbose bool, nonInteractive bool, confirmation
 
 	stepName := cases.Title(language.English).String(currentStep.String())
 
-	msg := stepName + " in progress."
-	fmt.Printf("\n%s\n\n", msg)
-	log.Print(msg)
+	text := stepName + " in progress."
+	fmt.Printf("\n%s\n\n", text)
+	log.Print(text)
 
 	return NewStep(currentStep, stepName, stepStore, substepStore, streams, verbose)
 }

--- a/cli/clistep/step.go
+++ b/cli/clistep/step.go
@@ -60,6 +60,11 @@ func NewStep(currentStep idl.Step, stepName string, stepStore StepStore, substep
 }
 
 func Begin(currentStep idl.Step, verbose bool, nonInteractive bool, confirmationText string) (*Step, error) {
+	// NOTE: only use streams within the substeps since they do not write to
+	// stdout/stderr when verbose is false. Thus, for general output write to
+	// stdout as usual such that it appears when verbose is not set.
+	streams := step.NewLogStdStreams(verbose)
+
 	stepStore, err := NewStepFileStore()
 	if err != nil {
 		context := fmt.Sprintf("Note: If commands were issued in order, ensure gpupgrade can write to %s", utils.GetStateDir())
@@ -98,7 +103,7 @@ func Begin(currentStep idl.Step, verbose bool, nonInteractive bool, confirmation
 	fmt.Printf("\n%s\n\n", msg)
 	log.Print(msg)
 
-	return NewStep(currentStep, stepName, stepStore, substepStore, step.StdStreams, verbose)
+	return NewStep(currentStep, stepName, stepStore, substepStore, streams, verbose)
 }
 
 func (s *Step) Err() error {

--- a/cli/commanders/data_migration_apply.go
+++ b/cli/commanders/data_migration_apply.go
@@ -41,7 +41,7 @@ func ApplyDataMigrationScripts(streams step.OutStreams, nonInteractive bool, gph
 		return err
 	}
 
-	_, err = fmt.Fprintf(streams.Stdout(), "Inspect the %q data migration SQL scripts in\n%s\n", phase, utils.Bold.Sprint(filepath.Join(currentScriptDir, phase.String())))
+	_, err = fmt.Fprintf(streams.Stdout(), "Inspect the %q data migration SQL scripts in\n%s", phase, utils.Bold.Sprint(filepath.Join(currentScriptDir, phase.String())))
 	if err != nil {
 		return err
 	}
@@ -132,12 +132,7 @@ func ApplyDataMigrationScripts(streams step.OutStreams, nonInteractive bool, gph
 		fmt.Print(color.YellowString("\nTo receive an upgrade time estimate send the stats output:\n%s\n", utils.Bold.Sprint(filepath.Join(logDir, "apply_"+phase.String()+".log"))))
 	}
 
-	fmt.Printf(`
-Logs:
-%s
-
-`, utils.Bold.Sprint(logDir))
-
+	fmt.Printf("\nLogs: %s\n\n", utils.Bold.Sprint(logDir))
 	return nil
 }
 
@@ -195,6 +190,7 @@ func ApplyDataMigrationScriptsPrompt(nonInteractive bool, reader *bufio.Reader, 
 		allScripts = append(allScripts, Script{Num: uint64(i), Name: script.Name()})
 	}
 
+	fmt.Println()
 	fmt.Println()
 	fmt.Printf(`Scripts to apply:
 %s`, allScripts.Description())

--- a/cli/commanders/data_migration_apply_test.go
+++ b/cli/commanders/data_migration_apply_test.go
@@ -333,7 +333,7 @@ func TestApplyDataMigrationScriptsPrompt(t *testing.T) {
 			t.Errorf("unexpected stderr %#v", string(stderr))
 		}
 
-		expected := "\nScripts to apply:\n"
+		expected := "\n\nScripts to apply:\n"
 		expected += "  parent_partitions_with_seg_entries\n"
 		expected += "  - Fixes non-empty segment relfiles for AO and AOCO parent partitions\n\n"
 		expected += "  unique_primary_foreign_key_constraint\n"
@@ -406,7 +406,7 @@ func TestApplyDataMigrationScriptsPrompt(t *testing.T) {
 			t.Errorf("unexpected stderr %#v", string(stderr))
 		}
 
-		expected := "\nScripts to apply:\n"
+		expected := "\n\nScripts to apply:\n"
 		expected += "  parent_partitions_with_seg_entries\n"
 		expected += "  - Fixes non-empty segment relfiles for AO and AOCO parent partitions\n\n"
 		expected += "  unique_primary_foreign_key_constraint\n"
@@ -460,7 +460,7 @@ func TestApplyDataMigrationScriptsPrompt(t *testing.T) {
 			t.Errorf("unexpected stderr %#v", string(stderr))
 		}
 
-		expected := "\nScripts to apply:\n"
+		expected := "\n\nScripts to apply:\n"
 		expected += "  parent_partitions_with_seg_entries\n"
 		expected += "  - Fixes non-empty segment relfiles for AO and AOCO parent partitions\n\n"
 		expected += "  unique_primary_foreign_key_constraint\n"
@@ -514,7 +514,7 @@ func TestApplyDataMigrationScriptsPrompt(t *testing.T) {
 			t.Errorf("unexpected stderr %#v", string(stderr))
 		}
 
-		expected := "\nScripts to apply:\n"
+		expected := "\n\nScripts to apply:\n"
 		expected += "  partitioned_tables_indexes\n"
 		expected += "  - Drops partition indexes\n\n"
 		expected += "Which \"finalize\" data migration SQL scripts to apply?\n"

--- a/cli/commanders/data_migration_apply_test.go
+++ b/cli/commanders/data_migration_apply_test.go
@@ -41,7 +41,7 @@ func TestApplyDataMigrationScripts(t *testing.T) {
 	}
 
 	t.Run("returns when there are no scripts to apply", func(t *testing.T) {
-		err := commanders.ApplyDataMigrationScripts(false, "", 0, logDir, currentDirFS, "", idl.Step_revert)
+		err := commanders.ApplyDataMigrationScripts(step.DevNullStream, false, "", 0, logDir, currentDirFS, "", idl.Step_revert)
 		if err != nil {
 			t.Fatalf("unexpected error %#v", err)
 		}
@@ -66,7 +66,7 @@ func TestApplyDataMigrationScripts(t *testing.T) {
 		commanders.SetPsqlFileCommand(exectest.NewCommand(SuccessScript))
 		defer commanders.ResetPsqlFileCommand()
 
-		err := commanders.ApplyDataMigrationScripts(false, "", 0, logDir, currentDirFS, currentScriptDir, idl.Step_stats)
+		err := commanders.ApplyDataMigrationScripts(step.DevNullStream, false, "", 0, logDir, currentDirFS, currentScriptDir, idl.Step_stats)
 		if err != nil {
 			t.Errorf("unexpected err %#v", err)
 		}
@@ -90,7 +90,7 @@ func TestApplyDataMigrationScripts(t *testing.T) {
 		resetStdin := testutils.SetStdin(t, "n\n")
 		defer resetStdin()
 
-		err := commanders.ApplyDataMigrationScripts(false, "", 0, logDir, currentDirFS, currentScriptDir, idl.Step_stats)
+		err := commanders.ApplyDataMigrationScripts(step.DevNullStream, false, "", 0, logDir, currentDirFS, currentScriptDir, idl.Step_stats)
 		if err != nil {
 			t.Fatalf("unexpected error %#v", err)
 		}
@@ -103,7 +103,7 @@ func TestApplyDataMigrationScripts(t *testing.T) {
 		}
 		defer utils.ResetSystemFunctions()
 
-		err := commanders.ApplyDataMigrationScripts(false, "", 0, logDir, currentDirFS, currentScriptDir, idl.Step_stats)
+		err := commanders.ApplyDataMigrationScripts(step.DevNullStream, false, "", 0, logDir, currentDirFS, currentScriptDir, idl.Step_stats)
 		if !errors.Is(err, expected) {
 			t.Errorf("got error %#v want %#v", err, expected)
 		}
@@ -129,7 +129,7 @@ func TestApplyDataMigrationScripts(t *testing.T) {
 		resetStdin := testutils.SetStdin(t, "a\n")
 		defer resetStdin()
 
-		err := commanders.ApplyDataMigrationScripts(false, "", 0, logDir, currentDirFS, currentScriptDir, idl.Step_stats)
+		err := commanders.ApplyDataMigrationScripts(step.DevNullStream, false, "", 0, logDir, currentDirFS, currentScriptDir, idl.Step_stats)
 		var exitError *exec.ExitError
 		if !errors.As(err, &exitError) {
 			t.Errorf("got %T, want %T", err, exitError)
@@ -153,7 +153,7 @@ func TestApplyDataMigrationScripts(t *testing.T) {
 		resetStdin := testutils.SetStdin(t, "a\n")
 		defer resetStdin()
 
-		err := commanders.ApplyDataMigrationScripts(false, "", 0, logDir, currentDirFS, currentScriptDir, idl.Step_stats)
+		err := commanders.ApplyDataMigrationScripts(step.DevNullStream, false, "", 0, logDir, currentDirFS, currentScriptDir, idl.Step_stats)
 		if !errors.Is(err, os.ErrPermission) {
 			t.Errorf("got error %#v want %#v", err, os.ErrPermission)
 		}

--- a/cli/commanders/data_migration_generate.go
+++ b/cli/commanders/data_migration_generate.go
@@ -124,14 +124,7 @@ func GenerateDataMigrationScripts(streams step.OutStreams, nonInteractive bool, 
 		return err
 	}
 
-	fmt.Printf(`
-Generated scripts:
-%s
-
-Logs:
-%s
-
-`, utils.Bold.Sprint(filepath.Join(outputDir, "current")), utils.Bold.Sprint(logDir))
+	fmt.Printf("\nGenerated scripts:%s\nLogs: %s\n\n", utils.Bold.Sprint(filepath.Join(outputDir, "current")), utils.Bold.Sprint(logDir))
 
 	return nil
 }
@@ -174,6 +167,7 @@ func ArchiveDataMigrationScriptsPrompt(streams step.OutStreams, nonInteractive b
 	}
 
 	for {
+		fmt.Println()
 		fmt.Printf(`Previously generated data migration scripts found from
 %s located in
 %s
@@ -220,7 +214,7 @@ Select: `)
 				return step.Skip
 			}
 
-			fmt.Printf("\nArchiving previously generated scripts under\n%s\n", utils.Bold.Sprint(archiveDir))
+			fmt.Printf("\nArchiving previously generated scripts under\n%s\n\n", utils.Bold.Sprint(archiveDir))
 			err = utils.System.MkdirAll(filepath.Dir(archiveDir), 0700)
 			if err != nil {
 				return fmt.Errorf("make directory: %w", err)

--- a/cli/commanders/data_migration_generate_test.go
+++ b/cli/commanders/data_migration_generate_test.go
@@ -53,7 +53,7 @@ func TestGenerateDataMigrationScripts(t *testing.T) {
 		}
 		defer utils.ResetSystemFunctions()
 
-		err := commanders.GenerateDataMigrationScripts(false, "", 0, "", "", fstest.MapFS{})
+		err := commanders.GenerateDataMigrationScripts(step.DevNullStream, false, "", 0, "", "", fstest.MapFS{})
 		if !errors.Is(err, os.ErrPermission) {
 			t.Errorf("got error %#v want %#v", err, os.ErrPermission)
 		}
@@ -70,7 +70,7 @@ func TestGenerateDataMigrationScripts(t *testing.T) {
 
 		outputDirFS := fstest.MapFS{"current": {Mode: os.ModeDir}}
 
-		err := commanders.GenerateDataMigrationScripts(false, "", 0, "", "", outputDirFS)
+		err := commanders.GenerateDataMigrationScripts(step.DevNullStream, false, "", 0, "", "", outputDirFS)
 		if err != nil {
 			t.Errorf("unexpected error: %#v", err)
 		}
@@ -88,7 +88,7 @@ func TestGenerateDataMigrationScripts(t *testing.T) {
 		}
 		defer utils.ResetSystemFunctions()
 
-		err := commanders.GenerateDataMigrationScripts(false, "", 0, "", "", fstest.MapFS{})
+		err := commanders.GenerateDataMigrationScripts(step.DevNullStream, false, "", 0, "", "", fstest.MapFS{})
 		if !errors.Is(err, expected) {
 			t.Errorf("got %v want %v", err, expected)
 		}
@@ -100,7 +100,7 @@ func TestGenerateDataMigrationScripts(t *testing.T) {
 		}
 		defer utils.ResetSystemFunctions()
 
-		err := commanders.GenerateDataMigrationScripts(false, "", 0, "", "", fstest.MapFS{})
+		err := commanders.GenerateDataMigrationScripts(step.DevNullStream, false, "", 0, "", "", fstest.MapFS{})
 		expected := "invalid port"
 		if !strings.Contains(err.Error(), expected) {
 			t.Errorf("got %+v, want %+v", err, expected)
@@ -120,14 +120,14 @@ func TestArchiveDataMigrationScriptsPrompt(t *testing.T) {
 		}
 		defer utils.ResetSystemFunctions()
 
-		err := commanders.ArchiveDataMigrationScriptsPrompt(false, nil, fsys, "")
+		err := commanders.ArchiveDataMigrationScriptsPrompt(step.DevNullStream, false, nil, fsys, "")
 		if !errors.Is(err, expected) {
 			t.Errorf("got %v want %v", err, expected)
 		}
 	})
 
 	t.Run("returns if scripts are 'not' already generated and there is nothing to archive", func(t *testing.T) {
-		err := commanders.ArchiveDataMigrationScriptsPrompt(false, nil, fstest.MapFS{}, "")
+		err := commanders.ArchiveDataMigrationScriptsPrompt(step.DevNullStream, false, nil, fstest.MapFS{}, "")
 		if err != nil {
 			t.Errorf("unexpected error: %#v", err)
 		}
@@ -135,7 +135,7 @@ func TestArchiveDataMigrationScriptsPrompt(t *testing.T) {
 
 	t.Run("errors when failing to read input", func(t *testing.T) {
 		reader := bufio.NewReader(strings.NewReader(""))
-		err := commanders.ArchiveDataMigrationScriptsPrompt(false, reader, fsys, "")
+		err := commanders.ArchiveDataMigrationScriptsPrompt(step.DevNullStream, false, reader, fsys, "")
 		expected := io.EOF
 		if !errors.Is(err, expected) {
 			t.Errorf("got error %#v, want %#v", err, expected)
@@ -149,7 +149,7 @@ func TestArchiveDataMigrationScriptsPrompt(t *testing.T) {
 		testutils.MustCreateDir(t, filepath.Join(outputDir, "current"))
 
 		reader := bufio.NewReader(strings.NewReader("a\n"))
-		err := commanders.ArchiveDataMigrationScriptsPrompt(false, reader, fsys, outputDir)
+		err := commanders.ArchiveDataMigrationScriptsPrompt(step.DevNullStream, false, reader, fsys, outputDir)
 		if err != nil {
 			t.Errorf("unexpected error: %#v", err)
 		}
@@ -166,7 +166,7 @@ func TestArchiveDataMigrationScriptsPrompt(t *testing.T) {
 		defer utils.ResetSystemFunctions()
 
 		reader := bufio.NewReader(strings.NewReader("a\n"))
-		err := commanders.ArchiveDataMigrationScriptsPrompt(false, reader, fsys, "")
+		err := commanders.ArchiveDataMigrationScriptsPrompt(step.DevNullStream, false, reader, fsys, "")
 		if !errors.Is(err, os.ErrPermission) {
 			t.Errorf("got error %#v want %#v", err, os.ErrPermission)
 		}
@@ -179,7 +179,7 @@ func TestArchiveDataMigrationScriptsPrompt(t *testing.T) {
 		defer utils.ResetSystemFunctions()
 
 		reader := bufio.NewReader(strings.NewReader("a\n"))
-		err := commanders.ArchiveDataMigrationScriptsPrompt(false, reader, fsys, "")
+		err := commanders.ArchiveDataMigrationScriptsPrompt(step.DevNullStream, false, reader, fsys, "")
 		var exitError *exec.ExitError
 		if !errors.As(err, &exitError) {
 			t.Errorf("got %T, want %T", err, exitError)
@@ -188,7 +188,7 @@ func TestArchiveDataMigrationScriptsPrompt(t *testing.T) {
 
 	t.Run("returns skip error when user selects 'c'ontinue", func(t *testing.T) {
 		reader := bufio.NewReader(strings.NewReader("c\n"))
-		err := commanders.ArchiveDataMigrationScriptsPrompt(false, reader, fsys, "")
+		err := commanders.ArchiveDataMigrationScriptsPrompt(step.DevNullStream, false, reader, fsys, "")
 		expected := step.Skip
 		if !errors.Is(err, expected) {
 			t.Errorf("got error %#v, want %#v", err, expected)
@@ -197,7 +197,7 @@ func TestArchiveDataMigrationScriptsPrompt(t *testing.T) {
 
 	t.Run("returns canceled error when user selects 'q'uit", func(t *testing.T) {
 		reader := bufio.NewReader(strings.NewReader("q\n"))
-		err := commanders.ArchiveDataMigrationScriptsPrompt(false, reader, fsys, "")
+		err := commanders.ArchiveDataMigrationScriptsPrompt(step.DevNullStream, false, reader, fsys, "")
 		expected := step.Quit
 		if !errors.Is(err, expected) {
 			t.Errorf("got error %#v, want %#v", err, expected)
@@ -208,7 +208,7 @@ func TestArchiveDataMigrationScriptsPrompt(t *testing.T) {
 		d := BufferStandardDescriptors(t)
 
 		reader := bufio.NewReader(strings.NewReader("b\nq\n"))
-		err := commanders.ArchiveDataMigrationScriptsPrompt(false, reader, fsys, "")
+		err := commanders.ArchiveDataMigrationScriptsPrompt(step.StdStreams, false, reader, fsys, "")
 		if !errors.Is(err, step.Quit) {
 			t.Errorf("got error %#v, want %#v", err, step.Quit)
 		}
@@ -307,7 +307,7 @@ func TestGenerateScriptsPerDatabase(t *testing.T) {
 		}
 		defer utils.ResetSystemFunctions()
 
-		err = commanders.GenerateDataMigrationScripts(true, "/usr/local/gpdb5", 0, "", outputDir, fstest.MapFS{})
+		err = commanders.GenerateDataMigrationScripts(step.DevNullStream, true, "/usr/local/gpdb5", 0, "", outputDir, fstest.MapFS{})
 		if err != nil {
 			t.Errorf("unexpected error: %#v", err)
 		}
@@ -340,7 +340,7 @@ func TestGenerateScriptsPerDatabase(t *testing.T) {
 		commanders.SetPsqlCommand(exectest.NewCommand(FailedMain))
 		defer commanders.ResetPsqlCommand()
 
-		err = commanders.GenerateDataMigrationScripts(false, "", 0, "", "", fstest.MapFS{})
+		err = commanders.GenerateDataMigrationScripts(step.DevNullStream, false, "", 0, "", "", fstest.MapFS{})
 		var exitError *exec.ExitError
 		if !errors.As(err, &exitError) {
 			t.Errorf("got %T, want %T", err, exitError)
@@ -377,7 +377,7 @@ func TestGenerateScriptsPerDatabase(t *testing.T) {
 		commanders.SetPsqlFileCommand(exectest.NewCommand(FailedMain))
 		defer commanders.ResetPsqlFileCommand()
 
-		err = commanders.GenerateDataMigrationScripts(false, "", 0, "", "", fstest.MapFS{})
+		err = commanders.GenerateDataMigrationScripts(step.DevNullStream, false, "", 0, "", "", fstest.MapFS{})
 		var exitError *exec.ExitError
 		if !errors.As(err, &exitError) {
 			t.Errorf("got %T, want %T", err, exitError)
@@ -414,7 +414,7 @@ func TestGenerateScriptsPerDatabase(t *testing.T) {
 		commanders.SetPsqlFileCommand(exectest.NewCommand(Success))
 		defer commanders.ResetPsqlFileCommand()
 
-		err = commanders.GenerateDataMigrationScripts(false, "", 0, "", "", fstest.MapFS{})
+		err = commanders.GenerateDataMigrationScripts(step.DevNullStream, false, "", 0, "", "", fstest.MapFS{})
 		var errs errorlist.Errors
 		if !errors.As(err, &errs) {
 			t.Fatalf("got error %#v, want type %T", err, errs)

--- a/cli/commanders/initialize.go
+++ b/cli/commanders/initialize.go
@@ -4,6 +4,7 @@
 package commanders
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -35,14 +36,14 @@ func CreateStateDir() (err error) {
 	return nil
 }
 
-func StartHub() (err error) {
+func StartHub(streams step.OutStreams) (err error) {
 	running, err := IsHubRunning()
 	if err != nil {
 		return xerrors.Errorf("is hub running: %w", err)
 	}
 
 	if running {
-		log.Printf("Hub already running. Skipping.")
+		fmt.Fprint(streams.Stdout(), "Hub already running. Skipping.")
 		return step.Skip
 	}
 
@@ -53,7 +54,11 @@ func StartHub() (err error) {
 		return xerrors.Errorf("%q failed with %q: %w", cmd.String(), string(output), err)
 	}
 
-	log.Printf("%s", output)
+	_, err = streams.Stdout().Write(output)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/cli/commanders/initialize_test.go
+++ b/cli/commanders/initialize_test.go
@@ -114,7 +114,7 @@ func TestStartHub_Succeeds(t *testing.T) {
 
 	execCommandHubCount = exectest.NewCommand(IsHubRunning_False)
 	execCommandHubStart = exectest.NewCommand(GpupgradeHub_good_Main)
-	err := StartHub()
+	err := StartHub(step.DevNullStream)
 	if err != nil {
 		t.Errorf("unexpected error %#v", err)
 	}
@@ -126,7 +126,7 @@ func TestStartHub_FailsToStartWhenHubIsRunningErrors(t *testing.T) {
 
 	execCommandHubCount = exectest.NewCommand(IsHubRunning_Error)
 	execCommandHubStart = exectest.NewCommand(GpupgradeHub_good_Main) // should not hit this, but fail it we do
-	err := StartHub()
+	err := StartHub(step.DevNullStream)
 	var expected *exec.ExitError
 	if !errors.As(err, &expected) {
 		t.Errorf("returned error %#v want %#v", err, expected)
@@ -139,7 +139,7 @@ func TestStartHub_IsSkippedWhenHubIsRunning(t *testing.T) {
 
 	execCommandHubCount = exectest.NewCommand(IsHubRunning_True)
 	execCommandHubStart = exectest.NewCommand(GpupgradeHub_bad_Main) // should not hit this, but fail if we do
-	err := StartHub()
+	err := StartHub(step.DevNullStream)
 
 	if !errors.Is(err, step.Skip) {
 		t.Errorf("unexpected error %#v", err)
@@ -152,7 +152,7 @@ func TestStartHub_FailsWhenStartingTheHubErrors(t *testing.T) {
 
 	execCommandHubCount = exectest.NewCommand(IsHubRunning_False)
 	execCommandHubStart = exectest.NewCommand(GpupgradeHub_bad_Main)
-	err := StartHub()
+	err := StartHub(step.DevNullStream)
 	if err == nil {
 		t.Errorf("expected error %#v got nil", err)
 	}

--- a/cli/commanders/steps.go
+++ b/cli/commanders/steps.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"strings"
 
@@ -14,6 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/substeps"
 	"github.com/greenplum-db/gpupgrade/utils"
 )
 
@@ -160,6 +162,7 @@ func UILoop(stream receiver, verbose bool) (*idl.Response, error) {
 			lastStep = x.Status.Step
 
 			fmt.Print(FormatStatus(x.Status))
+			log.Print(FormatStatus(x.Status))
 			if verbose {
 				fmt.Println()
 			}
@@ -201,7 +204,7 @@ func UILoop(stream receiver, verbose bool) (*idl.Response, error) {
 // FormatStatus panics if it doesn't have a string representation for a given
 // protobuf code.
 func FormatStatus(status *idl.SubstepStatus) string {
-	line, ok := SubstepDescriptions[status.Step]
+	line, ok := substeps.SubstepDescriptions[status.Step]
 	if !ok {
 		panic(fmt.Sprintf("unexpected step %#v", status.Step))
 	}

--- a/cli/commanders/steps_test.go
+++ b/cli/commanders/steps_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/cli/commanders"
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/substeps"
 	"github.com/greenplum-db/gpupgrade/utils"
 )
 
@@ -388,9 +389,9 @@ func TestFormatStatus(t *testing.T) {
 		ignoreInternalStepStatus := 1
 		numberOfSubsteps := len(idl.Substep_name) - ignoreUnknownStep - ignoreInternalStepStatus
 
-		if numberOfSubsteps != len(commanders.SubstepDescriptions) {
+		if numberOfSubsteps != len(substeps.SubstepDescriptions) {
 			t.Errorf("got %q, expected FormatStatus to be able to format all %d statuses %q. Formatted only %d",
-				commanders.SubstepDescriptions, len(idl.Substep_name), idl.Substep_name, len(commanders.SubstepDescriptions))
+				substeps.SubstepDescriptions, len(idl.Substep_name), idl.Substep_name, len(substeps.SubstepDescriptions))
 		}
 	})
 }

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -179,7 +179,7 @@ var restartServices = &cobra.Command{
 	Short: "restarts hub/agents that are not currently running",
 	Long:  "restarts hub/agents that are not currently running",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := commanders.StartHub()
+		err := commanders.StartHub(step.StdStreams)
 		if err != nil && !errors.Is(err, step.Skip) {
 			return err
 		}

--- a/cli/commands/confirmation_text.go
+++ b/cli/commands/confirmation_text.go
@@ -5,7 +5,7 @@ package commands
 
 import "github.com/fatih/color"
 
-const initializeConfirmationText = `
+var initializeConfirmationText = `
 You are about to initialize a major-version upgrade of Greenplum.
 
 %s will carry out the following steps:
@@ -27,9 +27,9 @@ agent_port:           %d
 
 You will still have the opportunity to revert the cluster to its original state 
 after this step.
-
+` + color.RedString(`
 WARNING: Do not perform operations on the cluster until gpupgrade is 
-finalized or reverted.
+finalized or reverted.`) + `
 
 Before proceeding, ensure the following have occurred:
  - Take a backup of the source Greenplum cluster
@@ -37,7 +37,7 @@ Before proceeding, ensure the following have occurred:
  - Run gpstate -e to ensure the source cluster's segments are up and in preferred roles
 `
 
-const executeConfirmationText = `
+var executeConfirmationText = `
 You are about to run the "execute" command for a major-version upgrade of Greenplum.
 This should be done only during a downtime window.
 %s
@@ -47,38 +47,38 @@ gpupgrade log files can be found on all hosts in %s
 
 You will still have the opportunity to revert the cluster to its original state
 after this step.
-
+` + color.RedString(`
 WARNING: Do not perform operations on the source cluster until gpupgrade is
 finalized or reverted.
-`
+`)
 
-const finalizeConfirmationText = `
+var finalizeConfirmationText = `
 You are about to finalize a major-version upgrade of Greenplum.
 This should be done only during a downtime window.
 
 %s will carry out the following steps:
 %s
 gpupgrade log files can be found on all hosts in %s
-
+` + color.RedString(`
 WARNING: You will not be able to revert the cluster to its original state after this step.
 
 WARNING: Do not perform operations on the source and target clusters until gpupgrade is 
 finalized or reverted.
-`
+`)
 
-const revertConfirmationText = `
+var revertConfirmationText = `
 You are about to revert this upgrade.
 This should be done only during a downtime window.
 
 %s will carry out the following steps:
 %s
 gpupgrade log files can be found on all hosts in %s
-
+` + color.RedString(`
 WARNING: You cannot revert if you do not have mirrors & standby configured, and execute has started.
 
 WARNING: Do not perform operations on the source and target clusters until gpupgrade revert
 has completed.
-`
+`)
 
 var revertWarningText = color.RedString(`
 WARNING

--- a/cli/commands/data_migration.go
+++ b/cli/commands/data_migration.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/cli/commanders"
 	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/utils"
 )
 
@@ -36,7 +37,7 @@ func dataMigrationGenerate() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputDir = filepath.Clean(outputDir)
 			seedDir = filepath.Clean(seedDir)
-			return commanders.GenerateDataMigrationScripts(nonInteractive, filepath.Clean(gphome), port, seedDir, outputDir, utils.System.DirFS(outputDir))
+			return commanders.GenerateDataMigrationScripts(step.StdStreams, nonInteractive, filepath.Clean(gphome), port, seedDir, outputDir, utils.System.DirFS(outputDir))
 		},
 	}
 
@@ -77,7 +78,7 @@ func dataMigrationApply() *cobra.Command {
 			}
 
 			currentDir := filepath.Join(filepath.Clean(inputDir), "current")
-			err = commanders.ApplyDataMigrationScripts(nonInteractive, filepath.Clean(gphome), port, logDir, utils.System.DirFS(currentDir), currentDir, parsedPhase)
+			err = commanders.ApplyDataMigrationScripts(step.StdStreams, nonInteractive, filepath.Clean(gphome), port, logDir, utils.System.DirFS(currentDir), currentDir, parsedPhase)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/execute.go
+++ b/cli/commands/execute.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -95,16 +96,14 @@ func execute() *cobra.Command {
 			})
 
 			return st.Complete(fmt.Sprintf(`
-Execute completed successfully.
-
 The target cluster is now running. You may now run queries against the target 
 database and perform any other validation desired prior to finalizing your upgrade.
 source %s
 export MASTER_DATA_DIRECTORY=%s
 export PGPORT=%d
-
+`+color.RedString(`
 WARNING: If any queries modify the target database prior to gpupgrade finalize, 
-it will be inconsistent with the source database. 
+it will be inconsistent with the source database.`)+`
 
 NEXT ACTIONS
 ------------

--- a/cli/commands/finalize.go
+++ b/cli/commands/finalize.go
@@ -82,9 +82,6 @@ func finalize() *cobra.Command {
 					return nil
 				}
 
-				fmt.Println()
-				fmt.Println()
-
 				currentDir := filepath.Join(response.GetLogArchiveDirectory(), "data-migration-scripts", "current")
 				return commanders.ApplyDataMigrationScripts(streams, nonInteractive, target.GPHome, target.CoordinatorPort(),
 					response.GetLogArchiveDirectory(), utils.System.DirFS(currentDir), currentDir, idl.Step_finalize)
@@ -121,8 +118,6 @@ If you postpone creating statistics then after the upgrade run "vacuumdb --all -
 			})
 
 			return st.Complete(fmt.Sprintf(`
-Finalize completed successfully.
-
 The target cluster has been upgraded to Greenplum %s
 
 The source cluster is not running. If copy mode was used you may start 

--- a/cli/commands/finalize.go
+++ b/cli/commands/finalize.go
@@ -86,7 +86,7 @@ func finalize() *cobra.Command {
 				fmt.Println()
 
 				currentDir := filepath.Join(response.GetLogArchiveDirectory(), "data-migration-scripts", "current")
-				return commanders.ApplyDataMigrationScripts(nonInteractive, target.GPHome, target.CoordinatorPort(),
+				return commanders.ApplyDataMigrationScripts(streams, nonInteractive, target.GPHome, target.CoordinatorPort(),
 					response.GetLogArchiveDirectory(), utils.System.DirFS(currentDir), currentDir, idl.Step_finalize)
 			})
 

--- a/cli/commands/help_text.go
+++ b/cli/commands/help_text.go
@@ -11,15 +11,15 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
-	"github.com/greenplum-db/gpupgrade/cli/commanders"
 	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/substeps"
 	"github.com/greenplum-db/gpupgrade/utils"
 )
 
-var initializeSubsteps commanders.Substeps
-var executeSubsteps commanders.Substeps
-var finalizeSubsteps commanders.Substeps
-var revertSubsteps commanders.Substeps
+var initializeSubsteps substeps.Substeps
+var executeSubsteps substeps.Substeps
+var finalizeSubsteps substeps.Substeps
+var revertSubsteps substeps.Substeps
 var InitializeHelp string
 var ExecuteHelp string
 var FinalizeHelp string
@@ -33,7 +33,7 @@ func init() {
 		panic(fmt.Sprintf("failed to get log directory: %v", err))
 	}
 
-	initializeSubsteps = commanders.Substeps{
+	initializeSubsteps = substeps.Substeps{
 		idl.Substep_verify_gpdb_versions,
 		idl.Substep_saving_source_cluster_config,
 		idl.Substep_start_hub,
@@ -54,7 +54,7 @@ func init() {
 		idl.Substep_check_upgrade,
 	}
 
-	executeSubsteps = commanders.Substeps{
+	executeSubsteps = substeps.Substeps{
 		idl.Substep_ensure_gpupgrade_agents_are_running,
 		idl.Substep_check_active_connections_on_source_cluster,
 		idl.Substep_wait_for_cluster_to_be_ready_before_upgrade_master,
@@ -65,7 +65,7 @@ func init() {
 		idl.Substep_start_target_cluster,
 	}
 
-	finalizeSubsteps = commanders.Substeps{
+	finalizeSubsteps = substeps.Substeps{
 		idl.Substep_ensure_gpupgrade_agents_are_running,
 		idl.Substep_check_active_connections_on_target_cluster,
 		idl.Substep_upgrade_mirrors,
@@ -86,7 +86,7 @@ func init() {
 		idl.Substep_delete_master_statedir,
 	}
 
-	revertSubsteps = commanders.Substeps{
+	revertSubsteps = substeps.Substeps{
 		idl.Substep_ensure_gpupgrade_agents_are_running,
 		idl.Substep_check_active_connections_on_target_cluster,
 		idl.Substep_shutdown_target_cluster,

--- a/cli/commands/initialize.go
+++ b/cli/commands/initialize.go
@@ -223,9 +223,6 @@ func initialize() *cobra.Command {
 					return nil
 				}
 
-				fmt.Println()
-				fmt.Println()
-
 				return commanders.GenerateDataMigrationScripts(streams, nonInteractive, sourceGPHome, sourcePort, filepath.Clean(dataMigrationSeedDir), generatedScriptsOutputDir, utils.System.DirFS(generatedScriptsOutputDir))
 			})
 
@@ -233,9 +230,6 @@ func initialize() *cobra.Command {
 				if nonInteractive {
 					return nil
 				}
-
-				fmt.Println()
-				fmt.Println()
 
 				currentDir := filepath.Join(generatedScriptsOutputDir, "current")
 				return commanders.ApplyDataMigrationScripts(streams, nonInteractive, sourceGPHome, sourcePort, logdir, utils.System.DirFS(currentDir), currentDir, idl.Step_stats)
@@ -246,9 +240,6 @@ func initialize() *cobra.Command {
 					return nil
 				}
 
-				fmt.Println()
-				fmt.Println()
-
 				currentDir := filepath.Join(filepath.Clean(generatedScriptsOutputDir), "current")
 				err = commanders.ApplyDataMigrationScripts(streams, nonInteractive, sourceGPHome, sourcePort,
 					logdir, utils.System.DirFS(currentDir), currentDir, idl.Step_initialize)
@@ -256,7 +247,6 @@ func initialize() *cobra.Command {
 					return err
 				}
 
-				fmt.Println()
 				prompt := fmt.Sprintf("Continue with gpupgrade %s?  Yy|Nn: ", idl.Step_initialize)
 				return clistep.Prompt(bufio.NewReader(os.Stdin), prompt)
 			})
@@ -305,7 +295,6 @@ func initialize() *cobra.Command {
 			}
 
 			return st.Complete(fmt.Sprintf(`
-Initialize completed successfully.
 %s
 NEXT ACTIONS
 ------------

--- a/cli/commands/revert.go
+++ b/cli/commands/revert.go
@@ -80,9 +80,6 @@ func revert() *cobra.Command {
 					return nil
 				}
 
-				fmt.Println()
-				fmt.Println()
-
 				currentDir := filepath.Join(response.GetLogArchiveDirectory(), "data-migration-scripts", "current")
 				return commanders.ApplyDataMigrationScripts(streams, nonInteractive, source.GPHome, source.CoordinatorPort(), response.GetLogArchiveDirectory(), utils.System.DirFS(currentDir), currentDir, idl.Step_revert)
 			})
@@ -96,8 +93,6 @@ func revert() *cobra.Command {
 			})
 
 			return st.Complete(fmt.Sprintf(`
-Revert completed successfully.
-
 The source cluster is now running version %s.
 source %s
 export MASTER_DATA_DIRECTORY=%s

--- a/cli/commands/revert.go
+++ b/cli/commands/revert.go
@@ -84,8 +84,7 @@ func revert() *cobra.Command {
 				fmt.Println()
 
 				currentDir := filepath.Join(response.GetLogArchiveDirectory(), "data-migration-scripts", "current")
-				return commanders.ApplyDataMigrationScripts(nonInteractive, source.GPHome, source.CoordinatorPort(),
-					response.GetLogArchiveDirectory(), utils.System.DirFS(currentDir), currentDir, idl.Step_revert)
+				return commanders.ApplyDataMigrationScripts(streams, nonInteractive, source.GPHome, source.CoordinatorPort(), response.GetLogArchiveDirectory(), utils.System.DirFS(currentDir), currentDir, idl.Step_revert)
 			})
 
 			st.Run(idl.Substep_delete_master_statedir, func(streams step.OutStreams) error {

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/idl/mock_idl"
 	"github.com/greenplum-db/gpupgrade/step"
+	"github.com/greenplum-db/gpupgrade/substeps"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/testutils/testlog"
 	"github.com/greenplum-db/gpupgrade/utils"
@@ -177,7 +178,7 @@ func TestStepRun(t *testing.T) {
 		}
 
 		contents := string(logOutput.Bytes())
-		expected := "skipping " + idl.Substep_check_upgrade.String()
+		expected := substeps.SubstepDescriptions[idl.Substep_check_upgrade].HelpText + " skipped"
 		if !strings.Contains(contents, expected) {
 			t.Errorf("expected %q in log file: %q", expected, contents)
 		}

--- a/substeps/substeps.go
+++ b/substeps/substeps.go
@@ -1,13 +1,15 @@
 // Copyright (c) 2017-2023 VMware, Inc. or its affiliates
 // SPDX-License-Identifier: Apache-2.0
 
-package commanders
+package substeps
 
 import (
 	"fmt"
 
 	"github.com/greenplum-db/gpupgrade/idl"
 )
+
+const Divider = "-----------------------------------------------------------------------------"
 
 type Substeps []idl.Substep
 


### PR DESCRIPTION
Have CLI streams write to both stdout and the log file to match consistency to the hub. Don't write to stdout if verbose is not set.

Update UI Output:
- Correctly add a divider betwen each substep when in non-verbose mode.
- Place step and substep duration timing in brackets to match progress status. Creates a clean and uniform UI.
- Clean up "Step in progress" text when main step starts. Both CLI and Hub where doing similar before.
- Correctly write to streams which outputs to both stdout and log file.
- Reword log text when substep is skipped based on run condition.


Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixCLIStreamLogging