### PR TITLE
port migratable finalize test drop_partition_seg_entries

### DIFF
--- a/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/expected/drop-partition-seg-entries.out
+++ b/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/expected/drop-partition-seg-entries.out
@@ -1,0 +1,69 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup migratable objects
+--------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION insert_dummy_segentry(segrelfqname text) RETURNS void AS $func$ BEGIN EXECUTE 'INSERT INTO ' || segrelfqname || ' VALUES(null)'; /* in func */ END $func$  LANGUAGE plpgsql;
+CREATE
+
+-- test AO parent partition with seg entries
+CREATE TABLE ao_root_partition (a int, b int) WITH (APPENDONLY=TRUE) DISTRIBUTED BY (a) PARTITION BY RANGE (a) SUBPARTITION BY RANGE (b) SUBPARTITION TEMPLATE (START(1) END (5) EVERY(1)) (START (1) END (2) EVERY (1));
+CREATE
+INSERT INTO ao_root_partition VALUES(1, 1);
+INSERT 1
+INSERT INTO ao_root_partition VALUES(1, 2);
+INSERT 1
+INSERT INTO ao_root_partition VALUES(1, 3);
+INSERT 1
+
+-- create an artificial aoseg entry for the root and interior partition.
+SET allow_system_table_mods TO DML;
+SET
+SELECT insert_dummy_segentry(s.interior_segrelfqname) FROM ( SELECT segrelid::regclass::text AS interior_segrelfqname FROM pg_appendonly WHERE relid IN ('ao_root_partition'::regclass, 'ao_root_partition_1_prt_1'::regclass) ) AS s;
+ insert_dummy_segentry 
+-----------------------
+                       
+                       
+(2 rows)
+RESET allow_system_table_mods;
+RESET
+
+-- test AOCO parent partition with seg entries
+CREATE TABLE aoco_root_partition (a int, b int) WITH (APPENDONLY=TRUE, ORIENTATION=COLUMN) DISTRIBUTED BY (a) PARTITION BY RANGE (a) SUBPARTITION BY RANGE (b) SUBPARTITION TEMPLATE (START(1) END(5) EVERY(1)) (START(1) END(2) EVERY(1));
+CREATE
+INSERT INTO aoco_root_partition VALUES(1, 1);
+INSERT 1
+INSERT INTO aoco_root_partition VALUES(1, 2);
+INSERT 1
+INSERT INTO aoco_root_partition VALUES(1, 3);
+INSERT 1
+
+-- create an artificial aocsseg entry for the root and interior partition.
+SET allow_system_table_mods TO DML;
+SET
+SELECT insert_dummy_segentry(s.interior_segrelfqname) FROM ( SELECT segrelid::regclass::text AS interior_segrelfqname FROM pg_appendonly WHERE relid IN ('aoco_root_partition'::regclass, 'aoco_root_partition_1_prt_1'::regclass) ) AS s;
+ insert_dummy_segentry 
+-----------------------
+                       
+                       
+(2 rows)
+RESET allow_system_table_mods;
+RESET
+
+-- check data
+SELECT * from ao_root_partition ORDER BY 1, 2;
+ a | b 
+---+---
+ 1 | 1 
+ 1 | 2 
+ 1 | 3 
+(3 rows)
+SELECT * FROM aoco_root_partition ORDER BY 1, 2;
+ a | b 
+---+---
+ 1 | 1 
+ 1 | 2 
+ 1 | 3 
+(3 rows)

--- a/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/migratable_source_schedule
+++ b/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/migratable_source_schedule
@@ -1,1 +1,1 @@
-test: tables_using_tsquery_type unique_primary_foreign_key_constraint heterogeneous_partition_tables partition_indexes
+test: tables_using_tsquery_type unique_primary_foreign_key_constraint heterogeneous_partition_tables partition_indexes drop-partition-seg-entries

