### PR TITLE
Add `gpupgrade check` to run subset of pg_upgrade checks

### DIFF
--- a/cli/bash/gpupgrade.bash
+++ b/cli/bash/gpupgrade.bash
@@ -421,6 +421,63 @@ _gpupgrade_apply()
     noun_aliases=()
 }
 
+_gpupgrade_check_help()
+{
+    last_command="gpupgrade_check_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_gpupgrade_check()
+{
+    last_command="gpupgrade_check"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("help")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--?")
+    flags+=("-?")
+    local_nonpersistent_flags+=("--?")
+    local_nonpersistent_flags+=("-?")
+    flags+=("--source-gphome=")
+    two_word_flags+=("--source-gphome")
+    local_nonpersistent_flags+=("--source-gphome")
+    local_nonpersistent_flags+=("--source-gphome=")
+    flags+=("--source-master-port=")
+    two_word_flags+=("--source-master-port")
+    local_nonpersistent_flags+=("--source-master-port")
+    local_nonpersistent_flags+=("--source-master-port=")
+    flags+=("--target-gphome=")
+    two_word_flags+=("--target-gphome")
+    local_nonpersistent_flags+=("--target-gphome")
+    local_nonpersistent_flags+=("--target-gphome=")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _gpupgrade_config_show_help()
 {
     last_command="gpupgrade_config_show_help"
@@ -902,6 +959,7 @@ _gpupgrade_root_command()
 
     commands=()
     commands+=("apply")
+    commands+=("check")
     commands+=("config")
     commands+=("execute")
     commands+=("finalize")

--- a/cli/commands/check.go
+++ b/cli/commands/check.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2017-2023 VMware, Inc. or its affiliates
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strconv"
+
+	"github.com/greenplum-db/gpupgrade/greenplum"
+	"github.com/greenplum-db/gpupgrade/greenplum/connection"
+	"github.com/greenplum-db/gpupgrade/idl"
+	"github.com/greenplum-db/gpupgrade/utils"
+	"github.com/greenplum-db/gpupgrade/utils/errorlist"
+	"github.com/spf13/cobra"
+)
+
+func check() *cobra.Command {
+	var sourceGPHome string
+	var targetGPHome string
+	var sourcePort int
+
+	cmd := &cobra.Command{
+		Use:   "check",
+		Short: "Executes a subset of pg_upgrade checks for upgrade from GPDB6 to GPDB7",
+		Long:  CheckHelp,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			_, err := os.Stat(sourceGPHome)
+			if os.IsNotExist(err) {
+				return fmt.Errorf(`source GPHOME "%s" does not exist`, sourceGPHome)
+			}
+			_, err = os.Stat(targetGPHome)
+			if os.IsNotExist(err) {
+				return fmt.Errorf(`target GPHOME "%s" does not exist`, targetGPHome)
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			// Get connection to db to get cluster info
+			db, err := connection.Bootstrap(idl.ClusterDestination_source, sourceGPHome, sourcePort)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if cErr := db.Close(); cErr != nil {
+					err = errorlist.Append(err, cErr)
+				}
+			}()
+
+			source, err := greenplum.ClusterFromDB(db, sourceGPHome, idl.ClusterDestination_source)
+			if err != nil {
+				return err
+			}
+
+			if source.Version.Major != 6 {
+				return fmt.Errorf(`Your cluster version was detected as %s. This command only runs only runs on gpdb6 to look for objects incompatible with GPDB7. `, source.Version.String())
+			}
+
+			const TimeStringFormat = "20060102T150405"
+			pgUpgradeTimestamp := utils.System.Now().Format(TimeStringFormat)
+			pgUpgradeDir, err := utils.GetPgUpgradeDir(greenplum.PrimaryRole, -1, pgUpgradeTimestamp, "7.0.0")
+			if err != nil {
+				return err
+			}
+
+			err = utils.System.MkdirAll(pgUpgradeDir, 0700)
+			if err != nil {
+				return err
+			}
+
+			pgUpgradeArgs := []string{
+				"-c",
+				"--continue-check-on-fatal",
+				"--retain",
+				"--output-dir", pgUpgradeDir,
+				"-d", source.CoordinatorDataDir(),
+				"-b", path.Join(sourceGPHome, "bin"),
+				"-p", strconv.Itoa(sourcePort),
+				"--check-not-in-place",
+			}
+
+			pgUpgradeBinary := path.Join(targetGPHome, "bin", "pg_upgrade")
+			command := exec.Command(pgUpgradeBinary, pgUpgradeArgs...)
+			command.Stdout = os.Stdout
+			command.Stderr = os.Stderr
+
+			pgUpgradeErr := command.Run()
+			if err != nil {
+				return pgUpgradeErr
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&sourceGPHome, "source-gphome", "/usr/local/gpdb6", "path for the source Greenplum installation")
+	cmd.Flags().StringVar(&targetGPHome, "target-gphome", "/usr/local/gpdb7", "path for the target Greenplum installation")
+	cmd.Flags().IntVar(&sourcePort, "source-master-port", 5432, "master port for source gpdb cluster")
+
+	return addHelpToCommand(cmd, CheckHelp)
+}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -78,6 +78,7 @@ func BuildRootCommand() *cobra.Command {
 	root.AddCommand(version())
 	root.AddCommand(dataMigrationGenerate())
 	root.AddCommand(dataMigrationApply())
+	root.AddCommand(check())
 	root.AddCommand(initialize())
 	root.AddCommand(execute())
 	root.AddCommand(finalize())

--- a/cli/commands/help_text.go
+++ b/cli/commands/help_text.go
@@ -16,10 +16,12 @@ import (
 	"github.com/greenplum-db/gpupgrade/utils"
 )
 
+var checkSubsteps substeps.Substeps
 var initializeSubsteps substeps.Substeps
 var executeSubsteps substeps.Substeps
 var finalizeSubsteps substeps.Substeps
 var revertSubsteps substeps.Substeps
+var CheckHelp string
 var InitializeHelp string
 var ExecuteHelp string
 var FinalizeHelp string
@@ -31,6 +33,10 @@ func init() {
 	logDir, err := utils.GetLogDir()
 	if err != nil {
 		panic(fmt.Sprintf("failed to get log directory: %v", err))
+	}
+
+	checkSubsteps = substeps.Substeps{
+		idl.Substep_check_upgrade,
 	}
 
 	initializeSubsteps = substeps.Substeps{
@@ -104,6 +110,7 @@ func init() {
 		idl.Substep_delete_master_statedir,
 	}
 
+	CheckHelp = fmt.Sprintf(checkHelpText, "check", checkSubsteps, logDir)
 	InitializeHelp = fmt.Sprintf(initializeHelpText, cases.Title(language.English).String(idl.Step_initialize.String()), initializeSubsteps, logDir)
 	ExecuteHelp = fmt.Sprintf(executeHelpText, cases.Title(language.English).String(idl.Step_execute.String()), executeSubsteps, logDir)
 	FinalizeHelp = fmt.Sprintf(finalizeHelpText, cases.Title(language.English).String(idl.Step_finalize.String()), finalizeSubsteps, logDir)
@@ -118,6 +125,25 @@ func init() {
 	}
 }
 
+const checkHelpText = `
+Runs checks only relevant when upgrading using gpbackup. This command is to be
+used to run relevant pre-upgrade checks to look for incompatible objects on
+source cluster as part of the process of upgrading from GPDB6 to GPDB7 using
+gpbackup.
+
+%s will carry out the following steps:
+%s
+Usage: gpupgrade check
+
+Optional Flags:
+
+  -h, --help                 displays help output for check
+      --source-gphome        source cluster gphome. Default '/usr/local/gpdb6'.
+      --target-gphome        target cluster gphome. Default '/usr/local/gpdb7'.
+      --source-master-port   source cluster port.   Default 5432.
+
+gpupgrade log files can be found on all hosts in %s
+`
 const initializeHelpText = `
 Runs pre-upgrade checks and prepares the cluster for upgrade.
 
@@ -283,6 +309,11 @@ Required Commands:
                   Greenplum version
 
 Optional Commands:
+
+  check           Runs checks only relevant when upgrading using gpbackup. This
+                  command is to be used to run relevant pre-upgrade checks to
+                  look for incompatible objects on source cluster as part of the
+                  process of upgrading from GPDB6 to GPDB7 using gpbackup.
 
   revert          returns the cluster to its original state
                   Note: revert cannot be used after gpupgrade finalize


### PR DESCRIPTION
Runs a subset of pg_upgrade checks against a source gpdb6 cluster in preparation for upgrade using gpbackup. Only checks relevant for upgrading using gpbackup.

gpdb commit reference:
https://github.com/greenplum-db/gpdb/pull/xxxxx

gpupgrade check PR https://github.com/greenplum-db/gpupgrade/pull/907
pg_upgrade --check-not-in-place PR https://github.com/greenplum-db/gpdb/pull/17236

```
    kyeap [ main ] ~/workspace/gpbackup
 --- $ gpupgrade check --source-master-port 6000
Performing Consistency Checks on Old Live Server
------------------------------------------------
Checking cluster versions                                   ok
Checking for external tables used in partitioning           ok
Checking for non-covering indexes on partitioned AO tables  ok
Checking for indexes on partitioned tables                  ok
Checking array types derived from partitions                ok
Checking for multi-column LIST partition keys               ok
Checking for functions dependent on plpython2               ok
Checking for views with removed operators                   ok
Checking for views with removed functions                   ok
Checking for SHA-256 hashed passwords                       ok
Checking for removed "abstime" data type in user tables     ok
Checking for removed "reltime" data type in user tables     ok
Checking for removed "tinterval" data type in user tables   ok
Checking for invalid "unknown" user columns                 ok
Checking for roles starting with "pg_"                      ok

*Clusters are compatible*
```

Design doc:
https://docs.google.com/document/d/1r17shvokIRZWWtvWS2OqsqUIS1BwTkitnssWllQx7hw/edit?usp=sharing
