### PR TITLE
Add non-upgradable tests for disallowed operator =>

### DIFF
--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/expected/disallowed_pg_operator.out
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/expected/disallowed_pg_operator.out
@@ -1,0 +1,35 @@
+-- Copyright (c) 2017-2024 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+CREATE OPERATOR => (leftarg = int8, procedure = numeric_fac);
+CREATE OPERATOR
+
+CREATE DATABASE test_disallowed_pg_operator;
+CREATE DATABASE
+1:@db_name test_disallowed_pg_operator:CREATE OPERATOR => (leftarg = int8, procedure = numeric_fac);
+CREATE OPERATOR
+1q: ... <quitting>
+
+---------------------------------------------------------------------------------
+--- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+---------------------------------------------------------------------------------
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --non-interactive;
+-- start_ignore
+-- end_ignore
+(exited with code 1)
+! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/databases_with_disallowed_pg_operator.txt;
+isolation2test
+test_disallowed_pg_operator
+
+
+---------------------------------------------------------------------------------
+--- Cleanup
+---------------------------------------------------------------------------------
+
+DROP OPERATOR => (bigint, NONE);
+DROP OPERATOR
+DROP DATABASE test_disallowed_pg_operator;
+DROP DATABASE

--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/non_upgradeable_schedule
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/non_upgradeable_schedule
@@ -6,3 +6,4 @@ test: unknown_types
 test: views_with_removed_operators
 test: views_with_removed_functions
 test: views_with_removed_types
+test: disallowed_pg_operator

--- a/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/sql/disallowed_pg_operator.sql
+++ b/test/acceptance/pg_upgrade/6-to-7/non_upgradeable_tests/sql/disallowed_pg_operator.sql
@@ -1,0 +1,24 @@
+-- Copyright (c) 2017-2024 VMware, Inc. or its affiliates
+-- SPDX-License-Identifier: Apache-2.0
+
+--------------------------------------------------------------------------------
+-- Create and setup non-upgradeable objects
+--------------------------------------------------------------------------------
+CREATE OPERATOR => (leftarg = int8, procedure = numeric_fac);
+
+CREATE DATABASE test_disallowed_pg_operator;
+1:@db_name test_disallowed_pg_operator:CREATE OPERATOR => (leftarg = int8, procedure = numeric_fac);
+1q:
+
+---------------------------------------------------------------------------------
+--- Assert that pg_upgrade --check correctly detects the non-upgradeable objects
+---------------------------------------------------------------------------------
+!\retcode gpupgrade initialize --source-gphome="${GPHOME_SOURCE}" --target-gphome=${GPHOME_TARGET} --source-master-port=${PGPORT} --disk-free-ratio 0 --non-interactive;
+! cat ~/gpAdminLogs/gpupgrade/pg_upgrade/p-1/databases_with_disallowed_pg_operator.txt;
+
+---------------------------------------------------------------------------------
+--- Cleanup
+---------------------------------------------------------------------------------
+
+DROP OPERATOR => (bigint, NONE);
+DROP DATABASE test_disallowed_pg_operator;


### PR DESCRIPTION
Postgres 9.5 and above no longer allows operator => to be created by the users. Upgrading from GP6 (9.4) to GP7 will fail due to this.

For example, when running the command `CREATE OPERATOR =>`, the user will see the following error: `ERROR:  syntax error at or near "=>"`.

So during metadata restore on the target cluster, pg_restore will error trying to create an operator that is no longer allowed. This check ensures that the user is alerted that they have an operator that is no longer allowed.

corresponding pg_upgrade change:
https://github.com/greenplum-db/gpdb/pull/17204