### PR TITLE
Fetch git tags in build.bash

### DIFF
--- a/ci/main/scripts/build.bash
+++ b/ci/main/scripts/build.bash
@@ -6,6 +6,7 @@ set -eux -o pipefail
 
 cd gpupgrade_src
 export GOFLAGS="-mod=readonly" # do not update dependencies during build
+git fetch --tags
 
 make oss-rpm
 ci/main/scripts/verify-rpm.bash gpupgrade-*.rpm "Open Source"


### PR DESCRIPTION
When building in Concourse, the resource cache may find an existing entry for the git resource `gpupgrade_src` if a particular commit SHA was tagged after Concourse cached it. In other words, Concourse doesn't update the git resource when tags are pushed. We can instead explicitly fetch tags in the build step to ensure the latest tag for a particular SHA is present. This resolves the resource caching issue and worst case is the git fetch --tags is a no-op.