### PR TITLE
Update role names across tests for clarity

### DIFF
--- a/data-migration-scripts/6-to-7-seed-scripts/test/create_nonupgradable_objects.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/test/create_nonupgradable_objects.sql
@@ -188,7 +188,7 @@ CREATE TABLE dropped_column (a int CONSTRAINT positive_int CHECK (b > 0), b int 
         (PARTITION part_1 START(1) END(5),
         PARTITION part_2 START(5));
 ALTER TABLE dropped_column DROP COLUMN d;
-ALTER TABLE dropped_column OWNER TO test_role1;
+ALTER TABLE dropped_column OWNER TO nonupgradeable_objects_role;
 
 -- Splitting the subpartition leads to its rewrite, eliminating its dropped column
 -- reference. So, after this, only part_2 and the root partition will have a

--- a/data-migration-scripts/6-to-7-seed-scripts/test/setup_nonupgradable_objects.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/test/setup_nonupgradable_objects.sql
@@ -3,5 +3,4 @@
 
 -- CREATE global objects
 CREATE DATABASE testdb;
-CREATE ROLE test_role1;
-CREATE ROLE test_role2;
+CREATE ROLE nonupgradeable_objects_role;

--- a/data-migration-scripts/6-to-7-seed-scripts/test/teardown_nonupgradable_objects.sql
+++ b/data-migration-scripts/6-to-7-seed-scripts/test/teardown_nonupgradable_objects.sql
@@ -3,5 +3,4 @@
 
 -- DROP global objects
 DROP DATABASE IF EXISTS testdb;
-DROP ROLE IF EXISTS test_role1;
-DROP ROLE IF EXISTS test_role2;
+DROP ROLE IF EXISTS nonupgradeable_objects_role;

--- a/test/acceptance/pg_upgrade/5-to-6/migratable_tests/source_cluster_regress/expected/heterogeneous_partition_tables.out
+++ b/test/acceptance/pg_upgrade/5-to-6/migratable_tests/source_cluster_regress/expected/heterogeneous_partition_tables.out
@@ -12,7 +12,7 @@ CREATE
 
 ALTER TABLE dropped_column DROP COLUMN d;
 ALTER
-ALTER TABLE dropped_column OWNER TO test_role1;
+ALTER TABLE dropped_column OWNER TO migratable_objects_role;
 ALTER
 
 -- Splitting the subpartition leads to its rewrite, eliminating its dropped column
@@ -79,12 +79,12 @@ SELECT * FROM heterogeneous_ml_partition_table ORDER BY 1, 2, 3;
 
 -- check owners
 SELECT c.relname, pg_catalog.pg_get_userbyid(c.relowner) FROM pg_partition_rule pr JOIN pg_class c ON c.oid = pr.parchildrelid WHERE c.relname LIKE 'dropped_column%' UNION SELECT c.relname, pg_catalog.pg_get_userbyid(c.relowner) FROM pg_partition p JOIN pg_class c ON c.oid = p.parrelid WHERE c.relname LIKE 'dropped_column%' ORDER BY 1,2;
- relname                           | pg_get_userbyid 
------------------------------------+-----------------
- dropped_column                    | test_role1      
- dropped_column_1_prt_part_2       | test_role1      
- dropped_column_1_prt_split_part_1 | test_role1      
- dropped_column_1_prt_split_part_2 | test_role1      
+ relname                           | pg_get_userbyid         
+-----------------------------------+-------------------------
+ dropped_column                    | migratable_objects_role 
+ dropped_column_1_prt_part_2       | migratable_objects_role 
+ dropped_column_1_prt_split_part_1 | migratable_objects_role 
+ dropped_column_1_prt_split_part_2 | migratable_objects_role 
 (4 rows)
 
 -- check constraints

--- a/test/acceptance/pg_upgrade/5-to-6/migratable_tests/source_cluster_regress/expected/tables_using_tsquery_type.out
+++ b/test/acceptance/pg_upgrade/5-to-6/migratable_tests/source_cluster_regress/expected/tables_using_tsquery_type.out
@@ -106,7 +106,7 @@ CREATE
 -- view on tsquery from multiple tables and multiple views
 CREATE VIEW view_on_tsquery_mult_tables_mult_views AS SELECT t1.name, t2.b, v1.altitude FROM tsquery_table1 t1, tsquery_table2 t2, view_on_tsquery v1, view_on_tsquery_mult_tables v2;
 CREATE
-ALTER TABLE view_on_tsquery_mult_tables_mult_views OWNER TO test_role1;
+ALTER TABLE view_on_tsquery_mult_tables_mult_views OWNER TO migratable_objects_role;
 ALTER
 
 -- check tsquery data
@@ -171,9 +171,9 @@ SELECT n.nspname, c.relname, a.attname FROM pg_catalog.pg_class c JOIN pg_catalo
 SELECT c.relname AS index_name FROM pg_index i JOIN pg_class c ON i.indexrelid = c.oid JOIN pg_class t ON i.indrelid = t.oid WHERE t.relname LIKE 'tsquery%';
  index_name                  
 -----------------------------
- tsquery_cluster_comment_idx 
  tsquery_composite_idx       
  tsquery_gist_idx            
+ tsquery_cluster_comment_idx 
  tsquery_table1_idx          
 (4 rows)
 
@@ -198,8 +198,8 @@ SELECT schemaname, viewname FROM pg_views WHERE schemaname NOT IN ('pg_catalog',
 (7 rows)
 
 -- check view owners
-SELECT schemaname, viewname, viewowner FROM pg_views WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'gp_toolkit') AND schemaname = 'tsquery_schema' AND viewowner = 'test_role1' ORDER BY 1, 2, 3;
- schemaname     | viewname                               | viewowner  
-----------------+----------------------------------------+------------
- tsquery_schema | view_on_tsquery_mult_tables_mult_views | test_role1 
+SELECT schemaname, viewname, viewowner FROM pg_views WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'gp_toolkit') AND schemaname = 'tsquery_schema' AND viewowner = 'migratable_objects_role' ORDER BY 1, 2, 3;
+ schemaname     | viewname                               | viewowner               
+----------------+----------------------------------------+-------------------------
+ tsquery_schema | view_on_tsquery_mult_tables_mult_views | migratable_objects_role 
 (1 row)

