### PR TITLE
Fix heterogeneous partition table test and remove matchsub

### DIFF
--- a/test/acceptance/pg_upgrade/5-to-6/migratable_tests/target_cluster_regress/expected/heterogeneous_partition_tables_5.out
+++ b/test/acceptance/pg_upgrade/5-to-6/migratable_tests/target_cluster_regress/expected/heterogeneous_partition_tables_5.out
@@ -4,10 +4,6 @@
 --------------------------------------------------------------------------------
 -- Create and setup migratable objects
 --------------------------------------------------------------------------------
--- start_matchsubs
--- m/^DETAIL:  Failing row contains \(.*\).$/
--- s/.//gs
--- end_matchsubs
 
 -- check data
 SELECT * FROM dropped_column ORDER BY 1, 2, 3;

--- a/test/acceptance/pg_upgrade/5-to-6/migratable_tests/target_cluster_regress/expected/heterogeneous_partition_tables_6.out
+++ b/test/acceptance/pg_upgrade/5-to-6/migratable_tests/target_cluster_regress/expected/heterogeneous_partition_tables_6.out
@@ -26,12 +26,12 @@ SELECT * FROM heterogeneous_ml_partition_table ORDER BY 1, 2, 3;
 
 -- check owners
 SELECT c.relname, pg_catalog.pg_get_userbyid(c.relowner) FROM pg_partition_rule pr JOIN pg_class c ON c.oid = pr.parchildrelid WHERE c.relname LIKE 'dropped_column%' UNION SELECT c.relname, pg_catalog.pg_get_userbyid(c.relowner) FROM pg_partition p JOIN pg_class c ON c.oid = p.parrelid WHERE c.relname LIKE 'dropped_column%' ORDER BY 1,2;
- relname                           | pg_get_userbyid        
------------------------------------+------------------------
- dropped_column                    | migratable_objects_role
- dropped_column_1_prt_part_2       | migratable_objects_role
- dropped_column_1_prt_split_part_1 | migratable_objects_role
- dropped_column_1_prt_split_part_2 | migratable_objects_role
+ relname                           | pg_get_userbyid         
+-----------------------------------+-------------------------
+ dropped_column                    | migratable_objects_role 
+ dropped_column_1_prt_part_2       | migratable_objects_role 
+ dropped_column_1_prt_split_part_1 | migratable_objects_role 
+ dropped_column_1_prt_split_part_2 | migratable_objects_role 
 (4 rows)
 
 -- check constraints

--- a/test/acceptance/pg_upgrade/5-to-6/migratable_tests/target_cluster_regress/sql/heterogeneous_partition_tables.sql
+++ b/test/acceptance/pg_upgrade/5-to-6/migratable_tests/target_cluster_regress/sql/heterogeneous_partition_tables.sql
@@ -4,10 +4,6 @@
 --------------------------------------------------------------------------------
 -- Create and setup migratable objects
 --------------------------------------------------------------------------------
--- start_matchsubs
--- m/^DETAIL:  Failing row contains \(.*\).$/
--- s/.//gs
--- end_matchsubs
 
 -- check data
 SELECT * FROM dropped_column ORDER BY 1, 2, 3;

--- a/testutils/acceptance/acceptance_test_utils.go
+++ b/testutils/acceptance/acceptance_test_utils.go
@@ -331,6 +331,8 @@ func RestoreDemoCluster(t *testing.T, backupDir string, source greenplum.Cluster
 }
 
 func Isolation2_regress(t *testing.T, sourceVersion semver.Version, gphome string, port string, inputDir string, outputDir string, schedule idl.Schedule) string {
+	t.Helper()
+
 	var cmdArgs []string
 	if schedule != idl.Schedule_non_upgradeable_schedule && strings.Contains(schedule.String(), "target") {
 		cmdArgs = append(cmdArgs, "--use-existing")


### PR DESCRIPTION
In the midst of all the complex merging of multiple large PRs that included changes in testing infrastructure, directory structure, filenames, testing patterns, and test porting, some mismerges happened. A patch using matchsubs was put in to fix the
heterogeneous_partition_tables test. While matchsubs is an acceptable way to make the test pass, the team has decided on to split 5X and 6X for exact answer file matching in favor of using matchsub. This change brings the isolation2 answer files in line with the team practices.

pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:remove-match-sub