### PR TITLE
setup isolation2 infrastructure to run migration tests in golang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ integration:
 
 .PHONY: acceptance
 acceptance:
-	go test -count=1 -timeout 1h15m -v ./test/acceptance
+	go test -count=1 -timeout 1h15m -v ./test/acceptance -skip TestMigrationScripts
 	bats ./test/acceptance/helpers/teardown_helpers.bats
 	bats ./test/acceptance/finalize.bats
 	bats ./test/acceptance/migration_scripts.bats
@@ -58,6 +58,7 @@ test check: unit integration acceptance
 
 .PHONY: pg-upgrade-tests
 pg-upgrade-tests:
+	go test -count=1 -v ./test/acceptance/ -run TestMigrationScripts
 	bats ./test/acceptance/pg_upgrade.bats
 
 .PHONY: coverage

--- a/ci/main/pipeline/4_pg_upgrade_jobs.yml
+++ b/ci/main/pipeline/4_pg_upgrade_jobs.yml
@@ -26,7 +26,7 @@
           source:
             # NOTE: Since we build isolation2 the build image OS needs to match
             # the GPDB target version we are testing.
-            repository: gcr.io/data-gpdb-public-images/gpdb{{.Target}}-{{.Platform}}-test
+            repository: gcr.io/data-gpdb-public-images/gpdb{{.Target}}-{{.Platform}}-test-golang
             tag: latest
         inputs:
           - name: enterprise_rpm