--- a/test/acceptance/pg_upgrade/5-to-6/migratable_tests/source_cluster_regress/sql/heterogeneous_partition_tables.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/migratable_tests/source_cluster_regress/sql/heterogeneous_partition_tables.sql
@@ -20,7 +20,7 @@ PARTITION BY RANGE (a)
 );
 
 ALTER TABLE dropped_column DROP COLUMN d;
-ALTER TABLE dropped_column OWNER TO test_role1;
+ALTER TABLE dropped_column OWNER TO migratable_objects_role;
 
 -- Splitting the subpartition leads to its rewrite, eliminating its dropped column
 -- reference. So, after this, only part_2 and the root partition will have a

--- a/test/acceptance/pg_upgrade/5-to-6/migratable_tests/source_cluster_regress/sql/tables_using_tsquery_type.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/migratable_tests/source_cluster_regress/sql/tables_using_tsquery_type.sql
@@ -81,7 +81,7 @@ CREATE VIEW view_on_tsquery_creation_order AS SELECT * FROM tsquery_table1;
 
 -- view on tsquery from multiple tables and multiple views
 CREATE VIEW view_on_tsquery_mult_tables_mult_views AS SELECT t1.name, t2.b, v1.altitude FROM tsquery_table1 t1, tsquery_table2 t2, view_on_tsquery v1, view_on_tsquery_mult_tables v2;
-ALTER TABLE view_on_tsquery_mult_tables_mult_views OWNER TO test_role1;
+ALTER TABLE view_on_tsquery_mult_tables_mult_views OWNER TO migratable_objects_role;
 
 -- check tsquery data
 SELECT * FROM tsquery_pt_table ORDER BY a;
@@ -134,5 +134,5 @@ SELECT schemaname, viewname, viewowner
 FROM pg_views
 WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'gp_toolkit')
 AND schemaname = 'tsquery_schema'
-AND viewowner = 'test_role1'
+AND viewowner = 'migratable_objects_role'
 ORDER BY 1, 2, 3;

--- a/test/acceptance/pg_upgrade/5-to-6/migratable_tests/target_cluster_regress/expected/heterogeneous_partition_tables_5.out
+++ b/test/acceptance/pg_upgrade/5-to-6/migratable_tests/target_cluster_regress/expected/heterogeneous_partition_tables_5.out
@@ -26,12 +26,12 @@ SELECT * FROM heterogeneous_ml_partition_table ORDER BY 1, 2, 3;
 
 -- check owners
 SELECT c.relname, pg_catalog.pg_get_userbyid(c.relowner) FROM pg_partition_rule pr JOIN pg_class c ON c.oid = pr.parchildrelid WHERE c.relname LIKE 'dropped_column%' UNION SELECT c.relname, pg_catalog.pg_get_userbyid(c.relowner) FROM pg_partition p JOIN pg_class c ON c.oid = p.parrelid WHERE c.relname LIKE 'dropped_column%' ORDER BY 1,2;
