### PR TITLE
Data type checks for reg*, sql_identifier, and unknown

### DIFF
--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/expected/reg_data_types.out
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/expected/reg_data_types.out
@@ -1,0 +1,73 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+
+-- The query that looks for these types had to be rewritten for 6 > 7 upgrade
+-- because the recursive query looking for these types of relations contained a
+-- self reference in a subquery. This specific type of query is disabled in 6x
+-- so it was rewritten in plpgsql.
+
+CREATE TYPE range_using_reg AS RANGE ( subtype = regproc );
+CREATE TYPE
+CREATE DOMAIN domain_using_reg AS range_using_reg;
+CREATE DOMAIN
+CREATE TABLE table_using_reg ( col1 regconfig, col2 regdictionary, col3 regoper, col4 regoperator, col5 regproc, col6 regprocedure, col7 range_using_reg, col8 domain_using_reg );
+CREATE TABLE
+
+-- build custom types that depend on each other to test recursive query used to
+-- find the tables that depend on reg types.
+CREATE TYPE reg_type AS ( t0 regproc );
+CREATE TYPE
+CREATE TYPE arr_reg_type1 AS ( t1 reg_type[] );
+CREATE TYPE
+CREATE TYPE arr_reg_type2 AS ( t2 arr_reg_type1[] );
+CREATE TYPE
+CREATE TYPE arr_reg_type3 AS ( t3 arr_reg_type2[] );
+CREATE TYPE
+CREATE TABLE table_using_multiple_layers_of_reg_type ( col1 reg_type, col2 arr_reg_type1, col3 arr_reg_type2, col4 arr_reg_type3 );
+CREATE TABLE
+
+---------------------------------------------------------------------------------
+--- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+---------------------------------------------------------------------------------
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --non-interactive;
+(exited with code 1)
+! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/tables_using_reg.txt;
+In database: isolation2test
+  public.table_using_reg.col1
+  public.table_using_reg.col2
+  public.table_using_reg.col3
+  public.table_using_reg.col4
+  public.table_using_reg.col5
+  public.table_using_reg.col6
+  public.table_using_reg.col7
+  public.table_using_reg.col8
+  public.table_using_multiple_layers_of_reg_type.col1
+  public.table_using_multiple_layers_of_reg_type.col2
+  public.table_using_multiple_layers_of_reg_type.col3
+  public.table_using_multiple_layers_of_reg_type.col4
+
+
+---------------------------------------------------------------------------------
+--- Workaround to unblock upgrade
+---------------------------------------------------------------------------------
+DROP TABLE table_using_multiple_layers_of_reg_type;
+DROP TABLE
+DROP TABLE table_using_reg;
+DROP TABLE
+
+DROP TYPE arr_reg_type3;
+DROP TYPE
+DROP TYPE arr_reg_type2;
+DROP TYPE
+DROP TYPE arr_reg_type1;
+DROP TYPE
+DROP TYPE reg_type;
+DROP TYPE
+DROP TYPE domain_using_reg;
+DROP TYPE
+DROP TYPE range_using_reg;
+DROP TYPE

--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/expected/sql_identifier_types.out
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/expected/sql_identifier_types.out
@@ -1,0 +1,68 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+
+-- The query that looks for these types had to be rewritten for 6 > 7 upgrade
+-- because the recursive query looking for these types of relations contained a
+-- self reference in a subquery. This specific type of query is disabled in 6x
+-- so it was rewritten in plpgsql.
+
+CREATE TYPE range_using_sql_identifier AS RANGE ( subtype = information_schema.sql_identifier );
+CREATE TYPE
+CREATE DOMAIN domain_using_sql_identifier AS range_using_sql_identifier;
+CREATE DOMAIN
+CREATE TABLE table_using_sql_identifier ( col1 information_schema.sql_identifier, col2 range_using_sql_identifier, col3 domain_using_sql_identifier );
+CREATE TABLE
+
+-- build custom types that depend on each other to test recursive query used to
+-- find the tables that depend on information_schema.sql_identifier types.
+CREATE TYPE sql_identifier_type AS ( t0 information_schema.sql_identifier );
+CREATE TYPE
+CREATE TYPE arr_sql_identifier_type1 AS ( t1 sql_identifier_type[] );
+CREATE TYPE
+CREATE TYPE arr_sql_identifier_type2 AS ( t2 arr_sql_identifier_type1[] );
+CREATE TYPE
+CREATE TYPE arr_sql_identifier_type3 AS ( t3 arr_sql_identifier_type2[] );
+CREATE TYPE
+CREATE TABLE table_using_multiple_layers_of_sql_identifier_type ( col1 sql_identifier_type, col2 arr_sql_identifier_type1, col3 arr_sql_identifier_type2, col4 arr_sql_identifier_type3 );
+CREATE TABLE
+
+---------------------------------------------------------------------------------
+--- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+---------------------------------------------------------------------------------
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --non-interactive;
+(exited with code 1)
+! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/tables_using_sql_identifier.txt;
+In database: isolation2test
+  public.table_using_sql_identifier.col1
+  public.table_using_sql_identifier.col2
+  public.table_using_sql_identifier.col3
+  public.table_using_multiple_layers_of_sql_identifier_type.col1
+  public.table_using_multiple_layers_of_sql_identifier_type.col2
+  public.table_using_multiple_layers_of_sql_identifier_type.col3
+  public.table_using_multiple_layers_of_sql_identifier_type.col4
+
+
+---------------------------------------------------------------------------------
+--- Workaround to unblock upgrade
+---------------------------------------------------------------------------------
+DROP TABLE table_using_multiple_layers_of_sql_identifier_type;
+DROP TABLE
+DROP TABLE table_using_sql_identifier;
+DROP TABLE
+
+DROP TYPE arr_sql_identifier_type3;
+DROP TYPE
+DROP TYPE arr_sql_identifier_type2;
+DROP TYPE
+DROP TYPE arr_sql_identifier_type1;
+DROP TYPE
+DROP TYPE sql_identifier_type;
+DROP TYPE
+DROP TYPE domain_using_sql_identifier;
+DROP TYPE
+DROP TYPE range_using_sql_identifier;
+DROP TYPE

--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/expected/unknown_types.out
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/expected/unknown_types.out
@@ -1,0 +1,68 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+
+-- The query that looks for these types had to be rewritten for 6 > 7 upgrade
+-- because the recursive query looking for these types of relations contained a
+-- self reference in a subquery. This specific type of query is disabled in 6x
+-- so it was rewritten in plpgsql.
+
+-- Data type 'unknown' is no longer allowed in table columns
+
+CREATE table unknown_test (v varchar(20), n numeric(20, 2), t timestamp(2));
+CREATE TABLE
+
+CREATE DOMAIN domain_using_unknown AS unknown;
+CREATE DOMAIN
+CREATE TABLE table_using_unknown ( col0 int, col1 unknown, col2 domain_using_unknown );
+CREATE TABLE
+
+-- build custom types that depend on each other to test recursive query used to
+-- find the tables that depend on unknown types.
+CREATE TYPE unknown_type AS ( t0 unknown );
+CREATE TYPE
+CREATE TYPE arr_unknown_type1 AS ( t1 unknown_type[] );
+CREATE TYPE
+CREATE TYPE arr_unknown_type2 AS ( t2 arr_unknown_type1[] );
+CREATE TYPE
+CREATE TYPE arr_unknown_type3 AS ( t3 arr_unknown_type2[] );
+CREATE TYPE
+CREATE TABLE table_using_multiple_layers_of_unknown_type ( col0 int, col1 unknown_type, col2 arr_unknown_type1, col3 arr_unknown_type2, col4 arr_unknown_type3 );
+CREATE TABLE
+
+---------------------------------------------------------------------------------
+--- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+---------------------------------------------------------------------------------
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --non-interactive;
+(exited with code 1)
+! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/tables_using_unknown.txt;
+In database: isolation2test
+  public.table_using_unknown.col1
+  public.table_using_unknown.col2
+  public.table_using_multiple_layers_of_unknown_type.col1
+  public.table_using_multiple_layers_of_unknown_type.col2
+  public.table_using_multiple_layers_of_unknown_type.col3
+  public.table_using_multiple_layers_of_unknown_type.col4
+
+
+---------------------------------------------------------------------------------
+--- Workaround to unblock upgrade
+---------------------------------------------------------------------------------
+DROP TABLE table_using_multiple_layers_of_unknown_type;
+DROP TABLE
+DROP TABLE table_using_unknown;
+DROP TABLE
+
+DROP TYPE arr_unknown_type3;
+DROP TYPE
+DROP TYPE arr_unknown_type2;
+DROP TYPE
+DROP TYPE arr_unknown_type1;
+DROP TYPE
+DROP TYPE unknown_type;
+DROP TYPE
+DROP TYPE domain_using_unknown;
+DROP TYPE

