### PR TITLE
bump go.mod golang version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,15 +37,15 @@ unit integration acceptance test: export PATH := $(CURDIR):$(PATH)
 
 .PHONY: unit
 unit:
-	go test --cover -count=1 $(shell go list ./... | grep -v test/integration$$ | grep -v test/acceptance$$ )
+	go test -count=1 $(shell go list ./... | grep -v test/integration$$ | grep -v test/acceptance$$ )
 
 .PHONY: integration
 integration:
-	go test --cover -count=1 ./test/integration
+	go test -count=1 ./test/integration
 
 .PHONY: acceptance
 acceptance:
-	go test --cover -count=1 -timeout 1h15m -v ./test/acceptance
+	go test -count=1 -timeout 1h15m -v ./test/acceptance
 	bats ./test/acceptance/helpers/teardown_helpers.bats
 	bats ./test/acceptance/initialize.bats
 	bats ./test/acceptance/finalize.bats

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/greenplum-db/gpupgrade
 
-go 1.19
+go 1.21
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0


### PR DESCRIPTION
Looks like there are still some errors to work through.

==================

Bump to go 1.21

However, using -cover in our testing results in tests that utilize the exectest package to fail with:
`warning: GOCOVERDIR not set, no coverage data emitted`

That is, the exectest package provides helpers for test code that wants to mock out pieces of the os/exec package, namely exec.Command(). For explanations see: https://web.archive.org/web/20220506055022/https://npf.io/2015/06/testing-exec-command/ https://web.archive.org/web/20220506055117/https://jamiethompson.me/posts/Unit-Testing-Exec-Command-In-Golang/

However, even when setting the GOCOVERDIR these test binaries still omit the above warning which interfers with our testing. For now disable -cover.

https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:bumpGolang