### PR TITLE
nonupgradable test to look for tables that use system defined types

### DIFF
--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/expected/system_defined_types.out
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/expected/system_defined_types.out
@@ -1,0 +1,78 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- System defined types are not guaranteed to have consistent oids when moving
+-- from on version of postgres to the next. The query that looks for these
+-- types had to be rewritten for upgrade because the recursive query looking
+-- for these types of relations contained a self reference in a subquery. This
+-- specific type of query is disabled in 6x so it was rewritten in plpgsql.
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+CREATE TABLE table_using_system_defined_type ( pg_type_column pg_type );
+CREATE TABLE
+
+-- build custom types that depend on each other to test recursive query used to
+-- find the tables that depend on system-defined types.
+CREATE TYPE custom_type_using_system_defined AS ( id int, t0 pg_type );
+CREATE TYPE
+CREATE TYPE arr_custom_type1 AS ( id int, t1 custom_type_using_system_defined[] );
+CREATE TYPE
+CREATE TYPE arr_custom_type2 AS ( id int, t2 arr_custom_type1[] );
+CREATE TYPE
+CREATE TYPE arr_custom_type3 AS ( id int, t3 arr_custom_type2[] );
+CREATE TYPE
+CREATE TABLE table_using_multiple_layers_of_system_types ( id int, ct0 custom_type_using_system_defined, ct1 arr_custom_type1, ct2 arr_custom_type2, ct3 arr_custom_type3 );
+CREATE TABLE
+
+CREATE TYPE custom_range_type_using_system_defined AS RANGE ( subtype = pg_type );
+CREATE TYPE
+CREATE TABLE table_using_system_defined_range ( id int, custom_range custom_range_type_using_system_defined NOT NULL );
+CREATE TABLE
+
+CREATE DOMAIN custom_domain_type_using_system_defined AS custom_range_type_using_system_defined;
+CREATE DOMAIN
+CREATE TABLE table_using_system_defined_domain ( id int, custom_domain custom_domain_type_using_system_defined NOT NULL );
+CREATE TABLE
+
+---------------------------------------------------------------------------------
+--- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+---------------------------------------------------------------------------------
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --non-interactive;
+(exited with code 1)
+! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/tables_using_composite.txt;
+In database: isolation2test
+  public.table_using_system_defined_type.pg_type_column
+  public.table_using_multiple_layers_of_system_types.ct0
+  public.table_using_multiple_layers_of_system_types.ct1
+  public.table_using_multiple_layers_of_system_types.ct2
+  public.table_using_multiple_layers_of_system_types.ct3
+  public.table_using_system_defined_range.custom_range
+  public.table_using_system_defined_domain.custom_domain
+
+
+---------------------------------------------------------------------------------
+--- Workaround to unblock upgrade
+---------------------------------------------------------------------------------
+DROP TABLE table_using_system_defined_domain;
+DROP TABLE
+DROP TABLE table_using_system_defined_range;
+DROP TABLE
+DROP TABLE table_using_multiple_layers_of_system_types;
+DROP TABLE
+DROP TABLE table_using_system_defined_type;
+DROP TABLE
+
+DROP TYPE custom_domain_type_using_system_defined;
+DROP TYPE
+DROP TYPE custom_range_type_using_system_defined;
+DROP TYPE
+DROP TYPE arr_custom_type3;
+DROP TYPE
+DROP TYPE arr_custom_type2;
+DROP TYPE
+DROP TYPE arr_custom_type1;
+DROP TYPE
+DROP TYPE custom_type_using_system_defined;
+DROP TYPE

--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/non_upgradeable_schedule
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/non_upgradeable_schedule
@@ -1,1 +1,1 @@
-test: sample
+test: sample system_defined_types

--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/sql/system_defined_types.sql
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/sql/system_defined_types.sql
@@ -1,0 +1,76 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+-- System defined types are not guaranteed to have consistent oids when moving
+-- from on version of postgres to the next. The query that looks for these
+-- types had to be rewritten for upgrade because the recursive query looking
+-- for these types of relations contained a self reference in a subquery. This
+-- specific type of query is disabled in 6x so it was rewritten in plpgsql.
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+CREATE TABLE table_using_system_defined_type (
+	pg_type_column pg_type
+);
+
+-- build custom types that depend on each other to test recursive query used to
+-- find the tables that depend on system-defined types.
+CREATE TYPE custom_type_using_system_defined AS (
+	id int,
+	t0 pg_type
+);
+CREATE TYPE arr_custom_type1 AS (
+	id int,
+	t1 custom_type_using_system_defined[]
+);
+CREATE TYPE arr_custom_type2 AS (
+	id int,
+	t2 arr_custom_type1[]
+);
+CREATE TYPE arr_custom_type3 AS (
+	id int,
+	t3 arr_custom_type2[]
+);
+CREATE TABLE table_using_multiple_layers_of_system_types (
+    id int,
+    ct0 custom_type_using_system_defined,
+    ct1 arr_custom_type1,
+    ct2 arr_custom_type2,
+    ct3 arr_custom_type3
+);
+
+CREATE TYPE custom_range_type_using_system_defined AS RANGE (
+    subtype = pg_type
+);
+CREATE TABLE table_using_system_defined_range (
+    id int,
+    custom_range custom_range_type_using_system_defined NOT NULL
+);
+
+CREATE DOMAIN custom_domain_type_using_system_defined AS custom_range_type_using_system_defined;
+CREATE TABLE table_using_system_defined_domain (
+    id int,
+    custom_domain custom_domain_type_using_system_defined NOT NULL
+);
+
+---------------------------------------------------------------------------------
+--- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+---------------------------------------------------------------------------------
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --non-interactive;
+! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/tables_using_composite.txt;
+
+---------------------------------------------------------------------------------
+--- Workaround to unblock upgrade
+---------------------------------------------------------------------------------
+DROP TABLE table_using_system_defined_domain;
+DROP TABLE table_using_system_defined_range;
+DROP TABLE table_using_multiple_layers_of_system_types;
+DROP TABLE table_using_system_defined_type;
+
+DROP TYPE custom_domain_type_using_system_defined;
+DROP TYPE custom_range_type_using_system_defined;
+DROP TYPE arr_custom_type3;
+DROP TYPE arr_custom_type2;
+DROP TYPE arr_custom_type1;
+DROP TYPE custom_type_using_system_defined;


### PR DESCRIPTION
System defined types are not guaranteed to have consistent oids when moving from on version of postgres to the next. The query that looks for these types had to be rewritten for upgrade because the recursive query looking for these types of relations contained a self reference in a subquery. This specific type of query is disabled in 6x so it was rewritten in pgpsql.

gpdb reference commit:
https://github.com/greenplum-db/gpdb/pull/16820