--- a/ci/main/scripts/pg-upgrade-tests.bash
+++ b/ci/main/scripts/pg-upgrade-tests.bash
@@ -35,6 +35,8 @@ run_pg_upgrade_tests() {
         set -eux -o pipefail
 
         export TERM=linux
+        export PATH=$PATH:/usr/local/go/bin
+        export GOFLAGS="-mod=readonly" # do not update dependencies during build
         export ISOLATION2_PATH=$(readlink -e gpdb_src/src/test/isolation2)
 
         cd gpupgrade_src

--- a/cli/commanders/data_migration.go
+++ b/cli/commanders/data_migration.go
@@ -52,7 +52,7 @@ func ResetPsqlFileCommand() {
 	psqlFileCommand = exec.Command
 }
 
-func applySQLFile(gphome string, port int, database string, path string, args ...string) ([]byte, error) {
+func ApplySQLFile(gphome string, port int, database string, path string, args ...string) ([]byte, error) {
 	args = append(args,
 		"--no-psqlrc", "--quiet",
 		"-d", database,

--- a/cli/commanders/data_migration_apply.go
+++ b/cli/commanders/data_migration_apply.go
@@ -166,7 +166,7 @@ func ApplyDataMigrationScriptSubDir(gphome string, port int, scriptDirFS fs.FS, 
 		}
 
 		log.Printf("  %s\n", entry.Name())
-		output, err := applySQLFile(gphome, port, "postgres", filepath.Join(scriptDir, entry.Name()), "-v", "ON_ERROR_STOP=1", "--echo-queries")
+		output, err := ApplySQLFile(gphome, port, "postgres", filepath.Join(scriptDir, entry.Name()), "-v", "ON_ERROR_STOP=1", "--echo-queries")
 		if err != nil {
 			return nil, err
 		}

--- a/cli/commanders/data_migration_generate.go
+++ b/cli/commanders/data_migration_generate.go
@@ -255,7 +255,7 @@ func GenerateScriptsPerDatabase(streams step.OutStreams, database DatabaseInfo, 
 
 	log.Print(string(output))
 
-	output, err = applySQLFile(gphome, port, database.Datname, filepath.Join(seedDir, "create_find_view_dep_function.sql"))
+	output, err = ApplySQLFile(gphome, port, database.Datname, filepath.Join(seedDir, "create_find_view_dep_function.sql"))
 	if err != nil {
 		return err
 	}
@@ -332,7 +332,7 @@ func GenerateScriptsPerPhase(phase idl.Step, database DatabaseInfo, gphome strin
 
 			var scriptOutput []byte
 			if strings.HasSuffix(script.Name(), ".sql") {
-				scriptOutput, err = applySQLFile(gphome, port, database.Datname, filepath.Join(seedDir, phase.String(), scriptDir.Name(), script.Name()),
+				scriptOutput, err = ApplySQLFile(gphome, port, database.Datname, filepath.Join(seedDir, phase.String(), scriptDir.Name(), script.Name()),
 					"-v", "ON_ERROR_STOP=1", "--no-align", "--tuples-only")
 				if err != nil {
 					return err

--- a/test/acceptance/5-to-6/migratable_tests/setup_migratable_globals.sql
+++ b/test/acceptance/5-to-6/migratable_tests/setup_migratable_globals.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE isolation2test;
+CREATE ROLE test_role1;

--- a/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/.gitignore
+++ b/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/.gitignore
@@ -1,0 +1,3 @@
+regression.diffs
+regression.out
+results/

--- a/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/expected/view_owners.out
+++ b/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/expected/view_owners.out
@@ -1,0 +1,19 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup migratable objects
+--------------------------------------------------------------------------------
+
+CREATE TABLE preserve_view_owner_table(i int);
+CREATE
+CREATE VIEW preserve_view_owner_view AS SELECT i FROM preserve_view_owner_table;
+CREATE
+ALTER TABLE preserve_view_owner_view OWNER TO test_role1;
+ALTER
+
+SELECT schemaname, viewname, viewowner FROM pg_views WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'gp_toolkit') ORDER BY 1,2,3;
+ schemaname | viewname                 | viewowner  
+------------+--------------------------+------------
+ public     | preserve_view_owner_view | test_role1 
+(1 row)

--- a/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/migratable_source_schedule
+++ b/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/migratable_source_schedule
@@ -1,0 +1,1 @@
+test: view_owners

--- a/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/sql/view_owners.sql
+++ b/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/sql/view_owners.sql
@@ -1,0 +1,15 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup migratable objects
+--------------------------------------------------------------------------------
+
+CREATE TABLE preserve_view_owner_table(i int);
+CREATE VIEW preserve_view_owner_view AS SELECT i FROM preserve_view_owner_table;
+ALTER TABLE preserve_view_owner_view OWNER TO test_role1;
+
+SELECT schemaname, viewname, viewowner
+FROM pg_views
+WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'gp_toolkit')
+ORDER BY 1,2,3;

--- a/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/.gitignore
+++ b/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/.gitignore
@@ -1,0 +1,3 @@
+regression.diffs
+regression.out
+results/

--- a/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/expected/view_owners.out
+++ b/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/expected/view_owners.out
@@ -1,0 +1,12 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup migratable objects
+--------------------------------------------------------------------------------
+
+SELECT schemaname, viewname, viewowner FROM pg_views WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'gp_toolkit') ORDER BY 1,2,3;
+ schemaname | viewname                 | viewowner  
+------------+--------------------------+------------
+ public     | preserve_view_owner_view | test_role1 
+(1 row)

--- a/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/migratable_source_schedule
+++ b/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/migratable_source_schedule
@@ -1,0 +1,1 @@
+test: view_owners

--- a/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/sql/view_owners.sql
+++ b/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/sql/view_owners.sql
@@ -1,0 +1,11 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup migratable objects
+--------------------------------------------------------------------------------
+
+SELECT schemaname, viewname, viewowner
+FROM pg_views
+WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'gp_toolkit')
+ORDER BY 1,2,3;

--- a/test/acceptance/5-to-6/migratable_tests/teardown_migratable_globals.sql
+++ b/test/acceptance/5-to-6/migratable_tests/teardown_migratable_globals.sql
@@ -1,0 +1,2 @@
+DROP DATABASE IF EXISTS isolation2test;
+DROP ROLE IF EXISTS test_role1;

--- a/test/acceptance/acceptance_suite_test.go
+++ b/test/acceptance/acceptance_suite_test.go
@@ -17,9 +17,11 @@ import (
 	"github.com/greenplum-db/gpupgrade/greenplum/connection"
 	"github.com/greenplum-db/gpupgrade/hub"
 	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/testutils"
 	"github.com/greenplum-db/gpupgrade/utils"
 	"github.com/greenplum-db/gpupgrade/utils/errorlist"
+	"github.com/greenplum-db/gpupgrade/utils/rsync"
 )
 
 var GPHOME_SOURCE string
@@ -49,6 +51,7 @@ func init() {
 	GPHOME_TARGET = testutils.MustGetEnv("GPHOME_TARGET")
 	PGPORT = testutils.MustGetEnv("PGPORT")
 }
+
 func MustGetRepoRoot(t *testing.T) string {
 	t.Helper()
 
@@ -58,6 +61,40 @@ func MustGetRepoRoot(t *testing.T) string {
 	}
 
 	return filepath.Dir(filepath.Dir(currentDir))
+}
+
+func generate(t *testing.T, outputDir string) string {
+	t.Helper()
+
+	cmd := exec.Command("gpupgrade", "generate",
+		"--non-interactive",
+		"--gphome", GPHOME_SOURCE,
+		"--port", PGPORT,
+		"--seed-dir", filepath.Join(MustGetRepoRoot(t), "data-migration-scripts"),
+		"--output-dir", filepath.Join(outputDir, "generated-scripts"))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("unexpected err: %#v stderr %q", err, output)
+	}
+
+	return strings.TrimSpace(string(output))
+}
+
+func apply(t *testing.T, gphome string, port string, phase idl.Step, inputDir string) string {
+	t.Helper()
+
+	cmd := exec.Command("gpupgrade", "apply",
+		"--non-interactive",
+		"--gphome", gphome,
+		"--port", port,
+		"--phase", phase.String(),
+		"--input-dir", filepath.Join(inputDir, "generated-scripts"))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("unexpected err: %#v stderr %q", err, output)
+	}
+
+	return strings.TrimSpace(string(output))
 }
 
 func initialize_stopBeforeClusterCreation(t *testing.T) string {
@@ -102,6 +139,19 @@ func execute(t *testing.T) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "execute",
+		"--non-interactive", "--verbose")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("unexpected err: %#v stderr %q", err, output)
+	}
+
+	return strings.TrimSpace(string(output))
+}
+
+func finalize(t *testing.T) string {
+	t.Helper()
+
+	cmd := exec.Command("gpupgrade", "finalize",
 		"--non-interactive", "--verbose")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -158,6 +208,11 @@ func GetIntermediateCluster(t *testing.T) greenplum.Cluster {
 	return getCluster(t, GPHOME_TARGET, testutils.MustConvertStringToInt(t, TARGET_PGPORT), idl.ClusterDestination_intermediate)
 }
 
+func GetTargetCluster(t *testing.T) greenplum.Cluster {
+	t.Helper()
+	return getCluster(t, GPHOME_TARGET, testutils.MustConvertStringToInt(t, PGPORT), idl.ClusterDestination_target)
+}
+
 func getCluster(t *testing.T, gphome string, port int, destination idl.ClusterDestination) greenplum.Cluster {
 	t.Helper()
 
@@ -177,6 +232,58 @@ func getCluster(t *testing.T, gphome string, port int, destination idl.ClusterDe
 	}
 
 	return cluster
+}
+
+// backupDemoCluster is used with restoreDemoCluster to restore a cluster after
+// finalize.
+func backupDemoCluster(t *testing.T, backupDir string, source greenplum.Cluster) {
+	src := filepath.Dir(filepath.Dir(source.CoordinatorDataDir())) + string(os.PathSeparator)
+	dest := backupDir + string(os.PathSeparator)
+
+	testutils.MustCreateDir(t, dest)
+
+	options := []rsync.Option{
+		rsync.WithSources(src),
+		rsync.WithDestination(dest),
+		rsync.WithOptions(rsync.Options...),
+		rsync.WithStream(step.DevNullStream),
+	}
+	err := rsync.Rsync(options...)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// restoreDemoCluster restores the cluster after finalize has been run.
+func restoreDemoCluster(t *testing.T, backupDir string, source greenplum.Cluster) {
+	// Depending on where we failed we need to stop either the source or target cluster.
+	err := source.Stop(step.DevNullStream)
+	if err != nil {
+		target := GetTargetCluster(t)
+		err = target.Stop(step.DevNullStream)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	src := backupDir + string(os.PathSeparator)
+	dest := filepath.Dir(filepath.Dir(source.CoordinatorDataDir())) + string(os.PathSeparator)
+
+	options := []rsync.Option{
+		rsync.WithSources(src),
+		rsync.WithDestination(dest),
+		rsync.WithOptions("--archive", "-I", "--delete"),
+		rsync.WithStream(step.DevNullStream),
+	}
+	err = rsync.Rsync(options...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = source.Start(step.DevNullStream)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func jq(t *testing.T, file string, args ...string) string {

--- a/test/acceptance/acceptance_suite_test.go
+++ b/test/acceptance/acceptance_suite_test.go
@@ -74,7 +74,7 @@ func generate(t *testing.T, outputDir string) string {
 		"--output-dir", filepath.Join(outputDir, "generated-scripts"))
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("unexpected err: %#v stderr %q", err, output)
+		t.Fatalf("unexpected err: %#v stderr %s", err, output)
 	}
 
 	return strings.TrimSpace(string(output))
@@ -91,7 +91,7 @@ func apply(t *testing.T, gphome string, port string, phase idl.Step, inputDir st
 		"--input-dir", filepath.Join(inputDir, "generated-scripts"))
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("unexpected err: %#v stderr %q", err, output)
+		t.Fatalf("unexpected err: %#v stderr %s", err, output)
 	}
 
 	return strings.TrimSpace(string(output))
@@ -110,7 +110,7 @@ func initialize_stopBeforeClusterCreation(t *testing.T) string {
 		"--disk-free-ratio", "0")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("unexpected err: %#v stderr %q", err, output)
+		t.Fatalf("unexpected err: %#v stderr %s", err, output)
 	}
 
 	return strings.TrimSpace(string(output))
@@ -129,7 +129,7 @@ func initialize(t *testing.T, mode idl.Mode) string {
 		"--disk-free-ratio", "0")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("unexpected err: %#v stderr %q", err, output)
+		t.Fatalf("unexpected err: %#v stderr %s", err, output)
 	}
 
 	return strings.TrimSpace(string(output))
@@ -142,7 +142,7 @@ func execute(t *testing.T) string {
 		"--non-interactive", "--verbose")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("unexpected err: %#v stderr %q", err, output)
+		t.Fatalf("unexpected err: %#v stderr %s", err, output)
 	}
 
 	return strings.TrimSpace(string(output))
@@ -155,7 +155,7 @@ func finalize(t *testing.T) string {
 		"--non-interactive", "--verbose")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("unexpected err: %#v stderr %q", err, output)
+		t.Fatalf("unexpected err: %#v stderr %s", err, output)
 	}
 
 	return strings.TrimSpace(string(output))
@@ -168,7 +168,7 @@ func revert(t *testing.T) string {
 		"--non-interactive", "--verbose")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("unexpected err: %#v stderr %q", err, output)
+		t.Fatalf("unexpected err: %#v stderr %s", err, output)
 	}
 
 	return strings.TrimSpace(string(output))

