### PR TITLE
port migratable finalize test drop_gphdfs

### DIFF
--- a/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/expected/drop_gphdfs.out
+++ b/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/expected/drop_gphdfs.out
@@ -5,6 +5,14 @@
 -- Create and setup migratable objects
 --------------------------------------------------------------------------------
 
+-- This is a workaround because the setup to drop this protocol in template1
+-- does not persist when when running in the CI for unknown reasons. It is in
+-- an ignore because it is not needed locally and produces different output.
+-- start_ignore
+DROP PROTOCOL IF EXISTS gphdfs CASCADE;
+DROP
+-- end_ignore
+
 -- create external gphdfs table fake the gphdfs protocol so that it doesn't
 -- actually have to be installed
 CREATE FUNCTION noop() RETURNS integer AS 'select 0' LANGUAGE SQL;

--- a/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/expected/drop_gphdfs.out
+++ b/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/expected/drop_gphdfs.out
@@ -1,0 +1,36 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup migratable objects
+--------------------------------------------------------------------------------
+
+-- create external gphdfs table fake the gphdfs protocol so that it doesn't
+-- actually have to be installed
+CREATE FUNCTION noop() RETURNS integer AS 'select 0' LANGUAGE SQL;
+CREATE
+CREATE PROTOCOL gphdfs (writefunc=noop, readfunc=noop);
+CREATE
+
+CREATE EXTERNAL TABLE ext_gphdfs (name text) LOCATION ('gphdfs://example.com/data/filename.txt') FORMAT 'TEXT' (DELIMITER '|');
+CREATE
+CREATE EXTERNAL TABLE "ext gphdfs" (name text) LOCATION ('gphdfs://example.com/data/filename.txt') FORMAT 'TEXT' (DELIMITER '|');
+CREATE
+
+-- check gphdfs
+SELECT proname FROM pg_proc WHERE proname='noop';
+ proname 
+---------
+ noop    
+(1 row)
+SELECT relname FROM pg_class WHERE relname LIKE '%gphdfs' AND relstorage='x';
+ relname    
+------------
+ ext gphdfs 
+ ext_gphdfs 
+(2 rows)
+SELECT ptcname FROM pg_extprotocol where ptcname='gphdfs';
+ ptcname 
+---------
+ gphdfs  
+(1 row)

--- a/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/migratable_source_schedule
+++ b/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/migratable_source_schedule
@@ -1,1 +1,1 @@
-test: tables_using_tsquery_type unique_primary_foreign_key_constraint heterogeneous_partition_tables partition_indexes drop-partition-seg-entries
+test: tables_using_tsquery_type unique_primary_foreign_key_constraint heterogeneous_partition_tables partition_indexes drop-partition-seg-entries drop_gphdfs

--- a/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/sql/drop_gphdfs.sql
+++ b/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/sql/drop_gphdfs.sql
@@ -1,0 +1,23 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup migratable objects
+--------------------------------------------------------------------------------
+
+-- create external gphdfs table fake the gphdfs protocol so that it doesn't
+-- actually have to be installed
+CREATE FUNCTION noop() RETURNS integer AS 'select 0' LANGUAGE SQL;
+CREATE PROTOCOL gphdfs (writefunc=noop, readfunc=noop);
+
+CREATE EXTERNAL TABLE ext_gphdfs (name text)
+	LOCATION ('gphdfs://example.com/data/filename.txt')
+	FORMAT 'TEXT' (DELIMITER '|');
+CREATE EXTERNAL TABLE "ext gphdfs" (name text)
+	LOCATION ('gphdfs://example.com/data/filename.txt')
+	FORMAT 'TEXT' (DELIMITER '|');
+
+-- check gphdfs
+SELECT proname FROM pg_proc WHERE proname='noop';
+SELECT relname FROM pg_class WHERE relname LIKE '%gphdfs' AND relstorage='x';
+SELECT ptcname FROM pg_extprotocol where ptcname='gphdfs';

--- a/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/sql/drop_gphdfs.sql
+++ b/test/acceptance/5-to-6/migratable_tests/source_cluster_regress/sql/drop_gphdfs.sql
@@ -5,6 +5,13 @@
 -- Create and setup migratable objects
 --------------------------------------------------------------------------------
 
