### PR TITLE
Fix Heterogenous data loss

### DIFF
--- a/cli/commanders/data_migration.go
+++ b/cli/commanders/data_migration.go
@@ -65,7 +65,7 @@ func ApplySQLFile(gphome string, port int, database string, path string, args ..
 	log.Printf("Executing: %q", cmd.String())
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("%q failed with %q: %w", cmd.String(), string(output), err)
+		return nil, fmt.Errorf("%s failed with %s: %w", cmd.String(), string(output), err)
 	}
 
 	return output, nil

--- a/data-migration-scripts/5-to-6-seed-scripts/initialize/heterogeneous_partitioned_tables/fix_heterogeneous_partition_tables.sql
+++ b/data-migration-scripts/5-to-6-seed-scripts/initialize/heterogeneous_partitioned_tables/fix_heterogeneous_partition_tables.sql
@@ -97,6 +97,7 @@ if res1 is not None:
         swap_sql = swap_sql + """
 CREATE TABLE __gpupgrade_tmp_executor.scratch_table (LIKE {schemaname}.{childrelname} INCLUDING CONSTRAINTS INCLUDING DEFAULTS);
 ALTER TABLE __gpupgrade_tmp_executor.scratch_table OWNER TO {childrelowner};
+INSERT INTO __gpupgrade_tmp_executor.scratch_table SELECT * FROM {schemaname}.{childrelname};
 ALTER TABLE {schemaname}.{parrelname} {partition_sql} {exchange_sql} WITH TABLE __gpupgrade_tmp_executor.scratch_table;
 DROP TABLE __gpupgrade_tmp_executor.scratch_table;
 """.format(**locals())

--- a/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/expected/heterogeneous_partition_tables.out
+++ b/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/expected/heterogeneous_partition_tables.out
@@ -5,7 +5,6 @@
 -- Create and setup migratable objects
 --------------------------------------------------------------------------------
 
--- start_ignore
 -- check data
 SELECT * FROM dropped_column ORDER BY 1, 2, 3;
  a | b | c 
@@ -24,7 +23,6 @@ SELECT * FROM heterogeneous_ml_partition_table ORDER BY 1, 2, 3;
  1        | 1         | 1     
  2        | 2         | 2     
 (2 rows)
--- end_ignore
 
 -- check owners
 SELECT c.relname, pg_catalog.pg_get_userbyid(c.relowner) FROM pg_partition_rule pr JOIN pg_class c ON c.oid = pr.parchildrelid WHERE c.relname LIKE 'dropped_column%' UNION SELECT c.relname, pg_catalog.pg_get_userbyid(c.relowner) FROM pg_partition p JOIN pg_class c ON c.oid = p.parrelid WHERE c.relname LIKE 'dropped_column%' ORDER BY 1,2;
@@ -75,7 +73,6 @@ INSERT 1
 INSERT INTO heterogeneous_ml_partition_table VALUES (3, 3, 3);
 INSERT 1
 
--- start_ignore
 -- check data
 SELECT * FROM dropped_column ORDER BY 1, 2, 3;
  a | b | c 
@@ -98,4 +95,3 @@ SELECT * FROM heterogeneous_ml_partition_table ORDER BY 1, 2, 3;
  2        | 2         | 2     
  3        | 3         | 3     
 (3 rows)
--- end_ignore

--- a/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/sql/heterogeneous_partition_tables.sql
+++ b/test/acceptance/5-to-6/migratable_tests/target_cluster_regress/sql/heterogeneous_partition_tables.sql
@@ -5,12 +5,10 @@
 -- Create and setup migratable objects
 --------------------------------------------------------------------------------
 
--- start_ignore
 -- check data
 SELECT * FROM dropped_column ORDER BY 1, 2, 3;
 SELECT * FROM child_has_dropped_column ORDER BY 1, 2, 3, 4;
 SELECT * FROM heterogeneous_ml_partition_table ORDER BY 1, 2, 3;
--- end_ignore
 
 -- check owners
 SELECT c.relname, pg_catalog.pg_get_userbyid(c.relowner)
@@ -62,9 +60,7 @@ INSERT INTO child_has_dropped_column VALUES (2, 2, 'b', 'bbb');
 
 INSERT INTO heterogeneous_ml_partition_table VALUES (3, 3, 3);
 
--- start_ignore
 -- check data
 SELECT * FROM dropped_column ORDER BY 1, 2, 3;
 SELECT * FROM child_has_dropped_column ORDER BY 1, 2, 3, 4;
 SELECT * FROM heterogeneous_ml_partition_table ORDER BY 1, 2, 3;
--- end_ignore


### PR DESCRIPTION
    Copy data from old to new partition when fixing heterogeneous partitions
    
    The heterogeneous partition data migration script was causing data loss
    when replacing partitions that had dropped columns. The procedure to
    resolve partitions with dropped columns was to...
    1. CREATE a temp table that has the same columns as the affected table
    2. ALTER temp table to match owners.
    3. EXCHANGE PARTITION to swap out affected partition with a replacement.
    4. DROP original partition.
    
    While this resolves the affected partition, This was missing the step to
    copy data to the new partition.
    
 pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:heterogenous-data-loss