--- a/test/acceptance/migratable_test.go
+++ b/test/acceptance/migratable_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package gpupgrade_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/testutils"
+)
+
+func TestMigrationScripts(t *testing.T) {
+	// Since finalize archives the stateDir (GPUPGRADE_HOME) backups and
+	// migration scripts cannot be stored here.
+	stateDir := testutils.GetTempDir(t, "stateDir")
+	defer testutils.MustRemoveAll(t, stateDir)
+
+	resetEnv := testutils.SetEnv(t, "GPUPGRADE_HOME", stateDir)
+	defer resetEnv()
+
+	backupDir := testutils.GetTempDir(t, "backup")
+	defer testutils.MustRemoveAll(t, backupDir)
+
+	migrationDir := testutils.GetTempDir(t, "migration")
+	defer testutils.MustRemoveAll(t, backupDir)
+
+	source := GetSourceCluster(t)
+
+	dir := "6-to-7"
+	if source.Version.Major == 5 {
+		dir = "5-to-6"
+	}
+
+	testDir := filepath.Join(MustGetRepoRoot(t), "test", "acceptance", dir, "migratable_tests")
+
+	t.Run("migration scripts generate sql to modify non-upgradeable objects and fix pg_upgrade check errors", func(t *testing.T) {
+		backupDemoCluster(t, backupDir, source)
+		defer restoreDemoCluster(t, backupDir, source)
+
+		// Remove any default non-upgradeable objects such as GPDB 5X gphdfs role.
+		generate(t, migrationDir)
+		apply(t, GPHOME_SOURCE, PGPORT, idl.Step_initialize, migrationDir)
+
+		testutils.MustApplySQLFile(t, GPHOME_SOURCE, PGPORT, filepath.Join(testDir, "setup_migratable_globals.sql"))
+		defer testutils.MustApplySQLFile(t, GPHOME_SOURCE, PGPORT, filepath.Join(testDir, "teardown_migratable_globals.sql"))
+
+		source_isolation2_regress(t, source.Version, testDir, "migratable_source_schedule")
+
+		generate(t, migrationDir)
+		apply(t, GPHOME_SOURCE, PGPORT, idl.Step_initialize, migrationDir)
+
+		initialize(t, idl.Mode_link)
+		defer revertIgnoreFailures(t) // cleanup in case we fail part way through
+		execute(t)
+		finalize(t)
+
+		apply(t, GPHOME_TARGET, PGPORT, idl.Step_finalize, migrationDir)
+
+		target_isolation2_regress(t, source.Version, testDir, "migratable_source_schedule")
+	})
+}
+
+func source_isolation2_regress(t *testing.T, sourceVersion semver.Version, testDir string, schedule string) string {
+	env := []string{"PGOPTIONS=-c optimizer=off"}
+	var binDir string
+
+	switch sourceVersion.Major {
+	case 5:
+		binDir = "--psqldir"
+		// Set PYTHONPATH directly since it is needed when running the
+		// pg_upgrade tests locally. Normally one would source
+		// greenplum_path.sh, but that causes the following issues:
+		// https://web.archive.org/web/20220506055918/https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/JN-YwjCCReY/m/0L9wBOvlAQAJ
+		env = append(env, "PYTHONPATH="+filepath.Join(GPHOME_SOURCE, "lib/python"))
+	case 6:
+		binDir = "--psqldir"
+	default:
+		binDir = "--bindir"
+	}
+
+	tests := "--schedule=" + filepath.Join(testDir, "source_cluster_regress", schedule)
+	focus := os.Getenv("FOCUS_TESTS")
+	if focus != "" {
+		tests = focus
+	}
+
+	cmd := exec.Command("./pg_isolation2_regress",
+		"--init-file", "init_file_isolation2",
+		"--inputdir", filepath.Join(testDir, "source_cluster_regress"),
+		"--outputdir", filepath.Join(testDir, "source_cluster_regress"),
+		binDir, filepath.Join(GPHOME_SOURCE, "bin"),
+		"--port", PGPORT,
+		tests)
+	cmd.Dir = testutils.MustGetEnv("ISOLATION2_PATH")
+	cmd.Env = append(os.Environ(), env...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("unexpected err: %#v stderr %s", err, output)
+	}
+
+	return strings.TrimSpace(string(output))
+}
+
+func target_isolation2_regress(t *testing.T, sourceVersion semver.Version, testDir string, schedule string) string {
+	env := []string{"PGOPTIONS=-c optimizer=off"}
+	var binDir string
+
+	switch sourceVersion.Major {
+	case 5:
+		binDir = "--psqldir"
+		// Set PYTHONPATH directly since it is needed when running the
+		// pg_upgrade tests locally. Normally one would source
+		// greenplum_path.sh, but that causes the following issues:
+		// https://web.archive.org/web/20220506055918/https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/JN-YwjCCReY/m/0L9wBOvlAQAJ
+		env = append(env, "PYTHONPATH="+filepath.Join(GPHOME_SOURCE, "lib/python"))
+	case 6:
+		binDir = "--psqldir"
+	default:
+		binDir = "--bindir"
+	}
+
+	tests := "--schedule=" + filepath.Join(testDir, "source_cluster_regress", schedule)
+	focus := os.Getenv("FOCUS_TESTS")
+	if focus != "" {
+		tests = focus
+	}
+
+	cmd := exec.Command("./pg_isolation2_regress",
+		"--init-file", "init_file_isolation2",
+		"--inputdir", filepath.Join(testDir, "target_cluster_regress"),
+		"--outputdir", filepath.Join(testDir, "target_cluster_regress"),
+		binDir, filepath.Join(GPHOME_TARGET, "bin"),
+		"--port", PGPORT,
+		"--use-existing",
+		tests)
+	cmd.Dir = testutils.MustGetEnv("ISOLATION2_PATH")
+	cmd.Env = append(os.Environ(), env...)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("unexpected err: %#v stderr %s", err, output)
+	}
+
+	return strings.TrimSpace(string(output))
+}