--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/non_upgradeable_schedule
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/non_upgradeable_schedule
@@ -1,3 +1,4 @@
 test: sample 
 test: system_defined_types
 test: reg_data_types
+test: sql_identifier_types

--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/non_upgradeable_schedule
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/non_upgradeable_schedule
@@ -1,1 +1,3 @@
-test: sample system_defined_types
+test: sample 
+test: system_defined_types
+test: reg_data_types

--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/non_upgradeable_schedule
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/non_upgradeable_schedule
@@ -2,3 +2,4 @@ test: sample
 test: system_defined_types
 test: reg_data_types
 test: sql_identifier_types
+test: unknown_types

--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/sql/reg_data_types.sql
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/sql/reg_data_types.sql
@@ -1,0 +1,66 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+
+-- The query that looks for these types had to be rewritten for 6 > 7 upgrade
+-- because the recursive query looking for these types of relations contained a
+-- self reference in a subquery. This specific type of query is disabled in 6x
+-- so it was rewritten in plpgsql.
+
+CREATE TYPE range_using_reg AS RANGE (
+    subtype = regproc
+);
+CREATE DOMAIN domain_using_reg AS range_using_reg;
+CREATE TABLE table_using_reg (
+	col1 regconfig,
+	col2 regdictionary,
+	col3 regoper,
+	col4 regoperator,
+	col5 regproc,
+	col6 regprocedure,
+    col7 range_using_reg,
+    col8 domain_using_reg
+);
+
+-- build custom types that depend on each other to test recursive query used to
+-- find the tables that depend on reg types.
+CREATE TYPE reg_type AS (
+	t0 regproc
+);
+CREATE TYPE arr_reg_type1 AS (
+	t1 reg_type[]
+);
+CREATE TYPE arr_reg_type2 AS (
+	t2 arr_reg_type1[]
+);
+CREATE TYPE arr_reg_type3 AS (
+	t3 arr_reg_type2[]
+);
+CREATE TABLE table_using_multiple_layers_of_reg_type (
+    col1 reg_type,
+    col2 arr_reg_type1,
+    col3 arr_reg_type2,
+    col4 arr_reg_type3
+);
+
+---------------------------------------------------------------------------------
+--- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+---------------------------------------------------------------------------------
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --non-interactive;
+! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/tables_using_reg.txt;
+
+---------------------------------------------------------------------------------
+--- Workaround to unblock upgrade
+---------------------------------------------------------------------------------
+DROP TABLE table_using_multiple_layers_of_reg_type;
+DROP TABLE table_using_reg;
+
+DROP TYPE arr_reg_type3;
+DROP TYPE arr_reg_type2;
+DROP TYPE arr_reg_type1;
+DROP TYPE reg_type;
+DROP TYPE domain_using_reg;
+DROP TYPE range_using_reg;

