### PR TITLE
fixed the port of mirrors is incorrent on the upgraded cluster

### DIFF
--- a/hub/update_conf_files.go
+++ b/hub/update_conf_files.go
@@ -79,7 +79,7 @@ func UpdatePostgresqlConfOnSegments(agentConns []*idl.Connection, intermediate *
 		for _, mirror := range mirrors {
 			opt := &idl.UpdateFileConfOptions{
 				Path:        filepath.Join(mirror.DataDir, "postgresql.conf"),
-				Pattern:     fmt.Sprintf(pattern, intermediate.Primaries[mirror.ContentID].Port),
+				Pattern:     fmt.Sprintf(pattern, intermediate.Mirrors[mirror.ContentID].Port),
 				Replacement: fmt.Sprintf(replacement, mirror.Port),
 			}
 


### PR DESCRIPTION
The port for mirror PG process is different from the value in gp_segment_configuration after upgrade.