### PR TITLE
fix flakey intialize aceptance test

### DIFF
--- a/test/acceptance/initialize_test.go
+++ b/test/acceptance/initialize_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -91,11 +92,12 @@ func TestInitialize(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		expected := fmt.Sprintf("Error: substep %q: "+
-			"temp_port_range contains port %s which overlaps with the source cluster ports on host %s. "+
-			"Specify a non-overlapping temp_port_range.", idl.Substep_saving_source_cluster_config, PGPORT, hostname)
-		if !strings.Contains(string(output), expected) {
-			t.Fatalf("expected %q to contain %q", output, expected)
+		match := fmt.Sprintf("Error: substep %q: "+
+			"temp_port_range contains port \\d+ which overlaps with the source cluster ports on host %s. "+
+			"Specify a non-overlapping temp_port_range.", idl.Substep_saving_source_cluster_config, hostname)
+		expected := regexp.MustCompile(match)
+		if !expected.Match(output) {
+			t.Fatalf("expected %s to contain %s", output, expected)
 		}
 	})
 


### PR DESCRIPTION
This test is flakey since the internal code ranges over a map to determine overlapped ports. Golang does not preserve ordering when ranging over maps. Thus, have the test just check for a number rather than a specific number for the port. This is easier than changing the production code.

https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fixIntializeFlake