### PR TITLE
move completed text to their own file

### DIFF
--- a/cli/commands/completed_text.go
+++ b/cli/commands/completed_text.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import "github.com/fatih/color"
+
+var InitializeCompletedText = `
+%s
+NEXT ACTIONS
+------------
+To proceed with the upgrade, run "gpupgrade execute --verbose"
+followed by "gpupgrade finalize --verbose".
+
+To return the cluster to its original state, run "gpupgrade revert --verbose".`
+
+var ExecuteCompletedText = `
+The target cluster is now running. You may now run queries against the target 
+database and perform any other validation desired prior to finalizing your upgrade.
+source %s
+export MASTER_DATA_DIRECTORY=%s
+export PGPORT=%d
+` + color.RedString(`
+WARNING: If any queries modify the target database prior to gpupgrade finalize, 
+it will be inconsistent with the source database.`) + `
+
+NEXT ACTIONS
+------------
+If you are satisfied with the state of the cluster, run "gpupgrade finalize --verbose" 
+to proceed with the upgrade.
+
+To return the cluster to its original state, run "gpupgrade revert --verbose".`
+
+var FinalizeCompletedText = `
+The target cluster has been upgraded to Greenplum %s
+
+The source cluster is not running. If copy mode was used you may start 
+the source cluster, but not at the same time as the target cluster. 
+To do so configure different ports to avoid conflicts. 
+
+You may delete the source cluster to recover space from all hosts. 
+All source cluster data directories end in "%s".
+MASTER_DATA_DIRECTORY=%s
+
+The gpupgrade logs can be found on the master and segment hosts in
+%s
+
+NEXT ACTIONS
+------------
+To use the upgraded cluster:
+1. Update any scripts to source %s
+2. If applicable, update the greenplum-db symlink to point to the target 
+   install location: %s -> %s
+3. In a new shell:
+   source %s
+   export MASTER_DATA_DIRECTORY=%s
+   export PGPORT=%d
+   
+   And connect to the database
+
+If you have not already, execute the “%s” data migration scripts with
+"gpupgrade apply --gphome %s --port %d --input-dir %s --phase %s"
+
+If you postponed creating optimizer statistics run
+"vacuumdb --all --analyze-in-stages"`
+
+var RevertCompletedText = `
+The source cluster is now running version %s.
+source %s
+export MASTER_DATA_DIRECTORY=%s
+export PGPORT=%d
+
+The gpupgrade logs can be found on the master and segment hosts in
+%s
+
+NEXT ACTIONS
+------------
+If you have not already, execute the “%s” data migration scripts with
+"gpupgrade apply --gphome %s --port %d --input-dir %s --phase %s"
+
+To restart the upgrade, run "gpupgrade initialize --verbose" again.`

--- a/cli/commands/execute.go
+++ b/cli/commands/execute.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -95,22 +94,7 @@ func execute() *cobra.Command {
 				return nil
 			})
 
-			return st.Complete(fmt.Sprintf(`
-The target cluster is now running. You may now run queries against the target 
-database and perform any other validation desired prior to finalizing your upgrade.
-source %s
-export MASTER_DATA_DIRECTORY=%s
-export PGPORT=%d
-`+color.RedString(`
-WARNING: If any queries modify the target database prior to gpupgrade finalize, 
-it will be inconsistent with the source database.`)+`
-
-NEXT ACTIONS
-------------
-If you are satisfied with the state of the cluster, run "gpupgrade finalize --verbose" 
-to proceed with the upgrade.
-
-To return the cluster to its original state, run "gpupgrade revert --verbose".`,
+			return st.Complete(fmt.Sprintf(ExecuteCompletedText,
 				filepath.Join(intermediate.GPHome, "greenplum_path.sh"),
 				intermediate.CoordinatorDataDir(),
 				intermediate.CoordinatorPort()))

--- a/cli/commands/finalize.go
+++ b/cli/commands/finalize.go
@@ -117,38 +117,7 @@ If you postpone creating statistics then after the upgrade run "vacuumdb --all -
 				return upgrade.DeleteDirectories([]string{utils.GetStateDir()}, upgrade.StateDirectoryFiles, streams)
 			})
 
-			return st.Complete(fmt.Sprintf(`
-The target cluster has been upgraded to Greenplum %s
-
-The source cluster is not running. If copy mode was used you may start 
-the source cluster, but not at the same time as the target cluster. 
-To do so configure different ports to avoid conflicts. 
-
-You may delete the source cluster to recover space from all hosts. 
-All source cluster data directories end in "%s".
-MASTER_DATA_DIRECTORY=%s
-
-The gpupgrade logs can be found on the master and segment hosts in
-%s
-
-NEXT ACTIONS
-------------
-To use the upgraded cluster:
-1. Update any scripts to source %s
-2. If applicable, update the greenplum-db symlink to point to the target 
-   install location: %s -> %s
-3. In a new shell:
-   source %s
-   export MASTER_DATA_DIRECTORY=%s
-   export PGPORT=%d
-   
-   And connect to the database
-
-If you have not already, execute the “%s” data migration scripts with
-"gpupgrade apply --gphome %s --port %d --input-dir %s --phase %s"
-
-If you postponed creating optimizer statistics run
-"vacuumdb --all --analyze-in-stages"`,
+			return st.Complete(fmt.Sprintf(FinalizeCompletedText,
 				target.Version,
 				fmt.Sprintf("%s.<contentID>%s", response.GetUpgradeID(), upgrade.OldSuffix),
 				response.GetArchivedSourceCoordinatorDataDirectory(),

--- a/cli/commands/initialize.go
+++ b/cli/commands/initialize.go
@@ -294,15 +294,7 @@ func initialize() *cobra.Command {
 				revertWarning = revertWarningText
 			}
 
-			return st.Complete(fmt.Sprintf(`
-%s
-NEXT ACTIONS
-------------
-To proceed with the upgrade, run "gpupgrade execute --verbose"
-followed by "gpupgrade finalize --verbose".
-
-To return the cluster to its original state, run "gpupgrade revert --verbose".`,
-				revertWarning))
+			return st.Complete(fmt.Sprintf(InitializeCompletedText, revertWarning))
 		},
 	}
 

--- a/cli/commands/revert.go
+++ b/cli/commands/revert.go
@@ -92,21 +92,7 @@ func revert() *cobra.Command {
 				return upgrade.DeleteDirectories([]string{utils.GetStateDir()}, upgrade.StateDirectoryFiles, streams)
 			})
 
-			return st.Complete(fmt.Sprintf(`
-The source cluster is now running version %s.
-source %s
-export MASTER_DATA_DIRECTORY=%s
-export PGPORT=%d
-
-The gpupgrade logs can be found on the master and segment hosts in
-%s
-
-NEXT ACTIONS
-------------
-If you have not already, execute the “%s” data migration scripts with
-"gpupgrade apply --gphome %s --port %d --input-dir %s --phase %s"
-
-To restart the upgrade, run "gpupgrade initialize --verbose" again.`,
+			return st.Complete(fmt.Sprintf(RevertCompletedText,
 				source.Version,
 				filepath.Join(source.GPHome, "greenplum_path.sh"), source.CoordinatorDataDir(), source.CoordinatorPort(),
 				response.GetLogArchiveDirectory(),


### PR DESCRIPTION
To help keep the CLI steps concise and focused on the logic move the completed step text to its own file similar to the existing confirmation text file. This also makes it easier for testing purposes.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:completedTextFix