### PR TITLE
fix revert tests

### DIFF
--- a/test/acceptance/revert_test.go
+++ b/test/acceptance/revert_test.go
@@ -76,7 +76,7 @@ func TestRevert(t *testing.T) {
 
 		// Since the logArchiveDir has a timestamp we need to do a partial check
 		logArchiveDir := MustGetLogArchiveDir(t, conf.UpgradeID)
-		logArchiveDir = logArchiveDir[:len(logArchiveDir)-3] + "*"
+		logArchiveDir = logArchiveDir[:len(logArchiveDir)-4] + "*"
 
 		testutils.RemotePathMustExist(t, conf.Intermediate.CoordinatorHostname(), logArchiveDir)
 
@@ -245,14 +245,14 @@ func verifyRevert(t *testing.T, source greenplum.Cluster, intermediate *greenplu
 	t.Helper()
 
 	// Since the logArchiveDir has a timestamp we need to do a partial check
-	logArchiveDir = logArchiveDir[:len(logArchiveDir)-3]
+	logArchiveDir = logArchiveDir[:len(logArchiveDir)-4]
 
 	match := fmt.Sprintf(commands.RevertCompletedText,
 		source.Version,
 		filepath.Join(source.GPHome, "greenplum_path.sh"), source.CoordinatorDataDir(), source.CoordinatorPort(),
-		logArchiveDir+`\d{3}`,
+		logArchiveDir+`\d{4}`,
 		idl.Step_revert,
-		source.GPHome, source.CoordinatorPort(), filepath.Join(logArchiveDir+`\d{3}`, "data-migration-scripts"), idl.Step_revert)
+		source.GPHome, source.CoordinatorPort(), filepath.Join(logArchiveDir+`\d{4}`, "data-migration-scripts"), idl.Step_revert)
 	expected := regexp.MustCompile(match)
 	if !expected.MatchString(revertOutput) {
 		t.Fatalf("expected %q to contain %v", revertOutput, expected)


### PR DESCRIPTION
Check the archive log directory timestamp with less precision since it takes awhile from when we derive the directory name with timestamp to when revert actually runs. For example, the CI was recently failing with directory timestamp:

20230809T170909
expecting:
20230809T171\d{3}

https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixTests