### PR TITLE
Keep LANG environment variable to preserve locale on target cluster

### DIFF
--- a/hub/init_target_cluster.go
+++ b/hub/init_target_cluster.go
@@ -88,6 +88,7 @@ func InitTargetCluster(stream step.OutStreams, intermediate *greenplum.Cluster) 
 		"HOME",
 		"USER",
 		"LOGNAME",
+		"LANG",
 	})
 
 	args := []string{"-a", "-I", utils.GetInitsystemConfig()}


### PR DESCRIPTION
In GPDB7, when initializing a cluster, how the default locale was determined if no locale is specified was changed.

Before, gpinitsystem would default the locale to en_US.utf8. This was done in gp_bash_functions.sh which was then sourced by gpinitsystem.

After the commit, gpinitsystem would let initdb determine default locale. If no locale is specified, initdb uses setlocale() to set locale to an empty string. when nothing is specified, setlocale first checks the environment for a default locale, if nothing is found it is then set to 'C'.

As part of it's process, to ensure there is no environment mixing, gpupgrade resets all env variables before running gpinitsystem. This included the LANG environment variable, which initdb eventually falls back to. To fix the issue where the target cluster is not preserving the source cluster's locale, do not reset the LANG environment variable when gpinitsystem is run.

GPDB7 reference commit for default locale:
https://github.com/greenplum-db/gpdb/commit/267d52c6bdf0893d69cb476e1160688241032828