### PR TITLE
move acceptance test helpers to testutils package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,9 @@ test check: unit integration acceptance
 
 .PHONY: pg-upgrade-tests
 pg-upgrade-tests:
-	go test -count=1 -v ./test/acceptance/ -run Test_PgUpgrade_Migratable_Tests
-	go test -count=1 -v ./test/acceptance/ -run Test_PgUpgrade_NonUpgradeable_Tests
-	go test -count=1 -v ./test/acceptance/ -run Test_PgUpgrade_Upgradeable_Tests
+	go test -count=1 -timeout 35m -v ./test/acceptance/ -run Test_PgUpgrade_Migratable_Tests
+	go test -count=1 -timeout 35m -v ./test/acceptance/ -run Test_PgUpgrade_NonUpgradeable_Tests
+	go test -count=1 -timeout 35m -v ./test/acceptance/ -run Test_PgUpgrade_Upgradeable_Tests
 
 .PHONY: coverage
 coverage:

--- a/hub/rename_data_directories_test.go
+++ b/hub/rename_data_directories_test.go
@@ -26,7 +26,7 @@ func TestRenameSegmentDataDirs(t *testing.T) {
 	testlog.SetupTestLogger()
 
 	m := hub.RenameMap{
-		"sdw1": {
+		"sdw1": []*idl.RenameDirectories{
 			{
 				Source: "/data/dbfast1/seg1_123ABC",
 				Target: "/data/dbfast1/seg1",
@@ -36,7 +36,7 @@ func TestRenameSegmentDataDirs(t *testing.T) {
 				Target: "/data/dbfast1/seg3",
 			},
 		},
-		"sdw2": {
+		"sdw2": []*idl.RenameDirectories{
 			{
 				Source: "/data/dbfast2/seg2_123ABC",
 				Target: "/data/dbfast2/seg2",

--- a/test/acceptance/args_test.go
+++ b/test/acceptance/args_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/cli/commands"
 	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/testutils/acceptance"
 )
 
 func TestArgs(t *testing.T) {
@@ -56,9 +57,9 @@ func TestArgs(t *testing.T) {
 	t.Run("gpupgrade initialize fails when --pg-upgrade-verbose is used without --verbose", func(t *testing.T) {
 		cmd := exec.Command("gpupgrade", "initialize",
 			"--non-interactive",
-			"--source-gphome", GPHOME_SOURCE,
-			"--target-gphome", GPHOME_TARGET,
-			"--source-master-port", PGPORT,
+			"--source-gphome", acceptance.GPHOME_SOURCE,
+			"--target-gphome", acceptance.GPHOME_TARGET,
+			"--source-master-port", acceptance.PGPORT,
 			"--stop-before-cluster-creation",
 			"--disk-free-ratio", "0",
 			"--pg-upgrade-verbose",
@@ -81,7 +82,7 @@ target-gphome = %s
 source-master-port = %s
 disk-free-ratio = 0
 stop-before-cluster-creation = true
-`, GPHOME_SOURCE, GPHOME_TARGET, PGPORT)
+`, acceptance.GPHOME_SOURCE, acceptance.GPHOME_TARGET, acceptance.PGPORT)
 		testutils.MustWriteToFile(t, configFile, contents)
 
 		cmd := exec.Command("gpupgrade", "initialize",
@@ -94,25 +95,25 @@ stop-before-cluster-creation = true
 		if err != nil {
 			t.Fatalf("unexpected err: %v stderr: %q", err, output)
 		}
-		defer revert(t)
+		defer acceptance.Revert(t)
 
 		actual := configShow(t, "--source-gphome")
-		if actual != GPHOME_SOURCE {
-			t.Errorf("got %q want %q", actual, GPHOME_SOURCE)
+		if actual != acceptance.GPHOME_SOURCE {
+			t.Errorf("got %q want %q", actual, acceptance.GPHOME_SOURCE)
 		}
 
 		actual = configShow(t, "--target-gphome")
-		if actual != GPHOME_TARGET {
-			t.Errorf("got %q want %q", actual, GPHOME_TARGET)
+		if actual != acceptance.GPHOME_TARGET {
+			t.Errorf("got %q want %q", actual, acceptance.GPHOME_TARGET)
 		}
 	})
 
 	t.Run("initialize sanitizes source-gphome and target-gphome", func(t *testing.T) {
 		cmd := exec.Command("gpupgrade", "initialize",
 			"--non-interactive",
-			"--source-gphome", GPHOME_SOURCE+string(os.PathSeparator),
-			"--target-gphome", GPHOME_TARGET+string(os.PathSeparator)+string(os.PathSeparator),
-			"--source-master-port", PGPORT,
+			"--source-gphome", acceptance.GPHOME_SOURCE+string(os.PathSeparator),
+			"--target-gphome", acceptance.GPHOME_TARGET+string(os.PathSeparator)+string(os.PathSeparator),
+			"--source-master-port", acceptance.PGPORT,
 			"--stop-before-cluster-creation",
 			"--disk-free-ratio", "0",
 		)
@@ -120,21 +121,21 @@ stop-before-cluster-creation = true
 		if err != nil {
 			t.Fatalf("unexpected err: %v stderr: %q", err, output)
 		}
-		defer revert(t)
+		defer acceptance.Revert(t)
 
 		actual := configShow(t, "--source-gphome")
-		if actual != GPHOME_SOURCE {
-			t.Errorf("got %q want %q", actual, GPHOME_SOURCE)
+		if actual != acceptance.GPHOME_SOURCE {
+			t.Errorf("got %q want %q", actual, acceptance.GPHOME_SOURCE)
 		}
 
 		actual = configShow(t, "--target-gphome")
-		if actual != GPHOME_TARGET {
-			t.Errorf("got %q want %q", actual, GPHOME_TARGET)
+		if actual != acceptance.GPHOME_TARGET {
+			t.Errorf("got %q want %q", actual, acceptance.GPHOME_TARGET)
 		}
 	})
 
 	t.Run("gpupgrade execute fails when --pg-upgrade-verbose is used without --verbose", func(t *testing.T) {
-		initialize_stopBeforeClusterCreation(t)
+		acceptance.Initialize_stopBeforeClusterCreation(t)
 
 		cmd := exec.Command("gpupgrade", "execute",
 			"--non-interactive",
@@ -144,7 +145,7 @@ stop-before-cluster-creation = true
 		if err == nil {
 			t.Errorf("expected error got nil")
 		}
-		defer revert(t)
+		defer acceptance.Revert(t)
 
 		expected := "Error: expected --verbose when using --pg-upgrade-verbose\n"
 		if string(output) != expected {

--- a/test/acceptance/config_test.go
+++ b/test/acceptance/config_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/config"
 	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/testutils/acceptance"
 )
 
 func TestConfig(t *testing.T) {
@@ -19,28 +20,28 @@ func TestConfig(t *testing.T) {
 	resetEnv := testutils.SetEnv(t, "GPUPGRADE_HOME", stateDir)
 	defer resetEnv()
 
-	initialize_stopBeforeClusterCreation(t)
-	defer revert(t)
+	acceptance.Initialize_stopBeforeClusterCreation(t)
+	defer acceptance.Revert(t)
 
 	t.Run("configuration can be read piece by piece", func(t *testing.T) {
 		actual := configShow(t, "--source-gphome")
-		if actual != GPHOME_SOURCE {
-			t.Errorf("got %q want %q", actual, GPHOME_SOURCE)
+		if actual != acceptance.GPHOME_SOURCE {
+			t.Errorf("got %q want %q", actual, acceptance.GPHOME_SOURCE)
 		}
 
 		actual = configShow(t, "--target-gphome")
-		if actual != GPHOME_TARGET {
-			t.Errorf("got %q want %q", actual, GPHOME_TARGET)
+		if actual != acceptance.GPHOME_TARGET {
+			t.Errorf("got %q want %q", actual, acceptance.GPHOME_TARGET)
 		}
 	})
 
 	t.Run("configuration can be dumped as a whole", func(t *testing.T) {
 		expected := []string{
-			GPHOME_SOURCE,
-			jq(t, config.GetConfigFile(), `.Intermediate.Primaries."-1".DataDir`),
-			GPHOME_TARGET,
-			TARGET_PGPORT,
-			jq(t, config.GetConfigFile(), ".UpgradeID"),
+			acceptance.GPHOME_SOURCE,
+			acceptance.Jq(t, config.GetConfigFile(), `.Intermediate.Primaries."-1".DataDir`),
+			acceptance.GPHOME_TARGET,
+			acceptance.TARGET_PGPORT,
+			acceptance.Jq(t, config.GetConfigFile(), ".UpgradeID"),
 		}
 
 		output := configShow(t, "")

--- a/test/acceptance/goversion_test.go
+++ b/test/acceptance/goversion_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+
+	"github.com/greenplum-db/gpupgrade/testutils/acceptance"
 )
 
 func TestGoVersion(t *testing.T) {
@@ -28,7 +30,7 @@ func TestGoVersion(t *testing.T) {
 func compiledVersion(t *testing.T) semver.Version {
 	t.Helper()
 
-	cmd := exec.Command("go", "version", filepath.Join(MustGetRepoRoot(t), "gpupgrade"))
+	cmd := exec.Command("go", "version", filepath.Join(acceptance.MustGetRepoRoot(t), "gpupgrade"))
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("unexpected err: %#v stderr %q", err, output)
@@ -42,7 +44,7 @@ func compiledVersion(t *testing.T) semver.Version {
 func goModVersion(t *testing.T) semver.Version {
 	t.Helper()
 
-	contents, err := os.ReadFile(filepath.Join(MustGetRepoRoot(t), "go.mod"))
+	contents, err := os.ReadFile(filepath.Join(acceptance.MustGetRepoRoot(t), "go.mod"))
 	if err != nil {
 		t.Fatalf("reading go.mod: %#v", err)
 	}

--- a/test/acceptance/pg_upgrade_non_upradeable_test.go
+++ b/test/acceptance/pg_upgrade_non_upradeable_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/testutils/acceptance"
 )
 
 func Test_PgUpgrade_NonUpgradeable_Tests(t *testing.T) {
@@ -20,21 +21,21 @@ func Test_PgUpgrade_NonUpgradeable_Tests(t *testing.T) {
 	resetEnv := testutils.SetEnv(t, "GPUPGRADE_HOME", stateDir)
 	defer resetEnv()
 
-	source := GetSourceCluster(t)
+	source := acceptance.GetSourceCluster(t)
 	dir := "6-to-7"
 	if source.Version.Major == 5 {
 		dir = "5-to-6"
 	}
 
-	testDir := filepath.Join(MustGetRepoRoot(t), "test", "acceptance", dir)
-	testutils.MustApplySQLFile(t, GPHOME_SOURCE, PGPORT, filepath.Join(testDir, "setup_globals.sql"))
-	defer testutils.MustApplySQLFile(t, GPHOME_SOURCE, PGPORT, filepath.Join(testDir, "teardown_globals.sql"))
+	testDir := filepath.Join(acceptance.MustGetRepoRoot(t), "test", "acceptance", dir)
+	testutils.MustApplySQLFile(t, acceptance.GPHOME_SOURCE, acceptance.PGPORT, filepath.Join(testDir, "setup_globals.sql"))
+	defer testutils.MustApplySQLFile(t, acceptance.GPHOME_SOURCE, acceptance.PGPORT, filepath.Join(testDir, "teardown_globals.sql"))
 
 	t.Run("pg_upgrade --check detects non-upgradeable objects", func(t *testing.T) {
 		nonUpgradeableTestDir := filepath.Join(testDir, "non_upgradeable_tests")
-		isolation2_regress(t, source.Version, GPHOME_SOURCE, PGPORT, nonUpgradeableTestDir, nonUpgradeableTestDir, idl.Schedule_non_upgradeable_schedule)
+		acceptance.Isolation2_regress(t, source.Version, acceptance.GPHOME_SOURCE, acceptance.PGPORT, nonUpgradeableTestDir, nonUpgradeableTestDir, idl.Schedule_non_upgradeable_schedule)
 
-		revert(t)
+		acceptance.Revert(t)
 	})
 
 }

--- a/test/acceptance/pg_upgrade_upradeable_test.go
+++ b/test/acceptance/pg_upgrade_upradeable_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/idl"
 	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/testutils/acceptance"
 )
 
 func Test_PgUpgrade_Upgradeable_Tests(t *testing.T) {
@@ -20,25 +21,25 @@ func Test_PgUpgrade_Upgradeable_Tests(t *testing.T) {
 	resetEnv := testutils.SetEnv(t, "GPUPGRADE_HOME", stateDir)
 	defer resetEnv()
 
-	source := GetSourceCluster(t)
+	source := acceptance.GetSourceCluster(t)
 	dir := "6-to-7"
 	if source.Version.Major == 5 {
 		dir = "5-to-6"
 	}
 
-	testDir := filepath.Join(MustGetRepoRoot(t), "test", "acceptance", dir)
-	testutils.MustApplySQLFile(t, GPHOME_SOURCE, PGPORT, filepath.Join(testDir, "setup_globals.sql"))
-	defer testutils.MustApplySQLFile(t, GPHOME_SOURCE, PGPORT, filepath.Join(testDir, "teardown_globals.sql"))
+	testDir := filepath.Join(acceptance.MustGetRepoRoot(t), "test", "acceptance", dir)
+	testutils.MustApplySQLFile(t, acceptance.GPHOME_SOURCE, acceptance.PGPORT, filepath.Join(testDir, "setup_globals.sql"))
+	defer testutils.MustApplySQLFile(t, acceptance.GPHOME_SOURCE, acceptance.PGPORT, filepath.Join(testDir, "teardown_globals.sql"))
 
 	t.Run("pg_upgrade upgradeable tests", func(t *testing.T) {
 		sourceTestDir := filepath.Join(testDir, "upgradeable_tests", "source_cluster_regress")
-		isolation2_regress(t, source.Version, GPHOME_SOURCE, PGPORT, sourceTestDir, sourceTestDir, idl.Schedule_upgradeable_source_schedule)
+		acceptance.Isolation2_regress(t, source.Version, acceptance.GPHOME_SOURCE, acceptance.PGPORT, sourceTestDir, sourceTestDir, idl.Schedule_upgradeable_source_schedule)
 
-		initialize(t, idl.Mode_link)
-		defer revert(t)
-		execute(t)
+		acceptance.Initialize(t, idl.Mode_link)
+		defer acceptance.Revert(t)
+		acceptance.Execute(t)
 
 		targetTestDir := filepath.Join(testDir, "upgradeable_tests", "target_cluster_regress")
-		isolation2_regress(t, source.Version, GPHOME_TARGET, TARGET_PGPORT, targetTestDir, targetTestDir, idl.Schedule_upgradeable_target_schedule)
+		acceptance.Isolation2_regress(t, source.Version, acceptance.GPHOME_TARGET, acceptance.TARGET_PGPORT, targetTestDir, targetTestDir, idl.Schedule_upgradeable_target_schedule)
 	})
 }

--- a/test/acceptance/services_test.go
+++ b/test/acceptance/services_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/greenplum-db/gpupgrade/config"
 	"github.com/greenplum-db/gpupgrade/testutils"
+	"github.com/greenplum-db/gpupgrade/testutils/acceptance"
 	"github.com/greenplum-db/gpupgrade/upgrade"
 )
 
@@ -24,12 +25,12 @@ func TestServices(t *testing.T) {
 	resetEnv := testutils.SetEnv(t, "GPUPGRADE_HOME", stateDir)
 	defer resetEnv()
 
-	initialize_stopBeforeClusterCreation(t)
-	defer revert(t)
+	acceptance.Initialize_stopBeforeClusterCreation(t)
+	defer acceptance.Revert(t)
 
 	// TODO: Move to integration/hub_test.go
 	t.Run("hub daemonizes and prints the PID when passed the --daemonize option", func(t *testing.T) {
-		killServices(t)
+		acceptance.KillServices(t)
 
 		cmd := exec.Command("gpupgrade", "hub", "--daemonize")
 		output, err := cmd.CombinedOutput()
@@ -43,12 +44,12 @@ func TestServices(t *testing.T) {
 			t.Fatalf("got %q want %q", hubOutput, expected)
 		}
 
-		killServices(t)
+		acceptance.KillServices(t)
 	})
 
 	// TODO: Move to integration/hub_test.go
 	t.Run("hub does not start if the configuration hasn't been initialized", func(t *testing.T) {
-		killServices(t)
+		acceptance.KillServices(t)
 
 		testutils.MustRename(t, config.GetConfigFile(), config.GetConfigFile()+".old")
 		defer testutils.MustRename(t, config.GetConfigFile()+".old", config.GetConfigFile())
@@ -63,7 +64,7 @@ func TestServices(t *testing.T) {
 
 	// TODO: Move to integration/hub_test.go
 	t.Run("subcommands return an error if the hub is not started", func(t *testing.T) {
-		killServices(t)
+		acceptance.KillServices(t)
 
 		commands := [][]string{
 			{"config", "show"},
@@ -83,17 +84,17 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("kill-services stops hub and agents", func(t *testing.T) {
-		restartServices(t)
+		acceptance.RestartServices(t)
 		processMustBeRunning(t, "gpupgrade hub")
 		processMustBeRunning(t, "gpupgrade agent")
 
-		killServices(t)
+		acceptance.KillServices(t)
 		processMustNotBeRunning(t, "gpupgrade hub")
 		processMustNotBeRunning(t, "gpupgrade agent")
 	})
 
 	t.Run("kill-services stops hub and agents on default port if config file does not exist", func(t *testing.T) {
-		restartServices(t)
+		acceptance.RestartServices(t)
 		processMustBeRunning(t, "gpupgrade hub")
 		processMustBeRunning(t, "gpupgrade agent")
 
@@ -110,37 +111,37 @@ func TestServices(t *testing.T) {
 			}
 		}()
 
-		killServices(t)
+		acceptance.KillServices(t)
 		processMustNotBeRunning(t, "gpupgrade hub")
 		processMustNotBeRunning(t, "gpupgrade agent")
 	})
 
 	t.Run("restart-services actually starts hub and agents", func(t *testing.T) {
-		killServices(t)
+		acceptance.KillServices(t)
 		processMustNotBeRunning(t, "gpupgrade hub")
 		processMustNotBeRunning(t, "gpupgrade agent")
 
-		restartServices(t)
+		acceptance.RestartServices(t)
 		processMustBeRunning(t, "gpupgrade hub")
 		processMustBeRunning(t, "gpupgrade agent")
 	})
 
 	t.Run("kill services can be run multiple times without issue", func(t *testing.T) {
-		killServices(t)
+		acceptance.KillServices(t)
 		processMustNotBeRunning(t, "gpupgrade hub")
 		processMustNotBeRunning(t, "gpupgrade agent")
 
-		killServices(t)
+		acceptance.KillServices(t)
 		processMustNotBeRunning(t, "gpupgrade hub")
 		processMustNotBeRunning(t, "gpupgrade agent")
 	})
 
 	t.Run("restart services can be run multiple times without issue", func(t *testing.T) {
-		restartServices(t)
+		acceptance.RestartServices(t)
 		processMustBeRunning(t, "gpupgrade hub")
 		processMustBeRunning(t, "gpupgrade agent")
 
-		restartServices(t)
+		acceptance.RestartServices(t)
 		processMustBeRunning(t, "gpupgrade hub")
 		processMustBeRunning(t, "gpupgrade agent")
 	})

--- a/testutils/acceptance/acceptance_test_utils.go
+++ b/testutils/acceptance/acceptance_test_utils.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2017-2023 VMware, Inc. or its affiliates
 // SPDX-License-Identifier: Apache-2.0
 
-package gpupgrade_test
+package acceptance
 
 import (
 	"log"
@@ -65,7 +65,7 @@ func MustGetRepoRoot(t *testing.T) string {
 	return filepath.Dir(filepath.Dir(currentDir))
 }
 
-func generate(t *testing.T, outputDir string) string {
+func Generate(t *testing.T, outputDir string) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "generate",
@@ -82,7 +82,7 @@ func generate(t *testing.T, outputDir string) string {
 	return strings.TrimSpace(string(output))
 }
 
-func apply(t *testing.T, gphome string, port string, phase idl.Step, inputDir string) string {
+func Apply(t *testing.T, gphome string, port string, phase idl.Step, inputDir string) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "apply",
@@ -99,7 +99,7 @@ func apply(t *testing.T, gphome string, port string, phase idl.Step, inputDir st
 	return strings.TrimSpace(string(output))
 }
 
-func initialize_stopBeforeClusterCreation(t *testing.T) string {
+func Initialize_stopBeforeClusterCreation(t *testing.T) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "initialize",
@@ -118,7 +118,7 @@ func initialize_stopBeforeClusterCreation(t *testing.T) string {
 	return strings.TrimSpace(string(output))
 }
 
-func initialize(t *testing.T, mode idl.Mode) string {
+func Initialize(t *testing.T, mode idl.Mode) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "initialize",
@@ -137,7 +137,7 @@ func initialize(t *testing.T, mode idl.Mode) string {
 	return strings.TrimSpace(string(output))
 }
 
-func execute(t *testing.T) string {
+func Execute(t *testing.T) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "execute",
@@ -150,7 +150,7 @@ func execute(t *testing.T) string {
 	return strings.TrimSpace(string(output))
 }
 
-func finalize(t *testing.T) string {
+func Finalize(t *testing.T) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "finalize",
@@ -163,7 +163,7 @@ func finalize(t *testing.T) string {
 	return strings.TrimSpace(string(output))
 }
 
-func revert(t *testing.T) string {
+func Revert(t *testing.T) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "revert",
@@ -176,7 +176,7 @@ func revert(t *testing.T) string {
 	return strings.TrimSpace(string(output))
 }
 
-func killServices(t *testing.T) string {
+func KillServices(t *testing.T) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "kill-services")
@@ -188,7 +188,7 @@ func killServices(t *testing.T) string {
 	return strings.TrimSpace(string(output))
 }
 
-func restartServices(t *testing.T) string {
+func RestartServices(t *testing.T) string {
 	t.Helper()
 
 	cmd := exec.Command("gpupgrade", "restart-services")
@@ -259,7 +259,7 @@ func getCluster(t *testing.T, gphome string, port int, destination idl.ClusterDe
 
 // backupDemoCluster is used with restoreDemoCluster to restore a cluster after
 // finalize.
-func backupDemoCluster(t *testing.T, backupDir string, source greenplum.Cluster) {
+func BackupDemoCluster(t *testing.T, backupDir string, source greenplum.Cluster) {
 	src := filepath.Dir(filepath.Dir(source.CoordinatorDataDir())) + string(os.PathSeparator)
 	dest := backupDir + string(os.PathSeparator)
 
@@ -278,7 +278,7 @@ func backupDemoCluster(t *testing.T, backupDir string, source greenplum.Cluster)
 }
 
 // restoreDemoCluster restores the cluster after finalize has been run.
-func restoreDemoCluster(t *testing.T, backupDir string, source greenplum.Cluster, target greenplum.Cluster) {
+func RestoreDemoCluster(t *testing.T, backupDir string, source greenplum.Cluster, target greenplum.Cluster) {
 	// Depending on where we failed we need to stop either the source or target cluster.
 	err := source.Stop(step.DevNullStream)
 	if err != nil {
@@ -308,7 +308,7 @@ func restoreDemoCluster(t *testing.T, backupDir string, source greenplum.Cluster
 	}
 }
 
-func isolation2_regress(t *testing.T, sourceVersion semver.Version, gphome string, port string, inputDir string, outputDir string, schedule idl.Schedule) string {
+func Isolation2_regress(t *testing.T, sourceVersion semver.Version, gphome string, port string, inputDir string, outputDir string, schedule idl.Schedule) string {
 	var cmdArgs []string
 	if schedule != idl.Schedule_non_upgradeable_schedule && strings.Contains(schedule.String(), "target") {
 		cmdArgs = append(cmdArgs, "--use-existing")
@@ -357,7 +357,7 @@ func isolation2_regress(t *testing.T, sourceVersion semver.Version, gphome strin
 	return strings.TrimSpace(string(output))
 }
 
-func jq(t *testing.T, file string, args ...string) string {
+func Jq(t *testing.T, file string, args ...string) string {
 	t.Helper()
 
 	cmd := exec.Command("jq", append(args, "--raw-output", file)...)


### PR DESCRIPTION
This will allow us to split up and make a clear distinction between pg_upgrade and gpupgrade acceptance tests.

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:moveToAcceptanceTestUtils