### PR TITLE
pg_upgrade nonupgradable test detecting views with removed operators

### DIFF
--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/expected/views_with_removed_operators.out
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/expected/views_with_removed_operators.out
@@ -1,0 +1,32 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+
+DROP SCHEMA IF EXISTS removed_operators CASCADE;
+DROP SCHEMA
+CREATE SCHEMA removed_operators;
+CREATE SCHEMA
+SET search_path to removed_operators;
+SET
+
+CREATE OR REPLACE VIEW view_with_int2vectoreq AS SELECT '1 2'::INT2VECTOR = '1 2'::INT2VECTOR;
+CREATE VIEW
+
+---------------------------------------------------------------------------------
+--- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+---------------------------------------------------------------------------------
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --non-interactive;
+(exited with code 1)
+! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/views_with_removed_operators.txt;
+Database: isolation2test
+  removed_operators.view_with_int2vectoreq
+
+
+---------------------------------------------------------------------------------
+--- Workaround to unblock upgrade
+---------------------------------------------------------------------------------
+DROP VIEW view_with_int2vectoreq;
+DROP VIEW

--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/non_upgradeable_schedule
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/non_upgradeable_schedule
@@ -3,3 +3,4 @@ test: system_defined_types
 test: reg_data_types
 test: sql_identifier_types
 test: unknown_types
+test: views_with_removed_operators

--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/sql/views_with_removed_operators.sql
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/sql/views_with_removed_operators.sql
@@ -1,0 +1,23 @@
+-- Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+
+DROP SCHEMA IF EXISTS removed_operators CASCADE;
+CREATE SCHEMA removed_operators;
+SET search_path to removed_operators;
+
+CREATE OR REPLACE VIEW view_with_int2vectoreq AS SELECT '1 2'::INT2VECTOR = '1 2'::INT2VECTOR;
+
+---------------------------------------------------------------------------------
+--- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+---------------------------------------------------------------------------------
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --non-interactive;
+! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/views_with_removed_operators.txt;
+
+---------------------------------------------------------------------------------
+--- Workaround to unblock upgrade
+---------------------------------------------------------------------------------
+DROP VIEW view_with_int2vectoreq;


### PR DESCRIPTION
Views that use deprecated operators will cause upgrade to fail. This happens during metadata restore on the target cluster because pg_restore will error trying to create a view using types that do not exist anymore. This is not ideal as we could be many hours into upgrade before a view using a deprecated operator causes pg_upgrade to fail. Test that pg_upgrade is looking for views using deprecated operators.