### PR TITLE
Move to acceptance test utils

### DIFF
--- a/hub/rename_data_directories_test.go
+++ b/hub/rename_data_directories_test.go
@@ -26,7 +26,7 @@ func TestRenameSegmentDataDirs(t *testing.T) {
 	testlog.SetupTestLogger()
 
 	m := hub.RenameMap{
-		"sdw1": {
+		"sdw1": []*idl.RenameDirectories{
 			{
 				Source: "/data/dbfast1/seg1_123ABC",
 				Target: "/data/dbfast1/seg1",
@@ -36,7 +36,7 @@ func TestRenameSegmentDataDirs(t *testing.T) {
 				Target: "/data/dbfast1/seg3",
 			},
 		},
-		"sdw2": {
+		"sdw2": []*idl.RenameDirectories{
 			{
 				Source: "/data/dbfast2/seg2_123ABC",
 				Target: "/data/dbfast2/seg2",

--- a/test/acceptance/5-to-6/upgradeable_tests/source_cluster_regress/expected/clog_preservation.out
+++ b/test/acceptance/5-to-6/upgradeable_tests/source_cluster_regress/expected/clog_preservation.out
@@ -19,11 +19,11 @@ CREATE
 -- These tuples would contain xmins that refer to CLOG that should not be
 -- truncated. We ensure that all tuples inserted end up in seg 0.
 
-!\retcode (/bin/bash -c "source ${GPHOME_SOURCE}/greenplum_path.sh && ${GPHOME_SOURCE}/bin/gpconfig -c debug_burn_xids -v on --skipvalidation");
+!\retcode (/bin/bash -c "source ${testutils.GPHOME_SOURCE}/greenplum_path.sh && ${testutils.GPHOME_SOURCE}/bin/gpconfig -c debug_burn_xids -v on --skipvalidation");
 -- start_ignore
 -- end_ignore
 (exited with code 0)
-!\retcode (/bin/bash -c "source ${GPHOME_SOURCE}/greenplum_path.sh && ${GPHOME_SOURCE}/bin/gpstop -au");
+!\retcode (/bin/bash -c "source ${testutils.GPHOME_SOURCE}/greenplum_path.sh && ${testutils.GPHOME_SOURCE}/bin/gpstop -au");
 -- start_ignore
 -- end_ignore
 (exited with code 0)
@@ -32,7 +32,7 @@ CREATE
 -- end_ignore
 (exited with code 0)
 
-!\retcode $GPHOME_SOURCE/bin/pgbench -n -f /tmp/clog_preservation.sql -c 8 -t 512 isolation2test;
+!\retcode $testutils.GPHOME_SOURCE/bin/pgbench -n -f /tmp/clog_preservation.sql -c 8 -t 512 isolation2test;
 -- start_ignore
 transaction type: Custom query
 scaling factor: 1
@@ -47,11 +47,11 @@ tps = 870.915114 (excluding connections establishing)
 -- end_ignore
 (exited with code 0)
 
-!\retcode (/bin/bash -c "source ${GPHOME_SOURCE}/greenplum_path.sh && ${GPHOME_SOURCE}/bin/gpconfig -r debug_burn_xids --skipvalidation");
+!\retcode (/bin/bash -c "source ${testutils.GPHOME_SOURCE}/greenplum_path.sh && ${testutils.GPHOME_SOURCE}/bin/gpconfig -r debug_burn_xids --skipvalidation");
 -- start_ignore
 -- end_ignore
 (exited with code 0)
-!\retcode (/bin/bash -c "source ${GPHOME_SOURCE}/greenplum_path.sh && ${GPHOME_SOURCE}/bin/gpstop -au");
+!\retcode (/bin/bash -c "source ${testutils.GPHOME_SOURCE}/greenplum_path.sh && ${testutils.GPHOME_SOURCE}/bin/gpstop -au");
 -- start_ignore
 -- end_ignore
 (exited with code 0)

--- a/test/acceptance/5-to-6/upgradeable_tests/source_cluster_regress/sql/clog_preservation.sql
+++ b/test/acceptance/5-to-6/upgradeable_tests/source_cluster_regress/sql/clog_preservation.sql
@@ -18,14 +18,14 @@ CREATE TABLE foo(i int);
 -- These tuples would contain xmins that refer to CLOG that should not be
 -- truncated. We ensure that all tuples inserted end up in seg 0.
 
-!\retcode (/bin/bash -c "source ${GPHOME_SOURCE}/greenplum_path.sh && ${GPHOME_SOURCE}/bin/gpconfig -c debug_burn_xids -v on --skipvalidation");
-!\retcode (/bin/bash -c "source ${GPHOME_SOURCE}/greenplum_path.sh && ${GPHOME_SOURCE}/bin/gpstop -au");
+!\retcode (/bin/bash -c "source ${testutils.GPHOME_SOURCE}/greenplum_path.sh && ${testutils.GPHOME_SOURCE}/bin/gpconfig -c debug_burn_xids -v on --skipvalidation");
+!\retcode (/bin/bash -c "source ${testutils.GPHOME_SOURCE}/greenplum_path.sh && ${testutils.GPHOME_SOURCE}/bin/gpstop -au");
 !\retcode echo "INSERT INTO foo VALUES(1);" > /tmp/clog_preservation.sql;
 
-!\retcode $GPHOME_SOURCE/bin/pgbench -n -f /tmp/clog_preservation.sql -c 8 -t 512 isolation2test;
+!\retcode $testutils.GPHOME_SOURCE/bin/pgbench -n -f /tmp/clog_preservation.sql -c 8 -t 512 isolation2test;
 
-!\retcode (/bin/bash -c "source ${GPHOME_SOURCE}/greenplum_path.sh && ${GPHOME_SOURCE}/bin/gpconfig -r debug_burn_xids --skipvalidation");
-!\retcode (/bin/bash -c "source ${GPHOME_SOURCE}/greenplum_path.sh && ${GPHOME_SOURCE}/bin/gpstop -au");
+!\retcode (/bin/bash -c "source ${testutils.GPHOME_SOURCE}/greenplum_path.sh && ${testutils.GPHOME_SOURCE}/bin/gpconfig -r debug_burn_xids --skipvalidation");
+!\retcode (/bin/bash -c "source ${testutils.GPHOME_SOURCE}/greenplum_path.sh && ${testutils.GPHOME_SOURCE}/bin/gpstop -au");
 !\retcode rm /tmp/clog_preservation.sql;
 
 -- NOTE: Do not scan the table here, as it will prevent CLOG lookups when we

--- a/test/acceptance/args_test.go
+++ b/test/acceptance/args_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/cli/commands"
 	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/testutils/acceptance"
 )
 
 func TestArgs(t *testing.T) {
@@ -56,9 +57,9 @@ func TestArgs(t *testing.T) {
 	t.Run("gpupgrade initialize fails when --pg-upgrade-verbose is used without --verbose", func(t *testing.T) {
 		cmd := exec.Command("gpupgrade", "initialize",
 			"--non-interactive",
-			"--source-gphome", GPHOME_SOURCE,
-			"--target-gphome", GPHOME_TARGET,
-			"--source-master-port", PGPORT,
+			"--source-gphome", acceptance.GPHOME_SOURCE,
+			"--target-gphome", acceptance.GPHOME_TARGET,
+			"--source-master-port", acceptance.PGPORT,
 			"--stop-before-cluster-creation",
 			"--disk-free-ratio", "0",
 			"--pg-upgrade-verbose",
@@ -81,7 +82,7 @@ target-gphome = %s
 source-master-port = %s
 disk-free-ratio = 0
 stop-before-cluster-creation = true
-`, GPHOME_SOURCE, GPHOME_TARGET, PGPORT)
+`, acceptance.GPHOME_SOURCE, acceptance.GPHOME_TARGET, acceptance.PGPORT)
 		testutils.MustWriteToFile(t, configFile, contents)
 
 		cmd := exec.Command("gpupgrade", "initialize",
@@ -94,25 +95,25 @@ stop-before-cluster-creation = true
 		if err != nil {
 			t.Fatalf("unexpected err: %v stderr: %q", err, output)
 		}
-		defer revert(t)
+		defer acceptance.Revert(t)
 
 		actual := configShow(t, "--source-gphome")
-		if actual != GPHOME_SOURCE {
-			t.Errorf("got %q want %q", actual, GPHOME_SOURCE)
+		if actual != acceptance.GPHOME_SOURCE {
+			t.Errorf("got %q want %q", actual, acceptance.GPHOME_SOURCE)
 		}
 
 		actual = configShow(t, "--target-gphome")
-		if actual != GPHOME_TARGET {
-			t.Errorf("got %q want %q", actual, GPHOME_TARGET)
+		if actual != acceptance.GPHOME_TARGET {
+			t.Errorf("got %q want %q", actual, acceptance.GPHOME_TARGET)
 		}
 	})
 
 	t.Run("initialize sanitizes source-gphome and target-gphome", func(t *testing.T) {
 		cmd := exec.Command("gpupgrade", "initialize",
 			"--non-interactive",
-			"--source-gphome", GPHOME_SOURCE+string(os.PathSeparator),
-			"--target-gphome", GPHOME_TARGET+string(os.PathSeparator)+string(os.PathSeparator),
-			"--source-master-port", PGPORT,
+			"--source-gphome", acceptance.GPHOME_SOURCE+string(os.PathSeparator),
+			"--target-gphome", acceptance.GPHOME_TARGET+string(os.PathSeparator)+string(os.PathSeparator),
+			"--source-master-port", acceptance.PGPORT,
 			"--stop-before-cluster-creation",
 			"--disk-free-ratio", "0",
 		)
@@ -120,21 +121,21 @@ stop-before-cluster-creation = true
 		if err != nil {
 			t.Fatalf("unexpected err: %v stderr: %q", err, output)
 		}
-		defer revert(t)
+		defer acceptance.Revert(t)
 
 		actual := configShow(t, "--source-gphome")
-		if actual != GPHOME_SOURCE {
-			t.Errorf("got %q want %q", actual, GPHOME_SOURCE)
+		if actual != acceptance.GPHOME_SOURCE {
+			t.Errorf("got %q want %q", actual, acceptance.GPHOME_SOURCE)
 		}
 
 		actual = configShow(t, "--target-gphome")
-		if actual != GPHOME_TARGET {
-			t.Errorf("got %q want %q", actual, GPHOME_TARGET)
+		if actual != acceptance.GPHOME_TARGET {
+			t.Errorf("got %q want %q", actual, acceptance.GPHOME_TARGET)
 		}
 	})
 
 	t.Run("gpupgrade execute fails when --pg-upgrade-verbose is used without --verbose", func(t *testing.T) {
-		initialize_stopBeforeClusterCreation(t)
+		acceptance.Initialize_stopBeforeClusterCreation(t)
 
 		cmd := exec.Command("gpupgrade", "execute",
 			"--non-interactive",
@@ -144,7 +145,7 @@ stop-before-cluster-creation = true
 		if err == nil {
 			t.Errorf("expected error got nil")
 		}
-		defer revert(t)
+		defer acceptance.Revert(t)
 
 		expected := "Error: expected --verbose when using --pg-upgrade-verbose\n"
 		if string(output) != expected {

--- a/test/acceptance/config_test.go
+++ b/test/acceptance/config_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/config"
 	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/testutils/acceptance"
 )
 
 func TestConfig(t *testing.T) {
@@ -19,28 +20,28 @@ func TestConfig(t *testing.T) {
 	resetEnv := testutils.SetEnv(t, "GPUPGRADE_HOME", stateDir)
 	defer resetEnv()
 
-	initialize_stopBeforeClusterCreation(t)
-	defer revert(t)
+	acceptance.Initialize_stopBeforeClusterCreation(t)
+	defer acceptance.Revert(t)
 
 	t.Run("configuration can be read piece by piece", func(t *testing.T) {
 		actual := configShow(t, "--source-gphome")
-		if actual != GPHOME_SOURCE {
-			t.Errorf("got %q want %q", actual, GPHOME_SOURCE)
+		if actual != acceptance.GPHOME_SOURCE {
+			t.Errorf("got %q want %q", actual, acceptance.GPHOME_SOURCE)
 		}
 
 		actual = configShow(t, "--target-gphome")
-		if actual != GPHOME_TARGET {
-			t.Errorf("got %q want %q", actual, GPHOME_TARGET)
+		if actual != acceptance.GPHOME_TARGET {
+			t.Errorf("got %q want %q", actual, acceptance.GPHOME_TARGET)
 		}
 	})
 
 	t.Run("configuration can be dumped as a whole", func(t *testing.T) {
 		expected := []string{
-			GPHOME_SOURCE,
-			jq(t, config.GetConfigFile(), `.Intermediate.Primaries."-1".DataDir`),
-			GPHOME_TARGET,
-			TARGET_PGPORT,
-			jq(t, config.GetConfigFile(), ".UpgradeID"),
+			acceptance.GPHOME_SOURCE,
+			acceptance.Jq(t, config.GetConfigFile(), `.Intermediate.Primaries."-1".DataDir`),
+			acceptance.GPHOME_TARGET,
+			acceptance.TARGET_PGPORT,
+			acceptance.Jq(t, config.GetConfigFile(), ".UpgradeID"),
 		}
 
 		output := configShow(t, "")

--- a/test/acceptance/goversion_test.go
+++ b/test/acceptance/goversion_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+
+	"github.com/greenplum-db/gpupgrade/testutils/acceptance"
 )
 
 func TestGoVersion(t *testing.T) {
@@ -28,7 +30,7 @@ func TestGoVersion(t *testing.T) {
 func compiledVersion(t *testing.T) semver.Version {
 	t.Helper()
 
-	cmd := exec.Command("go", "version", filepath.Join(MustGetRepoRoot(t), "gpupgrade"))
+	cmd := exec.Command("go", "version", filepath.Join(acceptance.MustGetRepoRoot(t), "gpupgrade"))
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("unexpected err: %#v stderr %q", err, output)
@@ -42,7 +44,7 @@ func compiledVersion(t *testing.T) semver.Version {
 func goModVersion(t *testing.T) semver.Version {
 	t.Helper()
 
-	contents, err := os.ReadFile(filepath.Join(MustGetRepoRoot(t), "go.mod"))
+	contents, err := os.ReadFile(filepath.Join(acceptance.MustGetRepoRoot(t), "go.mod"))
 	if err != nil {
 		t.Fatalf("reading go.mod: %#v", err)
 	}

--- a/test/acceptance/helpers/finalize_checks.bash
+++ b/test/acceptance/helpers/finalize_checks.bash
@@ -230,7 +230,7 @@ validate_mirrors_and_standby() {
     # step 2b: failover promote...
     ssh -n "${standby_host}" "
         source ${GPHOME_NEW}/greenplum_path.sh
-        export PGPORT=$standby_port
+        export testutils.PGPORT=$standby_port
         gpactivatestandby -a -d $standby_data_dir
     "
     wait_can_start_transactions "${standby_host}" "${standby_port}"
@@ -243,8 +243,8 @@ validate_mirrors_and_standby() {
     ssh -n "${standby_host}" "
         source ${GPHOME_NEW}/greenplum_path.sh
         export MASTER_DATA_DIRECTORY=${standby_data_dir}
-        export PGPORT=$standby_port
-        gprecoverseg -a       # TODO..why is PGPORT not actually needed here?
+        export testutils.PGPORT=$standby_port
+        gprecoverseg -a       # TODO..why is testutils.PGPORT not actually needed here?
     "
     wait_can_start_transactions $standby_host "${standby_port}"  #TODO: is this necessary?
 
@@ -257,7 +257,7 @@ validate_mirrors_and_standby() {
 
     ssh -n "${standby_host}" "
         source ${GPHOME_NEW}/greenplum_path.sh
-        export PGPORT=$standby_port; gpinitstandby -a -s $coordinator_host -P $coordinator_port -S $coordinator_data_dir
+        export testutils.PGPORT=$standby_port; gpinitstandby -a -s $coordinator_host -P $coordinator_port -S $coordinator_data_dir
     "
     check_replication_connections "${standby_host}" "${standby_port}"
     check_synchronized_cluster "${standby_host}" "${standby_port}"
@@ -271,7 +271,7 @@ validate_mirrors_and_standby() {
     ssh -n "${standby_host}" "
         source ${GPHOME_NEW}/greenplum_path.sh
         export MASTER_DATA_DIRECTORY=${standby_data_dir}
-        export PGPORT=$standby_port
+        export testutils.PGPORT=$standby_port
         gprecoverseg -ra
     "
     check_replication_connections "${standby_host}" "${standby_port}"
@@ -284,7 +284,7 @@ validate_mirrors_and_standby() {
     # 4c: rebalance standby
     ssh -n "${coordinator_host}" "
         source ${GPHOME_NEW}/greenplum_path.sh
-        export PGPORT=$coordinator_port
+        export testutils.PGPORT=$coordinator_port
         gpactivatestandby -a -d $coordinator_data_dir
     "
 
@@ -299,7 +299,7 @@ validate_mirrors_and_standby() {
 
     ssh -n "${coordinator_host}" "
         source ${GPHOME_NEW}/greenplum_path.sh
-        export PGPORT=$coordinator_port; gpinitstandby -a -s $standby_host -P $standby_port -S $standby_data_dir
+        export testutils.PGPORT=$coordinator_port; gpinitstandby -a -s $standby_host -P $standby_port -S $standby_data_dir
     "
     check_replication_connections "${coordinator_host}" "${coordinator_port}"
     check_synchronized_cluster "${coordinator_host}" "${coordinator_port}"

--- a/test/acceptance/helpers/tablespace_helpers.bash
+++ b/test/acceptance/helpers/tablespace_helpers.bash
@@ -8,7 +8,7 @@
 # Prints a line for each segment containing the hostname, dbid, and datadir,
 # separated by tabs.
 _query_5X_host_dbid_datadirs() {
-    "$GPHOME_SOURCE"/bin/psql -v ON_ERROR_STOP=1 -AtF$'\t' postgres -c "
+    "$testutils.GPHOME_SOURCE"/bin/psql -v ON_ERROR_STOP=1 -AtF$'\t' postgres -c "
         SELECT s.hostname,
                s.dbid,
                e.fselocation
@@ -50,10 +50,10 @@ create_tablespace_with_tables() {
     cat "$TABLESPACE_CONFIG"
 
     # unset LD_LIBRARY_PATH due to https://web.archive.org/web/20220506055918/https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/JN-YwjCCReY/m/0L9wBOvlAQAJ
-    (unset LD_LIBRARY_PATH; source "${GPHOME_SOURCE}"/greenplum_path.sh && gpfilespace --config "${TABLESPACE_CONFIG}")
+    (unset LD_LIBRARY_PATH; source "${testutils.GPHOME_SOURCE}"/greenplum_path.sh && gpfilespace --config "${TABLESPACE_CONFIG}")
 
     # create a tablespace in said filespace and some databases in that tablespace
-    "${GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -d postgres <<- EOF
+    "${testutils.GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -d postgres <<- EOF
         CREATE TABLESPACE batsTbsp FILESPACE batsFS;
 
         CREATE DATABASE foodb TABLESPACE batsTbsp;
@@ -61,7 +61,7 @@ create_tablespace_with_tables() {
 EOF
 
     # create various tables in the tablespace
-    "${GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -d postgres <<- EOF
+    "${testutils.GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -d postgres <<- EOF
         CREATE TABLE "${tablespace_table_prefix}_0" (a int) TABLESPACE batsTbsp;
         INSERT INTO "${tablespace_table_prefix}_0" SELECT i from generate_series(1,100)i;
 
@@ -77,13 +77,13 @@ EOF
 EOF
 
     # add a table to the database within the tablespace
-    "${GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -d foodb <<- EOF
+    "${testutils.GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -d foodb <<- EOF
         CREATE TABLE "${tablespace_table_prefix}_0" (a int);
         INSERT INTO "${tablespace_table_prefix}_0" SELECT i from generate_series(1,100)i;
 EOF
 
     # add a table to the database within the tablespace
-    "${GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -d eatdb <<- EOF
+    "${testutils.GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -d eatdb <<- EOF
         CREATE TABLE "${tablespace_table_prefix}_0" (a int);
         INSERT INTO "${tablespace_table_prefix}_0" SELECT i from generate_series(1,100)i;
 EOF
@@ -93,15 +93,15 @@ EOF
 delete_tablespace_data() {
    local tablespace_table_prefix=${1:-batsTable}
 
-    "${GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -d foodb <<- EOF
+    "${testutils.GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -d foodb <<- EOF
         DROP TABLE IF EXISTS "${tablespace_table_prefix}_0";
 EOF
 
-    "${GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -d eatdb <<- EOF
+    "${testutils.GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -d eatdb <<- EOF
         DROP TABLE IF EXISTS "${tablespace_table_prefix}_0";
 EOF
 
-    "${GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -d postgres <<- EOF
+    "${testutils.GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -d postgres <<- EOF
         DROP TABLE IF EXISTS "${tablespace_table_prefix}_0";
         DROP TABLE IF EXISTS "${tablespace_table_prefix}_1";
         DROP TABLE IF EXISTS "${tablespace_table_prefix}_2";
@@ -117,18 +117,18 @@ truncate_tablespace_data() {
        local tablespace_table_prefix=${1:-batsTable}
        local port=$2
 
-    "${GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -p "$port" -d postgres <<- EOF
+    "${testutils.GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -p "$port" -d postgres <<- EOF
         TRUNCATE "${tablespace_table_prefix}_0";
         TRUNCATE "${tablespace_table_prefix}_1";
         TRUNCATE "${tablespace_table_prefix}_2";
         TRUNCATE "${tablespace_table_prefix}_3";
 EOF
 
-    "${GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -p "$port" -d foodb <<- EOF
+    "${testutils.GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -p "$port" -d foodb <<- EOF
         TRUNCATE "${tablespace_table_prefix}_0";
 EOF
 
-    "${GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -p "$port" -d eatdb <<- EOF
+    "${testutils.GPHOME_SOURCE}"/bin/psql -v ON_ERROR_STOP=1 -p "$port" -d eatdb <<- EOF
         TRUNCATE "${tablespace_table_prefix}_0";
 EOF
 }
@@ -138,7 +138,7 @@ check_tablespace_data() {
 
     local rows
     for table in "${tablespace_table_prefix}_0" "${tablespace_table_prefix}_1" "${tablespace_table_prefix}_2" "${tablespace_table_prefix}_3"; do
-        rows=$("$GPHOME_TARGET"/bin/psql -v ON_ERROR_STOP=1 -d postgres -Atc "SELECT COUNT(*) FROM \"$table\";")
+        rows=$("$testutils.GPHOME_TARGET"/bin/psql -v ON_ERROR_STOP=1 -d postgres -Atc "SELECT COUNT(*) FROM \"$table\";")
         if (( rows != 100 )); then
             fail "failed verifying tablespaces. $table got $rows want 100"
         fi
@@ -146,14 +146,14 @@ check_tablespace_data() {
 
     local rows table
     table="${tablespace_table_prefix}_0"
-    rows=$("$GPHOME_TARGET"/bin/psql -v ON_ERROR_STOP=1 -d foodb -Atc "SELECT COUNT(*) FROM \"$table\";")
+    rows=$("$testutils.GPHOME_TARGET"/bin/psql -v ON_ERROR_STOP=1 -d foodb -Atc "SELECT COUNT(*) FROM \"$table\";")
     if (( rows != 100 )); then
         fail "failed verifying tablespaces. $table got $rows want 100"
     fi
 
     local rows table
     table="${tablespace_table_prefix}_0"
-    rows=$("$GPHOME_TARGET"/bin/psql -v ON_ERROR_STOP=1 -d eatdb -Atc "SELECT COUNT(*) FROM \"$table\";")
+    rows=$("$testutils.GPHOME_TARGET"/bin/psql -v ON_ERROR_STOP=1 -d eatdb -Atc "SELECT COUNT(*) FROM \"$table\";")
     if (( rows != 100 )); then
         fail "failed verifying tablespaces. $table got $rows want 100"
     fi

--- a/test/acceptance/migration_scripts.bats
+++ b/test/acceptance/migration_scripts.bats
@@ -9,7 +9,7 @@ SEED_DIR=$BATS_TEST_DIRNAME/../../data-migration-scripts
 
 setup() {
     # FIXME: We should support testing the migration scripts.
-    if is_GPDB6 "$GPHOME_SOURCE"; then
+    if is_GPDB6 "$testutils.GPHOME_SOURCE"; then
         skip "FIXME: migration scripts are not yet supported for 6-to-6 and 6-to-7 upgrades"
     fi
 
@@ -23,10 +23,10 @@ setup() {
 
     backup_source_cluster "$STATE_DIR"/backup
 
-    PSQL="$GPHOME_SOURCE/bin/psql -X --no-align --tuples-only"
+    PSQL="$testutils.GPHOME_SOURCE/bin/psql -X --no-align --tuples-only"
 
     export VERSION_SEED_DIR=6-to-7-seed-scripts
-    if is_GPDB5 "$GPHOME_SOURCE"; then
+    if is_GPDB5 "$testutils.GPHOME_SOURCE"; then
         export VERSION_SEED_DIR=5-to-6-seed-scripts
     fi
 
@@ -52,9 +52,9 @@ teardown() {
     # is resolved.
     PGOPTIONS='--client-min-messages=warning' $PSQL -v ON_ERROR_STOP=0 -d testdb -f "${SEED_DIR}"/"${VERSION_SEED_DIR}"/test/create_nonupgradable_objects.sql
     run gpupgrade initialize \
-        --source-gphome="$GPHOME_SOURCE" \
-        --target-gphome="$GPHOME_TARGET" \
-        --source-master-port="${PGPORT}" \
+        --source-gphome="$testutils.GPHOME_SOURCE" \
+        --target-gphome="$testutils.GPHOME_TARGET" \
+        --source-master-port="${testutils.PGPORT}" \
         --temp-port-range 6020-6040 \
         --disk-free-ratio 0 \
         --non-interactive \
@@ -67,24 +67,24 @@ teardown() {
 
     PGOPTIONS='--client-min-messages=warning' $PSQL -v ON_ERROR_STOP=1 -d testdb -f "${SEED_DIR}"/"${VERSION_SEED_DIR}"/test/drop_unfixable_objects.sql
 
-    root_child_indexes_before=$(get_indexes "$GPHOME_SOURCE")
-    tsquery_datatype_objects_before=$(get_tsquery_datatypes "$GPHOME_SOURCE")
-    name_datatype_objects_before=$(get_name_datatypes "$GPHOME_SOURCE")
-    fk_constraints_before=$(get_fk_constraints "$GPHOME_SOURCE")
-    primary_unique_constraints_before=$(get_primary_unique_constraints "$GPHOME_SOURCE")
-    partition_owners_before=$(get_partition_owners "$GPHOME_SOURCE")
-    partition_constraints_before=$(get_partition_constraints "$GPHOME_SOURCE")
-    partition_defaults_before=$(get_partition_defaults "$GPHOME_SOURCE")
-    view_owners_before=$(get_view_owners "$GPHOME_SOURCE")
+    root_child_indexes_before=$(get_indexes "$testutils.GPHOME_SOURCE")
+    tsquery_datatype_objects_before=$(get_tsquery_datatypes "$testutils.GPHOME_SOURCE")
+    name_datatype_objects_before=$(get_name_datatypes "$testutils.GPHOME_SOURCE")
+    fk_constraints_before=$(get_fk_constraints "$testutils.GPHOME_SOURCE")
+    primary_unique_constraints_before=$(get_primary_unique_constraints "$testutils.GPHOME_SOURCE")
+    partition_owners_before=$(get_partition_owners "$testutils.GPHOME_SOURCE")
+    partition_constraints_before=$(get_partition_constraints "$testutils.GPHOME_SOURCE")
+    partition_defaults_before=$(get_partition_defaults "$testutils.GPHOME_SOURCE")
+    view_owners_before=$(get_view_owners "$testutils.GPHOME_SOURCE")
 
     MIGRATION_DIR=`mktemp -d /tmp/migration.XXXXXX`
-    gpupgrade generate --non-interactive --gphome "$GPHOME_SOURCE" --port "$PGPORT" --seed-dir "$SEED_DIR" --output-dir "$MIGRATION_DIR"
-    gpupgrade apply    --non-interactive --gphome "$GPHOME_SOURCE" --port "$PGPORT" --input-dir "$MIGRATION_DIR" --phase initialize
+    gpupgrade generate --non-interactive --gphome "$testutils.GPHOME_SOURCE" --port "$testutils.PGPORT" --seed-dir "$SEED_DIR" --output-dir "$MIGRATION_DIR"
+    gpupgrade apply    --non-interactive --gphome "$testutils.GPHOME_SOURCE" --port "$testutils.PGPORT" --input-dir "$MIGRATION_DIR" --phase initialize
 
     gpupgrade initialize \
-        --source-gphome="$GPHOME_SOURCE" \
-        --target-gphome="$GPHOME_TARGET" \
-        --source-master-port="${PGPORT}" \
+        --source-gphome="$testutils.GPHOME_SOURCE" \
+        --target-gphome="$testutils.GPHOME_TARGET" \
+        --source-master-port="${testutils.PGPORT}" \
         --temp-port-range 6020-6040 \
         --disk-free-ratio 0 \
         --non-interactive \
@@ -92,18 +92,18 @@ teardown() {
     gpupgrade execute --non-interactive --verbose
     gpupgrade finalize --non-interactive --verbose
 
-    gpupgrade apply --non-interactive --gphome "$GPHOME_TARGET" --port "$PGPORT" --input-dir "$MIGRATION_DIR" --phase finalize
+    gpupgrade apply --non-interactive --gphome "$testutils.GPHOME_TARGET" --port "$testutils.PGPORT" --input-dir "$MIGRATION_DIR" --phase finalize
 
     # migration scripts should create the indexes on the target cluster
-    root_child_indexes_after=$(get_indexes "$GPHOME_TARGET")
-    tsquery_datatype_objects_after=$(get_tsquery_datatypes "$GPHOME_TARGET")
-    name_datatype_objects_after=$(get_name_datatypes "$GPHOME_TARGET")
-    fk_constraints_after=$(get_fk_constraints "$GPHOME_TARGET")
-    primary_unique_constraints_after=$(get_primary_unique_constraints "$GPHOME_TARGET")
-    partition_owners_after=$(get_partition_owners "$GPHOME_TARGET")
-    partition_constraints_after=$(get_partition_constraints "$GPHOME_TARGET")
-    partition_defaults_after=$(get_partition_defaults "$GPHOME_TARGET")
-    view_owners_after=$(get_view_owners "$GPHOME_TARGET")
+    root_child_indexes_after=$(get_indexes "$testutils.GPHOME_TARGET")
+    tsquery_datatype_objects_after=$(get_tsquery_datatypes "$testutils.GPHOME_TARGET")
+    name_datatype_objects_after=$(get_name_datatypes "$testutils.GPHOME_TARGET")
+    fk_constraints_after=$(get_fk_constraints "$testutils.GPHOME_TARGET")
+    primary_unique_constraints_after=$(get_primary_unique_constraints "$testutils.GPHOME_TARGET")
+    partition_owners_after=$(get_partition_owners "$testutils.GPHOME_TARGET")
+    partition_constraints_after=$(get_partition_constraints "$testutils.GPHOME_TARGET")
+    partition_defaults_after=$(get_partition_defaults "$testutils.GPHOME_TARGET")
+    view_owners_after=$(get_view_owners "$testutils.GPHOME_TARGET")
 
     # expect the index and tsquery datatype information to be same after the upgrade
     diff -U3 <(echo "$root_child_indexes_before") <(echo "$root_child_indexes_after")
@@ -123,12 +123,12 @@ teardown() {
     # is resolved.
     $PSQL -v ON_ERROR_STOP=0 -d testdb -f "${SEED_DIR}"/"${VERSION_SEED_DIR}"/test/create_nonupgradable_objects.sql
 
-    root_child_indexes_before=$(get_indexes "$GPHOME_SOURCE")
-    tsquery_datatype_objects_before=$(get_tsquery_datatypes "$GPHOME_SOURCE")
-    name_datatype_objects_before=$(get_name_datatypes "$GPHOME_SOURCE")
-    fk_constraints_before=$(get_fk_constraints "$GPHOME_SOURCE")
-    primary_unique_constraints_before=$(get_primary_unique_constraints "$GPHOME_SOURCE")
-    view_owners_before=$(get_view_owners "$GPHOME_SOURCE")
+    root_child_indexes_before=$(get_indexes "$testutils.GPHOME_SOURCE")
+    tsquery_datatype_objects_before=$(get_tsquery_datatypes "$testutils.GPHOME_SOURCE")
+    name_datatype_objects_before=$(get_name_datatypes "$testutils.GPHOME_SOURCE")
+    fk_constraints_before=$(get_fk_constraints "$testutils.GPHOME_SOURCE")
+    primary_unique_constraints_before=$(get_primary_unique_constraints "$testutils.GPHOME_SOURCE")
+    view_owners_before=$(get_view_owners "$testutils.GPHOME_SOURCE")
 
     # Ignore the test tables that break the diff for now.
     EXCLUSIONS+="-T testschema.heterogeneous_ml_partition_table "
@@ -136,13 +136,13 @@ teardown() {
     MIGRATION_DIR=`mktemp -d /tmp/migration.XXXXXX`
     register_teardown rm -r "$MIGRATION_DIR"
 
-    gpupgrade generate --non-interactive --gphome "$GPHOME_SOURCE" --port "$PGPORT" --seed-dir "$SEED_DIR" --output-dir "$MIGRATION_DIR"
-    gpupgrade apply    --non-interactive --gphome "$GPHOME_SOURCE" --port "$PGPORT" --input-dir "$MIGRATION_DIR" --phase initialize
+    gpupgrade generate --non-interactive --gphome "$testutils.GPHOME_SOURCE" --port "$testutils.PGPORT" --seed-dir "$SEED_DIR" --output-dir "$MIGRATION_DIR"
+    gpupgrade apply    --non-interactive --gphome "$testutils.GPHOME_SOURCE" --port "$testutils.PGPORT" --input-dir "$MIGRATION_DIR" --phase initialize
 
     run gpupgrade initialize \
-        --source-gphome="$GPHOME_SOURCE" \
-        --target-gphome="$GPHOME_TARGET" \
-        --source-master-port="${PGPORT}" \
+        --source-gphome="$testutils.GPHOME_SOURCE" \
+        --target-gphome="$testutils.GPHOME_TARGET" \
+        --source-master-port="${testutils.PGPORT}" \
         --temp-port-range 6020-6040 \
         --disk-free-ratio 0 \
         --non-interactive \
@@ -151,15 +151,15 @@ teardown() {
 
     gpupgrade revert --non-interactive --verbose
 
-    gpupgrade apply --non-interactive --gphome "$GPHOME_SOURCE" --port "$PGPORT" --input-dir "$MIGRATION_DIR" --phase revert
+    gpupgrade apply --non-interactive --gphome "$testutils.GPHOME_SOURCE" --port "$testutils.PGPORT" --input-dir "$MIGRATION_DIR" --phase revert
 
     # migration scripts should recreate indexes on the source cluster on revert
-    root_child_indexes_after=$(get_indexes "$GPHOME_SOURCE")
-    tsquery_datatype_objects_after=$(get_tsquery_datatypes "$GPHOME_SOURCE")
-    name_datatype_objects_after=$(get_name_datatypes "$GPHOME_SOURCE")
-    fk_constraints_after=$(get_fk_constraints "$GPHOME_SOURCE")
-    primary_unique_constraints_after=$(get_primary_unique_constraints "$GPHOME_SOURCE")
-    view_owners_after=$(get_view_owners "$GPHOME_SOURCE")
+    root_child_indexes_after=$(get_indexes "$testutils.GPHOME_SOURCE")
+    tsquery_datatype_objects_after=$(get_tsquery_datatypes "$testutils.GPHOME_SOURCE")
+    name_datatype_objects_after=$(get_name_datatypes "$testutils.GPHOME_SOURCE")
+    fk_constraints_after=$(get_fk_constraints "$testutils.GPHOME_SOURCE")
+    primary_unique_constraints_after=$(get_primary_unique_constraints "$testutils.GPHOME_SOURCE")
+    view_owners_after=$(get_view_owners "$testutils.GPHOME_SOURCE")
 
     # expect the index and tsquery datatype information to be same after the upgrade
     diff -U3 <(echo "$root_child_indexes_before") <(echo "$root_child_indexes_after")
@@ -177,12 +177,12 @@ teardown() {
     $PSQL -v ON_ERROR_STOP=0 -d testdb -f "${SEED_DIR}"/"${VERSION_SEED_DIR}"/test/create_nonupgradable_objects.sql
     $PSQL -v ON_ERROR_STOP=1 -d testdb -f "${SEED_DIR}"/"${VERSION_SEED_DIR}"/test/drop_unfixable_objects.sql
 
-    root_child_indexes_before=$(get_indexes "$GPHOME_SOURCE")
-    tsquery_datatype_objects_before=$(get_tsquery_datatypes "$GPHOME_SOURCE")
-    name_datatype_objects_before=$(get_name_datatypes "$GPHOME_SOURCE")
-    fk_constraints_before=$(get_fk_constraints "$GPHOME_SOURCE")
-    primary_unique_constraints_before=$(get_primary_unique_constraints "$GPHOME_SOURCE")
-    view_owners_before=$(get_view_owners "$GPHOME_SOURCE")
+    root_child_indexes_before=$(get_indexes "$testutils.GPHOME_SOURCE")
+    tsquery_datatype_objects_before=$(get_tsquery_datatypes "$testutils.GPHOME_SOURCE")
+    name_datatype_objects_before=$(get_name_datatypes "$testutils.GPHOME_SOURCE")
+    fk_constraints_before=$(get_fk_constraints "$testutils.GPHOME_SOURCE")
+    primary_unique_constraints_before=$(get_primary_unique_constraints "$testutils.GPHOME_SOURCE")
+    view_owners_before=$(get_view_owners "$testutils.GPHOME_SOURCE")
 
     # Ignore the test tables that break the diff for now.
     EXCLUSIONS+="-T testschema.heterogeneous_ml_partition_table "
@@ -190,13 +190,13 @@ teardown() {
     MIGRATION_DIR=`mktemp -d /tmp/migration.XXXXXX`
     register_teardown rm -r "$MIGRATION_DIR"
 
-    gpupgrade generate --non-interactive --gphome "$GPHOME_SOURCE" --port "$PGPORT" --seed-dir "$SEED_DIR" --output-dir "$MIGRATION_DIR"
-    gpupgrade apply    --non-interactive --gphome "$GPHOME_SOURCE" --port "$PGPORT" --input-dir "$MIGRATION_DIR" --phase initialize
+    gpupgrade generate --non-interactive --gphome "$testutils.GPHOME_SOURCE" --port "$testutils.PGPORT" --seed-dir "$SEED_DIR" --output-dir "$MIGRATION_DIR"
+    gpupgrade apply    --non-interactive --gphome "$testutils.GPHOME_SOURCE" --port "$testutils.PGPORT" --input-dir "$MIGRATION_DIR" --phase initialize
 
     gpupgrade initialize \
-        --source-gphome="$GPHOME_SOURCE" \
-        --target-gphome="$GPHOME_TARGET" \
-        --source-master-port="${PGPORT}" \
+        --source-gphome="$testutils.GPHOME_SOURCE" \
+        --target-gphome="$testutils.GPHOME_TARGET" \
+        --source-master-port="${testutils.PGPORT}" \
         --temp-port-range 6020-6040 \
         --disk-free-ratio 0 \
         --non-interactive \
@@ -204,15 +204,15 @@ teardown() {
     gpupgrade execute --non-interactive --verbose
     gpupgrade revert --non-interactive --verbose
 
-    gpupgrade apply --non-interactive --gphome "$GPHOME_SOURCE" --port "$PGPORT" --input-dir "$MIGRATION_DIR" --phase revert
+    gpupgrade apply --non-interactive --gphome "$testutils.GPHOME_SOURCE" --port "$testutils.PGPORT" --input-dir "$MIGRATION_DIR" --phase revert
 
     # migration scripts should create the indexes on the target cluster
-    root_child_indexes_after=$(get_indexes "$GPHOME_SOURCE")
-    tsquery_datatype_objects_after=$(get_tsquery_datatypes "$GPHOME_SOURCE")
-    name_datatype_objects_after=$(get_name_datatypes "$GPHOME_SOURCE")
-    fk_constraints_after=$(get_fk_constraints "$GPHOME_SOURCE")
-    primary_unique_constraints_after=$(get_primary_unique_constraints "$GPHOME_SOURCE")
-    view_owners_after=$(get_view_owners "$GPHOME_TARGET")
+    root_child_indexes_after=$(get_indexes "$testutils.GPHOME_SOURCE")
+    tsquery_datatype_objects_after=$(get_tsquery_datatypes "$testutils.GPHOME_SOURCE")
+    name_datatype_objects_after=$(get_name_datatypes "$testutils.GPHOME_SOURCE")
+    fk_constraints_after=$(get_fk_constraints "$testutils.GPHOME_SOURCE")
+    primary_unique_constraints_after=$(get_primary_unique_constraints "$testutils.GPHOME_SOURCE")
+    view_owners_after=$(get_view_owners "$testutils.GPHOME_TARGET")
 
     # expect the index and tsquery datatype information to be same after the upgrade
     diff -U3 <(echo "$root_child_indexes_before") <(echo "$root_child_indexes_after")
@@ -226,7 +226,7 @@ teardown() {
 @test "migration scripts ignore .psqlrc files" {
     # 5X doesn't support the PSQLRC envvar we need to avoid destroying the dev
     # environment.
-    if is_GPDB5 "$GPHOME_SOURCE"; then
+    if is_GPDB5 "$testutils.GPHOME_SOURCE"; then
         skip "GPDB 5 does not support alternative PSQLRC locations"
     fi
 
@@ -242,33 +242,33 @@ teardown() {
     export PSQLRC="$MIGRATION_DIR"/psqlrc
     printf '\! kill $PPID\n' > "$PSQLRC"
 
-    gpupgrade generate --non-interactive --gphome "$GPHOME_SOURCE" --port "$PGPORT" --seed-dir "$SEED_DIR" --output-dir "$MIGRATION_DIR"
+    gpupgrade generate --non-interactive --gphome "$testutils.GPHOME_SOURCE" --port "$testutils.PGPORT" --seed-dir "$SEED_DIR" --output-dir "$MIGRATION_DIR"
     $PSQL -v ON_ERROR_STOP=1 -d testdb -f "${SEED_DIR}"/"${VERSION_SEED_DIR}"/test/drop_unfixable_objects.sql
-    gpupgrade apply    --non-interactive --gphome "$GPHOME_SOURCE" --port "$PGPORT" --input-dir "$MIGRATION_DIR" --phase initialize
+    gpupgrade apply    --non-interactive --gphome "$testutils.GPHOME_SOURCE" --port "$testutils.PGPORT" --input-dir "$MIGRATION_DIR" --phase initialize
 
     gpupgrade initialize \
-        --source-gphome="$GPHOME_SOURCE" \
-        --target-gphome="$GPHOME_TARGET" \
-        --source-master-port="${PGPORT}" \
+        --source-gphome="$testutils.GPHOME_SOURCE" \
+        --target-gphome="$testutils.GPHOME_TARGET" \
+        --source-master-port="${testutils.PGPORT}" \
         --temp-port-range 6020-6040 \
         --disk-free-ratio 0 \
         --non-interactive \
         --verbose
     gpupgrade revert --non-interactive --verbose
 
-    gpupgrade apply --non-interactive --gphome "$GPHOME_TARGET" --port "$PGPORT" --input-dir "$MIGRATION_DIR" --phase revert
+    gpupgrade apply --non-interactive --gphome "$testutils.GPHOME_TARGET" --port "$testutils.PGPORT" --input-dir "$MIGRATION_DIR" --phase revert
 }
 
 get_indexes() {
     local gphome=$1
-    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$PGPORT" -Atc "
+    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$testutils.PGPORT" -Atc "
          SELECT indrelid::regclass, unnest(indkey)
          FROM pg_index pi
          JOIN pg_partition pp ON pi.indrelid=pp.parrelid
          JOIN pg_class pc ON pc.oid=pp.parrelid
          ORDER by 1,2;
         "
-    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$PGPORT" -Atc "
+    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$testutils.PGPORT" -Atc "
         SELECT indrelid::regclass, unnest(indkey)
         FROM pg_index pi
         JOIN pg_partition_rule pp ON pi.indrelid=pp.parchildrelid
@@ -280,7 +280,7 @@ get_indexes() {
 
 get_tsquery_datatypes() {
     local gphome=$1
-    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$PGPORT" -Atc "
+    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$testutils.PGPORT" -Atc "
         SELECT n.nspname, c.relname, a.attname
         FROM pg_catalog.pg_class c,
              pg_catalog.pg_namespace n,
@@ -303,7 +303,7 @@ get_tsquery_datatypes() {
 
 get_name_datatypes() {
     local gphome=$1
-    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$PGPORT" -Atc "
+    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$testutils.PGPORT" -Atc "
         SELECT n.nspname, c.relname, a.attname
         FROM pg_catalog.pg_class c,
              pg_catalog.pg_namespace n,
@@ -326,7 +326,7 @@ get_name_datatypes() {
 
 get_fk_constraints() {
     local gphome=$1
-    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$PGPORT" -Atc "
+    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$testutils.PGPORT" -Atc "
         SELECT nspname, relname, conname
         FROM pg_constraint cc
             JOIN
@@ -353,7 +353,7 @@ get_fk_constraints() {
 
 get_primary_unique_constraints() {
     local gphome=$1
-    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$PGPORT" -Atc "
+    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$testutils.PGPORT" -Atc "
     WITH CTE as
     (
         SELECT oid, *
@@ -400,7 +400,7 @@ get_primary_unique_constraints() {
 
 get_partition_owners() {
     local gphome=$1
-    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$PGPORT" -Atc "
+    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$testutils.PGPORT" -Atc "
     SELECT c.relname, pg_catalog.pg_get_userbyid(c.relowner)
     FROM pg_partition_rule pr
         JOIN pg_class c ON c.oid = pr.parchildrelid
@@ -414,7 +414,7 @@ get_partition_owners() {
 
 get_partition_constraints() {
     local gphome=$1
-    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$PGPORT" -Atc "
+    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$testutils.PGPORT" -Atc "
     SELECT c.relname, con.conname
     FROM pg_partition_rule pr
         JOIN pg_class c ON c.oid = pr.parchildrelid
@@ -434,7 +434,7 @@ get_partition_constraints() {
 
 get_partition_defaults() {
     local gphome=$1
-    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$PGPORT" -Atc "
+    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$testutils.PGPORT" -Atc "
     SELECT c.relname, att.attname, ad.adnum, ad.adsrc
     FROM pg_partition_rule pr
         JOIN pg_class c ON c.oid = pr.parchildrelid
@@ -452,7 +452,7 @@ get_partition_defaults() {
 
 get_view_owners() {
     local gphome=$1
-    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$PGPORT" -Atc "
+    $gphome/bin/psql -v ON_ERROR_STOP=1 -d testdb -p "$testutils.PGPORT" -Atc "
     SELECT schemaname, viewname, viewowner
     FROM pg_views
     WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'gp_toolkit')

--- a/test/acceptance/pg_upgrade_non_upradeable_test.go
+++ b/test/acceptance/pg_upgrade_non_upradeable_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/testutils/acceptance"
 )
 
 func Test_PgUpgrade_NonUpgradeable_Tests(t *testing.T) {
@@ -20,21 +21,21 @@ func Test_PgUpgrade_NonUpgradeable_Tests(t *testing.T) {
 	resetEnv := testutils.SetEnv(t, "GPUPGRADE_HOME", stateDir)
 	defer resetEnv()
 
-	source := GetSourceCluster(t)
+	source := acceptance.GetSourceCluster(t)
 	dir := "6-to-7"
 	if source.Version.Major == 5 {
 		dir = "5-to-6"
 	}
 
-	testDir := filepath.Join(MustGetRepoRoot(t), "test", "acceptance", dir)
-	testutils.MustApplySQLFile(t, GPHOME_SOURCE, PGPORT, filepath.Join(testDir, "setup_globals.sql"))
-	defer testutils.MustApplySQLFile(t, GPHOME_SOURCE, PGPORT, filepath.Join(testDir, "teardown_globals.sql"))
+	testDir := filepath.Join(acceptance.MustGetRepoRoot(t), "test", "acceptance", dir)
+	testutils.MustApplySQLFile(t, acceptance.GPHOME_SOURCE, acceptance.PGPORT, filepath.Join(testDir, "setup_globals.sql"))
+	defer testutils.MustApplySQLFile(t, acceptance.GPHOME_SOURCE, acceptance.PGPORT, filepath.Join(testDir, "teardown_globals.sql"))
 
 	t.Run("pg_upgrade --check detects non-upgradeable objects", func(t *testing.T) {
 		nonUpgradeableTestDir := filepath.Join(testDir, "non_upgradeable_tests")
-		isolation2_regress(t, source.Version, GPHOME_SOURCE, PGPORT, nonUpgradeableTestDir, nonUpgradeableTestDir, idl.Schedule_non_upgradeable_schedule)
+		acceptance.Isolation2_regress(t, source.Version, acceptance.GPHOME_SOURCE, acceptance.PGPORT, nonUpgradeableTestDir, nonUpgradeableTestDir, idl.Schedule_non_upgradeable_schedule)
 
-		revert(t)
+		acceptance.Revert(t)
 	})
 
 }

--- a/test/acceptance/pg_upgrade_upradeable_test.go
+++ b/test/acceptance/pg_upgrade_upradeable_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/testutils/acceptance"
 )
 
 func Test_PgUpgrade_Upgradeable_Tests(t *testing.T) {
@@ -20,25 +21,25 @@ func Test_PgUpgrade_Upgradeable_Tests(t *testing.T) {
 	resetEnv := testutils.SetEnv(t, "GPUPGRADE_HOME", stateDir)
 	defer resetEnv()
 
-	source := GetSourceCluster(t)
+	source := acceptance.GetSourceCluster(t)
 	dir := "6-to-7"
 	if source.Version.Major == 5 {
 		dir = "5-to-6"
 	}
 
-	testDir := filepath.Join(MustGetRepoRoot(t), "test", "acceptance", dir)
-	testutils.MustApplySQLFile(t, GPHOME_SOURCE, PGPORT, filepath.Join(testDir, "setup_globals.sql"))
-	defer testutils.MustApplySQLFile(t, GPHOME_SOURCE, PGPORT, filepath.Join(testDir, "teardown_globals.sql"))
+	testDir := filepath.Join(acceptance.MustGetRepoRoot(t), "test", "acceptance", dir)
+	testutils.MustApplySQLFile(t, acceptance.GPHOME_SOURCE, acceptance.PGPORT, filepath.Join(testDir, "setup_globals.sql"))
+	defer testutils.MustApplySQLFile(t, acceptance.GPHOME_SOURCE, acceptance.PGPORT, filepath.Join(testDir, "teardown_globals.sql"))
 
 	t.Run("pg_upgrade upgradeable tests", func(t *testing.T) {
 		sourceTestDir := filepath.Join(testDir, "upgradeable_tests", "source_cluster_regress")
-		isolation2_regress(t, source.Version, GPHOME_SOURCE, PGPORT, sourceTestDir, sourceTestDir, idl.Schedule_upgradeable_source_schedule)
+		acceptance.Isolation2_regress(t, source.Version, acceptance.GPHOME_SOURCE, acceptance.PGPORT, sourceTestDir, sourceTestDir, idl.Schedule_upgradeable_source_schedule)
 
-		initialize(t, idl.Mode_link)
-		defer revert(t)
-		execute(t)
+		acceptance.Initialize(t, idl.Mode_link)
+		defer acceptance.Revert(t)
+		acceptance.Execute(t)
 
 		targetTestDir := filepath.Join(testDir, "upgradeable_tests", "target_cluster_regress")
-		isolation2_regress(t, source.Version, GPHOME_TARGET, TARGET_PGPORT, targetTestDir, targetTestDir, idl.Schedule_upgradeable_target_schedule)
+		acceptance.Isolation2_regress(t, source.Version, acceptance.GPHOME_TARGET, acceptance.TARGET_PGPORT, targetTestDir, targetTestDir, idl.Schedule_upgradeable_target_schedule)
 	})
 }

--- a/test/acceptance/services_test.go
+++ b/test/acceptance/services_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/config"
 	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/testutils/acceptance"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 )
 
@@ -24,12 +25,12 @@ func TestServices(t *testing.T) {
 	resetEnv := testutils.SetEnv(t, "GPUPGRADE_HOME", stateDir)
 	defer resetEnv()
 
-	initialize_stopBeforeClusterCreation(t)
-	defer revert(t)
+	acceptance.Initialize_stopBeforeClusterCreation(t)
+	defer acceptance.Revert(t)
 
 	// TODO: Move to integration/hub_test.go
 	t.Run("hub daemonizes and prints the PID when passed the --daemonize option", func(t *testing.T) {
-		killServices(t)
+		acceptance.KillServices(t)
 
 		cmd := exec.Command("gpupgrade", "hub", "--daemonize")
 		output, err := cmd.CombinedOutput()
@@ -43,12 +44,12 @@ func TestServices(t *testing.T) {
 			t.Fatalf("got %q want %q", hubOutput, expected)
 		}
 
-		killServices(t)
+		acceptance.KillServices(t)
 	})
 
 	// TODO: Move to integration/hub_test.go
 	t.Run("hub does not start if the configuration hasn't been initialized", func(t *testing.T) {
-		killServices(t)
+		acceptance.KillServices(t)
 
 		testutils.MustRename(t, config.GetConfigFile(), config.GetConfigFile()+".old")
 		defer testutils.MustRename(t, config.GetConfigFile()+".old", config.GetConfigFile())
@@ -63,7 +64,7 @@ func TestServices(t *testing.T) {
 
 	// TODO: Move to integration/hub_test.go
 	t.Run("subcommands return an error if the hub is not started", func(t *testing.T) {
-		killServices(t)
+		acceptance.KillServices(t)
 
 		commands := [][]string{
 			{"config", "show"},
@@ -83,17 +84,17 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("kill-services stops hub and agents", func(t *testing.T) {
-		restartServices(t)
+		acceptance.RestartServices(t)
 		processMustBeRunning(t, "gpupgrade hub")
 		processMustBeRunning(t, "gpupgrade agent")
 
-		killServices(t)
+		acceptance.KillServices(t)
 		processMustNotBeRunning(t, "gpupgrade hub")
 		processMustNotBeRunning(t, "gpupgrade agent")
 	})
 
 	t.Run("kill-services stops hub and agents on default port if config file does not exist", func(t *testing.T) {
-		restartServices(t)
+		acceptance.RestartServices(t)
 		processMustBeRunning(t, "gpupgrade hub")
 		processMustBeRunning(t, "gpupgrade agent")
 
@@ -110,37 +111,37 @@ func TestServices(t *testing.T) {
 			}
 		}()
 
-		killServices(t)
+		acceptance.KillServices(t)
 		processMustNotBeRunning(t, "gpupgrade hub")
 		processMustNotBeRunning(t, "gpupgrade agent")
 	})
 
 	t.Run("restart-services actually starts hub and agents", func(t *testing.T) {
-		killServices(t)
+		acceptance.KillServices(t)
 		processMustNotBeRunning(t, "gpupgrade hub")
 		processMustNotBeRunning(t, "gpupgrade agent")
 
-		restartServices(t)
+		acceptance.RestartServices(t)
 		processMustBeRunning(t, "gpupgrade hub")
 		processMustBeRunning(t, "gpupgrade agent")
 	})
 
 	t.Run("kill services can be run multiple times without issue", func(t *testing.T) {
-		killServices(t)
+		acceptance.KillServices(t)
 		processMustNotBeRunning(t, "gpupgrade hub")
 		processMustNotBeRunning(t, "gpupgrade agent")
 
-		killServices(t)
+		acceptance.KillServices(t)
 		processMustNotBeRunning(t, "gpupgrade hub")
 		processMustNotBeRunning(t, "gpupgrade agent")
 	})
 
 	t.Run("restart services can be run multiple times without issue", func(t *testing.T) {
-		restartServices(t)
+		acceptance.RestartServices(t)
 		processMustBeRunning(t, "gpupgrade hub")
 		processMustBeRunning(t, "gpupgrade agent")
 
-		restartServices(t)
+		acceptance.RestartServices(t)
 		processMustBeRunning(t, "gpupgrade hub")
 		processMustBeRunning(t, "gpupgrade agent")
 	})

--- a/testutils/acceptance/acceptance_test_utils.go
+++ b/testutils/acceptance/acceptance_test_utils.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2017-2023 VMware, Inc. or its affiliates
 // SPDX-License-Identifier: Apache-2.0
 
-package gpupgrade_test
+package acceptance
 
 import (
 	"log"
@@ -65,7 +65,7 @@ func MustGetRepoRoot(t *testing.T) string {
 	return filepath.Dir(filepath.Dir(currentDir))
 }
 
-func generate(t *testing.T, outputDir string) string {
+func Generate(t *testing.T, outputDir string) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "generate",
@@ -82,7 +82,7 @@ func generate(t *testing.T, outputDir string) string {
 	return strings.TrimSpace(string(output))
 }
 
-func apply(t *testing.T, gphome string, port string, phase idl.Step, inputDir string) string {
+func Apply(t *testing.T, gphome string, port string, phase idl.Step, inputDir string) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "apply",
@@ -99,7 +99,7 @@ func apply(t *testing.T, gphome string, port string, phase idl.Step, inputDir st
 	return strings.TrimSpace(string(output))
 }
 
-func initialize_stopBeforeClusterCreation(t *testing.T) string {
+func Initialize_stopBeforeClusterCreation(t *testing.T) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "initialize",
@@ -118,7 +118,7 @@ func initialize_stopBeforeClusterCreation(t *testing.T) string {
 	return strings.TrimSpace(string(output))
 }
 
-func initialize(t *testing.T, mode idl.Mode) string {
+func Initialize(t *testing.T, mode idl.Mode) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "initialize",
@@ -137,7 +137,7 @@ func initialize(t *testing.T, mode idl.Mode) string {
 	return strings.TrimSpace(string(output))
 }
 
-func execute(t *testing.T) string {
+func Execute(t *testing.T) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "execute",
@@ -150,7 +150,7 @@ func execute(t *testing.T) string {
 	return strings.TrimSpace(string(output))
 }
 
-func finalize(t *testing.T) string {
+func Finalize(t *testing.T) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "finalize",
@@ -163,7 +163,7 @@ func finalize(t *testing.T) string {
 	return strings.TrimSpace(string(output))
 }
 
-func revert(t *testing.T) string {
+func Revert(t *testing.T) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "revert",
@@ -176,7 +176,7 @@ func revert(t *testing.T) string {
 	return strings.TrimSpace(string(output))
 }
 
-func killServices(t *testing.T) string {
+func KillServices(t *testing.T) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "kill-services")
@@ -188,7 +188,7 @@ func killServices(t *testing.T) string {
 	return strings.TrimSpace(string(output))
 }
 
-func restartServices(t *testing.T) string {
+func RestartServices(t *testing.T) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "restart-services")
@@ -259,7 +259,7 @@ func getCluster(t *testing.T, gphome string, port int, destination idl.ClusterDe
 
 // backupDemoCluster is used with restoreDemoCluster to restore a cluster after
 // finalize.
-func backupDemoCluster(t *testing.T, backupDir string, source greenplum.Cluster) {
+func BackupDemoCluster(t *testing.T, backupDir string, source greenplum.Cluster) {
 	src := filepath.Dir(filepath.Dir(source.CoordinatorDataDir())) + string(os.PathSeparator)
 	dest := backupDir + string(os.PathSeparator)
 
@@ -278,7 +278,7 @@ func backupDemoCluster(t *testing.T, backupDir string, source greenplum.Cluster)
 }
 
 // restoreDemoCluster restores the cluster after finalize has been run.
-func restoreDemoCluster(t *testing.T, backupDir string, source greenplum.Cluster, target greenplum.Cluster) {
+func RestoreDemoCluster(t *testing.T, backupDir string, source greenplum.Cluster, target greenplum.Cluster) {
 	// Depending on where we failed we need to stop either the source or target cluster.
 	err := source.Stop(step.DevNullStream)
 	if err != nil {
@@ -308,7 +308,7 @@ func restoreDemoCluster(t *testing.T, backupDir string, source greenplum.Cluster
 	}
 }
 
-func isolation2_regress(t *testing.T, sourceVersion semver.Version, gphome string, port string, inputDir string, outputDir string, schedule idl.Schedule) string {
+func Isolation2_regress(t *testing.T, sourceVersion semver.Version, gphome string, port string, inputDir string, outputDir string, schedule idl.Schedule) string {
 	var cmdArgs []string
 	if schedule != idl.Schedule_non_upgradeable_schedule && strings.Contains(schedule.String(), "target") {
 		cmdArgs = append(cmdArgs, "--use-existing")
@@ -357,7 +357,7 @@ func isolation2_regress(t *testing.T, sourceVersion semver.Version, gphome strin
 	return strings.TrimSpace(string(output))
 }
 
-func jq(t *testing.T, file string, args ...string) string {
+func Jq(t *testing.T, file string, args ...string) string {
 	t.Helper()
 
 	cmd := exec.Command("jq", append(args, "--raw-output", file)...)


### PR DESCRIPTION
Move acceptance test helpers to testutils package. This will allow us to split up and make a clear distinction between pg_upgrade and gpupgrade acceptance tests.

https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:moveToAcceptanceTestUtils