- relname                           | pg_get_userbyid 
------------------------------------+-----------------
- dropped_column                    | test_role1      
- dropped_column_1_prt_part_2       | test_role1      
- dropped_column_1_prt_split_part_1 | test_role1      
- dropped_column_1_prt_split_part_2 | test_role1      
+ relname                           | pg_get_userbyid         
+-----------------------------------+-------------------------
+ dropped_column                    | migratable_objects_role 
+ dropped_column_1_prt_part_2       | migratable_objects_role 
+ dropped_column_1_prt_split_part_1 | migratable_objects_role 
+ dropped_column_1_prt_split_part_2 | migratable_objects_role 
 (4 rows)
 
 -- check constraints

--- a/test/acceptance/pg_upgrade/5-to-6/migratable_tests/target_cluster_regress/expected/heterogeneous_partition_tables_5.out
+++ b/test/acceptance/pg_upgrade/5-to-6/migratable_tests/target_cluster_regress/expected/heterogeneous_partition_tables_5.out
@@ -4,6 +4,10 @@
 --------------------------------------------------------------------------------
 -- Create and setup migratable objects
 --------------------------------------------------------------------------------
+-- start_matchsubs
+-- m/^DETAIL:  Failing row contains \(.*\).$/
+-- s/.//gs
+-- end_matchsubs
 
 -- check data
 SELECT * FROM dropped_column ORDER BY 1, 2, 3;

--- a/test/acceptance/pg_upgrade/5-to-6/migratable_tests/target_cluster_regress/expected/heterogeneous_partition_tables_6.out
+++ b/test/acceptance/pg_upgrade/5-to-6/migratable_tests/target_cluster_regress/expected/heterogeneous_partition_tables_6.out
@@ -26,12 +26,12 @@ SELECT * FROM heterogeneous_ml_partition_table ORDER BY 1, 2, 3;
 
 -- check owners
 SELECT c.relname, pg_catalog.pg_get_userbyid(c.relowner) FROM pg_partition_rule pr JOIN pg_class c ON c.oid = pr.parchildrelid WHERE c.relname LIKE 'dropped_column%' UNION SELECT c.relname, pg_catalog.pg_get_userbyid(c.relowner) FROM pg_partition p JOIN pg_class c ON c.oid = p.parrelid WHERE c.relname LIKE 'dropped_column%' ORDER BY 1,2;
- relname                           | pg_get_userbyid 
------------------------------------+-----------------
- dropped_column                    | test_role1      
- dropped_column_1_prt_part_2       | test_role1      
- dropped_column_1_prt_split_part_1 | test_role1      
- dropped_column_1_prt_split_part_2 | test_role1      
+ relname                           | pg_get_userbyid        
+-----------------------------------+------------------------
+ dropped_column                    | migratable_objects_role
+ dropped_column_1_prt_part_2       | migratable_objects_role
+ dropped_column_1_prt_split_part_1 | migratable_objects_role
+ dropped_column_1_prt_split_part_2 | migratable_objects_role
 (4 rows)
 
 -- check constraints

--- a/test/acceptance/pg_upgrade/5-to-6/migratable_tests/target_cluster_regress/expected/tables_using_tsquery_type.out
+++ b/test/acceptance/pg_upgrade/5-to-6/migratable_tests/target_cluster_regress/expected/tables_using_tsquery_type.out
@@ -96,10 +96,10 @@ SELECT schemaname, viewname FROM pg_views WHERE schemaname NOT IN ('pg_catalog',
 (7 rows)
 
 -- check view owners
-SELECT schemaname, viewname, viewowner FROM pg_views WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'gp_toolkit') AND schemaname = 'tsquery_schema' AND viewowner = 'test_role1' ORDER BY 1, 2, 3;
- schemaname     | viewname                               | viewowner  
-----------------+----------------------------------------+------------
- tsquery_schema | view_on_tsquery_mult_tables_mult_views | test_role1 
+SELECT schemaname, viewname, viewowner FROM pg_views WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'gp_toolkit') AND schemaname = 'tsquery_schema' AND viewowner = 'migratable_objects_role' ORDER BY 1, 2, 3;
+ schemaname     | viewname                               | viewowner               
+----------------+----------------------------------------+-------------------------
+ tsquery_schema | view_on_tsquery_mult_tables_mult_views | migratable_objects_role 
 (1 row)
 
 INSERT INTO tsquery_pt_table VALUES (1, 'b & c'::tsquery, 'b & c'::tsquery, 'b & c'::tsquery);