--- a/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/sql/drop-partition-seg-entries.sql
+++ b/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/sql/drop-partition-seg-entries.sql
@@ -1,0 +1,58 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup migratable objects
+--------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION insert_dummy_segentry(segrelfqname text)
+    RETURNS void AS
+$func$
+BEGIN
+    EXECUTE 'INSERT INTO ' || segrelfqname || ' VALUES(null)'; /* in func */
+END
+$func$  LANGUAGE plpgsql;
+
+-- test AO parent partition with seg entries
+CREATE TABLE ao_root_partition (a int, b int) WITH (APPENDONLY=TRUE)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE (a)
+	SUBPARTITION BY RANGE (b)
+	SUBPARTITION TEMPLATE (START(1) END (5) EVERY(1)) (START (1) END (2) EVERY (1));
+INSERT INTO ao_root_partition VALUES(1, 1);
+INSERT INTO ao_root_partition VALUES(1, 2);
+INSERT INTO ao_root_partition VALUES(1, 3);
+
+-- create an artificial aoseg entry for the root and interior partition.
+SET allow_system_table_mods TO DML;
+SELECT insert_dummy_segentry(s.interior_segrelfqname)
+FROM (
+    SELECT segrelid::regclass::text AS interior_segrelfqname
+    FROM pg_appendonly
+    WHERE relid IN ('ao_root_partition'::regclass, 'ao_root_partition_1_prt_1'::regclass)
+) AS s;
+RESET allow_system_table_mods;
+
+-- test AOCO parent partition with seg entries
+CREATE TABLE aoco_root_partition (a int, b int) WITH (APPENDONLY=TRUE, ORIENTATION=COLUMN)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE (a)
+    SUBPARTITION BY RANGE (b)
+    SUBPARTITION TEMPLATE (START(1) END(5) EVERY(1)) (START(1) END(2) EVERY(1));
+INSERT INTO aoco_root_partition VALUES(1, 1);
+INSERT INTO aoco_root_partition VALUES(1, 2);
+INSERT INTO aoco_root_partition VALUES(1, 3);
+
+-- create an artificial aocsseg entry for the root and interior partition.
+SET allow_system_table_mods TO DML;
+SELECT insert_dummy_segentry(s.interior_segrelfqname)
+FROM (
+    SELECT segrelid::regclass::text AS interior_segrelfqname
+    FROM pg_appendonly
+    WHERE relid IN ('aoco_root_partition'::regclass, 'aoco_root_partition_1_prt_1'::regclass)
+) AS s;
+RESET allow_system_table_mods;
+
+-- check data
+SELECT * from ao_root_partition ORDER BY 1, 2;
+SELECT * FROM aoco_root_partition ORDER BY 1, 2;

--- a/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/expected/drop-partition-seg-entries.out
+++ b/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/expected/drop-partition-seg-entries.out
@@ -1,0 +1,46 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup migratable objects
+--------------------------------------------------------------------------------
+
+-- check data
+SELECT * from ao_root_partition ORDER BY 1, 2;
+ a | b 
+---+---
+ 1 | 1 
+ 1 | 2 
+ 1 | 3 
+(3 rows)
+SELECT * FROM aoco_root_partition ORDER BY 1, 2;
+ a | b 
+---+---
+ 1 | 1 
+ 1 | 2 
+ 1 | 3 
+(3 rows)
+
+-- exercise object
+INSERT INTO ao_root_partition VALUES(1, 4);
+INSERT 1
+INSERT INTO aoco_root_partition VALUES(1, 4);
+INSERT 1
+
+-- check data
+SELECT * from ao_root_partition ORDER BY 1, 2;
+ a | b 
+---+---
+ 1 | 1 
+ 1 | 2 
+ 1 | 3 
+ 1 | 4 
+(4 rows)
+SELECT * FROM aoco_root_partition ORDER BY 1, 2;
+ a | b 
+---+---
+ 1 | 1 
+ 1 | 2 
+ 1 | 3 
+ 1 | 4 
+(4 rows)

--- a/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/migratable_target_schedule
+++ b/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/migratable_target_schedule
@@ -1,1 +1,1 @@
-test: tables_using_tsquery_type unique_primary_foreign_key_constraint heterogeneous_partition_tables partition_indexes
+test: tables_using_tsquery_type unique_primary_foreign_key_constraint heterogeneous_partition_tables partition_indexes drop-partition-seg-entries

--- a/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/sql/drop-partition-seg-entries.sql
+++ b/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/sql/drop-partition-seg-entries.sql
@@ -1,0 +1,18 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup migratable objects
+--------------------------------------------------------------------------------
+
+-- check data
+SELECT * from ao_root_partition ORDER BY 1, 2;
+SELECT * FROM aoco_root_partition ORDER BY 1, 2;
+
+-- exercise object
+INSERT INTO ao_root_partition VALUES(1, 4);
+INSERT INTO aoco_root_partition VALUES(1, 4);
+
+-- check data
+SELECT * from ao_root_partition ORDER BY 1, 2;
+SELECT * FROM aoco_root_partition ORDER BY 1, 2;


### PR DESCRIPTION
commit message from where this test was introduced
```
data-migration-script to drop parent partitions with seg entries

The ICW regression database has more AO and AOCO parent
partitions with seg entries which is currently causing the 5 to 6
upgrade jobs to fail. Thus, the easiest way to address all these tables
seems to add a pre-initialize data migration script. There is no need
for a post-finalize or post-revert script since the seg entries are not
needed.
```

gpupgrade reference commit:
ec53ecd39ba0ec15bb91bfe8f064f02cc3a33873


pipeline:
https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:partition-seg-entries