### PR TITLE
Add 7x support to QueryPgStatActivity looking for active connections

### DIFF
--- a/greenplum/query_pg_stat_activity.go
+++ b/greenplum/query_pg_stat_activity.go
@@ -41,9 +41,16 @@ func (s StatActivities) Error() string {
 }
 
 func QueryPgStatActivity(db *sql.DB, cluster *Cluster) error {
-	query := `SELECT application_name, usename, datname, query FROM pg_stat_activity WHERE pid <> pg_backend_pid() ORDER BY application_name, usename, datname;`
-	if cluster.Version.Major < 6 {
+	var query string
+	switch cluster.Version.Major {
+	case 7:
+		query = `SELECT application_name, usename, datname, query FROM pg_stat_activity WHERE pid <> pg_backend_pid() AND client_addr IS NOT NULL ORDER BY application_name, usename, datname;`
+	case 6:
+		query = `SELECT application_name, usename, datname, query FROM pg_stat_activity WHERE pid <> pg_backend_pid() ORDER BY application_name, usename, datname;`
+	case 5:
 		query = `SELECT application_name, usename, datname, current_query FROM pg_stat_activity WHERE procpid <> pg_backend_pid() ORDER BY application_name, usename, datname;`
+	default:
+		return xerrors.Errorf("pg_stat_activity: unsupported cluster version")
 	}
 
 	rows, err := db.Query(query)


### PR DESCRIPTION
7x pg_stat_activity query uses the client_addr to filter out potential internal processes.

From the postgres docs:
client_addr | inet | IP address of the client connected to this backend. If this field is null, it indicates either that the client is connected via a Unix socket on the server machine or that this is an internal process such as autovacuum.

source:
https://www.postgresql.org/docs/12/monitoring-stats.html