--- a/test/acceptance/pg_upgrade/5-to-6/migratable_tests/target_cluster_regress/sql/heterogeneous_partition_tables.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/migratable_tests/target_cluster_regress/sql/heterogeneous_partition_tables.sql
@@ -4,6 +4,10 @@
 --------------------------------------------------------------------------------
 -- Create and setup migratable objects
 --------------------------------------------------------------------------------
+-- start_matchsubs
+-- m/^DETAIL:  Failing row contains \(.*\).$/
+-- s/.//gs
+-- end_matchsubs
 
 -- check data
 SELECT * FROM dropped_column ORDER BY 1, 2, 3;

--- a/test/acceptance/pg_upgrade/5-to-6/migratable_tests/target_cluster_regress/sql/tables_using_tsquery_type.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/migratable_tests/target_cluster_regress/sql/tables_using_tsquery_type.sql
@@ -57,7 +57,7 @@ SELECT schemaname, viewname, viewowner
 FROM pg_views
 WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'gp_toolkit')
 AND schemaname = 'tsquery_schema'
-AND viewowner = 'test_role1'
+AND viewowner = 'migratable_objects_role'
 ORDER BY 1, 2, 3;
 
 INSERT INTO tsquery_pt_table VALUES (1, 'b & c'::tsquery, 'b & c'::tsquery, 'b & c'::tsquery);