--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/sql/sql_identifier_types.sql
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/sql/sql_identifier_types.sql
@@ -1,0 +1,61 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+
+-- The query that looks for these types had to be rewritten for 6 > 7 upgrade
+-- because the recursive query looking for these types of relations contained a
+-- self reference in a subquery. This specific type of query is disabled in 6x
+-- so it was rewritten in plpgsql.
+
+CREATE TYPE range_using_sql_identifier AS RANGE (
+    subtype = information_schema.sql_identifier
+);
+CREATE DOMAIN domain_using_sql_identifier AS range_using_sql_identifier;
+CREATE TABLE table_using_sql_identifier (
+	col1 information_schema.sql_identifier,
+	col2 range_using_sql_identifier,
+	col3 domain_using_sql_identifier
+);
+
+-- build custom types that depend on each other to test recursive query used to
+-- find the tables that depend on information_schema.sql_identifier types.
+CREATE TYPE sql_identifier_type AS (
+	t0 information_schema.sql_identifier
+);
+CREATE TYPE arr_sql_identifier_type1 AS (
+	t1 sql_identifier_type[]
+);
+CREATE TYPE arr_sql_identifier_type2 AS (
+	t2 arr_sql_identifier_type1[]
+);
+CREATE TYPE arr_sql_identifier_type3 AS (
+	t3 arr_sql_identifier_type2[]
+);
+CREATE TABLE table_using_multiple_layers_of_sql_identifier_type (
+    col1 sql_identifier_type,
+    col2 arr_sql_identifier_type1,
+    col3 arr_sql_identifier_type2,
+    col4 arr_sql_identifier_type3
+);
+
+---------------------------------------------------------------------------------
+--- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+---------------------------------------------------------------------------------
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --non-interactive;
+! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/tables_using_sql_identifier.txt;
+
+---------------------------------------------------------------------------------
+--- Workaround to unblock upgrade
+---------------------------------------------------------------------------------
+DROP TABLE table_using_multiple_layers_of_sql_identifier_type;
+DROP TABLE table_using_sql_identifier;
+
+DROP TYPE arr_sql_identifier_type3;
+DROP TYPE arr_sql_identifier_type2;
+DROP TYPE arr_sql_identifier_type1;
+DROP TYPE sql_identifier_type;
+DROP TYPE domain_using_sql_identifier;
+DROP TYPE range_using_sql_identifier;

--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/sql/unknown_types.sql
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/sql/unknown_types.sql
@@ -1,0 +1,62 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+
+-- The query that looks for these types had to be rewritten for 6 > 7 upgrade
+-- because the recursive query looking for these types of relations contained a
+-- self reference in a subquery. This specific type of query is disabled in 6x
+-- so it was rewritten in plpgsql.
+
+-- Data type 'unknown' is no longer allowed in table columns
+
+CREATE table unknown_test (v varchar(20), n numeric(20, 2), t timestamp(2));
+
+CREATE DOMAIN domain_using_unknown AS unknown;
+CREATE TABLE table_using_unknown (
+	col0 int,
+	col1 unknown,
+	col2 domain_using_unknown
+);
+
+-- build custom types that depend on each other to test recursive query used to
+-- find the tables that depend on unknown types.
+CREATE TYPE unknown_type AS (
+	t0 unknown
+);
+CREATE TYPE arr_unknown_type1 AS (
+	t1 unknown_type[]
+);
+CREATE TYPE arr_unknown_type2 AS (
+	t2 arr_unknown_type1[]
+);
+CREATE TYPE arr_unknown_type3 AS (
+	t3 arr_unknown_type2[]
+);
+CREATE TABLE table_using_multiple_layers_of_unknown_type (
+    col0 int,
+    col1 unknown_type,
+    col2 arr_unknown_type1,
+    col3 arr_unknown_type2,
+    col4 arr_unknown_type3
+);
+
+---------------------------------------------------------------------------------
+--- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+---------------------------------------------------------------------------------
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --non-interactive;
+! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/tables_using_unknown.txt;
+
+---------------------------------------------------------------------------------
+--- Workaround to unblock upgrade
+---------------------------------------------------------------------------------
+DROP TABLE table_using_multiple_layers_of_unknown_type;
+DROP TABLE table_using_unknown;
+
+DROP TYPE arr_unknown_type3;
+DROP TYPE arr_unknown_type2;
+DROP TYPE arr_unknown_type1;
+DROP TYPE unknown_type;
+DROP TYPE domain_using_unknown;


### PR DESCRIPTION
The query that looks for these types had to be rewritten for 6 > 7 upgrade
because the recursive query looking for these types of relations contained a
self reference in a subquery. This specific type of query is disabled in 6x
so it was rewritten in plpgsql.