--- a/test/acceptance/revert_test.go
+++ b/test/acceptance/revert_test.go
@@ -76,7 +76,7 @@ func TestRevert(t *testing.T) {
 
 		// Since the logArchiveDir has a timestamp we need to do a partial check
 		logArchiveDir := MustGetLogArchiveDir(t, conf.UpgradeID)
-		logArchiveDir = logArchiveDir[:len(logArchiveDir)-4] + "*"
+		logArchiveDir = logArchiveDir[:len(logArchiveDir)-5] + "*"
 
 		testutils.RemotePathMustExist(t, conf.Intermediate.CoordinatorHostname(), logArchiveDir)
 
@@ -245,14 +245,14 @@ func verifyRevert(t *testing.T, source greenplum.Cluster, intermediate *greenplu
 	t.Helper()
 
 	// Since the logArchiveDir has a timestamp we need to do a partial check
-	logArchiveDir = logArchiveDir[:len(logArchiveDir)-4]
+	logArchiveDir = logArchiveDir[:len(logArchiveDir)-5]
 
 	match := fmt.Sprintf(commands.RevertCompletedText,
 		source.Version,
 		filepath.Join(source.GPHome, "greenplum_path.sh"), source.CoordinatorDataDir(), source.CoordinatorPort(),
-		logArchiveDir+`\d{4}`,
+		logArchiveDir+`\d{5}`,
 		idl.Step_revert,
-		source.GPHome, source.CoordinatorPort(), filepath.Join(logArchiveDir+`\d{4}`, "data-migration-scripts"), idl.Step_revert)
+		source.GPHome, source.CoordinatorPort(), filepath.Join(logArchiveDir+`\d{5}`, "data-migration-scripts"), idl.Step_revert)
 	expected := regexp.MustCompile(match)
 	if !expected.MatchString(revertOutput) {
 		t.Fatalf("expected %q to contain %v", revertOutput, expected)

--- a/testutils/remote_test_utils.go
+++ b/testutils/remote_test_utils.go
@@ -6,7 +6,6 @@ package testutils
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -117,7 +116,7 @@ func MustWriteToRemoteFile(t *testing.T, host string, path string, contents stri
 	}
 	err := rsync.Rsync(options...)
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 }
 

--- a/testutils/test_utils.go
+++ b/testutils/test_utils.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/blang/semver/v4"
 
+	"github.com/greenplum-db/gpupgrade/cli/commanders"
 	"github.com/greenplum-db/gpupgrade/greenplum"
 	"github.com/greenplum-db/gpupgrade/step"
 	"github.com/greenplum-db/gpupgrade/upgrade"
@@ -522,6 +523,15 @@ func VerifyClusterIsRunning(t *testing.T, cluster greenplum.Cluster) {
 	}
 
 	err = cluster.RunGreenplumCmd(step.DevNullStream, "pg_isready", "-q", "-p", strconv.Itoa(cluster.CoordinatorPort()))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func MustApplySQLFile(t *testing.T, gphome string, port string, path string) {
+	t.Helper()
+
+	_, err := commanders.ApplySQLFile(gphome, MustConvertStringToInt(t, port), "postgres", path, "-v", "ON_ERROR_STOP=1")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Ported 1 test. And setup the golang framework to run isolation2 tests.

pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:port-migration-scripts