--- a/test/acceptance/pg_upgrade/5-to-6/setup_globals.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/setup_globals.sql
@@ -2,8 +2,9 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 DROP DATABASE IF EXISTS isolation2test;
-CREATE ROLE testrole;
-CREATE ROLE test_role1;
+CREATE ROLE upgradable_objects_role;
+CREATE ROLE nonupgradeable_objects_role;
+CREATE ROLE migratable_objects_role;
 
 CREATE RESOURCE QUEUE test_queue WITH (
     ACTIVE_STATEMENTS = 2,
@@ -20,7 +21,7 @@ CREATE RESOURCE GROUP test_group WITH (
     MEMORY_SHARED_QUOTA = 5,
     MEMORY_SPILL_RATIO = 5
 );
-CREATE ROLE test_role resource group test_group resource queue test_queue;
+CREATE ROLE resource_group_queue_role resource group test_group resource queue test_queue;
 
 CREATE FUNCTION drop_gphdfs() RETURNS VOID AS $$
 DECLARE

--- a/test/acceptance/pg_upgrade/5-to-6/teardown_globals.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/teardown_globals.sql
@@ -2,9 +2,10 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 DROP DATABASE IF EXISTS isolation2test;
-DROP ROLE testrole;
-DROP ROLE test_role1;
+DROP ROLE upgradable_objects_role;
+DROP ROLE nonupgradeable_objects_role;
+DROP ROLE migratable_objects_role;
+DROP ROLE resource_group_queue_role;
 
-DROP ROLE test_role;
 DROP RESOURCE GROUP test_group;
 DROP RESOURCE QUEUE test_queue;

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/expected/partitioned_heap_table.out
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/expected/partitioned_heap_table.out
@@ -140,7 +140,7 @@ INSERT 11
 
 CREATE TABLE p_alter_owner (id INTEGER, name TEXT) DISTRIBUTED BY (id) PARTITION BY RANGE(id) (START(1) END(3) EVERY(1));
 CREATE
-ALTER TABLE p_alter_owner OWNER TO testrole;
+ALTER TABLE p_alter_owner OWNER TO upgradable_objects_role;
 ALTER
 
 --

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/expected/resource_group_queue.out
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/expected/resource_group_queue.out
@@ -52,9 +52,9 @@ SELECT groupname, concurrency, proposed_concurrency, cpu_rate_limit, memory_limi
  test_group    | 5           | 5                    | 5              | 5            | 5                     | 5                   | 5                            | 5                  | 5                           
 (3 rows)
 
--- Validate resource queue and group assignment to test_role
-SELECT rolname, rsqname, rsgname FROM pg_roles, pg_resgroup, pg_resqueue WHERE pg_roles.rolresgroup=pg_resgroup.oid AND pg_roles.rolresqueue=pg_resqueue.oid AND rolname='test_role';
- rolname   | rsqname    | rsgname    
------------+------------+------------
- test_role | test_queue | test_group 
+-- Validate resource queue and group assignment to resource_group_queue_role
+SELECT rolname, rsqname, rsgname FROM pg_roles, pg_resgroup, pg_resqueue WHERE pg_roles.rolresgroup=pg_resgroup.oid AND pg_roles.rolresqueue=pg_resqueue.oid AND rolname='resource_group_queue_role';
+ rolname                   | rsqname    | rsgname    
+---------------------------+------------+------------
+ resource_group_queue_role | test_queue | test_group 
 (1 row)

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/sql/partitioned_heap_table.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/sql/partitioned_heap_table.sql
@@ -107,7 +107,7 @@ INSERT INTO dropped_and_added_column SELECT i, i, i, i FROM generate_series(10, 
 ---
 
 CREATE TABLE p_alter_owner (id INTEGER, name TEXT) DISTRIBUTED BY (id) PARTITION BY RANGE(id) (START(1) END(3) EVERY(1));
-ALTER TABLE p_alter_owner OWNER TO testrole;
+ALTER TABLE p_alter_owner OWNER TO upgradable_objects_role;
 
 --
 -- list partitioned by custom type where equality operator is in different schema

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/sql/resource_group_queue.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/source_cluster_regress/sql/resource_group_queue.sql
@@ -36,8 +36,8 @@ SELECT groupname, concurrency, proposed_concurrency, cpu_rate_limit,
     FROM gp_toolkit.gp_resgroup_config
     ORDER BY groupname;
 
--- Validate resource queue and group assignment to test_role
+-- Validate resource queue and group assignment to resource_group_queue_role
 SELECT rolname, rsqname, rsgname FROM pg_roles, pg_resgroup, pg_resqueue
     WHERE pg_roles.rolresgroup=pg_resgroup.oid
     AND pg_roles.rolresqueue=pg_resqueue.oid
-    AND rolname='test_role';
+    AND rolname='resource_group_queue_role';

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/partitioned_heap_table.out
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/partitioned_heap_table.out
@@ -103,11 +103,11 @@ SELECT c, d FROM dropped_and_added_column WHERE a=10;
 (2 rows)
 
 SELECT c.relname, pg_catalog.pg_get_userbyid(c.relowner) as owner FROM pg_class c WHERE relname like 'p_alter_owner%';
- relname               | owner    
------------------------+----------
- p_alter_owner         | testrole 
- p_alter_owner_1_prt_1 | testrole 
- p_alter_owner_1_prt_2 | testrole 
+ relname               | owner                   
+-----------------------+-------------------------
+ p_alter_owner         | upgradable_objects_role 
+ p_alter_owner_1_prt_1 | upgradable_objects_role 
+ p_alter_owner_1_prt_2 | upgradable_objects_role 
 (3 rows)
 
 INSERT INTO equal_operator_not_in_search_path_table VALUES (1, '(1,1)');

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/resource_group_queue.out
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/expected/resource_group_queue.out
@@ -24,9 +24,9 @@ SELECT groupname, concurrency, cpu_rate_limit, memory_limit, memory_shared_quota
  test_group    | 5           | 5              | 5            | 5                   | 5                  | 5                  | vmtracker      | -1     
 (3 rows)
 
--- Validate resource queue and group assignment to test_role
-SELECT rolname, rsqname, rsgname FROM pg_roles, pg_resgroup, pg_resqueue WHERE pg_roles.rolresgroup=pg_resgroup.oid AND pg_roles.rolresqueue=pg_resqueue.oid AND rolname='test_role';
- rolname   | rsqname    | rsgname    
------------+------------+------------
- test_role | test_queue | test_group 
+-- Validate resource queue and group assignment to resource_group_queue_role
+SELECT rolname, rsqname, rsgname FROM pg_roles, pg_resgroup, pg_resqueue WHERE pg_roles.rolresgroup=pg_resgroup.oid AND pg_roles.rolresqueue=pg_resqueue.oid AND rolname='resource_group_queue_role';
+ rolname                   | rsqname    | rsgname    
+---------------------------+------------+------------
+ resource_group_queue_role | test_queue | test_group 
 (1 row)

--- a/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/resource_group_queue.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/upgradeable_tests/target_cluster_regress/sql/resource_group_queue.sql
@@ -18,8 +18,8 @@ SELECT groupname, concurrency, cpu_rate_limit, memory_limit, memory_shared_quota
     FROM gp_toolkit.gp_resgroup_config
     ORDER BY groupname;
 
--- Validate resource queue and group assignment to test_role
+-- Validate resource queue and group assignment to resource_group_queue_role
 SELECT rolname, rsqname, rsgname FROM pg_roles, pg_resgroup, pg_resqueue
     WHERE pg_roles.rolresgroup=pg_resgroup.oid
     AND pg_roles.rolresqueue=pg_resqueue.oid
-    AND rolname='test_role';
+    AND rolname='resource_group_queue_role';


### PR DESCRIPTION
Remove test_role2 which is not used for anything.

Rename remaining test roles to correspond to the type of test they're being used in, `upgradeable|nonupgradeable|migrateable`