+-- This is a workaround because the setup to drop this protocol in template1
+-- does not persist when when running in the CI for unknown reasons. It is in
+-- an ignore because it is not needed locally and produces different output.
+-- start_ignore
+DROP PROTOCOL IF EXISTS gphdfs CASCADE;
+-- end_ignore
+
 -- create external gphdfs table fake the gphdfs protocol so that it doesn't
 -- actually have to be installed
 CREATE FUNCTION noop() RETURNS integer AS 'select 0' LANGUAGE SQL;

--- a/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/expected/drop_gphdfs.out
+++ b/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/expected/drop_gphdfs.out
@@ -1,0 +1,10 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Since we test data migration scripts both 1) after upgrading and 2) reverting
+-- after initialize and execute we reuse the same expected file to avoid code
+-- duplication. We have one file for 5X named _5.out and another for 6X named
+-- _6.out. A base file name.out is needed to prevent pg_isolation_regress from
+-- failing with missing expected output. The isolation2 framework first compares
+-- the base expected file name.out, and then any subsequent files such as _5.out,
+-- and _6.out. If any of them match the test passes.

--- a/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/expected/drop_gphdfs_5.out
+++ b/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/expected/drop_gphdfs_5.out
@@ -1,0 +1,24 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup migratable objects
+--------------------------------------------------------------------------------
+
+-- check gphdfs
+SELECT proname FROM pg_proc WHERE proname='noop';
+ proname 
+---------
+ noop    
+(1 row)
+SELECT relname FROM pg_class WHERE relname LIKE '%gphdfs' AND relstorage='x';
+ relname    
+------------
+ ext gphdfs 
+ ext_gphdfs 
+(2 rows)
+SELECT ptcname FROM pg_extprotocol where ptcname='gphdfs';
+ ptcname 
+---------
+ gphdfs  
+(1 row)

--- a/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/expected/drop_gphdfs_6.out
+++ b/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/expected/drop_gphdfs_6.out
@@ -1,0 +1,22 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup migratable objects
+--------------------------------------------------------------------------------
+
+-- check gphdfs
+SELECT proname FROM pg_proc WHERE proname='noop';
+ proname 
+---------
+ noop    
+(1 row)
+SELECT relname FROM pg_class WHERE relname LIKE '%gphdfs' AND relstorage='x';
+ relname 
+---------
+(0 rows)
+SELECT ptcname FROM pg_extprotocol where ptcname='gphdfs';
+ ptcname 
+---------
+ gphdfs  
+(1 row)

--- a/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/migratable_target_schedule
+++ b/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/migratable_target_schedule
@@ -1,1 +1,1 @@
-test: tables_using_tsquery_type unique_primary_foreign_key_constraint heterogeneous_partition_tables partition_indexes drop-partition-seg-entries
+test: tables_using_tsquery_type unique_primary_foreign_key_constraint heterogeneous_partition_tables partition_indexes drop-partition-seg-entries drop_gphdfs

--- a/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/sql/drop_gphdfs.sql
+++ b/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/sql/drop_gphdfs.sql
@@ -1,0 +1,11 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup migratable objects
+--------------------------------------------------------------------------------
+
+-- check gphdfs
+SELECT proname FROM pg_proc WHERE proname='noop';
+SELECT relname FROM pg_class WHERE relname LIKE '%gphdfs' AND relstorage='x';
+SELECT ptcname FROM pg_extprotocol where ptcname='gphdfs';

--- a/test/acceptance/5-to-6/setup_globals.sql
+++ b/test/acceptance/5-to-6/setup_globals.sql
@@ -41,3 +41,4 @@ $$ LANGUAGE plpgsql;
 
 SELECT drop_gphdfs();
 DROP FUNCTION drop_gphdfs();
+DROP PROTOCOL IF EXISTS gphdfs CASCADE;


### PR DESCRIPTION
original commit message:
```
migration: recreate GPHDFS tables after revert

Use pg_dump to get the original table definitions. We add a few test
tables to create_nonupgradable_objects.sql to exercise the new code.

Also chmod +x migration_scripts.bats while we're at it.

```

gpupgrade reference commit:
84e1da89f5bf61aa9f22a047f28bd5d4a2d255f0

pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:port-drop-gphdfs